### PR TITLE
Make drum pad names read-only in update-device

### DIFF
--- a/src/tools/device/update/update-device-chains.test.js
+++ b/src/tools/device/update/update-device-chains.test.js
@@ -383,18 +383,27 @@ describe("updateDevice - Chain and DrumPad support", () => {
       expect(result).toEqual({ id: "789" });
     });
 
-    it("should set name on a DrumPad", () => {
+    it("should warn when name is used on a DrumPad (read-only)", () => {
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
       const result = updateDevice({
         ids: "790",
         name: "Hi-Hat",
       });
 
-      expect(liveApiSet).toHaveBeenCalledWithThis(
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "updateDevice: 'name' is read-only for DrumPad",
+      );
+      expect(liveApiSet).not.toHaveBeenCalledWith(
         expect.objectContaining({ _path: "id 790" }),
         "name",
-        "Hi-Hat",
+        expect.anything(),
       );
       expect(result).toEqual({ id: "790" });
+
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/src/tools/device/update/update-device.def.js
+++ b/src/tools/device/update/update-device.def.js
@@ -12,7 +12,7 @@ export const toolDefUpdateDevice = defineTool("ppal-update-device", {
     ids: z
       .string()
       .describe("comma-separated ID(s) to update (device, chain, or drum pad)"),
-    name: z.string().optional().describe("display name"),
+    name: z.string().optional().describe("display name (not drum pads)"),
     collapsed: z.boolean().optional().describe("collapse/expand device view"),
     params: z
       .string()

--- a/src/tools/device/update/update-device.js
+++ b/src/tools/device/update/update-device.js
@@ -45,7 +45,7 @@ function warnIfSet(paramName, value, type) {
  * Update device(s), chain(s), or drum pad(s) by ID
  * @param {object} args - The parameters
  * @param {string} args.ids - Comma-separated ID(s)
- * @param {string} [args.name] - Display name
+ * @param {string} [args.name] - Display name (not drum pads)
  * @param {boolean} [args.collapsed] - Collapse/expand device view (devices only)
  * @param {string} [args.params] - JSON: {"paramId": value} (devices only)
  * @param {string} [args.macroVariation] - Rack variation action (racks only)
@@ -124,9 +124,13 @@ function updateTarget(target, options) {
     throw new Error(`updateDevice: cannot update ${type} objects`);
   }
 
-  // Universal: name works on all types
+  // Name works on devices and chains, but DrumPad names are read-only
   if (options.name != null) {
-    target.set("name", options.name);
+    if (type === "DrumPad") {
+      console.error("updateDevice: 'name' is read-only for DrumPad");
+    } else {
+      target.set("name", options.name);
+    }
   }
 
   if (isDeviceType(type)) {


### PR DESCRIPTION
Drum pad names are read-only in the Live API. Previously, update-device would silently attempt to set them. Now it warns and ignores the request, following the existing pattern for unsupported properties.