### PR TITLE
add provider choice pages to docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -71,6 +71,16 @@ export default defineConfig({
         ],
       },
       {
+        text: "Choose by Provider",
+        items: [
+          { text: "Claude / Anthropic", link: "/installation/choose-claude" },
+          { text: "ChatGPT / OpenAI", link: "/installation/choose-openai" },
+          { text: "Gemini / Google", link: "/installation/choose-gemini" },
+          { text: "Local / Offline", link: "/installation/choose-local" },
+          { text: "Multiple Providers", link: "/installation/choose-multi" },
+        ],
+      },
+      {
         text: "Built-in Chat UI",
         items: [
           { text: "Overview", link: "/installation/chat-ui" },

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,6 +13,20 @@ Choose your preferred AI platform to get started with Producer Pal:
 
 :::
 
+## Which AI Do You Use?
+
+Pick your preferred AI provider:
+
+- **[Anthropic / Claude](./installation/choose-claude)** — Claude Desktop,
+  claude.ai, or Claude Code
+- **[OpenAI / ChatGPT](./installation/choose-openai)** — ChatGPT web app or
+  Codex CLI
+- **[Google / Gemini](./installation/choose-gemini)** — Built-in Chat UI or
+  Gemini CLI
+- **[Local / Offline](./installation/choose-local)** — Ollama or LM Studio
+- **[Multiple Providers](./installation/choose-multi)** — OpenRouter,
+  flexibility across providers
+
 ## Recommended Options
 
 These are the easiest and most reliable ways to use Producer Pal:

--- a/docs/installation/choose-claude.md
+++ b/docs/installation/choose-claude.md
@@ -1,0 +1,23 @@
+# Using Claude with Producer Pal
+
+Anthropic's Claude models work great with Producer Pal. Requires a subscription
+($20/mo Pro) or API credits.
+
+## Options
+
+| Option                             | Best For               | Trade-offs                                            |
+| ---------------------------------- | ---------------------- | ----------------------------------------------------- |
+| [Claude Desktop](./claude-desktop) | Most users             | Easiest setup, best experience. Desktop app required. |
+| [claude.ai](./claude-web)          | Browser-only workflows | Requires [web tunnel](./web-tunnels) setup.           |
+| [Claude Code](./claude-code)       | Developers             | Terminal-based, great for coding workflows.           |
+
+## Recommendation
+
+**Claude Desktop** is the easiest and most reliable option. It's what Producer
+Pal was originally built for.
+
+## Model Notes
+
+- Claude Sonnet 4 or Opus 4.5 recommended for complex musical tasks
+- Haiku works for simple operations but may struggle with multi-step
+  arrangements

--- a/docs/installation/choose-gemini.md
+++ b/docs/installation/choose-gemini.md
@@ -1,0 +1,22 @@
+# Using Gemini with Producer Pal
+
+Google's Gemini models integrate well with Producer Pal through multiple
+options. Free tier available with rate limits.
+
+## Options
+
+| Option                       | Best For   | Trade-offs                                                        |
+| ---------------------------- | ---------- | ----------------------------------------------------------------- |
+| [Built-in Chat UI](./gemini) | Most users | Native integration, easy setup. Free tier has strict rate limits. |
+| [Gemini CLI](./gemini-cli)   | Developers | Terminal-based, same rate limits as API.                          |
+
+## Recommendation
+
+**Built-in Chat UI with Gemini** is the simplest path. Get a
+[free API key](https://aistudio.google.com/apikey) to get started.
+
+## Model Notes
+
+- Gemini 2.0 Flash or 2.5 Pro recommended
+- Free tier: ~15 requests/minute, may hit limits during intensive sessions
+- Paid tier removes most limits

--- a/docs/installation/choose-local.md
+++ b/docs/installation/choose-local.md
@@ -1,0 +1,30 @@
+# Running Producer Pal Locally / Offline
+
+Run AI models entirely on your machine with no cloud dependency or subscription.
+Requires a capable GPU (8GB+ VRAM recommended).
+
+## Options
+
+| Option                   | Best For             | Trade-offs                                   |
+| ------------------------ | -------------------- | -------------------------------------------- |
+| [Ollama](./ollama)       | Easiest local setup  | Uses Built-in Chat UI. Model quality varies. |
+| [LM Studio](./lm-studio) | GUI model management | Standalone app, more configuration options.  |
+
+## Recommendation
+
+**Ollama with the Built-in Chat UI** is the simplest local setup.
+
+## Model Notes
+
+- Local models are significantly less capable than cloud models for complex
+  musical tasks
+- Best for: simple clip creation, basic playback control, experimentation
+- Challenging for: multi-step arrangements, complex notation, nuanced musical
+  decisions
+- Recommended models: Qwen 2.5 32B, Llama 3.3 70B (if hardware permits)
+
+## Hardware Requirements
+
+- **Minimum:** 8GB VRAM, runs 7B-13B models
+- **Recommended:** 16GB+ VRAM for 30B+ models
+- **Optimal:** 24GB+ VRAM for 70B models

--- a/docs/installation/choose-multi.md
+++ b/docs/installation/choose-multi.md
@@ -1,0 +1,36 @@
+# Using Multiple AI Providers
+
+Want flexibility to switch between providers or access many models? OpenRouter
+and the Built-in Chat UI support this.
+
+## Options
+
+| Option                                        | Best For              | Trade-offs                                           |
+| --------------------------------------------- | --------------------- | ---------------------------------------------------- |
+| [Built-in Chat UI](./chat-ui-other-providers) | Provider flexibility  | Supports OpenRouter, direct APIs. Requires API keys. |
+| [OpenRouter](https://openrouter.ai)           | Access to 100+ models | Single API key, pay-per-use. Configure via Chat UI.  |
+
+## Why Multiple Providers?
+
+- **Cost optimization:** Use cheaper models for simple tasks, powerful ones for
+  complex work
+- **Availability:** Fallback options when one provider is down or rate-limited
+- **Experimentation:** Compare how different models handle musical tasks
+- **EU data sovereignty:** Access Mistral models via OpenRouter for EU-compliant
+  option
+
+## Setup
+
+Use the [Built-in Chat UI](./chat-ui) with OpenRouter:
+
+1. Get an [OpenRouter API key](https://openrouter.ai/keys)
+2. In Producer Pal Chat UI, select OpenRouter as provider
+3. Enter your API key
+4. Choose from available models
+
+## Recommended Models via OpenRouter
+
+- **Gemini 3 Flash**
+- **Claude Sonnet 4.5**
+- **GPT-4.5**
+- **Mistral Large**

--- a/docs/installation/choose-openai.md
+++ b/docs/installation/choose-openai.md
@@ -1,0 +1,22 @@
+# Using ChatGPT / OpenAI with Producer Pal
+
+OpenAI's models work with Producer Pal through their web app or CLI tools.
+Requires ChatGPT Plus ($20/mo) or API credits.
+
+## Options
+
+| Option                                        | Best For               | Trade-offs                                    |
+| --------------------------------------------- | ---------------------- | --------------------------------------------- |
+| [ChatGPT Web](./chatgpt-web)                  | Existing ChatGPT users | Requires [web tunnel](./web-tunnels) setup.   |
+| [Codex CLI](./codex-cli)                      | Developers             | Terminal-based, good for scripting workflows. |
+| [Built-in Chat UI](./chat-ui-other-providers) | Direct API access      | Requires API key, pay-per-use pricing.        |
+
+## Recommendation
+
+**ChatGPT Web** if you already have ChatGPT Plus. **Built-in Chat UI** if you
+prefer API pricing.
+
+## Model Notes
+
+- GPT-4o recommended for best results
+- o1/o3 reasoning models not yet tested with Producer Pal


### PR DESCRIPTION
Add new documentation pages to help users find the right installation path based on their preferred AI provider:
- choose-claude.md: Claude Desktop, claude.ai, Claude Code
- choose-openai.md: ChatGPT web, Codex CLI, Built-in Chat UI
- choose-gemini.md: Built-in Chat UI, Gemini CLI
- choose-local.md: Ollama, LM Studio
- choose-multi.md: OpenRouter, multiple providers

Also updates the installation overview with a "Which AI Do You Use?" decision tree and adds a "Choose by Provider" section to the sidebar.