### PR TITLE
Fix chat header to always show provider/model with fallback to settings

### DIFF
--- a/webui/src/components/chat/ChatScreen.tsx
+++ b/webui/src/components/chat/ChatScreen.tsx
@@ -109,6 +109,8 @@ export function ChatScreen({
         mcpStatus={mcpStatus}
         activeModel={activeModel}
         activeProvider={activeProvider}
+        model={model}
+        provider={provider}
         enabledToolsCount={enabledToolsCount}
         totalToolsCount={totalToolsCount}
         hasMessages={messages.length > 0}

--- a/webui/src/components/chat/controls/ChatHeader.test.tsx
+++ b/webui/src/components/chat/controls/ChatHeader.test.tsx
@@ -10,6 +10,8 @@ describe("ChatHeader", () => {
     mcpStatus: "connected" as const,
     activeModel: null,
     activeProvider: null,
+    model: "gemini-2.5-pro",
+    provider: "gemini" as const,
     enabledToolsCount: 20,
     totalToolsCount: 20,
     hasMessages: false,
@@ -53,9 +55,10 @@ describe("ChatHeader", () => {
   });
 
   describe("activeModel display", () => {
-    it("does not show model when activeModel is null", () => {
+    it("shows fallback model when activeModel is null", () => {
       render(<ChatHeader {...defaultProps} activeModel={null} />);
-      expect(screen.queryByText(/Gemini/)).toBeNull();
+      // Falls back to model prop from settings
+      expect(screen.getByText("Google | Gemini 2.5 Pro")).toBeDefined();
     });
 
     it("shows provider and model name when both are set", () => {
@@ -102,7 +105,7 @@ describe("ChatHeader", () => {
       expect(screen.getByText("OpenAI | unknown-model")).toBeDefined();
     });
 
-    it("does not show model when activeProvider is null", () => {
+    it("shows fallback provider when activeProvider is null", () => {
       render(
         <ChatHeader
           {...defaultProps}
@@ -110,7 +113,8 @@ describe("ChatHeader", () => {
           activeProvider={null}
         />,
       );
-      expect(screen.queryByText(/Gemini 2.5 Pro/)).toBeNull();
+      // Falls back to provider prop from settings
+      expect(screen.getByText("Google | Gemini 2.5 Pro")).toBeDefined();
     });
   });
 

--- a/webui/src/components/chat/controls/ChatHeader.tsx
+++ b/webui/src/components/chat/controls/ChatHeader.tsx
@@ -6,6 +6,8 @@ interface ChatHeaderProps {
   mcpStatus: "connected" | "connecting" | "error";
   activeModel: string | null;
   activeProvider: Provider | null;
+  model: string;
+  provider: Provider;
   enabledToolsCount: number;
   totalToolsCount: number;
   hasMessages: boolean;
@@ -54,6 +56,8 @@ export function ChatHeader({
   mcpStatus,
   activeModel,
   activeProvider,
+  model,
+  provider,
   enabledToolsCount,
   totalToolsCount,
   hasMessages,
@@ -106,11 +110,10 @@ export function ChatHeader({
             : "ml-auto flex gap-3 items-baseline"
         }
       >
-        {activeModel && activeProvider && (
-          <span className="text-xs text-gray-500 dark:text-gray-400">
-            {getProviderName(activeProvider)} | {getModelName(activeModel)}
-          </span>
-        )}
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          {getProviderName(activeProvider ?? provider)} |{" "}
+          {getModelName(activeModel ?? model)}
+        </span>
         <span className="text-xs text-gray-500 dark:text-gray-400">
           {enabledToolsCount}/{totalToolsCount} tools
         </span>

--- a/webui/src/hooks/chat/use-chat.test.ts
+++ b/webui/src/hooks/chat/use-chat.test.ts
@@ -126,6 +126,7 @@ const mockAdapter: ChatAdapter<MockChatClient, TestMessage, TestConfig> = {
 
 describe("useChat", () => {
   const defaultProps = {
+    provider: "gemini" as const,
     apiKey: "test-key",
     model: "test-model",
     thinking: "Default",

--- a/webui/src/hooks/chat/use-chat.ts
+++ b/webui/src/hooks/chat/use-chat.ts
@@ -6,6 +6,7 @@ import {
   MAX_RETRY_ATTEMPTS,
 } from "#webui/lib/rate-limit";
 import type { UIMessage } from "#webui/types/messages";
+import type { Provider } from "#webui/types/settings";
 import {
   handleMessageStream,
   validateMcpConnection,
@@ -80,6 +81,7 @@ interface UseChatProps<
   TMessage,
   TConfig,
 > {
+  provider: Provider;
   apiKey: string;
   model: string;
   thinking: string;
@@ -106,6 +108,7 @@ interface UseChatReturn {
   messages: UIMessage[];
   isAssistantResponding: boolean;
   activeModel: string | null;
+  activeProvider: Provider | null;
   activeThinking: string | null;
   activeTemperature: number | null;
   rateLimitState: RateLimitState | null;
@@ -127,6 +130,7 @@ export function useChat<
   TMessage,
   TConfig,
 >({
+  provider,
   apiKey,
   model,
   thinking,
@@ -141,6 +145,7 @@ export function useChat<
   const [messages, setMessages] = useState<UIMessage[]>([]);
   const [isAssistantResponding, setIsAssistantResponding] = useState(false);
   const [activeModel, setActiveModel] = useState<string | null>(null);
+  const [activeProvider, setActiveProvider] = useState<Provider | null>(null);
   const [activeThinking, setActiveThinking] = useState<string | null>(null);
   const [activeTemperature, setActiveTemperature] = useState<number | null>(
     null,
@@ -156,6 +161,7 @@ export function useChat<
     setMessages([]);
     clientRef.current = null;
     setActiveModel(null);
+    setActiveProvider(null);
     setActiveThinking(null);
     setActiveTemperature(null);
     setRateLimitState(null);
@@ -188,6 +194,7 @@ export function useChat<
       clientRef.current = adapter.createClient(apiKey, config);
       await clientRef.current.initialize();
       setActiveModel(model);
+      setActiveProvider(provider);
       setActiveThinking(effectiveThinking);
       setActiveTemperature(effectiveTemperature);
     },
@@ -196,6 +203,7 @@ export function useChat<
       mcpError,
       checkMcpConnection,
       model,
+      provider,
       temperature,
       thinking,
       enabledTools,
@@ -407,6 +415,7 @@ export function useChat<
     messages,
     isAssistantResponding,
     activeModel,
+    activeProvider,
     activeThinking,
     activeTemperature,
     rateLimitState,

--- a/webui/src/hooks/chat/use-gemini-chat.test.ts
+++ b/webui/src/hooks/chat/use-gemini-chat.test.ts
@@ -27,6 +27,7 @@ vi.mock("../config.js", () => ({
 
 describe("useGeminiChat", () => {
   const defaultProps = {
+    provider: "gemini" as const,
     apiKey: "test-key",
     model: "gemini-2.5-flash",
     thinking: "Default",

--- a/webui/src/hooks/chat/use-gemini-chat.ts
+++ b/webui/src/hooks/chat/use-gemini-chat.ts
@@ -1,8 +1,10 @@
 import type { UIMessage } from "#webui/types/messages";
+import type { Provider } from "#webui/types/settings";
 import { geminiAdapter } from "./gemini-adapter";
 import { useChat, type RateLimitState } from "./use-chat";
 
 interface UseGeminiChatProps {
+  provider: Provider;
   apiKey: string;
   model: string;
   thinking: string;
@@ -18,6 +20,7 @@ interface UseGeminiChatReturn {
   messages: UIMessage[];
   isAssistantResponding: boolean;
   activeModel: string | null;
+  activeProvider: Provider | null;
   activeThinking: string | null;
   activeTemperature: number | null;
   rateLimitState: RateLimitState | null;
@@ -43,6 +46,7 @@ interface UseGeminiChatReturn {
  * @returns {UseGeminiChatReturn} Chat state and handlers
  */
 export function useGeminiChat({
+  provider,
   apiKey,
   model,
   thinking,
@@ -54,6 +58,7 @@ export function useGeminiChat({
   checkMcpConnection,
 }: UseGeminiChatProps): UseGeminiChatReturn {
   return useChat({
+    provider,
     apiKey,
     model,
     thinking,

--- a/webui/src/hooks/chat/use-openai-chat.test.ts
+++ b/webui/src/hooks/chat/use-openai-chat.test.ts
@@ -38,6 +38,7 @@ vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
 
 describe("useOpenAIChat", () => {
   const defaultProps = {
+    provider: "openai" as const,
     apiKey: "test-key",
     model: "gpt-4",
     thinking: "Low",

--- a/webui/src/hooks/chat/use-openai-chat.ts
+++ b/webui/src/hooks/chat/use-openai-chat.ts
@@ -1,8 +1,10 @@
 import type { UIMessage } from "#webui/types/messages";
+import type { Provider } from "#webui/types/settings";
 import { openaiAdapter } from "./openai-adapter";
 import { useChat, type RateLimitState } from "./use-chat";
 
 interface UseOpenAIChatProps {
+  provider: Provider;
   apiKey: string;
   model: string;
   thinking: string; // Will be mapped to reasoningEffort
@@ -19,6 +21,7 @@ interface UseOpenAIChatReturn {
   messages: UIMessage[];
   isAssistantResponding: boolean;
   activeModel: string | null;
+  activeProvider: Provider | null;
   activeThinking: string | null;
   activeTemperature: number | null;
   rateLimitState: RateLimitState | null;
@@ -45,6 +48,7 @@ interface UseOpenAIChatReturn {
  * @returns {UseOpenAIChatReturn} Chat state and handlers
  */
 export function useOpenAIChat({
+  provider,
   apiKey,
   model,
   thinking,
@@ -57,6 +61,7 @@ export function useOpenAIChat({
   checkMcpConnection,
 }: UseOpenAIChatProps): UseOpenAIChatReturn {
   return useChat({
+    provider,
     apiKey,
     model,
     thinking,


### PR DESCRIPTION
- Lock provider in chat hook state when chat initializes
- Header shows locked-in values during chat, settings values as fallback before chat
- Before chat: Shows provider/model from settings
- During chat: Shows same values (now locked)
- After changing settings during chat: Header still shows original chat's values
- After restart: Header updates to show new settings values