### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Official website: <a href="https://producer-pal.org">producer-pal.org</a>
 
 ## Quick Start
 
+[![Run in Smithery](https://smithery.ai/badge/skills/adamjmurray)](https://smithery.ai/skills?ns=adamjmurray&utm_source=github&utm_medium=badge)
+
+
 1. **Install**: Download
    [Producer_Pal.amxd](https://github.com/adamjmurray/producer-pal/releases/latest/download/Producer_Pal.amxd)
 2. **Setup**: Follow the


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/adamjmurray)](https://smithery.ai/skills?ns=adamjmurray&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.