### PR TITLE
Fix react-hooks/refs violations in useChat

### DIFF
--- a/webui/src/hooks/chat/use-chat.ts
+++ b/webui/src/hooks/chat/use-chat.ts
@@ -1,8 +1,9 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { useCallback, useRef, useState } from "preact/hooks";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import {
   detectRateLimit,
   calculateRetryDelay,
@@ -62,10 +63,10 @@ export function useChat<
   const abortControllerRef = useRef<AbortController | null>(null);
   const retryAbortRef = useRef<AbortController | null>(null);
   const thinkingRef = useRef(active.activeThinking);
-  const temperatureRef = useRef(active.activeTemperature);
 
-  thinkingRef.current = active.activeThinking;
-  temperatureRef.current = active.activeTemperature;
+  useEffect(() => {
+    thinkingRef.current = active.activeThinking;
+  }, [active.activeThinking]);
 
   const clearConversation = useCallback(() => {
     setMessages([]);


### PR DESCRIPTION
Move thinkingRef sync into a useEffect to avoid updating refs during render, and drop temperatureRef which was assigned but never read.

https://claude.ai/code/session_01RqEQsZoaMtMfVtV8PftvCu

## What does this PR do?

<!-- Brief description -->

## Type of change

- [ ] Documentation
- [ ] Bug fix
- [ ] Test improvement
- [ ] Other (describe below)

---

## Before submitting

### Did you discuss this change first?

For anything beyond typo fixes and minor doc improvements, please
[open a discussion](https://github.com/adamjmurray/producer-pal/discussions)
before writing code. I maintain the core tools and feature roadmap myself, and
unsolicited feature PRs will likely be closed.

See [DEVELOPERS.md](./DEVELOPERS.md) for contribution guidelines.

### Does CI pass?

- [ ] I ran `npm run check` locally and all checks pass

PRs with failing builds will not be reviewed.

---

## Additional context

<!-- Optional: screenshots, links to discussions, anything else relevant -->
