### PR TITLE
Reorganize roadmap.md structure and add section links

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,17 +19,10 @@ reach out directly.
 
 ## In Progress
 
-### v1.3.2
+### 1.3.x
 
 - Rack macro variation management
-  - Select macro variation
-  - Create/update macro variation
-  - Delete macro variation
-  - Randomize macros
 - Support moving/reordering devices
-
-### v1.3.3
-
 - A/B comparison of device parameters
 - Arrangement cue support
 - Change the samples played by Simpler


### PR DESCRIPTION
- Add navigation links at top (Get Involved, In Progress, Released, Future Plans)
- Reorder sections: Get Involved → In Progress → Released → Future Plans
- Reverse release history to show newest first (1.3.1 → 0.9)
- Rename "Planned" section to "Future Plans"