### PR TITLE
[v.1.4.10] Take lane support: read and write

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -103,6 +103,8 @@ It works with virtually any AI, including its
   - Auto-tile clips to fill longer arrangement durations
 - Apply [transforms](#transforms) to each duplicated clip (e.g. transpose
   copies, vary velocities) without a separate update step
+- Stack MIDI variations on [take lanes](#take-lanes) with `takeLane: "new"` +
+  transforms — audition alternates at the same arrangement position
 - Copy devices to any track, return track, or rack chain
 - Route duplicated tracks to source instrument for MIDI layering
 
@@ -144,6 +146,8 @@ limitation).
 
 - Get detailed track information
 - View all clips in Session and Arrangement
+- List [take lanes](#take-lanes) and their clips (with the `arrangement-clips`
+  include)
 - See devices, routing options, and drum pad mappings
 - Check track states (muted, soloed, armed)
 - View mixer properties: gain, pan, panning mode, and send levels
@@ -192,6 +196,7 @@ limitation).
 - Generate MIDI clips with notes, velocities, and timing using
   [custom notation](#custom-music-notation)
 - Place clips in Session slots or Arrangement timeline
+- Place arrangement clips on [take lanes](#take-lanes) with `takeLane`
 - Support for probability, velocity ranges, and complex rhythms
 - Apply [transforms](#transforms) to shape notes with math expressions
 - Auto-create scenes as needed
@@ -311,6 +316,24 @@ Apply complex changes to clips using math expressions via
 - **Selectors**: Target specific pitch ranges (e.g., `C3:`, `C3-C5:`) or time
   ranges (e.g., `1|1-2|4:`), or both in either order (e.g., `C3 1|1-2|4:` or
   `1|1-2|4 C3:`)
+
+## Take Lanes {#take-lanes}
+
+Live's take lanes stack alternate versions of an arrangement clip at the same
+position — only the active take plays. They're the natural way to audition
+variations side by side without cluttering the timeline.
+
+- Target a lane with `takeLane` on [Create Clip](#ppal-create-clip) and
+  [Duplicate](#ppal-duplicate): `0` (or omit) = main lane, `1+` = that lane
+  (auto-created up to it), `"new"` = append a fresh lane.
+- Generate variations with a few [Duplicate](#ppal-duplicate) calls using
+  `takeLane: "new"` plus [transforms](#transforms) to vary each copy.
+- Name a newly created lane with `takeLaneName`.
+- [Read Track](#ppal-read-track) lists take lanes (with the `arrangement-clips`
+  include).
+- Limits: 8 take lanes per track; duplicating to a take lane is MIDI-only.
+  Producer Pal can't delete take lanes or pick the active take — comping stays
+  in Live's UI. Expand the take-lane arrow on a track header to see them.
 
 ## Network Control
 

--- a/src/live-api-adapter/live-api-extensions.ts
+++ b/src/live-api-adapter/live-api-extensions.ts
@@ -311,6 +311,17 @@ if (typeof LiveAPI !== "undefined") {
     });
   }
 
+  if (
+    !Object.prototype.hasOwnProperty.call(LiveAPI.prototype, "takeLaneIndex")
+  ) {
+    Object.defineProperty(LiveAPI.prototype, "takeLaneIndex", {
+      get: function (this: LiveAPI) {
+        const match = this.path.match(/take_lanes (\d+)/);
+        return match ? Number(match[1]) : null;
+      },
+    });
+  }
+
   // Device index extension - matches LAST "devices X" for nested rack support
   if (!Object.prototype.hasOwnProperty.call(LiveAPI.prototype, "deviceIndex")) {
     Object.defineProperty(LiveAPI.prototype, "deviceIndex", {

--- a/src/shared/live-api-path-builders.ts
+++ b/src/shared/live-api-path-builders.ts
@@ -11,6 +11,7 @@
 //   livePath.track(0).device(1)                      // "live_set tracks 0 devices 1"
 //   livePath.track(0).clipSlot(2).clip()             // "live_set tracks 0 clip_slots 2 clip"
 //   livePath.track(0).arrangementClip(0)             // "live_set tracks 0 arrangement_clips 0"
+//   livePath.track(0).takeLane(1).arrangementClip(0) // "live_set tracks 0 take_lanes 1 arrangement_clips 0"
 //   livePath.track(0).device(0).parameter(1)         // "live_set tracks 0 devices 0 parameters 1"
 //   livePath.track(0).device(0).chain(1).device(0)   // "live_set tracks 0 devices 0 chains 1 devices 0"
 //   livePath.returnTrack(0).device(1)                // "live_set return_tracks 0 devices 1"
@@ -93,6 +94,24 @@ class ClipSlotPath {
   }
 }
 
+// Intermediate builder: take lane path with .arrangementClip() chaining
+class TakeLanePath {
+  private readonly base: string;
+
+  constructor(trackBase: string, laneIndex: number) {
+    this.base = `${trackBase} take_lanes ${laneIndex}`;
+  }
+
+  toString(): string {
+    return this.base;
+  }
+
+  // "...take_lanes X arrangement_clips Y"
+  arrangementClip(clipIndex: number): string {
+    return `${this.base} arrangement_clips ${clipIndex}`;
+  }
+}
+
 // Intermediate builder: track path with chaining methods
 export class TrackPath {
   private readonly base: string;
@@ -118,6 +137,11 @@ export class TrackPath {
   // "...arrangement_clips X"
   arrangementClip(clipIndex: number): string {
     return `${this.base} arrangement_clips ${clipIndex}`;
+  }
+
+  // "...take_lanes X" (chainable — returns TakeLanePath)
+  takeLane(laneIndex: number): TakeLanePath {
+    return new TakeLanePath(this.base, laneIndex);
   }
 
   // "...mixer_device"

--- a/src/skills/standard.ts
+++ b/src/skills/standard.ts
@@ -241,4 +241,12 @@ Audio effects:
 
 \`arrangementStart\` moves arrangement clips; \`toSlot\` (trackIndex/sceneIndex, e.g., "2/3") moves session clips. Moving clips changes their IDs - re-read to get new IDs.
 \`arrangementLength\` sets arrangement playback region. \`split\` divides arrangement clips at bar|beat positions.
+
+### Take Lanes (Arrangement Variations)
+
+Stack alternate takes of an arrangement clip at the same position; only the active take plays (the user auditions/comps in Live's UI).
+
+- \`takeLane\` on create-clip + duplicate (arrangement only; duplicate is MIDI-only): omit/\`0\` = main lane; \`1+\` = that lane (auto-created up to it); \`"new"\` = append a fresh lane. \`takeLaneName\` names a lane this call creates.
+- Variation workflow: a few duplicate calls with \`takeLane: "new"\` + \`transforms\` to vary each copy. read-track \`arrangement-clips\` include lists \`takeLanes\`.
+- 8 lanes/track max; the target position must be free on that lane. One-way: Producer Pal can't delete or comp take lanes — that's done in Live (expand the track's take-lane arrow to see them).
 `;

--- a/src/test/mocks/mock-live-api.ts
+++ b/src/test/mocks/mock-live-api.ts
@@ -188,6 +188,7 @@ export class LiveAPI {
   declare category: "regular" | "return" | "master" | null;
   declare sceneIndex: number | null;
   declare clipSlotIndex: number | null;
+  declare takeLaneIndex: number | null;
   declare deviceIndex: number | null;
   declare timeSignature: string | null;
   declare getColor: () => string | null;

--- a/src/tools/actions/delete/delete.ts
+++ b/src/tools/actions/delete/delete.ts
@@ -192,6 +192,16 @@ function deleteSceneObject(id: string, object: LiveAPI): boolean {
  * @returns true if deleted, false if skipped with warning
  */
 function deleteClipObject(id: string, object: LiveAPI): boolean {
+  // Take-lane clips cannot be removed via the API (delete_clip is a no-op for
+  // them and there is no delete_take_lane) — the user must delete in Live's UI.
+  if (object.path.includes("take_lanes")) {
+    console.warn(
+      `delete: cannot delete take-lane clip "${id}" via the API; remove it in Live's UI`,
+    );
+
+    return false;
+  }
+
   const trackIndex = object.path.match(/live_set tracks (\d+)/)?.[1];
 
   if (!trackIndex) {

--- a/src/tools/actions/delete/tests/delete.test.ts
+++ b/src/tools/actions/delete/tests/delete.test.ts
@@ -118,6 +118,33 @@ describe("deleteObject", () => {
     ]);
   });
 
+  it("should warn and skip take-lane clips (cannot delete via API)", () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn");
+
+    registerMockObject("take_lane_clip", {
+      path: livePath.track(0).takeLane(0).arrangementClip(0),
+      type: "Clip",
+    });
+    const track0 = registerMockObject("live_set/tracks/0", {
+      path: livePath.track(0),
+    });
+
+    const result = deleteObject({ ids: "take_lane_clip", type: "clip" });
+
+    expect(track0.call).not.toHaveBeenCalledWith(
+      "delete_clip",
+      expect.anything(),
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("cannot delete take-lane clip"),
+    );
+    expect(result).toStrictEqual({
+      id: "take_lane_clip",
+      type: "clip",
+      deleted: false,
+    });
+  });
+
   it("should throw an error when neither ids nor path is provided", () => {
     const expectedError = "delete failed: ids or path is required";
 

--- a/src/tools/actions/duplicate/duplicate.def.ts
+++ b/src/tools/actions/duplicate/duplicate.def.ts
@@ -99,6 +99,18 @@ export const toolDefDuplicate = defineTool("ppal-duplicate", {
             ),
         }
       : {}),
+
+    takeLane: z.coerce
+      .string()
+      .optional()
+      .describe(
+        'arrangement take lane (MIDI clips only): omit/0 = main lane, 1+ = that lane (auto-created), "new" = append a fresh lane for a variation',
+      ),
+
+    takeLaneName: z
+      .string()
+      .optional()
+      .describe("name for a take lane newly created by this call"),
   },
   smallModelModeConfig: {
     toolDescription:
@@ -112,6 +124,8 @@ export const toolDefDuplicate = defineTool("ppal-duplicate", {
       "routeToSource",
       "transforms",
       "code",
+      "takeLane",
+      "takeLaneName",
     ],
     descriptionOverrides: {
       name: "name",

--- a/src/tools/actions/duplicate/duplicate.ts
+++ b/src/tools/actions/duplicate/duplicate.ts
@@ -5,6 +5,7 @@
 
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import * as console from "#src/shared/v8-max-console.ts";
+import { normalizeTakeLaneTarget } from "#src/tools/shared/arrangement/take-lane-helpers.ts";
 import { parseCommaSeparatedIds } from "#src/tools/shared/utils.ts";
 import {
   getColorForIndex,
@@ -54,6 +55,8 @@ interface DuplicateArgs {
   toPath?: string;
   transforms?: string;
   code?: string;
+  takeLane?: number | string;
+  takeLaneName?: string;
 }
 
 interface DuplicateParams {
@@ -84,6 +87,8 @@ interface DuplicateParams {
  * @param args.toPath - Destination path
  * @param args.transforms - Transform expressions applied per duplicated clip
  * @param args.code - JavaScript function body applied per duplicated clip
+ * @param args.takeLane - Arrangement take lane target for clips (0/omitted = main, 1+, "new")
+ * @param args.takeLaneName - Name for a take lane newly created by this call
  * @param context - Context object
  * @returns Result object(s)
  */
@@ -105,6 +110,8 @@ export async function duplicate(
     toPath,
     transforms,
     code,
+    takeLane,
+    takeLaneName,
   }: DuplicateArgs,
   context: Partial<ToolContext> = {},
 ): Promise<object | object[]> {
@@ -144,6 +151,15 @@ export async function duplicate(
     );
   }
 
+  // takeLane only applies to clips
+  const takeLaneTarget = normalizeTakeLaneTarget(takeLane);
+
+  if (type !== "clip" && takeLaneTarget != null) {
+    console.warn(
+      `takeLane ignored: only supported when duplicating clips (type "${type}")`,
+    );
+  }
+
   // Handle device duplication (supports comma-separated toPath for multiple destinations)
   if (type === "device") {
     return duplicateDeviceWithPaths(object, toPath, name, count);
@@ -161,6 +177,8 @@ export async function duplicate(
         arrangementStart,
         locator,
         arrangementLength,
+        takeLaneTarget,
+        takeLaneName,
         context,
       )
     : duplicateTrackOrSceneWithCount(

--- a/src/tools/actions/duplicate/helpers/duplicate-clip-position-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/duplicate-clip-position-helpers.ts
@@ -5,6 +5,8 @@
 
 import { barBeatToAbletonBeats } from "#src/notation/barbeat/time/barbeat-time.ts";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
+import * as console from "#src/shared/v8-max-console.ts";
+import { type TakeLaneTarget } from "#src/tools/shared/arrangement/take-lane-helpers.ts";
 import { resolveLocatorRefListToBeats } from "#src/tools/shared/locator/locator-helpers.ts";
 import {
   getColorForIndex,
@@ -23,6 +25,7 @@ import {
   duplicateClipSlot,
   duplicateClipToArrangement,
 } from "./duplicate-helpers.ts";
+import { duplicateClipsToTakeLane } from "./duplicate-take-lane-helpers.ts";
 
 /**
  * Duplicates a clip to explicit positions
@@ -35,6 +38,8 @@ import {
  * @param arrangementStart - Comma-separated bar|beat positions for arrangement
  * @param locator - Arrangement locator ID(s) or name(s) for position
  * @param arrangementLength - Duration in bar|beat format
+ * @param takeLaneTarget - Normalized take lane target for arrangement clips, or null for main lane
+ * @param takeLaneName - Name for a take lane newly created by this call
  * @param context - Context object with holdingAreaStartBeats
  * @returns Array of result objects
  */
@@ -48,11 +53,19 @@ export async function duplicateClipWithPositions(
   arrangementStart: string | undefined,
   locator: string | undefined,
   arrangementLength: string | undefined,
+  takeLaneTarget: TakeLaneTarget | null,
+  takeLaneName: string | undefined,
   context: Partial<ToolContext>,
 ): Promise<object[]> {
   const createdObjects: object[] = [];
 
   if (destination === "session") {
+    if (takeLaneTarget != null) {
+      console.warn(
+        "duplicate: takeLane ignored for session destination (arrangement-only)",
+      );
+    }
+
     const slots = parseSlotList(toSlot);
     const trackIndex = object.trackIndex;
     const sourceSceneIndex = object.sceneIndex;
@@ -100,6 +113,21 @@ export async function duplicateClipWithPositions(
       songTimeSigNumerator,
       songTimeSigDenominator,
     );
+
+    // Take lane targeting: re-create on the lane (no duplicate API for lanes)
+    if (takeLaneTarget != null) {
+      return duplicateClipsToTakeLane(
+        object,
+        id,
+        positionsInBeats,
+        name,
+        color,
+        takeLaneTarget,
+        takeLaneName,
+        songTimeSigNumerator,
+        songTimeSigDenominator,
+      );
+    }
 
     const parsedNames = parseCommaSeparatedNames(name, positionsInBeats.length);
     const parsedColors = parseCommaSeparatedColors(

--- a/src/tools/actions/duplicate/helpers/duplicate-clip-position-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/duplicate-clip-position-helpers.ts
@@ -116,6 +116,12 @@ export async function duplicateClipWithPositions(
 
     // Take lane targeting: re-create on the lane (no duplicate API for lanes)
     if (takeLaneTarget != null) {
+      if (arrangementLength != null) {
+        console.warn(
+          "duplicate: arrangementLength ignored for take-lane duplication (the copy uses the source clip's length)",
+        );
+      }
+
       return duplicateClipsToTakeLane(
         object,
         id,

--- a/src/tools/actions/duplicate/helpers/duplicate-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/duplicate-helpers.ts
@@ -69,6 +69,8 @@ export interface MinimalClipInfo {
   slot?: string;
   trackIndex?: number;
   arrangementStart?: string;
+  /** 1-based take lane number, present only for clips on a take lane */
+  takeLane?: number;
   name?: string;
   noteCount?: number;
   transformed?: number;
@@ -117,6 +119,13 @@ export function getMinimalClipInfo(
 
     if (!omitFields.includes("arrangementStart")) {
       result.arrangementStart = arrangementStart;
+    }
+
+    // Surface the take lane (1-based) when the clip landed on one
+    const takeLaneIndex = clip.takeLaneIndex;
+
+    if (takeLaneIndex != null) {
+      result.takeLane = takeLaneIndex + 1;
     }
 
     return result;

--- a/src/tools/actions/duplicate/helpers/duplicate-take-lane-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/duplicate-take-lane-helpers.ts
@@ -1,0 +1,168 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { abletonBeatsToBarBeat } from "#src/notation/barbeat/time/barbeat-time.ts";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import * as console from "#src/shared/v8-max-console.ts";
+import {
+  assertNoTakeLaneOverlap,
+  resolveTakeLane,
+  type TakeLaneTarget,
+} from "#src/tools/shared/arrangement/take-lane-helpers.ts";
+import {
+  getColorForIndex,
+  parseCommaSeparatedColors,
+} from "#src/tools/shared/validation/color-utils.ts";
+import {
+  getNameForIndex,
+  parseCommaSeparatedNames,
+  warnExtraNames,
+} from "#src/tools/shared/validation/name-utils.ts";
+import {
+  getMinimalClipInfo,
+  type MinimalClipInfo,
+} from "./duplicate-helpers.ts";
+
+/**
+ * Duplicate a MIDI clip onto a take lane at one or more arrangement positions.
+ *
+ * Take lanes have no `duplicate_clip_to_arrangement`, so this re-creates the
+ * clip on the lane via `create_midi_clip` and copies the notes plus loop/marker
+ * properties. MIDI only: audio sources warn and are skipped (no v1 take-lane
+ * audio support). Overlaps are checked up front so nothing is created on error.
+ * @param sourceClip - The clip being duplicated
+ * @param id - Source clip ID (for messages)
+ * @param positionsInBeats - Target arrangement start positions in Ableton beats
+ * @param name - Base name (comma-separated for per-clip names)
+ * @param color - Base color (comma-separated, cycles)
+ * @param target - Normalized take lane target (lane number or "new")
+ * @param takeLaneName - Name for a take lane newly created by this call
+ * @param songTimeSigNumerator - Song time signature numerator (for labels)
+ * @param songTimeSigDenominator - Song time signature denominator (for labels)
+ * @returns Array of minimal clip info objects for the created clips
+ */
+export function duplicateClipsToTakeLane(
+  sourceClip: LiveAPI,
+  id: string,
+  positionsInBeats: number[],
+  name: string | undefined,
+  color: string | undefined,
+  target: TakeLaneTarget,
+  takeLaneName: string | undefined,
+  songTimeSigNumerator: number,
+  songTimeSigDenominator: number,
+): object[] {
+  if (sourceClip.getProperty("is_midi_clip") !== 1) {
+    console.warn(
+      `duplicate: takeLane supports MIDI clips only; audio clip "${id}" was not duplicated to a take lane`,
+    );
+
+    return [];
+  }
+
+  const trackIndex = sourceClip.trackIndex;
+
+  if (trackIndex == null) {
+    throw new Error(
+      `duplicate failed: no track index for clip id "${id}" (path=${sourceClip.path})`,
+    );
+  }
+
+  const track = LiveAPI.from(livePath.track(trackIndex));
+  const length = sourceClip.getProperty("length") as number;
+  const { lane, laneNumber } = resolveTakeLane(track, target, takeLaneName);
+
+  // Check every target position before creating anything (fail cleanly)
+  for (const startBeats of positionsInBeats) {
+    const label = abletonBeatsToBarBeat(
+      startBeats,
+      songTimeSigNumerator,
+      songTimeSigDenominator,
+    );
+
+    assertNoTakeLaneOverlap(lane, startBeats, length, laneNumber, label);
+  }
+
+  const parsedNames = parseCommaSeparatedNames(name, positionsInBeats.length);
+  const parsedColors = parseCommaSeparatedColors(
+    color,
+    positionsInBeats.length,
+  );
+
+  warnExtraNames(parsedNames, positionsInBeats.length, "duplicate");
+
+  const created = positionsInBeats.map((startBeats, i) =>
+    copyMidiClipToTakeLane(
+      sourceClip,
+      lane,
+      startBeats,
+      length,
+      getNameForIndex(name, i, parsedNames),
+      getColorForIndex(color, i, parsedColors),
+    ),
+  );
+
+  console.warn(
+    `duplicate: created on take lane ${laneNumber}. Expand the take-lanes arrow on the track header in Live to see it.`,
+  );
+
+  return created;
+}
+
+/**
+ * Re-create a MIDI clip on a take lane, copying the source's notes and
+ * loop/marker/signature properties.
+ * @param sourceClip - The clip being copied
+ * @param lane - The destination take lane LiveAPI object
+ * @param startBeats - Arrangement start position in Ableton beats
+ * @param length - Source clip length in beats (note read window + clip length)
+ * @param name - Name for the new clip
+ * @param color - Color for the new clip
+ * @returns Minimal clip info for the created clip
+ */
+function copyMidiClipToTakeLane(
+  sourceClip: LiveAPI,
+  lane: LiveAPI,
+  startBeats: number,
+  length: number,
+  name: string | undefined,
+  color: string | undefined,
+): MinimalClipInfo {
+  const newClipResult = lane.call(
+    "create_midi_clip",
+    startBeats,
+    length,
+  ) as string;
+  const newClip = LiveAPI.from(newClipResult);
+
+  const notesJson = sourceClip.call(
+    "get_notes_extended",
+    0,
+    128,
+    0,
+    length,
+  ) as string;
+  const notes = JSON.parse(notesJson).notes;
+
+  if (Array.isArray(notes) && notes.length > 0) {
+    newClip.call("add_new_notes", { notes });
+  }
+
+  // Order mirrors create-clip's buildClipProperties to satisfy Live's
+  // loop_end > loop_start constraint while applying values.
+  newClip.setAll({
+    start_marker: sourceClip.getProperty("start_marker"),
+    loop_start: sourceClip.getProperty("loop_start"),
+    loop_end: sourceClip.getProperty("loop_end"),
+    end_marker: sourceClip.getProperty("end_marker"),
+    looping: sourceClip.getProperty("looping"),
+    signature_numerator: sourceClip.getProperty("signature_numerator"),
+    signature_denominator: sourceClip.getProperty("signature_denominator"),
+    name,
+    color,
+  });
+
+  return getMinimalClipInfo(newClip);
+}

--- a/src/tools/actions/duplicate/helpers/duplicate-take-lane-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/duplicate-take-lane-helpers.ts
@@ -6,11 +6,13 @@
 import { abletonBeatsToBarBeat } from "#src/notation/barbeat/time/barbeat-time.ts";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import * as console from "#src/shared/v8-max-console.ts";
+import { MAX_CLIP_BEATS } from "#src/tools/constants.ts";
 import {
   assertNoTakeLaneOverlap,
   resolveTakeLane,
   type TakeLaneTarget,
 } from "#src/tools/shared/arrangement/take-lane-helpers.ts";
+import { rawNotesToNoteEvents } from "#src/tools/shared/clip-notes.ts";
 import {
   getColorForIndex,
   parseCommaSeparatedColors,
@@ -117,7 +119,7 @@ export function duplicateClipsToTakeLane(
  * @param sourceClip - The clip being copied
  * @param lane - The destination take lane LiveAPI object
  * @param startBeats - Arrangement start position in Ableton beats
- * @param length - Source clip length in beats (note read window + clip length)
+ * @param length - Source clip length in beats (clip creation + overlap window)
  * @param name - Name for the new clip
  * @param color - Color for the new clip
  * @returns Minimal clip info for the created clip
@@ -137,21 +139,30 @@ function copyMidiClipToTakeLane(
   ) as string;
   const newClip = LiveAPI.from(newClipResult);
 
+  // Read all notes (not just within `length`): markers below can expose content
+  // beyond the visible length, so capture it to faithfully copy the source.
   const notesJson = sourceClip.call(
     "get_notes_extended",
     0,
     128,
     0,
-    length,
+    MAX_CLIP_BEATS,
   ) as string;
-  const notes = JSON.parse(notesJson).notes;
+  const rawNotes = (JSON.parse(notesJson).notes ?? []) as Record<
+    string,
+    unknown
+  >[];
 
-  if (Array.isArray(notes) && notes.length > 0) {
-    newClip.call("add_new_notes", { notes });
+  if (rawNotes.length > 0) {
+    // Strip Live's extra note properties (note_id, mute, release_velocity) so
+    // stale ids aren't re-fed when copying one source to multiple positions.
+    newClip.call("add_new_notes", { notes: rawNotesToNoteEvents(rawNotes) });
   }
 
   // Order mirrors create-clip's buildClipProperties to satisfy Live's
-  // loop_end > loop_start constraint while applying values.
+  // loop_end > loop_start constraint while applying values. Name/color fall back
+  // to the source so an un-overridden duplicate matches it (as native duplicate
+  // does); color is a Live int, so it bypasses setColor's #RRGGBB path.
   newClip.setAll({
     start_marker: sourceClip.getProperty("start_marker"),
     loop_start: sourceClip.getProperty("loop_start"),
@@ -160,9 +171,14 @@ function copyMidiClipToTakeLane(
     looping: sourceClip.getProperty("looping"),
     signature_numerator: sourceClip.getProperty("signature_numerator"),
     signature_denominator: sourceClip.getProperty("signature_denominator"),
-    name,
-    color,
+    name: name ?? sourceClip.getProperty("name"),
   });
+
+  if (color != null) {
+    newClip.setColor(color);
+  } else {
+    newClip.set("color", sourceClip.getProperty("color"));
+  }
 
   return getMinimalClipInfo(newClip);
 }

--- a/src/tools/actions/duplicate/tests/duplicate-take-lane.test.ts
+++ b/src/tools/actions/duplicate/tests/duplicate-take-lane.test.ts
@@ -134,7 +134,19 @@ describe("duplicate take lane", () => {
     });
     expect(newClip?.set).toHaveBeenCalledWith("loop_end", 4);
     expect(newClip?.set).toHaveBeenCalledWith("looping", 1);
-    expect(result).toMatchObject({ trackIndex: 0, arrangementStart: "5|1" });
+    expect(result).toMatchObject({
+      trackIndex: 0,
+      arrangementStart: "5|1",
+      takeLane: 1,
+    });
+  });
+
+  it("warns and ignores arrangementLength for take-lane duplication", async () => {
+    await duplicateToFreshLane({ arrangementLength: "2:0" });
+
+    expect(consoleMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining("arrangementLength ignored for take-lane"),
+    );
   });
 
   it("strips Live note metadata before re-adding to the take lane", async () => {

--- a/src/tools/actions/duplicate/tests/duplicate-take-lane.test.ts
+++ b/src/tools/actions/duplicate/tests/duplicate-take-lane.test.ts
@@ -72,6 +72,35 @@ function registerArrangementSource(
   });
 }
 
+/**
+ * Register a MIDI source on an empty take-lane track, run a take-lane duplicate,
+ * and return the newly created lane clip mock for assertions.
+ * @param overrides - Extra duplicate args merged over the take-lane defaults
+ * @param notes - Notes returned by the source's get_notes_extended
+ * @returns The new lane clip mock, or undefined if none was created
+ */
+async function duplicateToFreshLane(
+  overrides: Partial<Parameters<typeof duplicate>[0]> = {},
+  notes: Array<Record<string, number>> = [SOURCE_NOTE],
+): Promise<ReturnType<typeof lookupMockObject>> {
+  registerLiveSet();
+  registerArrangementSource(true, notes);
+  registerTakeLaneTrack({ initialLanes: 0 });
+
+  await duplicate({
+    type: "clip",
+    id: "src_clip",
+    arrangementStart: "1|1",
+    takeLane: "new",
+    ...overrides,
+  });
+
+  return lookupMockObject(
+    undefined,
+    livePath.track(0).takeLane(0).arrangementClip(0),
+  );
+}
+
 describe("duplicate take lane", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -108,22 +137,30 @@ describe("duplicate take lane", () => {
     expect(result).toMatchObject({ trackIndex: 0, arrangementStart: "5|1" });
   });
 
-  it("skips add_new_notes when the source clip is empty", async () => {
-    registerLiveSet();
-    registerArrangementSource(true, []);
-    registerTakeLaneTrack({ initialLanes: 0 });
+  it("strips Live note metadata before re-adding to the take lane", async () => {
+    const newClip = await duplicateToFreshLane({}, [
+      { ...SOURCE_NOTE, note_id: 7, mute: 0, release_velocity: 64 },
+    ]);
 
-    await duplicate({
-      type: "clip",
-      id: "src_clip",
-      arrangementStart: "1|1",
-      takeLane: "new",
+    // note_id/mute/release_velocity must not survive into add_new_notes
+    expect(newClip?.call).toHaveBeenCalledWith("add_new_notes", {
+      notes: [SOURCE_NOTE],
+    });
+  });
+
+  it("applies explicit name and color overrides to the take-lane copy", async () => {
+    const newClip = await duplicateToFreshLane({
+      name: "Variation A",
+      color: "#FF0000",
     });
 
-    const newClip = lookupMockObject(
-      undefined,
-      livePath.track(0).takeLane(0).arrangementClip(0),
-    );
+    expect(newClip?.set).toHaveBeenCalledWith("name", "Variation A");
+    // setColor("#FF0000") converts to Live's 0x00RRGGBB int
+    expect(newClip?.set).toHaveBeenCalledWith("color", 0xff0000);
+  });
+
+  it("skips add_new_notes when the source clip is empty", async () => {
+    const newClip = await duplicateToFreshLane({}, []);
 
     expect(newClip?.call).not.toHaveBeenCalledWith(
       "add_new_notes",

--- a/src/tools/actions/duplicate/tests/duplicate-take-lane.test.ts
+++ b/src/tools/actions/duplicate/tests/duplicate-take-lane.test.ts
@@ -1,0 +1,206 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import "./duplicate-mocks-test-helpers.ts";
+import {
+  lookupMockObject,
+  registerMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+import { registerTakeLaneTrack } from "#src/tools/shared/arrangement/tests/take-lane-test-helpers.ts";
+
+// Capture take lane warnings
+vi.mock(import("#src/shared/v8-max-console.ts"), () => ({
+  error: vi.fn(),
+  log: vi.fn(),
+  warn: vi.fn(),
+}));
+
+import { duplicate } from "#src/tools/actions/duplicate/duplicate.ts";
+import { duplicateClipsToTakeLane } from "#src/tools/actions/duplicate/helpers/duplicate-take-lane-helpers.ts";
+import { registerSessionClipDuplication } from "#src/tools/actions/duplicate/helpers/duplicate-test-helpers.ts";
+import * as consoleMock from "#src/shared/v8-max-console.ts";
+
+const SOURCE_NOTE = {
+  pitch: 60,
+  start_time: 0,
+  duration: 1,
+  velocity: 100,
+  probability: 1,
+  velocity_deviation: 0,
+};
+
+/** Register the live_set time signature mock. */
+function registerLiveSet(): void {
+  registerMockObject("live-set", {
+    path: livePath.liveSet,
+    properties: { signature_numerator: 4, signature_denominator: 4 },
+  });
+}
+
+/**
+ * Register a source arrangement clip (track 0, main lane) for duplication.
+ * @param midi - Whether the source is a MIDI clip
+ * @param notes - Notes returned by the source's get_notes_extended
+ */
+function registerArrangementSource(
+  midi: boolean,
+  notes: Array<Record<string, number>> = [SOURCE_NOTE],
+): void {
+  registerMockObject("src_clip", {
+    path: livePath.track(0).arrangementClip(0),
+    type: "Clip",
+    properties: {
+      is_midi_clip: midi ? 1 : 0,
+      is_arrangement_clip: 1,
+      length: 4,
+      start_time: 0,
+      loop_start: 0,
+      loop_end: 4,
+      start_marker: 0,
+      end_marker: 4,
+      looping: 1,
+      signature_numerator: 4,
+      signature_denominator: 4,
+    },
+    methods: {
+      get_notes_extended: () => JSON.stringify({ notes }),
+    },
+  });
+}
+
+describe("duplicate take lane", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("duplicates a MIDI clip onto a fresh take lane (notes + loop copied)", async () => {
+    registerLiveSet();
+    registerArrangementSource(true);
+    const track = registerTakeLaneTrack({ initialLanes: 0 });
+
+    const result = (await duplicate({
+      type: "clip",
+      id: "src_clip",
+      arrangementStart: "5|1",
+      takeLane: "new",
+    })) as { id: string; trackIndex: number; arrangementStart: string };
+
+    expect(track.call).toHaveBeenCalledWith("create_take_lane");
+
+    const lane = lookupMockObject(undefined, livePath.track(0).takeLane(0));
+
+    expect(lane?.call).toHaveBeenCalledWith("create_midi_clip", 16, 4);
+
+    const newClip = lookupMockObject(
+      undefined,
+      livePath.track(0).takeLane(0).arrangementClip(0),
+    );
+
+    expect(newClip?.call).toHaveBeenCalledWith("add_new_notes", {
+      notes: [SOURCE_NOTE],
+    });
+    expect(newClip?.set).toHaveBeenCalledWith("loop_end", 4);
+    expect(newClip?.set).toHaveBeenCalledWith("looping", 1);
+    expect(result).toMatchObject({ trackIndex: 0, arrangementStart: "5|1" });
+  });
+
+  it("skips add_new_notes when the source clip is empty", async () => {
+    registerLiveSet();
+    registerArrangementSource(true, []);
+    registerTakeLaneTrack({ initialLanes: 0 });
+
+    await duplicate({
+      type: "clip",
+      id: "src_clip",
+      arrangementStart: "1|1",
+      takeLane: "new",
+    });
+
+    const newClip = lookupMockObject(
+      undefined,
+      livePath.track(0).takeLane(0).arrangementClip(0),
+    );
+
+    expect(newClip?.call).not.toHaveBeenCalledWith(
+      "add_new_notes",
+      expect.anything(),
+    );
+  });
+
+  it("skips an audio source with a warning (MIDI-only)", async () => {
+    registerLiveSet();
+    registerArrangementSource(false);
+    const track = registerTakeLaneTrack({ initialLanes: 0 });
+
+    const result = await duplicate({
+      type: "clip",
+      id: "src_clip",
+      arrangementStart: "5|1",
+      takeLane: "new",
+    });
+
+    expect(consoleMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining("takeLane supports MIDI clips only"),
+    );
+    expect(track.call).not.toHaveBeenCalledWith("create_take_lane");
+    expect(result).toStrictEqual([]);
+  });
+
+  it("warns and ignores takeLane for a session destination", async () => {
+    registerSessionClipDuplication({ destClipProperties: {} });
+
+    await duplicate({
+      type: "clip",
+      id: "clip1",
+      toSlot: "0/1",
+      takeLane: "new",
+    });
+
+    expect(consoleMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining("takeLane ignored for session destination"),
+    );
+  });
+
+  it("warns and ignores takeLane for non-clip types", async () => {
+    registerMockObject("track1", { path: livePath.track(0) });
+    registerMockObject("live_set", { path: livePath.liveSet });
+    registerMockObject("live_set/tracks/1", {
+      path: livePath.track(1),
+      properties: { devices: [], clip_slots: [], arrangement_clips: [] },
+    });
+
+    await duplicate({ type: "track", id: "track1", takeLane: "new" });
+
+    expect(consoleMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "takeLane ignored: only supported when duplicating clips",
+      ),
+    );
+  });
+
+  it("throws when the source clip has no track index", () => {
+    registerMockObject("orphan_clip", {
+      path: "live_set scenes 0",
+      type: "Clip",
+      properties: { is_midi_clip: 1 },
+    });
+
+    expect(() =>
+      duplicateClipsToTakeLane(
+        LiveAPI.from("orphan_clip"),
+        "orphan_clip",
+        [0],
+        undefined,
+        undefined,
+        "new",
+        undefined,
+        4,
+        4,
+      ),
+    ).toThrow(/no track index for clip id "orphan_clip"/);
+  });
+});

--- a/src/tools/clip/create/create-clip.def.ts
+++ b/src/tools/clip/create/create-clip.def.ts
@@ -111,10 +111,29 @@ export const toolDefCreateClip = defineTool("ppal-create-clip", {
       .enum(["play-scene", "play-clip"])
       .optional()
       .describe("auto-play session clips (play-scene keeps scene in sync)"),
+
+    takeLane: z.coerce
+      .string()
+      .optional()
+      .describe(
+        'arrangement take lane: omit/0 = main lane, 1+ = that lane (auto-created), "new" = append a fresh lane (for variations)',
+      ),
+
+    takeLaneName: z
+      .string()
+      .optional()
+      .describe("name for a take lane newly created by this call"),
   },
 
   smallModelModeConfig: {
-    excludeParams: ["transforms", "code", "firstStart", "auto"],
+    excludeParams: [
+      "transforms",
+      "code",
+      "firstStart",
+      "auto",
+      "takeLane",
+      "takeLaneName",
+    ],
     descriptionOverrides: {
       slot: "session clip slot(s): trackIndex/sceneIndex (e.g., '0/0')",
       arrangementStart: "arrangement clip bar|beat position (e.g., '1|1')",

--- a/src/tools/clip/create/create-clip.ts
+++ b/src/tools/clip/create/create-clip.ts
@@ -6,10 +6,7 @@
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import { computeLoopDeadline } from "#src/tools/clip/helpers/loop-deadline.ts";
 import { select } from "#src/tools/session/select.ts";
-import {
-  parseTimeSignature,
-  unwrapSingleResult,
-} from "#src/tools/shared/utils.ts";
+import { unwrapSingleResult } from "#src/tools/shared/utils.ts";
 import { parseCommaSeparatedColors } from "#src/tools/shared/validation/color-utils.ts";
 import {
   parseCommaSeparatedNames,
@@ -18,12 +15,16 @@ import {
 import {
   parseArrangementStartList,
   parseSlotList,
+  type SlotPosition,
 } from "#src/tools/shared/validation/position-parsing.ts";
-import { convertTimingParameters } from "./helpers/create-clip-helpers.ts";
 import {
   createClips,
   prepareClipData,
 } from "./helpers/create-clip-loop-helpers.ts";
+import {
+  resolveClipTimingContext,
+  resolveCreateClipTakeLane,
+} from "./helpers/create-clip-prep-helpers.ts";
 import {
   handleAutoPlayback,
   validateCreateClipParams,
@@ -64,6 +65,10 @@ export interface CreateClipArgs {
   focus?: boolean;
   /** JavaScript code to generate notes (MIDI clips only) */
   code?: string | null;
+  /** Arrangement take lane target: 0/omitted = main lane, 1+ = that lane, "new" = append */
+  takeLane?: number | string | null;
+  /** Name for a take lane newly created by this call */
+  takeLaneName?: string | null;
 }
 
 /**
@@ -85,6 +90,8 @@ export interface CreateClipArgs {
  * @param args.auto - Automatic playback action
  * @param args.focus - Select the created clip and show clip detail view
  * @param args.code - JavaScript code to generate notes (MIDI clips only)
+ * @param args.takeLane - Arrangement take lane target (0/omitted = main, 1+ = lane, "new")
+ * @param args.takeLaneName - Name for a take lane newly created by this call
  * @param _context - Internal context object (unused)
  * @returns Single clip object when one position, array when multiple positions
  */
@@ -106,6 +113,8 @@ export async function createClip(
     auto = null,
     focus,
     code = null,
+    takeLane = null,
+    takeLaneName = null,
   }: CreateClipArgs,
   _context: Partial<ToolContext> = {},
 ): Promise<object | object[]> {
@@ -125,32 +134,23 @@ export async function createClip(
 
   const liveSet = LiveAPI.from(livePath.liveSet);
 
-  // Get song time signature for arrangementStart conversion
-  const songTimeSigNumerator = liveSet.getProperty(
-    "signature_numerator",
-  ) as number;
-  const songTimeSigDenominator = liveSet.getProperty(
-    "signature_denominator",
-  ) as number;
-
-  // Determine clip time signature (custom or from song)
-  const { timeSigNumerator, timeSigDenominator } = resolveTimeSignature(
-    timeSignature,
+  // Resolve time signatures and convert timing parameters to Ableton beats
+  // (arrangementStart is converted per-position later)
+  const {
     songTimeSigNumerator,
     songTimeSigDenominator,
-  );
-
-  // Convert timing parameters to Ableton beats (excluding arrangementStart, done per-position)
-  const { startBeats, firstStartBeats, endBeats } = convertTimingParameters(
-    null, // arrangementStart converted per-position
+    timeSigNumerator,
+    timeSigDenominator,
+    startBeats,
+    firstStartBeats,
+    endBeats,
+  } = resolveClipTimingContext(
+    liveSet,
+    timeSignature,
     start,
     firstStart,
     length,
     looping,
-    timeSigNumerator,
-    timeSigDenominator,
-    songTimeSigNumerator,
-    songTimeSigDenominator,
   );
 
   // Parse notation and determine clip length
@@ -174,6 +174,18 @@ export async function createClip(
     sessionSlots.length + arrangementStarts.length,
   );
 
+  // Resolve the arrangement take lane (auto-creates lanes, checks overlap)
+  const takeLaneCreator = resolveCreateClipTakeLane(
+    takeLane,
+    takeLaneName,
+    sessionSlots.length,
+    arrangementStarts,
+    trackIndex,
+    initialClipLength,
+    songTimeSigNumerator,
+    songTimeSigDenominator,
+  );
+
   // Create session clips first, then arrangement (order gives arrangement focus priority)
   const clipsForView = (
     view: "session" | "arrangement",
@@ -182,6 +194,7 @@ export async function createClip(
     createClips({
       view,
       trackIndex: trackIndex ?? 0,
+      takeLane: takeLaneCreator,
       sessionSlots,
       arrangementStarts,
       baseName: name,
@@ -215,11 +228,28 @@ export async function createClip(
   );
   const createdClips = [...sessionClips, ...arrangementClips];
 
+  return finalizeCreatedClips(createdClips, auto, sessionSlots, focus);
+}
+
+/**
+ * Handle auto-playback and focus for the created clips, then unwrap the result.
+ * @param createdClips - All created clip result objects
+ * @param auto - Automatic playback action
+ * @param sessionSlots - Parsed session slot positions
+ * @param focus - Whether to select the last created clip
+ * @returns Single clip object when one, array when multiple
+ */
+function finalizeCreatedClips(
+  createdClips: object[],
+  auto: string | null,
+  sessionSlots: SlotPosition[],
+  focus: boolean | undefined,
+): object | object[] {
   // Handle automatic playback (session clips only, guard inside handles no-op)
   handleAutoPlayback(auto, "session", sessionSlots);
 
-  // Focus last created clip: arrangement clips are after session clips,
-  // so arrangement gets priority (the arrangement is where the final song lives)
+  // Focus last created clip: arrangement clips are after session clips, so
+  // arrangement gets priority (the arrangement is where the final song lives)
   if (focus && createdClips.length > 0) {
     const lastClip = createdClips.at(-1) as { id: string };
 
@@ -253,33 +283,6 @@ function parseMultiClipParams(
   warnExtraNames(parsedNames, totalPositionCount, "createClip");
 
   return { parsedNames, parsedColors };
-}
-
-/**
- * Resolve clip time signature from parameter or song defaults
- * @param timeSignature - Custom time signature string (e.g. "4/4"), or null
- * @param songTimeSigNumerator - Song time signature numerator
- * @param songTimeSigDenominator - Song time signature denominator
- * @returns Resolved numerator and denominator
- */
-function resolveTimeSignature(
-  timeSignature: string | null,
-  songTimeSigNumerator: number,
-  songTimeSigDenominator: number,
-): { timeSigNumerator: number; timeSigDenominator: number } {
-  if (timeSignature != null) {
-    const parsed = parseTimeSignature(timeSignature);
-
-    return {
-      timeSigNumerator: parsed.numerator,
-      timeSigDenominator: parsed.denominator,
-    };
-  }
-
-  return {
-    timeSigNumerator: songTimeSigNumerator,
-    timeSigDenominator: songTimeSigDenominator,
-  };
 }
 
 /**

--- a/src/tools/clip/create/helpers/create-clip-audio-helpers.ts
+++ b/src/tools/clip/create/helpers/create-clip-audio-helpers.ts
@@ -48,16 +48,18 @@ export interface AudioArrangementClipResult {
 }
 
 /**
- * Creates an audio clip in arrangement view
+ * Creates an audio clip in arrangement view on a track or take lane
  * @param trackIndex - Track index (0-based)
  * @param arrangementStartBeats - Start position in Ableton beats
  * @param sampleFile - Absolute path to audio file
+ * @param takeLane - Take lane to create on, or null for the track's main lane
  * @returns Object with clip and arrangementStartBeats
  */
 export function createAudioArrangementClip(
   trackIndex: number,
   arrangementStartBeats: number | null,
   sampleFile: string,
+  takeLane: LiveAPI | null = null,
 ): AudioArrangementClipResult {
   // Live API limit check
   if (
@@ -69,10 +71,10 @@ export function createAudioArrangementClip(
     );
   }
 
-  const track = LiveAPI.from(livePath.track(trackIndex));
+  const target = takeLane ?? LiveAPI.from(livePath.track(trackIndex));
 
   // Create audio clip at position
-  const newClipResult = track.call(
+  const newClipResult = target.call(
     "create_audio_clip",
     sampleFile,
     arrangementStartBeats,

--- a/src/tools/clip/create/helpers/create-clip-helpers.ts
+++ b/src/tools/clip/create/helpers/create-clip-helpers.ts
@@ -135,19 +135,21 @@ interface ArrangementClipResult {
 }
 
 /**
- * Creates an arrangement clip on a track
+ * Creates an arrangement clip on a track or a take lane
  * @param trackIndex - Track index (0-based)
  * @param arrangementStartBeats - Starting position in beats
  * @param clipLength - Clip length in beats
+ * @param takeLane - Take lane to create on, or null for the track's main lane
  * @returns Object with clip and arrangementStartBeats
  */
 function createArrangementClip(
   trackIndex: number,
   arrangementStartBeats: number | null,
   clipLength: number,
+  takeLane: LiveAPI | null = null,
 ): ArrangementClipResult {
-  const track = LiveAPI.from(livePath.track(trackIndex));
-  const newClipResult = track.call(
+  const target = takeLane ?? LiveAPI.from(livePath.track(trackIndex));
+  const newClipResult = target.call(
     "create_midi_clip",
     arrangementStartBeats,
     clipLength,
@@ -183,6 +185,7 @@ function createArrangementClip(
  * @param length - Original length parameter
  * @param sampleFile - Audio file path (for audio clips)
  * @param transformedCount - Number of notes matched by transform selectors
+ * @param takeLane - Take lane to create arrangement clips on, or null for main lane
  * @returns Clip result for this iteration
  */
 export function processClipIteration(
@@ -206,6 +209,7 @@ export function processClipIteration(
   length: string | null,
   sampleFile: string | null,
   transformedCount: number | undefined,
+  takeLane: LiveAPI | null = null,
 ): object {
   let clip: LiveAPI;
   let currentSceneIndex: number | undefined;
@@ -231,6 +235,7 @@ export function processClipIteration(
         trackIndex,
         arrangementStartBeats,
         sampleFile,
+        takeLane,
       );
 
       clip = result.clip;
@@ -266,6 +271,7 @@ export function processClipIteration(
         trackIndex,
         arrangementStartBeats,
         clipLength,
+        takeLane,
       );
 
       clip = result.clip;

--- a/src/tools/clip/create/helpers/create-clip-loop-helpers.ts
+++ b/src/tools/clip/create/helpers/create-clip-loop-helpers.ts
@@ -44,6 +44,8 @@ export interface CreateClipsParams {
   deadline: number | null;
   code: string | null;
   transformedCount: number | undefined;
+  /** Take lane to create arrangement clips on, or null for the main lane */
+  takeLane: LiveAPI | null;
 }
 
 /**
@@ -80,6 +82,7 @@ export async function createClips(
     deadline,
     code,
     transformedCount,
+    takeLane,
   } = params;
 
   const createdClips: object[] = [];
@@ -148,6 +151,8 @@ export async function createClips(
         length,
         sampleFile,
         transformedCount,
+        // Take lanes apply only to arrangement clips (ignored for session view)
+        takeLane,
       );
 
       createdClips.push(clipResult);

--- a/src/tools/clip/create/helpers/create-clip-prep-helpers.ts
+++ b/src/tools/clip/create/helpers/create-clip-prep-helpers.ts
@@ -1,0 +1,164 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { barBeatToAbletonBeats } from "#src/notation/barbeat/time/barbeat-time.ts";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import * as console from "#src/shared/v8-max-console.ts";
+import {
+  assertNoTakeLaneOverlap,
+  normalizeTakeLaneTarget,
+  resolveTakeLane,
+} from "#src/tools/shared/arrangement/take-lane-helpers.ts";
+import { parseTimeSignature } from "#src/tools/shared/utils.ts";
+import { convertTimingParameters } from "./create-clip-helpers.ts";
+
+export interface ClipTimingContext {
+  songTimeSigNumerator: number;
+  songTimeSigDenominator: number;
+  timeSigNumerator: number;
+  timeSigDenominator: number;
+  startBeats: number | null;
+  firstStartBeats: number | null;
+  endBeats: number | null;
+}
+
+/**
+ * Resolve song/clip time signatures and convert timing parameters to beats.
+ * Bundles the song time signature read, clip time signature resolution, and
+ * bar|beat-to-beats conversion used at the start of clip creation.
+ * @param liveSet - The live_set LiveAPI object
+ * @param timeSignature - Custom clip time signature (e.g. "4/4"), or null
+ * @param start - Loop start position in bar|beat format, or null
+ * @param firstStart - First playback start in bar|beat format, or null
+ * @param length - Clip length in bar:beat duration format, or null
+ * @param looping - Whether the clip is looping
+ * @returns Resolved time signatures and converted timing in beats
+ */
+export function resolveClipTimingContext(
+  liveSet: LiveAPI,
+  timeSignature: string | null,
+  start: string | null,
+  firstStart: string | null,
+  length: string | null,
+  looping: boolean | null,
+): ClipTimingContext {
+  const songTimeSigNumerator = liveSet.getProperty(
+    "signature_numerator",
+  ) as number;
+  const songTimeSigDenominator = liveSet.getProperty(
+    "signature_denominator",
+  ) as number;
+
+  const { timeSigNumerator, timeSigDenominator } = resolveTimeSignature(
+    timeSignature,
+    songTimeSigNumerator,
+    songTimeSigDenominator,
+  );
+
+  const { startBeats, firstStartBeats, endBeats } = convertTimingParameters(
+    null, // arrangementStart converted per-position
+    start,
+    firstStart,
+    length,
+    looping,
+    timeSigNumerator,
+    timeSigDenominator,
+    songTimeSigNumerator,
+    songTimeSigDenominator,
+  );
+
+  return {
+    songTimeSigNumerator,
+    songTimeSigDenominator,
+    timeSigNumerator,
+    timeSigDenominator,
+    startBeats,
+    firstStartBeats,
+    endBeats,
+  };
+}
+
+/**
+ * Resolve the take lane for arrangement clip creation. Returns the TakeLane to
+ * create clips on, or null to use the main lane. Warns (and ignores takeLane)
+ * for session-only requests; auto-creates lanes and checks for position overlap.
+ * @param takeLane - Raw takeLane argument (0/null = main, 1+ = lane, "new")
+ * @param takeLaneName - Name for a newly created lane
+ * @param sessionSlotCount - Number of session slots in this request
+ * @param arrangementStarts - Parsed arrangement bar|beat positions
+ * @param trackIndex - Arrangement track index
+ * @param clipLength - Clip length in beats (overlap window)
+ * @param songTimeSigNumerator - Song time signature numerator
+ * @param songTimeSigDenominator - Song time signature denominator
+ * @returns The take lane LiveAPI, or null for the main lane
+ */
+export function resolveCreateClipTakeLane(
+  takeLane: number | string | null,
+  takeLaneName: string | null,
+  sessionSlotCount: number,
+  arrangementStarts: string[],
+  trackIndex: number | null,
+  clipLength: number,
+  songTimeSigNumerator: number,
+  songTimeSigDenominator: number,
+): LiveAPI | null {
+  const target = normalizeTakeLaneTarget(takeLane);
+
+  if (target == null) return null;
+
+  if (sessionSlotCount > 0) {
+    console.warn(
+      "createClip: takeLane ignored for session clips (arrangement-only)",
+    );
+  }
+
+  if (arrangementStarts.length === 0 || trackIndex == null) return null;
+
+  const track = LiveAPI.from(livePath.track(trackIndex));
+  const { lane, laneNumber } = resolveTakeLane(track, target, takeLaneName);
+
+  for (const pos of arrangementStarts) {
+    const startBeats = barBeatToAbletonBeats(
+      pos,
+      songTimeSigNumerator,
+      songTimeSigDenominator,
+    );
+
+    assertNoTakeLaneOverlap(lane, startBeats, clipLength, laneNumber, pos);
+  }
+
+  console.warn(
+    `createClip: targeting take lane ${laneNumber}. Expand the take-lanes arrow on the track header in Live to see it.`,
+  );
+
+  return lane;
+}
+
+/**
+ * Resolve clip time signature from parameter or song defaults.
+ * @param timeSignature - Custom time signature string (e.g. "4/4"), or null
+ * @param songTimeSigNumerator - Song time signature numerator
+ * @param songTimeSigDenominator - Song time signature denominator
+ * @returns Resolved numerator and denominator
+ */
+function resolveTimeSignature(
+  timeSignature: string | null,
+  songTimeSigNumerator: number,
+  songTimeSigDenominator: number,
+): { timeSigNumerator: number; timeSigDenominator: number } {
+  if (timeSignature != null) {
+    const parsed = parseTimeSignature(timeSignature);
+
+    return {
+      timeSigNumerator: parsed.numerator,
+      timeSigDenominator: parsed.denominator,
+    };
+  }
+
+  return {
+    timeSigNumerator: songTimeSigNumerator,
+    timeSigDenominator: songTimeSigDenominator,
+  };
+}

--- a/src/tools/clip/create/helpers/create-clip-result-helpers.ts
+++ b/src/tools/clip/create/helpers/create-clip-result-helpers.ts
@@ -90,6 +90,8 @@ export interface ClipResultObject {
   slot?: string;
   trackIndex?: number;
   arrangementStart?: string | null;
+  /** 1-based take lane number, present only for clips on a take lane */
+  takeLane?: number;
   noteCount?: number;
   transformed?: number;
   length?: string;
@@ -135,6 +137,13 @@ export function buildClipResult(
   } else {
     clipResult.trackIndex = trackIndex;
     clipResult.arrangementStart = arrangementStart;
+
+    // Surface the take lane (1-based) when the clip landed on one
+    const takeLaneIndex = clip.takeLaneIndex;
+
+    if (takeLaneIndex != null) {
+      clipResult.takeLane = takeLaneIndex + 1;
+    }
   }
 
   // For MIDI clips: include noteCount if notes were provided

--- a/src/tools/clip/create/tests/create-clip-take-lanes.test.ts
+++ b/src/tools/clip/create/tests/create-clip-take-lanes.test.ts
@@ -43,7 +43,7 @@ describe("createClip take lanes", () => {
       arrangementStart: "1|1",
       notes: "C3",
       takeLane: "new",
-    })) as { id: string };
+    })) as { id: string; takeLane?: number };
 
     expect(track.call).toHaveBeenCalledWith("create_take_lane");
     expect(track.call).not.toHaveBeenCalledWith(
@@ -56,6 +56,8 @@ describe("createClip take lanes", () => {
 
     expect(lane?.call).toHaveBeenCalledWith("create_midi_clip", 0, 4);
     expect(result.id).toMatch(/^tl_clip_/);
+    // result surfaces the 1-based lane the clip landed on
+    expect(result.takeLane).toBe(1);
   });
 
   it("creates an audio arrangement clip on a take lane", async () => {

--- a/src/tools/clip/create/tests/create-clip-take-lanes.test.ts
+++ b/src/tools/clip/create/tests/create-clip-take-lanes.test.ts
@@ -1,0 +1,151 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import {
+  registerMockObject,
+  lookupMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+import { registerTakeLaneTrack } from "#src/tools/shared/arrangement/tests/take-lane-test-helpers.ts";
+
+// Capture take lane warnings (session-ignore, hints)
+vi.mock(import("#src/shared/v8-max-console.ts"), () => ({
+  error: vi.fn(),
+  log: vi.fn(),
+  warn: vi.fn(),
+}));
+
+import { createClip } from "#src/tools/clip/create/create-clip.ts";
+import * as consoleMock from "#src/shared/v8-max-console.ts";
+
+/** Register the live_set time signature mock used by createClip. */
+function registerLiveSet(): void {
+  registerMockObject("live-set", {
+    path: livePath.liveSet,
+    properties: { signature_numerator: 4, signature_denominator: 4 },
+  });
+}
+
+describe("createClip take lanes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a MIDI arrangement clip on a fresh take lane", async () => {
+    registerLiveSet();
+    const track = registerTakeLaneTrack({ initialLanes: 0 });
+
+    const result = (await createClip({
+      trackIndex: 0,
+      arrangementStart: "1|1",
+      notes: "C3",
+      takeLane: "new",
+    })) as { id: string };
+
+    expect(track.call).toHaveBeenCalledWith("create_take_lane");
+    expect(track.call).not.toHaveBeenCalledWith(
+      "create_midi_clip",
+      expect.anything(),
+      expect.anything(),
+    );
+
+    const lane = lookupMockObject(undefined, livePath.track(0).takeLane(0));
+
+    expect(lane?.call).toHaveBeenCalledWith("create_midi_clip", 0, 4);
+    expect(result.id).toMatch(/^tl_clip_/);
+  });
+
+  it("creates an audio arrangement clip on a take lane", async () => {
+    registerLiveSet();
+    registerTakeLaneTrack({ initialLanes: 0 });
+
+    await createClip({
+      trackIndex: 0,
+      arrangementStart: "1|1",
+      sampleFile: "/samples/loop.wav",
+      takeLane: "new",
+    });
+
+    const lane = lookupMockObject(undefined, livePath.track(0).takeLane(0));
+
+    expect(lane?.call).toHaveBeenCalledWith(
+      "create_audio_clip",
+      "/samples/loop.wav",
+      0,
+    );
+  });
+
+  it("targets an existing lane by number without creating one", async () => {
+    registerLiveSet();
+    const track = registerTakeLaneTrack({ initialLanes: 2 });
+
+    await createClip({
+      trackIndex: 0,
+      arrangementStart: "1|1",
+      notes: "C3",
+      takeLane: 1,
+    });
+
+    expect(track.call).not.toHaveBeenCalledWith("create_take_lane");
+    const lane = lookupMockObject(undefined, livePath.track(0).takeLane(0));
+
+    expect(lane?.call).toHaveBeenCalledWith("create_midi_clip", 0, 4);
+  });
+
+  it("names a newly created lane via takeLaneName", async () => {
+    registerLiveSet();
+    registerTakeLaneTrack({ initialLanes: 0 });
+
+    await createClip({
+      trackIndex: 0,
+      arrangementStart: "1|1",
+      notes: "C3",
+      takeLane: "new",
+      takeLaneName: "Variation B",
+    });
+
+    const lane = lookupMockObject(undefined, livePath.track(0).takeLane(0));
+
+    expect(lane?.set).toHaveBeenCalledWith("name", "Variation B");
+  });
+
+  it("errors when a clip already exists at the target position on the lane", async () => {
+    registerLiveSet();
+    // Pre-populate lane 0 with a clip covering bar 1 (beats 0-4)
+    const track = registerTakeLaneTrack({ initialLanes: 1 });
+    const lane = lookupMockObject(undefined, livePath.track(0).takeLane(0));
+
+    lane?.call("create_midi_clip", 0); // occupy beats 0-4
+    expect(track.id).toBeDefined();
+
+    await expect(
+      createClip({
+        trackIndex: 0,
+        arrangementStart: "1|1",
+        notes: "C3",
+        takeLane: 1,
+      }),
+    ).rejects.toThrow(/Clip exists at 1\|1 on take lane 1/);
+  });
+
+  it("warns and ignores takeLane for session-only requests", async () => {
+    registerLiveSet();
+    registerMockObject("clip-slot-0-0", {
+      path: livePath.track(0).clipSlot(0),
+      properties: { has_clip: 0 },
+    });
+    registerMockObject("session-clip", {
+      path: livePath.track(0).clipSlot(0).clip(),
+      properties: { length: 4 },
+    });
+
+    await createClip({ slot: "0/0", notes: "C3", takeLane: "new" });
+
+    expect(consoleMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining("takeLane ignored for session clips"),
+    );
+  });
+});

--- a/src/tools/clip/update/helpers/update-clip-transform-helpers.ts
+++ b/src/tools/clip/update/helpers/update-clip-transform-helpers.ts
@@ -12,25 +12,10 @@ import {
 import * as console from "#src/shared/v8-max-console.ts";
 import { type NoteUpdateResult } from "#src/tools/clip/helpers/clip-result-helpers.ts";
 import { MAX_CLIP_BEATS } from "#src/tools/constants.ts";
-import { getPlayableNoteCount } from "#src/tools/shared/clip-notes.ts";
-
-/**
- * Convert a raw note from the Live API to a NoteEvent for add_new_notes.
- * The Live API returns extra properties (note_id, mute, release_velocity)
- * that must be stripped before passing to add_new_notes.
- * @param rawNote - Note object from get_notes_extended
- * @returns NoteEvent compatible with add_new_notes
- */
-function toNoteEvent(rawNote: Record<string, unknown>): NoteEvent {
-  return {
-    pitch: rawNote.pitch as number,
-    start_time: rawNote.start_time as number,
-    duration: rawNote.duration as number,
-    velocity: rawNote.velocity as number,
-    probability: rawNote.probability as number,
-    velocity_deviation: rawNote.velocity_deviation as number,
-  };
-}
+import {
+  getPlayableNoteCount,
+  rawNotesToNoteEvents,
+} from "#src/tools/shared/clip-notes.ts";
 
 /**
  * Apply transforms to existing notes without changing the notes themselves.
@@ -64,7 +49,7 @@ export function applyTransformsToExistingNotes(
   }
 
   // Convert raw notes to NoteEvent format (strips extra Live API properties)
-  const notes: NoteEvent[] = rawNotes.map(toNoteEvent);
+  const notes: NoteEvent[] = rawNotesToNoteEvents(rawNotes);
 
   const transformed = applyTransforms(
     notes,

--- a/src/tools/live-set/tests/read-live-set-inclusion.test.ts
+++ b/src/tools/live-set/tests/read-live-set-inclusion.test.ts
@@ -127,6 +127,29 @@ describe("readLiveSet - inclusion", () => {
     expect(result.returnTracks).toBeUndefined();
   });
 
+  it("includes takeLaneCount per track when tracks are listed", () => {
+    // Minimal track objects: the count path only reads take_lanes; other track
+    // properties fall back to mock defaults.
+    setupLiveSetPathMappedMocks({
+      liveSetId: "live_set",
+      objects: {
+        LiveSet: { name: "Take Lane Count Test", tracks: children("a", "b") },
+        [String(livePath.track(0))]: {
+          name: "Has Lanes",
+          take_lanes: children("lane1", "lane2"),
+        },
+        [String(livePath.track(1))]: { name: "No Lanes" },
+        [String(livePath.masterTrack())]: { name: "Master" },
+      },
+    });
+
+    const result = readLiveSet({ include: ["tracks"] });
+    const tracks = result.tracks as Array<Record<string, unknown>>;
+
+    expect(tracks[0]!.takeLaneCount).toBe(2);
+    expect(tracks[1]).not.toHaveProperty("takeLaneCount");
+  });
+
   it("omits name property when Live Set name is empty string", () => {
     setupLiveSetPathMappedMocks({
       liveSetId: "live_set",

--- a/src/tools/shared/arrangement/take-lane-helpers.ts
+++ b/src/tools/shared/arrangement/take-lane-helpers.ts
@@ -1,0 +1,134 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Take lane targeting shared by ppal-create-clip and ppal-duplicate.
+ *
+ * Live API notes (verified against Live 12):
+ * - `Track.take_lanes` excludes the main lane; `create_take_lane()` appends one
+ *   and returns its ref. New lane index = prior `take_lanes.length`.
+ * - `TakeLane.create_midi_clip(start, length)` / `create_audio_clip(file, start)`
+ *   create arrangement clips on the lane and return the new clip ref directly.
+ * - There is no `delete_take_lane` and `Track.delete_clip` does not remove
+ *   take-lane clips, so take lanes are append-only (clean up in Live's UI).
+ */
+
+/** Maximum take lanes per track (soft cap; total non-main lanes). */
+export const MAX_TAKE_LANES = 8;
+
+/** Normalized take lane target: a 1-based lane number, or "new" to append. */
+export type TakeLaneTarget = number | "new";
+
+export interface ResolvedTakeLane {
+  /** The resolved TakeLane LiveAPI object. */
+  lane: LiveAPI;
+  /** 1-based lane number (matches the takeLane param). */
+  laneNumber: number;
+}
+
+/**
+ * Normalize a raw takeLane argument to a target, or null for the main lane.
+ * `0`, `null`, `undefined`, and `""` mean the main lane (unchanged behavior).
+ * @param takeLane - Raw takeLane value from a tool argument
+ * @returns A TakeLaneTarget, or null to target the main lane
+ */
+export function normalizeTakeLaneTarget(
+  takeLane: number | string | null | undefined,
+): TakeLaneTarget | null {
+  if (
+    takeLane == null ||
+    takeLane === "" ||
+    takeLane === 0 ||
+    takeLane === "0"
+  ) {
+    return null;
+  }
+
+  if (takeLane === "new") {
+    return "new";
+  }
+
+  const n = typeof takeLane === "number" ? takeLane : Number(takeLane);
+
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(
+      `takeLane must be 0, a positive integer, or "new" (got "${takeLane}")`,
+    );
+  }
+
+  return n;
+}
+
+/**
+ * Resolve (auto-creating as needed) the target take lane on a track.
+ * A numeric target ensures at least that many lanes exist (auto-creating up to
+ * the index, mirroring scene auto-create); "new" appends a fresh lane. The
+ * MAX_TAKE_LANES cap is enforced. takeLaneName is applied only to a lane this
+ * call creates — never renaming an existing lane.
+ * @param track - The regular track LiveAPI to resolve the lane on
+ * @param target - Normalized take lane target (lane number or "new")
+ * @param takeLaneName - Optional name for a newly created lane
+ * @returns The resolved take lane and its 1-based number
+ */
+export function resolveTakeLane(
+  track: LiveAPI,
+  target: TakeLaneTarget,
+  takeLaneName?: string | null,
+): ResolvedTakeLane {
+  const currentCount = track.getChildIds("take_lanes").length;
+  const targetCount = target === "new" ? currentCount + 1 : target;
+
+  if (targetCount > MAX_TAKE_LANES) {
+    throw new Error(
+      `Track has reached the ${MAX_TAKE_LANES} take lane limit. Delete unwanted lanes in Live first.`,
+    );
+  }
+
+  // Auto-create lanes until the target lane exists (empty lanes persist).
+  for (let i = currentCount; i < targetCount; i++) {
+    track.call("create_take_lane");
+  }
+
+  const laneIndex = targetCount - 1;
+  const lane = track.child("take_lanes", String(laneIndex));
+  const laneWasCreated = laneIndex >= currentCount;
+
+  if (laneWasCreated && takeLaneName != null && takeLaneName !== "") {
+    lane.setAll({ name: takeLaneName });
+  }
+
+  return { lane, laneNumber: targetCount };
+}
+
+/**
+ * Throw a clean error if any clip on the lane overlaps the target time range.
+ * No-op for lanes with no conflicting clip (including freshly created lanes).
+ * @param lane - The resolved take lane LiveAPI object
+ * @param startBeats - New clip start position in Ableton beats
+ * @param lengthBeats - New clip length in beats (overlap window width)
+ * @param laneNumber - 1-based lane number (for the message)
+ * @param positionLabel - bar|beat label of the position (for the message)
+ */
+export function assertNoTakeLaneOverlap(
+  lane: LiveAPI,
+  startBeats: number,
+  lengthBeats: number,
+  laneNumber: number,
+  positionLabel: string,
+): void {
+  const newEnd = startBeats + lengthBeats;
+
+  for (const clip of lane.getChildren("arrangement_clips")) {
+    const existingStart = clip.getProperty("start_time") as number;
+    const existingEnd = clip.getProperty("end_time") as number;
+
+    if (existingStart < newEnd && existingEnd > startBeats) {
+      throw new Error(
+        `Clip exists at ${positionLabel} on take lane ${laneNumber}. ` +
+          `Use update-clip to modify, or takeLane: "new" for a fresh lane.`,
+      );
+    }
+  }
+}

--- a/src/tools/shared/arrangement/tests/take-lane-helpers.test.ts
+++ b/src/tools/shared/arrangement/tests/take-lane-helpers.test.ts
@@ -1,0 +1,138 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import {
+  assertNoTakeLaneOverlap,
+  MAX_TAKE_LANES,
+  normalizeTakeLaneTarget,
+  resolveTakeLane,
+} from "#src/tools/shared/arrangement/take-lane-helpers.ts";
+import {
+  registerTakeLaneTrack,
+  registerTakeLaneWithClips,
+} from "./take-lane-test-helpers.ts";
+
+describe("normalizeTakeLaneTarget", () => {
+  it("treats main-lane values as null", () => {
+    expect(normalizeTakeLaneTarget(null)).toBeNull();
+    expect(normalizeTakeLaneTarget(undefined)).toBeNull();
+    expect(normalizeTakeLaneTarget("")).toBeNull();
+    expect(normalizeTakeLaneTarget(0)).toBeNull();
+    expect(normalizeTakeLaneTarget("0")).toBeNull();
+  });
+
+  it('passes "new" through', () => {
+    expect(normalizeTakeLaneTarget("new")).toBe("new");
+  });
+
+  it("coerces positive integers (number or string)", () => {
+    expect(normalizeTakeLaneTarget(3)).toBe(3);
+    expect(normalizeTakeLaneTarget("2")).toBe(2);
+  });
+
+  it("throws on invalid values", () => {
+    expect(() => normalizeTakeLaneTarget(-1)).toThrow(/takeLane must be/);
+    expect(() => normalizeTakeLaneTarget(1.5)).toThrow(/takeLane must be/);
+    expect(() => normalizeTakeLaneTarget("abc")).toThrow(/takeLane must be/);
+  });
+});
+
+describe("resolveTakeLane", () => {
+  it('appends a fresh lane for "new"', () => {
+    const track = registerTakeLaneTrack({ initialLanes: 1 });
+    const trackApi = LiveAPI.from(livePath.track(0));
+
+    const { lane, laneNumber } = resolveTakeLane(trackApi, "new");
+
+    expect(laneNumber).toBe(2);
+    expect(lane.path).toBe("live_set tracks 0 take_lanes 1");
+    expect(track.call).toHaveBeenCalledWith("create_take_lane");
+  });
+
+  it("reuses an existing lane for a number within range", () => {
+    const track = registerTakeLaneTrack({ initialLanes: 2 });
+    const trackApi = LiveAPI.from(livePath.track(0));
+
+    const { lane, laneNumber } = resolveTakeLane(trackApi, 1);
+
+    expect(laneNumber).toBe(1);
+    expect(lane.path).toBe("live_set tracks 0 take_lanes 0");
+    expect(track.call).not.toHaveBeenCalledWith("create_take_lane");
+  });
+
+  it("auto-creates lanes up to the target index", () => {
+    const track = registerTakeLaneTrack({ initialLanes: 0 });
+    const trackApi = LiveAPI.from(livePath.track(0));
+
+    const { lane, laneNumber } = resolveTakeLane(trackApi, 3);
+
+    expect(laneNumber).toBe(3);
+    expect(lane.path).toBe("live_set tracks 0 take_lanes 2");
+    expect(track.call).toHaveBeenCalledTimes(3);
+  });
+
+  it("names a newly created lane but never renames an existing one", () => {
+    registerTakeLaneTrack({ initialLanes: 1 });
+    const trackApi = LiveAPI.from(livePath.track(0));
+
+    const created = resolveTakeLane(trackApi, "new", "Variation A");
+
+    expect(created.lane.set).toHaveBeenCalledWith("name", "Variation A");
+
+    const existing = resolveTakeLane(
+      LiveAPI.from(livePath.track(0)),
+      1,
+      "Should Not Rename",
+    );
+
+    expect(existing.lane.set).not.toHaveBeenCalledWith(
+      "name",
+      "Should Not Rename",
+    );
+  });
+
+  it("enforces the take lane cap", () => {
+    registerTakeLaneTrack({ initialLanes: MAX_TAKE_LANES });
+    const trackApi = LiveAPI.from(livePath.track(0));
+
+    expect(() => resolveTakeLane(trackApi, "new")).toThrow(
+      /reached the 8 take lane limit/,
+    );
+    expect(() => resolveTakeLane(trackApi, MAX_TAKE_LANES + 1)).toThrow(
+      /reached the 8 take lane limit/,
+    );
+  });
+});
+
+describe("assertNoTakeLaneOverlap", () => {
+  it("throws when a clip overlaps the target range", () => {
+    registerTakeLaneWithClips(0, 0, [{ start: 0, end: 4 }]);
+    const laneApi = LiveAPI.from(livePath.track(0).takeLane(0));
+
+    expect(() => assertNoTakeLaneOverlap(laneApi, 2, 4, 1, "1|3")).toThrow(
+      /Clip exists at 1\|3 on take lane 1/,
+    );
+  });
+
+  it("does not throw for a non-overlapping position", () => {
+    registerTakeLaneWithClips(0, 0, [{ start: 0, end: 4 }]);
+    const laneApi = LiveAPI.from(livePath.track(0).takeLane(0));
+
+    expect(() =>
+      assertNoTakeLaneOverlap(laneApi, 4, 4, 1, "2|1"),
+    ).not.toThrow();
+  });
+
+  it("does not throw for an empty lane", () => {
+    registerTakeLaneWithClips(0, 0, []);
+    const laneApi = LiveAPI.from(livePath.track(0).takeLane(0));
+
+    expect(() =>
+      assertNoTakeLaneOverlap(laneApi, 0, 4, 1, "1|1"),
+    ).not.toThrow();
+  });
+});

--- a/src/tools/shared/arrangement/tests/take-lane-test-helpers.ts
+++ b/src/tools/shared/arrangement/tests/take-lane-test-helpers.ts
@@ -1,0 +1,146 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import { children } from "#src/test/mocks/mock-live-api.ts";
+import {
+  registerMockObject,
+  type RegisteredMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+
+let uid = 0;
+
+export interface TakeLaneTrackOptions {
+  trackIndex?: number;
+  /** Number of pre-existing (empty) take lanes */
+  initialLanes?: number;
+  /** Length in beats for clips created on lanes */
+  clipLength?: number;
+}
+
+/**
+ * Register a regular track with stateful take-lane support. `create_take_lane`
+ * appends a lane and grows the track's `take_lanes` list; each lane's
+ * `create_midi_clip` / `create_audio_clip` registers and returns a fresh
+ * arrangement clip and grows the lane's `arrangement_clips` list.
+ * @param options - Track index, initial lane count, and clip length
+ * @returns The registered track mock object
+ */
+export function registerTakeLaneTrack(
+  options: TakeLaneTrackOptions = {},
+): RegisteredMockObject {
+  const { trackIndex = 0, initialLanes = 0, clipLength = 4 } = options;
+  const laneIds: string[] = [];
+
+  // Mutating the props objects is reflected by the registry's get() (read live),
+  // so create_take_lane / create_*_clip grow the child lists statefully.
+  const registerLane = (laneIndex: number): string => {
+    const laneId = `tl_lane_${uid++}`;
+    const laneClips: string[] = [];
+    const laneProps: Record<string, unknown> = {
+      name: "Lane",
+      arrangement_clips: children(),
+    };
+
+    const createClip = (kind: string, startBeats: unknown): unknown[] => {
+      const clipId = `tl_clip_${uid++}`;
+      const start = typeof startBeats === "number" ? startBeats : 0;
+
+      registerMockObject(clipId, {
+        path: String(
+          livePath
+            .track(trackIndex)
+            .takeLane(laneIndex)
+            .arrangementClip(laneClips.length),
+        ),
+        type: "Clip",
+        properties: {
+          is_arrangement_clip: 1,
+          [kind]: 1,
+          length: clipLength,
+          start_time: start,
+          end_time: start + clipLength,
+        },
+      });
+      laneClips.push(clipId);
+      laneProps.arrangement_clips = children(...laneClips);
+
+      return ["id", clipId];
+    };
+
+    registerMockObject(laneId, {
+      path: String(livePath.track(trackIndex).takeLane(laneIndex)),
+      type: "TakeLane",
+      properties: laneProps,
+      methods: {
+        create_midi_clip: (_start) => createClip("is_midi_clip", _start),
+        create_audio_clip: (_file, _start) =>
+          createClip("is_audio_clip", _start),
+      },
+    });
+
+    return laneId;
+  };
+
+  for (let i = 0; i < initialLanes; i++) {
+    laneIds.push(registerLane(i));
+  }
+
+  const trackProps: Record<string, unknown> = {
+    has_midi_input: 1,
+    is_foldable: 0,
+    take_lanes: children(...laneIds),
+  };
+
+  return registerMockObject(`tl_track_${trackIndex}`, {
+    path: livePath.track(trackIndex),
+    type: "Track",
+    properties: trackProps,
+    methods: {
+      create_take_lane: () => {
+        const laneId = registerLane(laneIds.length);
+
+        laneIds.push(laneId);
+        trackProps.take_lanes = children(...laneIds);
+
+        return ["id", laneId];
+      },
+    },
+  });
+}
+
+/**
+ * Register a take lane (under a track) holding clips at given time ranges, for
+ * overlap testing. The track itself is not registered here.
+ * @param trackIndex - Owning track index
+ * @param laneIndex - 0-based lane index
+ * @param clips - Clip time ranges in beats
+ * @returns The registered take lane mock object
+ */
+export function registerTakeLaneWithClips(
+  trackIndex: number,
+  laneIndex: number,
+  clips: Array<{ start: number; end: number }>,
+): RegisteredMockObject {
+  const clipIds = clips.map((clip, i) => {
+    const clipId = `tl_existing_clip_${uid++}`;
+
+    registerMockObject(clipId, {
+      path: String(
+        livePath.track(trackIndex).takeLane(laneIndex).arrangementClip(i),
+      ),
+      type: "Clip",
+      properties: { start_time: clip.start, end_time: clip.end },
+    });
+
+    return clipId;
+  });
+
+  return registerMockObject(`tl_lane_existing_${uid++}`, {
+    path: String(livePath.track(trackIndex).takeLane(laneIndex)),
+    type: "TakeLane",
+    properties: { name: "Lane", arrangement_clips: children(...clipIds) },
+  });
+}

--- a/src/tools/shared/clip-notes.ts
+++ b/src/tools/shared/clip-notes.ts
@@ -3,6 +3,8 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import { type NoteEvent } from "#src/notation/types.ts";
+
 /**
  * Get the note count within the playable region of a clip.
  * @param clip - LiveAPI clip object
@@ -15,4 +17,25 @@ export function getPlayableNoteCount(clip: LiveAPI): number {
   );
 
   return result?.notes?.length ?? 0;
+}
+
+/**
+ * Normalize raw notes from get_notes_extended into NoteEvents for add_new_notes.
+ * The Live API returns extra properties (note_id, mute, release_velocity) that
+ * must be stripped before re-adding, or stale note_ids get re-fed on repeated
+ * writes (e.g. copying one source to multiple positions).
+ * @param rawNotes - Note objects from get_notes_extended
+ * @returns NoteEvents safe to pass to add_new_notes
+ */
+export function rawNotesToNoteEvents(
+  rawNotes: Record<string, unknown>[],
+): NoteEvent[] {
+  return rawNotes.map((rawNote) => ({
+    pitch: rawNote.pitch as number,
+    start_time: rawNote.start_time as number,
+    duration: rawNote.duration as number,
+    velocity: rawNote.velocity as number,
+    probability: rawNote.probability as number,
+    velocity_deviation: rawNote.velocity_deviation as number,
+  }));
 }

--- a/src/tools/track/read/helpers/read-track-helpers.ts
+++ b/src/tools/track/read/helpers/read-track-helpers.ts
@@ -11,10 +11,17 @@ import {
 import { DEVICE_TYPE, STATE } from "#src/tools/constants.ts";
 import { getDeviceType } from "#src/tools/shared/device/device-reader.ts";
 import { computeState } from "#src/tools/shared/device/helpers/device-state-helpers.ts";
+import { stripFields } from "#src/tools/shared/utils.ts";
 import {
   processAvailableRouting,
   processCurrentRouting,
 } from "#src/tools/track/helpers/track-routing-helpers.ts";
+
+/** A non-main take lane with its name and arrangement clips */
+export interface ReadTakeLaneResult {
+  name: string;
+  clips: ReadClipResult[];
+}
 
 interface SendInfo {
   gainDb: unknown;
@@ -108,6 +115,34 @@ export function readArrangementClips(
  */
 export function countArrangementClips(track: LiveAPI): number {
   return track.getChildIds("arrangement_clips").length;
+}
+
+/**
+ * Read all non-main take lanes from a track. Take lanes are arrangement-only
+ * and the main lane is not included in the track's take_lanes collection.
+ * @param track - Track object
+ * @param include - Include array for nested clip reads
+ * @returns Array of take lanes, each with its name and arrangement clips
+ */
+export function readTakeLanes(
+  track: LiveAPI,
+  include?: string[],
+): ReadTakeLaneResult[] {
+  return track.getChildren("take_lanes").map((lane) => {
+    const clips = lane
+      .getChildIds("arrangement_clips")
+      .map((clipId) => readClip({ clipId, ...(include && { include }) }))
+      .filter((clip) => clip.id != null);
+
+    // Strip fields redundant with the parent track context (take lane clips are
+    // always arrangement clips on this track, matching its MIDI/audio type)
+    stripFields(clips, "trackIndex", "view", "type");
+
+    return {
+      name: lane.getProperty("name") as string,
+      clips,
+    };
+  });
 }
 
 /**

--- a/src/tools/track/read/read-track.def.ts
+++ b/src/tools/track/read/read-track.def.ts
@@ -51,7 +51,7 @@ export const toolDefReadTrack = defineTool("ppal-read-track", {
       )
       .default([])
       .describe(
-        'session-clips, arrangement-clips = clip lists. notes, timing, sample = clip detail (use with clips). devices, drum-map, routings, available-routings, mixer = track data. color = track + clip color. "*" = all',
+        'session-clips, arrangement-clips = clip lists (arrangement-clips also lists take lanes). notes, timing, sample = clip detail (use with clips). devices, drum-map, routings, available-routings, mixer = track data. color = track + clip color. "*" = all',
       ),
   },
 
@@ -59,7 +59,7 @@ export const toolDefReadTrack = defineTool("ppal-read-track", {
     excludeEnumValues: { include: ["available-routings", "*"] },
     descriptionOverrides: {
       include:
-        "session-clips, arrangement-clips = clip lists. notes, timing, sample = clip detail (use with clips). devices, drum-map, routings, mixer = track data. color = track + clip color",
+        "session-clips, arrangement-clips = clip lists (arrangement-clips also lists take lanes). notes, timing, sample = clip detail (use with clips). devices, drum-map, routings, mixer = track data. color = track + clip color",
     },
   },
 });

--- a/src/tools/track/read/read-track.ts
+++ b/src/tools/track/read/read-track.ts
@@ -32,6 +32,8 @@ import {
   readArrangementClips,
   readMixerProperties,
   readSessionClips,
+  readTakeLanes,
+  type ReadTakeLaneResult,
 } from "./helpers/read-track-helpers.ts";
 
 interface ReadTrackArgs {
@@ -58,6 +60,11 @@ interface SessionClipsResult {
 interface ArrangementClipsResult {
   arrangementClips?: ReadClipResult[];
   arrangementClipCount?: number;
+}
+
+interface TakeLanesResult {
+  takeLanes?: ReadTakeLaneResult[];
+  takeLaneCount?: number;
 }
 
 /**
@@ -176,6 +183,40 @@ function processArrangementClips(
 }
 
 /**
+ * Process non-main take lanes for a track. Returns the full take lane list
+ * (with clips) when arrangement clips are included, otherwise just a count.
+ * The field is omitted entirely when the track has no take lanes.
+ * @param track - Track object
+ * @param isGroup - Whether the track is a group
+ * @param category - Track category (regular, return, or master)
+ * @param includeArrangementClips - Whether to include full take lane clip details
+ * @param include - Include array for nested reads
+ * @returns Object with takeLanes array, takeLaneCount, or empty
+ */
+function processTakeLanes(
+  track: LiveAPI,
+  isGroup: boolean,
+  category: string,
+  includeArrangementClips: boolean,
+  include: string[] | undefined,
+): TakeLanesResult {
+  // Take lanes are arrangement-only and only exist on non-group regular tracks
+  if (isGroup || category !== "regular") {
+    return {};
+  }
+
+  const count = track.getChildIds("take_lanes").length;
+
+  if (count === 0) {
+    return {};
+  }
+
+  return includeArrangementClips
+    ? { takeLanes: readTakeLanes(track, include) }
+    : { takeLaneCount: count };
+}
+
+/**
  * Add drum map to result from categorized device structure
  * @param result - Result object to add drum map to
  * @param categorizedDevices - Categorized device structure with chains for drum detection
@@ -283,6 +324,18 @@ export function readTrackGeneric({
   Object.assign(
     result,
     processArrangementClips(
+      track,
+      isGroup,
+      category,
+      includeArrangementClips,
+      include,
+    ),
+  );
+
+  // Take lanes (non-main arrangement lanes used for comping/variations)
+  Object.assign(
+    result,
+    processTakeLanes(
       track,
       isGroup,
       category,

--- a/src/tools/track/read/tests/read-track-take-lanes.test.ts
+++ b/src/tools/track/read/tests/read-track-take-lanes.test.ts
@@ -1,0 +1,164 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { livePath, type PathLike } from "#src/shared/live-api-path-builders.ts";
+import { children } from "#src/test/mocks/mock-live-api.ts";
+import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
+import { readTrack } from "../read-track.ts";
+
+interface TakeLane {
+  name: string;
+  clips: Array<Record<string, unknown>>;
+}
+
+/**
+ * Register a MIDI track (index 2) with a main arrangement clip and two
+ * non-main take lanes ("Take A" with one clip, "Take B" with two clips).
+ * @param trackOverrides - Extra track property overrides
+ */
+function registerTrackWithTakeLanes(
+  trackOverrides: Record<string, unknown> = {},
+): void {
+  registerMockObject("track3", {
+    path: livePath.track(2),
+    type: "Track",
+    properties: {
+      has_midi_input: 1,
+      name: "Track with Take Lanes",
+      clip_slots: [],
+      arrangement_clips: children("main_clip"),
+      take_lanes: children("lane1", "lane2"),
+      devices: [],
+      ...trackOverrides,
+    },
+  });
+  registerArrangementClip("main_clip", livePath.track(2).arrangementClip(0));
+  registerMockObject("lane1", {
+    path: String(livePath.track(2).takeLane(0)),
+    type: "TakeLane",
+    properties: { name: "Take A", arrangement_clips: children("clip_a") },
+  });
+  registerMockObject("lane2", {
+    path: String(livePath.track(2).takeLane(1)),
+    type: "TakeLane",
+    properties: {
+      name: "Take B",
+      arrangement_clips: children("clip_b1", "clip_b2"),
+    },
+  });
+  registerArrangementClip("clip_a", livePath.track(2).takeLane(0).arrangementClip(0)); // prettier-ignore
+  registerArrangementClip("clip_b1", livePath.track(2).takeLane(1).arrangementClip(0)); // prettier-ignore
+  registerArrangementClip("clip_b2", livePath.track(2).takeLane(1).arrangementClip(1)); // prettier-ignore
+}
+
+/**
+ * Register a minimal MIDI arrangement clip mock.
+ * @param id - Mock object ID
+ * @param path - Canonical Live API path for the clip
+ */
+function registerArrangementClip(id: string, path: PathLike) {
+  registerMockObject(id, {
+    path: String(path),
+    type: "Clip",
+    properties: { is_arrangement_clip: 1, is_midi_clip: 1, name: id },
+  });
+}
+
+describe("readTrack take lanes", () => {
+  it("returns takeLaneCount in overview when arrangement-clips not included", () => {
+    registerTrackWithTakeLanes();
+
+    const result = readTrack({ trackIndex: 2 });
+
+    expect(result.takeLaneCount).toBe(2);
+    expect(result).not.toHaveProperty("takeLanes");
+  });
+
+  it("returns the full takeLanes list when arrangement-clips is included", () => {
+    registerTrackWithTakeLanes();
+
+    const result = readTrack({ trackIndex: 2, include: ["arrangement-clips"] });
+
+    expect(result).not.toHaveProperty("takeLaneCount");
+
+    const takeLanes = result.takeLanes as TakeLane[];
+
+    expect(takeLanes).toHaveLength(2);
+    expect(takeLanes[0]!.name).toBe("Take A");
+    expect(takeLanes[0]!.clips.map((c) => c.id)).toStrictEqual(["clip_a"]);
+    expect(takeLanes[1]!.name).toBe("Take B");
+    expect(takeLanes[1]!.clips.map((c) => c.id)).toStrictEqual([
+      "clip_b1",
+      "clip_b2",
+    ]);
+  });
+
+  it("strips fields redundant with the parent track from take lane clips", () => {
+    registerTrackWithTakeLanes();
+
+    const result = readTrack({ trackIndex: 2, include: ["arrangement-clips"] });
+    const clip = (result.takeLanes as TakeLane[])[0]!.clips[0]!;
+
+    expect(clip.id).toBe("clip_a");
+    expect(clip).not.toHaveProperty("view");
+    expect(clip).not.toHaveProperty("type");
+    expect(clip).not.toHaveProperty("trackIndex");
+  });
+
+  it("omits the field entirely when the track has no take lanes", () => {
+    registerMockObject("track3", {
+      path: livePath.track(2),
+      type: "Track",
+      properties: {
+        has_midi_input: 1,
+        name: "No Take Lanes",
+        clip_slots: [],
+        arrangement_clips: [],
+        devices: [],
+      },
+    });
+
+    const overview = readTrack({ trackIndex: 2 });
+
+    expect(overview).not.toHaveProperty("takeLaneCount");
+    expect(overview).not.toHaveProperty("takeLanes");
+
+    const detailed = readTrack({
+      trackIndex: 2,
+      include: ["arrangement-clips"],
+    });
+
+    expect(detailed).not.toHaveProperty("takeLanes");
+  });
+
+  it("omits take lanes for group tracks", () => {
+    registerTrackWithTakeLanes({ is_foldable: 1 });
+
+    const result = readTrack({ trackIndex: 2 });
+
+    expect(result.isGroup).toBe(true);
+    expect(result).not.toHaveProperty("takeLaneCount");
+    expect(result).not.toHaveProperty("takeLanes");
+  });
+
+  it("omits take lanes for return tracks", () => {
+    registerMockObject("return1", {
+      path: livePath.returnTrack(0),
+      type: "Track",
+      properties: {
+        has_midi_input: 0,
+        name: "Return A",
+        take_lanes: children("lane1", "lane2"),
+        devices: [],
+      },
+    });
+
+    const result = readTrack({ trackType: "return", trackIndex: 0 });
+
+    expect(result).not.toHaveProperty("takeLaneCount");
+    expect(result).not.toHaveProperty("takeLanes");
+  });
+});

--- a/src/types/live-api.d.ts
+++ b/src/types/live-api.d.ts
@@ -116,6 +116,9 @@ declare global {
     /** Extract clip slot index from path */
     readonly clipSlotIndex: number | null;
 
+    /** Extract take lane index from path (0-based), or null if not on a take lane */
+    readonly takeLaneIndex: number | null;
+
     /** Extract device index from path (last device in nested racks) */
     readonly deviceIndex: number | null;
 


### PR DESCRIPTION
Implements take lane support across the read and write tools (the v1.4.10 take lane feature set).

## Read side
- `ppal-read-track`: adds a `takeLanes` field (with the `arrangement-clips` include) listing each non-main lane as `{name, clips}`; `takeLaneCount` in the overview otherwise.
- `ppal-read-live-set`: surfaces `takeLaneCount` per track.

## Write side
- `ppal-create-clip` and `ppal-duplicate` gain `takeLane` + `takeLaneName`:
  - `0`/omitted = main lane (unchanged), `1+` = that lane (auto-created up to it), `"new"` = append a fresh lane for a variation.
  - `takeLaneName` applies only to a lane the call creates (no surprise renames).
  - Arrangement-only (warns for session); 8-lane cap; errors cleanly when a clip already exists at the target position on the lane.
- create-clip routes both MIDI and audio creation to the resolved lane.
- duplicate re-creates MIDI clips on the lane (copying notes + loop/marker props), since take lanes have no `duplicate_clip_to_arrangement`. Audio sources warn and skip (MIDI-only for v1).
- `ppal-delete` warns and skips take-lane clips — Live exposes no way to delete them or their lanes via the API.

## Variation workflow
A few `ppal-duplicate` calls with `takeLane: "new"` + `transforms` stack auditionable variations at the same arrangement position. Comping stays in Live's UI.

## Notes / API constraints (verified against Live 12)
- No `delete_take_lane`; `Track.delete_clip` does not remove take-lane clips — take lanes are append-only from Producer Pal.
- No active-take read and no comp-to-main API.
- No auto-expand-on-select API; tool responses hint the user to expand the take-lane arrow.

Skills and the docs site are updated. Full `npm run check` and `npm run check:build` pass (functions 100%, branches 95.7%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)