### PR TITLE
Add Google Gemini Live as a second voice provider

### DIFF
--- a/docs/guide/chat-ui.md
+++ b/docs/guide/chat-ui.md
@@ -135,7 +135,7 @@ key:
 To enter voice mode, open [Settings](#settings), set the **Provider**, and
 select that provider's voice model. The chat composer is replaced by the voice
 controls described below. See [Voice settings](#voice) for the voice, volume,
-and (OpenAI only) speed and turn-detection options.
+turn-detection, and (OpenAI only) speed options.
 
 > Voice works in Chrome and other Chromium browsers like Edge (Edge is untested
 > but likely fine). Firefox can't drive OpenAI's voice transport, but the Google
@@ -266,30 +266,35 @@ Each slider has a **Reset** link to restore its default. Changes apply on the
 next session (Stop, then Talk) — except **Volume**, which takes effect
 immediately.
 
-On **Google (Gemini)**, only **Volume** appears — speed, turn detection, and the
-barge-in toggle are OpenAI only. (Gemini interrupts automatically when you start
-speaking, so it has no barge-in setting.)
+Both providers offer volume, turn detection, and barge-in. The turn-detection
+controls differ because each provider exposes its own voice-activity-detection
+(VAD) knobs. **Speed** is OpenAI only (the Gemini Live API has no playback-speed
+setting).
 
 - **Volume** - Output loudness of the assistant's voice (0–100%, default 100%).
   Adjustable live during a session, so you can balance the assistant against the
   music coming from Ableton without touching Live's mixer.
 - **Speed** _(OpenAI only)_ - Playback speed of the assistant's voice
   (0.5×–1.5×, default 1.0×).
-- **Turn detection** _(OpenAI only)_ - How the model decides you've finished
-  speaking — voice activity detection, or "VAD":
-  - **Server VAD (volume-based)** - Detects the end of your turn from audio
-    volume. Adds two tuning sliders:
-    - **Threshold** - Activation volume (0–1). Higher values ignore quieter
-      input.
-    - **Pause** - How long (in milliseconds) to wait after you stop speaking
-      before ending your turn.
-  - **Semantic VAD (model-based)** - The model decides when you've finished a
-    thought. Adds one setting:
-    - **Eagerness** - How quickly it responds: Auto, Low (waits longer), Medium,
-      or High (responds sooner).
-- **Enable barge-in** _(OpenAI only)_ - When on, speaking interrupts the
-  assistant while it's still talking. Off by default. Use headphones — without
-  them, the assistant's own voice can trigger interruptions.
+- **Turn detection** - How the model decides you've finished speaking — voice
+  activity detection, or "VAD". The controls differ by provider:
+  - **OpenAI** picks a VAD mode:
+    - **Server VAD (volume-based)** - Detects the end of your turn from audio
+      volume. Adds **Threshold** (activation volume, 0–1; higher ignores quieter
+      input) and **Pause** (how long to wait after you stop speaking).
+    - **Semantic VAD (model-based)** - The model decides when you've finished a
+      thought. Adds **Eagerness** (Auto, Low, Medium, or High).
+  - **Google (Gemini)** exposes sensitivity and timing directly:
+    - **Start-of-speech / End-of-speech sensitivity** - High (detects more
+      readily) or Low.
+    - **Silence** - How long (ms) to wait after you stop speaking before ending
+      your turn.
+    - **Prefix padding** - How much audio (ms) to keep before detected speech
+      onset.
+- **Enable barge-in** - When on, speaking interrupts the assistant while it's
+  still talking. **Off by default for OpenAI, on by default for Gemini.** Use
+  headphones — without them, the assistant's own voice can trigger
+  interruptions.
 
 ### Tools
 

--- a/docs/guide/chat-ui.md
+++ b/docs/guide/chat-ui.md
@@ -125,17 +125,21 @@ overrides it for individual messages.
 
 ## Voice Mode
 
-Producer Pal includes an experimental hands-free voice mode that uses OpenAI's
-realtime model to talk with the AI out loud. It is **OpenAI only** (for now) and
-**requires an OpenAI API key**.
+Producer Pal includes an experimental hands-free voice mode for talking with the
+AI out loud. It's available on two providers, each requiring that provider's API
+key:
 
-To enter voice mode, open [Settings](#settings), set the **Provider** to
-**OpenAI**, and select the **GPT Realtime 2 (Voice)** model. The chat composer
-is replaced by the voice controls described below. See [Voice settings](#voice)
-for the voice, volume, speed, and turn-detection options.
+- **OpenAI** — the **GPT Realtime 2 (Voice)** model
+- **Google** — the **Gemini 3.1 Flash Live (Voice)** model
 
-> Voice currently works in Chrome (other Chromium browsers like Edge are likely
-> fine but untested). Firefox is not supported.
+To enter voice mode, open [Settings](#settings), set the **Provider**, and
+select that provider's voice model. The chat composer is replaced by the voice
+controls described below. See [Voice settings](#voice) for the voice, volume,
+and (OpenAI only) speed and turn-detection options.
+
+> Voice works in Chrome and other Chromium browsers like Edge (Edge is untested
+> but likely fine). Firefox can't drive OpenAI's voice transport, but the Google
+> (Gemini) voice model works in Firefox.
 
 <img src="/img/producer-pal-chat-voice-mode.png" alt="Voice mode" width="500"/>
 
@@ -241,17 +245,19 @@ You may need to change the URL if:
 ### Voice
 
 Producer Pal includes an experimental voice mode for spoken conversations with
-the AI. Voice mode is **OpenAI only** (for now) and **requires an OpenAI API
-key**. To use it, set the **Provider** to **OpenAI** and select the **GPT
-Realtime 2 (Voice)** model on the [Connection](#connection) tab — the **Voice**
-dropdown and a collapsible **Voice Settings** section then appear.
+the AI, available on **OpenAI** and **Google (Gemini)**. To use it, set the
+**Provider** and select that provider's voice model on the
+[Connection](#connection) tab — **GPT Realtime 2 (Voice)** for OpenAI or
+**Gemini 3.1 Flash Live (Voice)** for Google. The **Voice** dropdown and a
+collapsible **Voice Settings** section then appear.
 
 <img src="/img/producer-pal-chat-settings-voice.png" alt="Voice settings" width="500"/>
 
-- **Voice** - The spoken voice the assistant uses (Marin, Cedar, Alloy, and
-  more). Marin and Cedar are recommended for the best audio quality. The voice
-  locks once a session starts talking, so changing it applies on the next
-  session (Stop, then Talk).
+- **Voice** - The spoken voice the assistant uses; the choices depend on the
+  provider. OpenAI offers Marin, Cedar, Alloy, and more (Marin and Cedar are
+  recommended for the best audio quality); Google offers Puck, Charon, Kore, and
+  more. The voice locks once a session starts talking, so changing it applies on
+  the next session (Stop, then Talk).
 
 #### Voice Settings
 
@@ -260,12 +266,17 @@ Each slider has a **Reset** link to restore its default. Changes apply on the
 next session (Stop, then Talk) — except **Volume**, which takes effect
 immediately.
 
+On **Google (Gemini)**, only **Volume** appears — speed, turn detection, and the
+barge-in toggle are OpenAI only. (Gemini interrupts automatically when you start
+speaking, so it has no barge-in setting.)
+
 - **Volume** - Output loudness of the assistant's voice (0–100%, default 100%).
   Adjustable live during a session, so you can balance the assistant against the
   music coming from Ableton without touching Live's mixer.
-- **Speed** - Playback speed of the assistant's voice (0.5×–1.5×, default 1.0×).
-- **Turn detection** - How the model decides you've finished speaking — voice
-  activity detection, or "VAD":
+- **Speed** _(OpenAI only)_ - Playback speed of the assistant's voice
+  (0.5×–1.5×, default 1.0×).
+- **Turn detection** _(OpenAI only)_ - How the model decides you've finished
+  speaking — voice activity detection, or "VAD":
   - **Server VAD (volume-based)** - Detects the end of your turn from audio
     volume. Adds two tuning sliders:
     - **Threshold** - Activation volume (0–1). Higher values ignore quieter
@@ -276,9 +287,9 @@ immediately.
     thought. Adds one setting:
     - **Eagerness** - How quickly it responds: Auto, Low (waits longer), Medium,
       or High (responds sooner).
-- **Enable barge-in** - When on, speaking interrupts the assistant while it's
-  still talking. Off by default. Use headphones — without them, the assistant's
-  own voice can trigger interruptions.
+- **Enable barge-in** _(OpenAI only)_ - When on, speaking interrupts the
+  assistant while it's still talking. Off by default. Use headphones — without
+  them, the assistant's own voice can trigger interruptions.
 
 ### Tools
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@codemirror/language": "6.12.3",
         "@codemirror/state": "6.6.0",
         "@codemirror/view": "6.42.1",
+        "@google/genai": "2.6.0",
         "@lezer/highlight": "1.2.3",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@openai/agents": "0.11.4",
@@ -1693,6 +1694,30 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.6.0.tgz",
+      "integrity": "sha512-HjoW3mPuEn7pnuKABJl9VbDoWDSF4nbwYKYvYYor7YjPeDxrrBxHzu2d1Prcd+BAuC4w+85UP6y7ZdcrQAoO7g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -2584,6 +2609,69 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.16",
@@ -4136,6 +4224,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
     "node_modules/@types/sarif": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
@@ -5211,6 +5305,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ai": {
       "version": "6.0.184",
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.184.tgz",
@@ -5513,6 +5616,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
@@ -5524,6 +5647,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -5653,6 +5785,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -6323,6 +6461,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6599,6 +6746,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -7468,6 +7624,12 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -7585,6 +7747,29 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fflate": {
@@ -7732,6 +7917,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -7826,6 +8023,34 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/gensync": {
@@ -8021,6 +8246,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -8270,6 +8521,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -9018,6 +9282,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -9095,6 +9368,27 @@
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -9425,6 +9719,12 @@
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -9852,6 +10152,44 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-forge": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
@@ -10160,6 +10498,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -10520,6 +10871,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -10964,6 +11339,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -11178,6 +11562,26 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
@@ -13046,6 +13450,15 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@codemirror/language": "6.12.3",
     "@codemirror/state": "6.6.0",
     "@codemirror/view": "6.42.1",
+    "@google/genai": "2.6.0",
     "@lezer/highlight": "1.2.3",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@openai/agents": "0.11.4",

--- a/src/mcp-server/create-express-app.ts
+++ b/src/mcp-server/create-express-app.ts
@@ -19,6 +19,7 @@ import { TOOL_NAMES, createMcpServer } from "./create-mcp-server.ts";
 import { isLocalOrigin } from "./helpers/request-origin.ts";
 import { callLiveApi } from "./max-api-adapter.ts";
 import * as console from "./node-for-max-logger.ts";
+import { registerGeminiVoiceTokenRoute } from "./routes/gemini-voice-token-route.ts";
 import { registerRestApiRoutes } from "./routes/rest-api-routes.ts";
 import { registerVoiceTokenRoute } from "./routes/voice-token-route.ts";
 
@@ -287,6 +288,7 @@ export function createExpressApp(): Express {
   registerRestApiRoutes(app, () => config, callLiveApi);
 
   registerVoiceTokenRoute(app, () => chatUIEnabled);
+  registerGeminiVoiceTokenRoute(app, () => chatUIEnabled);
 
   return app;
 }

--- a/src/mcp-server/routes/gemini-voice-token-route.ts
+++ b/src/mcp-server/routes/gemini-voice-token-route.ts
@@ -1,0 +1,62 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type Express, type Request, type Response } from "express";
+import { isLocalOrigin } from "../helpers/request-origin.ts";
+
+const GEMINI_KEY_HEADER = "x-gemini-key";
+
+/**
+ * Register POST /gemini-voice-token, the Gemini counterpart to /voice-token.
+ *
+ * Producer Pal runs on localhost against the user's own Gemini key, which the
+ * browser already holds (it uses it for text chat). For the Gemini Live path the
+ * browser opens the WebSocket to Google directly (client-to-server, which Google
+ * recommends as faster for audio), so the key would reach Google from the
+ * browser regardless. This route therefore returns the key as-is
+ * (`ephemeral: false`) — it exists to (a) apply the same chatUIEnabled + local-
+ * origin gating as the rest of the chat surface and (b) keep one seam the client
+ * already calls, so swapping in ephemeral tokens later is a server-only change.
+ *
+ * Hardening upgrade (when wanted): mint a short-lived token via the v1alpha
+ * `auth_tokens` endpoint and return `{ value: token.name, ephemeral: true }`;
+ * the client already honors the `ephemeral` flag (connects on v1alpha). The
+ * long-lived key is never logged here in either case.
+ *
+ * @param app - Express application
+ * @param isChatUIEnabled - Returns whether the chat UI is currently enabled
+ */
+export function registerGeminiVoiceTokenRoute(
+  app: Express,
+  isChatUIEnabled: () => boolean,
+): void {
+  app.post("/gemini-voice-token", (req: Request, res: Response): void => {
+    if (!isChatUIEnabled()) {
+      res.status(403).json({ error: "Chat UI is disabled" });
+
+      return;
+    }
+
+    const origin = req.get("Origin");
+
+    if (origin && !isLocalOrigin(origin)) {
+      res
+        .status(403)
+        .json({ error: "cross-origin /gemini-voice-token is not allowed" });
+
+      return;
+    }
+
+    const apiKey = req.get(GEMINI_KEY_HEADER);
+
+    if (!apiKey) {
+      res.status(400).json({ error: `Missing ${GEMINI_KEY_HEADER} header` });
+
+      return;
+    }
+
+    res.json({ value: apiKey, ephemeral: false });
+  });
+}

--- a/src/mcp-server/routes/tests/gemini-voice-token-route.test.ts
+++ b/src/mcp-server/routes/tests/gemini-voice-token-route.test.ts
@@ -1,0 +1,91 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  mockMax,
+  setupExpressAppServer,
+} from "../../tests/express-app-test-helpers.ts";
+import {
+  type PostTokenOptions,
+  postTokenRequest,
+} from "./voice-token-test-helpers.ts";
+
+const REAL_FETCH = globalThis.fetch;
+
+/**
+ * POST to /gemini-voice-token with Gemini defaults.
+ *
+ * @param baseUrl - Base URL of the test Express server
+ * @param opts - Key/body/origin overrides
+ * @returns The fetch Response
+ */
+async function postGeminiToken(
+  baseUrl: string,
+  opts: Pick<PostTokenOptions, "key" | "body" | "origin"> = {},
+): Promise<Response> {
+  return await postTokenRequest(baseUrl, {
+    path: "/gemini-voice-token",
+    keyHeader: "X-Gemini-Key",
+    defaultKey: "gem-test",
+    ...opts,
+  });
+}
+
+describe("gemini-voice-token route", () => {
+  const appState = setupExpressAppServer();
+
+  beforeEach(() => {
+    globalThis.fetch = REAL_FETCH;
+  });
+
+  it("returns 400 when X-Gemini-Key header is missing", async () => {
+    const res = await postGeminiToken(appState.baseUrl, { key: null });
+
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+
+    expect(json.error.toLowerCase()).toContain("x-gemini-key");
+  });
+
+  it("returns 403 when the chat UI is disabled", async () => {
+    const setChatUIEnabled = mockMax.handlers.get("chatUIEnabled") as (
+      input: unknown,
+    ) => void;
+
+    setChatUIEnabled(0);
+
+    try {
+      const res = await postGeminiToken(appState.baseUrl);
+
+      expect(res.status).toBe(403);
+      const json = (await res.json()) as { error: string };
+
+      expect(json.error).toBe("Chat UI is disabled");
+    } finally {
+      setChatUIEnabled(1);
+    }
+  });
+
+  it("blocks cross-origin requests with 403", async () => {
+    const res = await postGeminiToken(appState.baseUrl, {
+      origin: "https://evil.example.com",
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the key as a non-ephemeral credential (localhost passthrough)", async () => {
+    const res = await postGeminiToken(appState.baseUrl, {
+      key: "gem-secret-key",
+      body: { model: "gemini-3.1-flash-live-preview" },
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+
+    expect(json).toStrictEqual({ value: "gem-secret-key", ephemeral: false });
+  });
+});

--- a/src/mcp-server/routes/tests/voice-token-route.test.ts
+++ b/src/mcp-server/routes/tests/voice-token-route.test.ts
@@ -8,6 +8,10 @@ import {
   mockMax,
   setupExpressAppServer,
 } from "../../tests/express-app-test-helpers.ts";
+import {
+  type PostTokenOptions,
+  postTokenRequest,
+} from "./voice-token-test-helpers.ts";
 
 const REAL_FETCH = globalThis.fetch;
 
@@ -72,33 +76,22 @@ function jsonResponse(status: number, body: unknown): Response {
 }
 
 /**
- * Issue a POST to the local /voice-token endpoint with sane defaults so each
+ * Issue a POST to the local /voice-token endpoint with OpenAI defaults so each
  * test only needs to specify the bits it cares about.
  *
  * @param baseUrl - Base URL of the test Express server
- * @param opts - Optional overrides
- * @param opts.key - OpenAI API key header value; `null` to omit the header
- * @param opts.body - Request body (object stringified, string passed through)
- * @param opts.origin - Optional Origin header for cross-origin testing
+ * @param opts - Key/body/origin overrides
  * @returns The fetch Response
  */
 async function postVoiceToken(
   baseUrl: string,
-  opts: { key?: string | null; body?: unknown; origin?: string } = {},
+  opts: Pick<PostTokenOptions, "key" | "body" | "origin"> = {},
 ): Promise<Response> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-
-  if (opts.key !== null) headers["X-OpenAI-Key"] = opts.key ?? "sk-test";
-  if (opts.origin) headers.Origin = opts.origin;
-  const body =
-    typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body ?? {});
-
-  return await fetch(`${baseUrl}/voice-token`, {
-    method: "POST",
-    headers,
-    body,
+  return await postTokenRequest(baseUrl, {
+    path: "/voice-token",
+    keyHeader: "X-OpenAI-Key",
+    defaultKey: "sk-test",
+    ...opts,
   });
 }
 

--- a/src/mcp-server/routes/tests/voice-token-test-helpers.ts
+++ b/src/mcp-server/routes/tests/voice-token-test-helpers.ts
@@ -1,0 +1,49 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** Options for posting to a voice-token endpoint in tests. */
+export interface PostTokenOptions {
+  /** Endpoint path, e.g. "/voice-token" or "/gemini-voice-token". */
+  path: string;
+  /** API-key header name, e.g. "X-OpenAI-Key" or "X-Gemini-Key". */
+  keyHeader: string;
+  /** Default key value when `key` is omitted. */
+  defaultKey: string;
+  /** Key header value; `null` to omit the header entirely. */
+  key?: string | null;
+  /** Request body (object is stringified, string passed through). */
+  body?: unknown;
+  /** Optional Origin header for cross-origin testing. */
+  origin?: string;
+}
+
+/**
+ * Issue a POST to a voice-token endpoint with sane defaults. Shared by the
+ * OpenAI and Gemini token-route tests (same request shape, different endpoint +
+ * key header).
+ *
+ * @param baseUrl - Base URL of the test Express server
+ * @param opts - Endpoint, header, and request overrides
+ * @returns The fetch Response
+ */
+export async function postTokenRequest(
+  baseUrl: string,
+  opts: PostTokenOptions,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (opts.key !== null) headers[opts.keyHeader] = opts.key ?? opts.defaultKey;
+  if (opts.origin) headers.Origin = opts.origin;
+  const body =
+    typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body ?? {});
+
+  return await fetch(`${baseUrl}${opts.path}`, {
+    method: "POST",
+    headers,
+    body,
+  });
+}

--- a/webui/src/components/settings/connection-tab-helpers.tsx
+++ b/webui/src/components/settings/connection-tab-helpers.tsx
@@ -12,6 +12,7 @@ import {
   REALTIME_VOICES,
 } from "#webui/lib/constants/models";
 import { type Provider } from "#webui/types/settings";
+import { GeminiTurnDetectionControls } from "./controls/GeminiTurnDetectionControls";
 import { THINKING_LEVELS } from "./controls/thinking-levels";
 import { Tooltip } from "./controls/Tooltip";
 import { TurnDetectionControls } from "./controls/TurnDetectionControls";
@@ -163,9 +164,10 @@ interface VoiceSettingsProps {
 }
 
 /**
- * Voice-mode settings, shown only for the OpenAI realtime model. The voice
- * selector sits at the top level; speed and turn detection are tucked into a
- * collapsed "Voice Settings" disclosure. Returns null otherwise.
+ * Voice-mode settings, shown only for a realtime model selection (OpenAI or
+ * Gemini). The voice selector sits at the top level; volume and the provider's
+ * turn-detection controls are tucked into a collapsed "Voice Settings"
+ * disclosure. Returns null otherwise.
  * @param props - Component props
  * @param props.provider - Current provider
  * @param props.model - Current model id
@@ -194,8 +196,9 @@ export function VoiceSettings({
   activeVoice,
 }: VoiceSettingsProps) {
   if (!isRealtimeSelection(provider, model)) return null;
-  // Speed + turn-detection map to OpenAI Realtime config that Gemini Live has no
-  // equivalent for, so only the voice picker and (live) volume show for Gemini.
+  // Each provider gets its own turn-detection controls (the VAD configs don't
+  // map 1:1). Speed has no Gemini equivalent (the Live API has no speaking-rate
+  // field), so it stays OpenAI-only.
   const isGemini = provider === "gemini";
   const voices = isGemini ? GEMINI_REALTIME_VOICES : REALTIME_VOICES;
 
@@ -214,7 +217,12 @@ export function VoiceSettings({
         </summary>
         <div className="mt-3 space-y-3">
           <VoiceVolumeSlider volume={voiceVolume} setVolume={setVoiceVolume} />
-          {!isGemini && (
+          {isGemini ? (
+            <GeminiTurnDetectionControls
+              settings={turnDetection}
+              setSettings={setTurnDetection}
+            />
+          ) : (
             <>
               <VoiceSpeedSlider speed={voiceSpeed} setSpeed={setVoiceSpeed} />
               <TurnDetectionControls

--- a/webui/src/components/settings/connection-tab-helpers.tsx
+++ b/webui/src/components/settings/connection-tab-helpers.tsx
@@ -6,7 +6,11 @@
 import { DisclosureChevron } from "#webui/components/chat/controls/header/HeaderIcons";
 import { ThinkingStateIcon } from "#webui/components/chat/controls/ThinkingToggle";
 import { type TurnDetectionSettings } from "#webui/hooks/settings/turn-detection-helpers";
-import { isRealtimeSelection } from "#webui/lib/constants/models";
+import {
+  GEMINI_REALTIME_VOICES,
+  isRealtimeSelection,
+  REALTIME_VOICES,
+} from "#webui/lib/constants/models";
 import { type Provider } from "#webui/types/settings";
 import { THINKING_LEVELS } from "./controls/thinking-levels";
 import { Tooltip } from "./controls/Tooltip";
@@ -190,6 +194,10 @@ export function VoiceSettings({
   activeVoice,
 }: VoiceSettingsProps) {
   if (!isRealtimeSelection(provider, model)) return null;
+  // Speed + turn-detection map to OpenAI Realtime config that Gemini Live has no
+  // equivalent for, so only the voice picker and (live) volume show for Gemini.
+  const isGemini = provider === "gemini";
+  const voices = isGemini ? GEMINI_REALTIME_VOICES : REALTIME_VOICES;
 
   return (
     <>
@@ -197,6 +205,7 @@ export function VoiceSettings({
         voice={realtimeVoice}
         setVoice={setRealtimeVoice}
         activeVoice={activeVoice}
+        voices={voices}
       />
       <details className="disclosure open:rounded-lg open:border open:border-zinc-300 dark:open:border-zinc-700 open:bg-zinc-200 dark:open:bg-zinc-900 open:p-3">
         <summary className="text-sm cursor-pointer select-none flex items-center gap-1 list-none [&::-webkit-details-marker]:hidden">
@@ -205,11 +214,15 @@ export function VoiceSettings({
         </summary>
         <div className="mt-3 space-y-3">
           <VoiceVolumeSlider volume={voiceVolume} setVolume={setVoiceVolume} />
-          <VoiceSpeedSlider speed={voiceSpeed} setSpeed={setVoiceSpeed} />
-          <TurnDetectionControls
-            settings={turnDetection}
-            setSettings={setTurnDetection}
-          />
+          {!isGemini && (
+            <>
+              <VoiceSpeedSlider speed={voiceSpeed} setSpeed={setVoiceSpeed} />
+              <TurnDetectionControls
+                settings={turnDetection}
+                setSettings={setTurnDetection}
+              />
+            </>
+          )}
           <p className="text-xs text-zinc-500 dark:text-zinc-400">
             Applied on the next session (Stop, then Talk) — except Volume, which
             is live.

--- a/webui/src/components/settings/controls/GeminiTurnDetectionControls.tsx
+++ b/webui/src/components/settings/controls/GeminiTurnDetectionControls.tsx
@@ -1,0 +1,149 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { Tooltip } from "#webui/components/settings/controls/Tooltip";
+import { LabeledSlider } from "#webui/components/settings/controls/TurnDetectionControls";
+import {
+  DEFAULT_GEMINI_VAD,
+  GEMINI_VAD_PREFIX_MAX,
+  GEMINI_VAD_PREFIX_MIN,
+  GEMINI_VAD_SILENCE_MAX,
+  GEMINI_VAD_SILENCE_MIN,
+  type GeminiVadSettings,
+  type SpeechSensitivity,
+  type TurnDetectionSettings,
+} from "#webui/hooks/settings/turn-detection-helpers";
+
+const SELECT_CLASS =
+  "w-full px-3 py-2 bg-white dark:bg-zinc-700 border border-zinc-300 dark:border-zinc-600 rounded";
+
+const SENSITIVITY_OPTIONS: { value: SpeechSensitivity; label: string }[] = [
+  { value: "low", label: "Low (less sensitive)" },
+  { value: "high", label: "High (more sensitive)" },
+];
+
+export interface GeminiTurnDetectionControlsProps {
+  settings: TurnDetectionSettings;
+  setSettings: (settings: TurnDetectionSettings) => void;
+}
+
+/**
+ * Gemini Live VAD controls: start/end-of-speech sensitivity, silence window,
+ * prefix padding, and the barge-in toggle. Edits the nested `gemini` block of
+ * the shared turn-detection settings. Rendered inside the parent "Voice
+ * Settings" disclosure for the Gemini provider; mid-session edits apply on the
+ * next Stop → Talk.
+ *
+ * @param props - Component props
+ * @param props.settings - Current in-modal turn-detection settings
+ * @param props.setSettings - Setter for the in-modal settings object
+ * @returns Gemini turn-detection controls element
+ */
+export function GeminiTurnDetectionControls({
+  settings,
+  setSettings,
+}: GeminiTurnDetectionControlsProps) {
+  const vad = settings.gemini;
+  const update = (partial: Partial<GeminiVadSettings>) =>
+    setSettings({ ...settings, gemini: { ...vad, ...partial } });
+
+  return (
+    <>
+      <SensitivitySelect
+        id="gemini-start-sensitivity"
+        label="Start-of-speech sensitivity"
+        value={vad.startSensitivity}
+        onChange={(startSensitivity) => update({ startSensitivity })}
+      />
+      <SensitivitySelect
+        id="gemini-end-sensitivity"
+        label="End-of-speech sensitivity"
+        value={vad.endSensitivity}
+        onChange={(endSensitivity) => update({ endSensitivity })}
+      />
+      <LabeledSlider
+        label={`Silence (${vad.silenceDurationMs} ms)`}
+        value={vad.silenceDurationMs}
+        defaultValue={DEFAULT_GEMINI_VAD.silenceDurationMs}
+        min={GEMINI_VAD_SILENCE_MIN}
+        max={GEMINI_VAD_SILENCE_MAX}
+        step={50}
+        testId="gemini-silence"
+        onChange={(silenceDurationMs) => update({ silenceDurationMs })}
+      />
+      <LabeledSlider
+        label={`Prefix padding (${vad.prefixPaddingMs} ms)`}
+        value={vad.prefixPaddingMs}
+        defaultValue={DEFAULT_GEMINI_VAD.prefixPaddingMs}
+        min={GEMINI_VAD_PREFIX_MIN}
+        max={GEMINI_VAD_PREFIX_MAX}
+        step={10}
+        testId="gemini-prefix"
+        onChange={(prefixPaddingMs) => update({ prefixPaddingMs })}
+      />
+      <label className="flex items-center gap-2 text-sm cursor-pointer">
+        <input
+          type="checkbox"
+          id="gemini-barge-in"
+          checked={vad.interruptResponse}
+          onChange={(e) =>
+            update({
+              interruptResponse: (e.target as HTMLInputElement).checked,
+            })
+          }
+          data-testid="gemini-barge-in"
+        />
+        Enable barge-in
+        <Tooltip text="Speak to interrupt Producer Pal while it's talking. On by default for Gemini. Use headphones — without them, the assistant's own voice can trigger interruptions." />
+      </label>
+    </>
+  );
+}
+
+interface SensitivitySelectProps {
+  id: string;
+  label: string;
+  value: SpeechSensitivity;
+  onChange: (value: SpeechSensitivity) => void;
+}
+
+/**
+ * A labeled High/Low sensitivity dropdown.
+ * @param props - Component props
+ * @param props.id - Element id + data-testid
+ * @param props.label - Visible label text
+ * @param props.value - Current sensitivity value
+ * @param props.onChange - Called with the selected sensitivity
+ * @returns Sensitivity selector element
+ */
+function SensitivitySelect({
+  id,
+  label,
+  value,
+  onChange,
+}: SensitivitySelectProps) {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm mb-2">
+        {label}
+      </label>
+      <select
+        id={id}
+        value={value}
+        onChange={(e) =>
+          onChange((e.target as HTMLSelectElement).value as SpeechSensitivity)
+        }
+        className={SELECT_CLASS}
+        data-testid={id}
+      >
+        {SENSITIVITY_OPTIONS.map(({ value: v, label: l }) => (
+          <option key={v} value={v}>
+            {l}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/webui/src/components/settings/controls/TurnDetectionControls.tsx
+++ b/webui/src/components/settings/controls/TurnDetectionControls.tsx
@@ -202,7 +202,7 @@ interface LabeledSliderProps {
  * @param props.onChange - Called with the parsed numeric value on input
  * @returns Labeled slider element
  */
-function LabeledSlider({
+export function LabeledSlider({
   label,
   value,
   defaultValue,

--- a/webui/src/components/settings/controls/VoiceSelector.tsx
+++ b/webui/src/components/settings/controls/VoiceSelector.tsx
@@ -12,6 +12,8 @@ export interface VoiceSelectorProps {
    * If set and different from `voice`, an inline notice explains that the
    * pending change applies on the next session. */
   activeVoice: string | null;
+  /** Provider-appropriate voice options. Defaults to the OpenAI voices. */
+  voices?: readonly { value: string; label: string }[];
 }
 
 /**
@@ -23,14 +25,21 @@ export interface VoiceSelectorProps {
  * @param props.voice - Currently selected voice id
  * @param props.setVoice - Setter for the in-modal voice value
  * @param props.activeVoice - Voice baked into the live session (or null when idle)
+ * @param props.voices - Provider-appropriate voice options (defaults to OpenAI)
  * @returns Voice selector element
  */
 export function VoiceSelector({
   voice,
   setVoice,
   activeVoice,
+  voices = REALTIME_VOICES,
 }: VoiceSelectorProps) {
-  const pendingChange = activeVoice != null && activeVoice !== voice;
+  // The saved voice can belong to the other provider (one shared field); show a
+  // valid option from this provider's list so the dropdown isn't blank/wrong.
+  const selected = voices.some((v) => v.value === voice)
+    ? voice
+    : (voices[0]?.value ?? voice);
+  const pendingChange = activeVoice != null && activeVoice !== selected;
 
   return (
     <div>
@@ -39,12 +48,12 @@ export function VoiceSelector({
       </label>
       <select
         id="voice-select"
-        value={voice}
+        value={selected}
         onChange={(e) => setVoice((e.target as HTMLSelectElement).value)}
         className="w-full px-3 py-2 bg-white dark:bg-zinc-700 border border-zinc-300 dark:border-zinc-600 rounded"
         data-testid="voice-select"
       >
-        {REALTIME_VOICES.map(({ value, label }) => (
+        {voices.map(({ value, label }) => (
           <option key={value} value={value}>
             {label}
           </option>

--- a/webui/src/components/settings/controls/tests/GeminiTurnDetectionControls.test.tsx
+++ b/webui/src/components/settings/controls/tests/GeminiTurnDetectionControls.test.tsx
@@ -1,0 +1,158 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @vitest-environment happy-dom
+ */
+import { fireEvent, render, screen } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+import { GeminiTurnDetectionControls } from "#webui/components/settings/controls/GeminiTurnDetectionControls";
+import {
+  DEFAULT_GEMINI_VAD,
+  DEFAULT_TURN_DETECTION,
+} from "#webui/hooks/settings/turn-detection-helpers";
+
+const settings = DEFAULT_TURN_DETECTION;
+
+describe("GeminiTurnDetectionControls", () => {
+  it("renders all four VAD controls plus the barge-in toggle", () => {
+    render(
+      <GeminiTurnDetectionControls settings={settings} setSettings={vi.fn()} />,
+    );
+
+    expect(screen.getByTestId("gemini-start-sensitivity")).toBeTruthy();
+    expect(screen.getByTestId("gemini-end-sensitivity")).toBeTruthy();
+    expect(screen.getByTestId("gemini-silence")).toBeTruthy();
+    expect(screen.getByTestId("gemini-prefix")).toBeTruthy();
+    expect(
+      screen.getByText(`Silence (${DEFAULT_GEMINI_VAD.silenceDurationMs} ms)`),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        `Prefix padding (${DEFAULT_GEMINI_VAD.prefixPaddingMs} ms)`,
+      ),
+    ).toBeTruthy();
+  });
+
+  it("reflects the barge-in default (on for Gemini)", () => {
+    render(
+      <GeminiTurnDetectionControls settings={settings} setSettings={vi.fn()} />,
+    );
+
+    const toggle = screen.getByTestId("gemini-barge-in") as HTMLInputElement;
+
+    expect(toggle.checked).toBe(true);
+  });
+
+  it("updates start-of-speech sensitivity", () => {
+    const setSettings = vi.fn();
+
+    render(
+      <GeminiTurnDetectionControls
+        settings={settings}
+        setSettings={setSettings}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("gemini-start-sensitivity"), {
+      target: { value: "high" },
+    });
+
+    expect(setSettings).toHaveBeenCalledWith({
+      ...settings,
+      gemini: { ...settings.gemini, startSensitivity: "high" },
+    });
+  });
+
+  it("updates end-of-speech sensitivity", () => {
+    const setSettings = vi.fn();
+
+    render(
+      <GeminiTurnDetectionControls
+        settings={settings}
+        setSettings={setSettings}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("gemini-end-sensitivity"), {
+      target: { value: "high" },
+    });
+
+    expect(setSettings).toHaveBeenCalledWith({
+      ...settings,
+      gemini: { ...settings.gemini, endSensitivity: "high" },
+    });
+  });
+
+  it("updates silence and prefix padding from the sliders", () => {
+    const setSettings = vi.fn();
+
+    render(
+      <GeminiTurnDetectionControls
+        settings={settings}
+        setSettings={setSettings}
+      />,
+    );
+
+    fireEvent.input(screen.getByTestId("gemini-silence"), {
+      target: { value: "1200" },
+    });
+    expect(setSettings).toHaveBeenCalledWith({
+      ...settings,
+      gemini: { ...settings.gemini, silenceDurationMs: 1200 },
+    });
+
+    fireEvent.input(screen.getByTestId("gemini-prefix"), {
+      target: { value: "150" },
+    });
+    expect(setSettings).toHaveBeenCalledWith({
+      ...settings,
+      gemini: { ...settings.gemini, prefixPaddingMs: 150 },
+    });
+  });
+
+  it("toggles barge-in off", () => {
+    const setSettings = vi.fn();
+
+    render(
+      <GeminiTurnDetectionControls
+        settings={settings}
+        setSettings={setSettings}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("gemini-barge-in"));
+
+    expect(setSettings).toHaveBeenCalledWith({
+      ...settings,
+      gemini: { ...settings.gemini, interruptResponse: false },
+    });
+  });
+
+  it("resets silence to its default via the Reset link", () => {
+    const setSettings = vi.fn();
+    const tuned = {
+      ...settings,
+      gemini: { ...settings.gemini, silenceDurationMs: 1500 },
+    };
+
+    render(
+      <GeminiTurnDetectionControls
+        settings={tuned}
+        setSettings={setSettings}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("gemini-silence-reset"));
+
+    expect(setSettings).toHaveBeenCalledWith({
+      ...tuned,
+      gemini: {
+        ...tuned.gemini,
+        silenceDurationMs: DEFAULT_GEMINI_VAD.silenceDurationMs,
+      },
+    });
+  });
+});

--- a/webui/src/components/settings/controls/tests/TurnDetectionControls.test.tsx
+++ b/webui/src/components/settings/controls/tests/TurnDetectionControls.test.tsx
@@ -15,6 +15,7 @@ import {
 } from "#webui/hooks/settings/turn-detection-helpers";
 
 const serverVad: TurnDetectionSettings = {
+  ...DEFAULT_TURN_DETECTION,
   mode: "server_vad",
   threshold: 0.5,
   silenceDurationMs: 200,

--- a/webui/src/components/settings/controls/tests/VoiceSelector.test.tsx
+++ b/webui/src/components/settings/controls/tests/VoiceSelector.test.tsx
@@ -9,6 +9,7 @@
 import { render, screen, fireEvent } from "@testing-library/preact";
 import { describe, expect, it, vi } from "vitest";
 import { VoiceSelector } from "#webui/components/settings/controls/VoiceSelector";
+import { GEMINI_REALTIME_VOICES } from "#webui/lib/constants/models";
 
 describe("VoiceSelector", () => {
   it("renders the saved voice and all options", () => {
@@ -61,5 +62,39 @@ describe("VoiceSelector", () => {
     const notice = screen.getByText(/applies on the next session/i);
 
     expect(notice.textContent).toContain('Active session is using "marin"');
+  });
+
+  it("renders the Gemini voice list when given the Gemini voices", () => {
+    render(
+      <VoiceSelector
+        voice="Puck"
+        setVoice={vi.fn()}
+        activeVoice={null}
+        voices={GEMINI_REALTIME_VOICES}
+      />,
+    );
+
+    const select = screen.getByTestId("voice-select") as HTMLSelectElement;
+
+    expect(select.value).toBe("Puck");
+    expect(screen.getByRole("option", { name: "Charon" })).toBeTruthy();
+    expect(screen.queryByRole("option", { name: /Marin/ })).toBeNull();
+  });
+
+  it("falls back to the first option when the saved voice isn't in the list", () => {
+    // A stale OpenAI voice ("marin") under the Gemini list shows the first Gemini
+    // voice instead of a blank/invalid selection.
+    render(
+      <VoiceSelector
+        voice="marin"
+        setVoice={vi.fn()}
+        activeVoice={null}
+        voices={GEMINI_REALTIME_VOICES}
+      />,
+    );
+
+    const select = screen.getByTestId("voice-select") as HTMLSelectElement;
+
+    expect(select.value).toBe(GEMINI_REALTIME_VOICES[0].value);
   });
 });

--- a/webui/src/components/settings/controls/tests/VoiceSelector.test.tsx
+++ b/webui/src/components/settings/controls/tests/VoiceSelector.test.tsx
@@ -77,7 +77,7 @@ describe("VoiceSelector", () => {
     const select = screen.getByTestId("voice-select") as HTMLSelectElement;
 
     expect(select.value).toBe("Puck");
-    expect(screen.getByRole("option", { name: "Charon" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: /Charon/ })).toBeTruthy();
     expect(screen.queryByRole("option", { name: /Marin/ })).toBeNull();
   });
 

--- a/webui/src/components/settings/tests/connection-tab-helpers.test.tsx
+++ b/webui/src/components/settings/tests/connection-tab-helpers.test.tsx
@@ -14,7 +14,10 @@ import {
   VoiceSettings,
 } from "#webui/components/settings/connection-tab-helpers";
 import { DEFAULT_TURN_DETECTION } from "#webui/hooks/settings/turn-detection-helpers";
-import { OPENAI_REALTIME_MODEL } from "#webui/lib/constants/models";
+import {
+  GEMINI_REALTIME_MODEL,
+  OPENAI_REALTIME_MODEL,
+} from "#webui/lib/constants/models";
 
 describe("ThinkingSelector", () => {
   it("calls setThinking when a new option is selected", () => {
@@ -121,5 +124,21 @@ describe("VoiceSettings", () => {
     expect(
       screen.getByTestId("turn-detection-mode").closest("details"),
     ).not.toBeNull();
+  });
+
+  it("shows Gemini VAD controls, not OpenAI speed/turn detection, for a Gemini realtime model", () => {
+    render(
+      <VoiceSettings
+        {...realtimeProps}
+        provider="gemini"
+        model={GEMINI_REALTIME_MODEL}
+        realtimeVoice="Puck"
+      />,
+    );
+
+    expect(screen.getByTestId("gemini-start-sensitivity")).toBeTruthy();
+    expect(screen.getByTestId("gemini-barge-in")).toBeTruthy();
+    expect(screen.queryByTestId("voice-speed-slider")).toBeNull();
+    expect(screen.queryByTestId("turn-detection-mode")).toBeNull();
   });
 });

--- a/webui/src/components/tests/App-test-helpers.ts
+++ b/webui/src/components/tests/App-test-helpers.ts
@@ -8,6 +8,7 @@ import { useChat } from "#webui/hooks/chat/use-chat";
 import { useConversations } from "#webui/hooks/chat/use-conversations";
 import { useMcpConnection } from "#webui/hooks/connection/use-mcp-connection";
 import { useRemoteConfig } from "#webui/hooks/connection/use-remote-config";
+import { DEFAULT_TURN_DETECTION } from "#webui/hooks/settings/turn-detection-helpers";
 import { useSettings } from "#webui/hooks/settings/use-settings";
 import { useTheme } from "#webui/hooks/theme/use-theme";
 import { useViewState } from "#webui/hooks/view-state/use-view-state";
@@ -59,6 +60,8 @@ export const mockSettingsHook = {
   liveApiEnabledDirty: false,
   setLiveApiEnabled: vi.fn(),
   seedLiveApiEnabled: vi.fn(),
+
+  savedTurnDetection: DEFAULT_TURN_DETECTION,
 };
 
 /**

--- a/webui/src/components/voice/VoiceApp.test.tsx
+++ b/webui/src/components/voice/VoiceApp.test.tsx
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   getMcpUrl: vi.fn(),
   useVoiceSession: vi.fn(),
+  useGeminiVoiceSession: vi.fn(),
   isFirefox: vi.fn(),
   useUpdateCheck: vi.fn(),
   useVoicePersistence: vi.fn(),
@@ -31,6 +32,10 @@ vi.mock(import("#webui/hooks/voice/use-voice-session"), () => ({
   useVoiceSession: mocks.useVoiceSession,
 }));
 
+vi.mock(import("#webui/hooks/voice/gemini/use-gemini-voice-session"), () => ({
+  useGeminiVoiceSession: mocks.useGeminiVoiceSession,
+}));
+
 vi.mock(import("#webui/hooks/use-update-check"), () => ({
   useUpdateCheck: mocks.useUpdateCheck,
 }));
@@ -44,6 +49,7 @@ vi.mock(import("#webui/hooks/chat/use-conversation-transfer"), () => ({
 }));
 
 import { type ModeContext } from "#webui/components/mode-context";
+import { GEMINI_REALTIME_MODEL } from "#webui/lib/constants/models";
 import { createTestSummary } from "#webui/test-utils/conversation-test-helpers";
 import {
   basePersistence,
@@ -105,6 +111,7 @@ beforeEach(() => {
   mocks.isFirefox.mockReturnValue(false);
   mocks.useUpdateCheck.mockReturnValue(null);
   mocks.useVoiceSession.mockReturnValue(baseSession());
+  mocks.useGeminiVoiceSession.mockReturnValue(baseSession());
   mocks.useVoicePersistence.mockReturnValue(basePersistence());
   mocks.useConversationTransfer.mockReturnValue({
     notification: null,
@@ -118,6 +125,7 @@ beforeEach(() => {
 afterEach(() => {
   mocks.getMcpUrl.mockReset();
   mocks.useVoiceSession.mockReset();
+  mocks.useGeminiVoiceSession.mockReset();
   mocks.isFirefox.mockReset();
   mocks.useUpdateCheck.mockReset();
   mocks.useVoicePersistence.mockReset();
@@ -141,6 +149,28 @@ describe("VoiceApp", () => {
     renderVoiceApp({ provider: "anthropic", apiKey: "sk-ant" });
 
     expect(screen.getByText(/openai api key required/i)).toBeDefined();
+  });
+
+  it("shows a Gemini-key-required banner for a Gemini realtime selection with no key", () => {
+    renderVoiceApp({
+      provider: "gemini",
+      apiKey: "",
+      model: GEMINI_REALTIME_MODEL,
+    });
+
+    expect(screen.getByText(/gemini api key required/i)).toBeDefined();
+    expect(screen.queryByText(/openai api key required/i)).toBeNull();
+  });
+
+  it("hides the banner for a Gemini selection with a key and a Gemini voice", () => {
+    renderVoiceApp({
+      provider: "gemini",
+      apiKey: "gem-key",
+      model: GEMINI_REALTIME_MODEL,
+      savedRealtimeVoice: "Puck",
+    });
+
+    expect(screen.queryByText(/api key required/i)).toBeNull();
   });
 
   it("renders the Talk button when idle and clicking it calls connect()", () => {

--- a/webui/src/components/voice/VoiceApp.tsx
+++ b/webui/src/components/voice/VoiceApp.tsx
@@ -59,8 +59,10 @@ export function VoiceApp(props: VoiceAppProps) {
     persistence,
     transfer,
     messages,
-    openAiKey,
-    firefoxDetected,
+    voiceKey,
+    voiceProviderName,
+    isUnsupportedBrowser,
+    activeVoiceId,
     historyPanelOpen,
     setHistoryPanelOpen,
     isConnected,
@@ -70,7 +72,9 @@ export function VoiceApp(props: VoiceAppProps) {
     headerInfo,
   } = useVoiceModeState(props);
 
-  const savedVoice = props.settings.savedRealtimeVoice;
+  // The validated voice the active backend will use (provider-aware), not the
+  // raw shared saved field — so the controls' pending-change notice is accurate.
+  const savedVoice = activeVoiceId;
 
   const conversationPanel = buildConversationPanel({
     isOpen: historyPanelOpen,
@@ -95,8 +99,9 @@ export function VoiceApp(props: VoiceAppProps) {
       <VoiceTranscript
         messages={messages}
         assistantThinking={voice.assistantThinking}
-        firefoxDetected={firefoxDetected}
-        hasOpenAiKey={openAiKey != null}
+        isUnsupportedBrowser={isUnsupportedBrowser}
+        hasVoiceKey={voiceKey != null}
+        providerName={voiceProviderName}
       />
 
       {voice.error && (
@@ -116,10 +121,10 @@ export function VoiceApp(props: VoiceAppProps) {
 
       <VoiceControls
         voice={voice}
-        openAiKey={openAiKey}
+        voiceKey={voiceKey}
         isBusy={isBusy}
         isConnected={isConnected}
-        isUnsupportedBrowser={firefoxDetected}
+        isUnsupportedBrowser={isUnsupportedBrowser}
         onToggleConnection={onToggleConnection}
         savedVoice={savedVoice}
         thinking={props.settings.thinking}

--- a/webui/src/components/voice/VoiceControls.tsx
+++ b/webui/src/components/voice/VoiceControls.tsx
@@ -10,7 +10,8 @@ type VoiceSessionState = ReturnType<typeof useVoiceSession>;
 
 interface VoiceControlsProps {
   voice: VoiceSessionState;
-  openAiKey: string | null;
+  /** Active provider's API key (OpenAI or Gemini); null disables Talk. */
+  voiceKey: string | null;
   isBusy: boolean;
   isConnected: boolean;
   isUnsupportedBrowser: boolean;
@@ -28,11 +29,12 @@ interface VoiceControlsProps {
  * is a contextual inline button next to the primary action when connected.
  *
  * @param props - component props
- * @param props.voice - The useVoiceSession hook return value
- * @param props.openAiKey - User's OpenAI API key (controls disabled state)
+ * @param props.voice - The voice session hook return value (OpenAI or Gemini)
+ * @param props.voiceKey - Active provider's API key (controls disabled state)
  * @param props.isBusy - True during connecting/disconnecting transitions
  * @param props.isConnected - True when the realtime session is live
- * @param props.isUnsupportedBrowser - True when the browser is known broken (Firefox)
+ * @param props.isUnsupportedBrowser - True when the browser can't drive the
+ *   active backend (Firefox + OpenAI WebRTC)
  * @param props.onToggleConnection - Toggle connect/disconnect
  * @param props.savedVoice - User's saved realtime voice preference (post-save)
  * @param props.thinking - Current thinking level
@@ -41,7 +43,7 @@ interface VoiceControlsProps {
  */
 export function VoiceControls({
   voice,
-  openAiKey,
+  voiceKey,
   isBusy,
   isConnected,
   isUnsupportedBrowser,
@@ -100,7 +102,7 @@ export function VoiceControls({
             <button
               type="button"
               onClick={onToggleConnection}
-              disabled={isBusy || !openAiKey || isUnsupportedBrowser}
+              disabled={isBusy || !voiceKey || isUnsupportedBrowser}
               className={`px-6 py-2 rounded-lg text-base font-semibold transition-colors shadow disabled:opacity-40 disabled:cursor-not-allowed ${
                 isConnected
                   ? "bg-red-600 hover:bg-red-700 text-white"

--- a/webui/src/components/voice/VoiceTranscript.tsx
+++ b/webui/src/components/voice/VoiceTranscript.tsx
@@ -9,8 +9,10 @@ import { type UIMessage } from "#webui/types/messages";
 interface VoiceTranscriptProps {
   messages: UIMessage[];
   assistantThinking: boolean;
-  firefoxDetected: boolean;
-  hasOpenAiKey: boolean;
+  isUnsupportedBrowser: boolean;
+  hasVoiceKey: boolean;
+  /** Active voice provider name ("OpenAI" | "Gemini") for the key-required copy. */
+  providerName: string;
 }
 
 // Voice transcripts are read-only — the user can't edit past turns or retry
@@ -27,35 +29,40 @@ const noopAsync = async (): Promise<void> => undefined;
  * @param props - component props
  * @param props.messages - Voice transcript rendered as chat UIMessages
  * @param props.assistantThinking - True between response.created and response.done
- * @param props.firefoxDetected - True when the browser is Firefox (unsupported)
- * @param props.hasOpenAiKey - True when an OpenAI API key is configured
+ * @param props.isUnsupportedBrowser - True when the browser can't drive the
+ *   active backend (Firefox + OpenAI WebRTC; Gemini works in Firefox)
+ * @param props.hasVoiceKey - True when the active provider's API key is set
+ * @param props.providerName - Active voice provider name for the key copy
  * @returns Transcript section
  */
 export function VoiceTranscript({
   messages,
   assistantThinking,
-  firefoxDetected,
-  hasOpenAiKey,
+  isUnsupportedBrowser,
+  hasVoiceKey,
+  providerName,
 }: VoiceTranscriptProps) {
   return (
     <div className="flex-1 overflow-y-auto px-4 py-4 sm:px-6 flex flex-col gap-4">
-      {firefoxDetected && (
+      {isUnsupportedBrowser && (
         <div className="rounded-md border border-red-300 bg-red-50 dark:bg-red-950/30 dark:border-red-700 p-4 text-sm">
           <p className="font-medium mb-1">
-            Firefox is not supported for voice.
+            Firefox is not supported for this voice provider.
           </p>
           <p>
-            Voice currently works in Chrome (other Chromium browsers like Edge
-            are likely fine but untested). Please open this page in Chrome.
+            OpenAI voice currently works in Chrome (other Chromium browsers like
+            Edge are likely fine but untested). Please open this page in Chrome,
+            or use the Gemini voice provider, which works in Firefox.
           </p>
         </div>
       )}
 
-      {!hasOpenAiKey && (
+      {!hasVoiceKey && (
         <div className="rounded-md border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 p-4 text-sm">
-          <p className="font-medium mb-1">OpenAI API key required.</p>
+          <p className="font-medium mb-1">{providerName} API key required.</p>
           <p>
-            Open Settings, select the OpenAI provider, and paste your API key.
+            Open Settings, select the {providerName} provider, and paste your
+            API key.
           </p>
         </div>
       )}

--- a/webui/src/components/voice/voice-app-test-helpers.ts
+++ b/webui/src/components/voice/voice-app-test-helpers.ts
@@ -11,9 +11,11 @@ import { type UseSettingsReturn } from "#webui/types/settings";
 
 export interface PropOverrides {
   apiKey?: string;
-  provider?: "openai" | "anthropic";
+  provider?: "openai" | "anthropic" | "gemini";
   onOpenSettings?: () => void;
   savedRealtimeVoice?: string;
+  /** Override the saved/active model (defaults to the OpenAI realtime model). */
+  model?: string;
 }
 
 /**
@@ -27,14 +29,15 @@ export interface PropOverrides {
 export function makeProps(o: PropOverrides = {}): VoiceAppProps {
   const apiKey = o.apiKey ?? "sk-test";
   const provider = o.provider ?? "openai";
+  const model = o.model ?? "gpt-realtime-2";
 
   return {
     settings: {
       provider,
       savedProvider: provider,
       apiKey,
-      model: "gpt-realtime-2",
-      savedModel: "gpt-realtime-2",
+      model,
+      savedModel: model,
       enabledTools: {},
       savedRealtimeVoice: o.savedRealtimeVoice ?? "marin",
     } as unknown as UseSettingsReturn,

--- a/webui/src/components/voice/voice-app-test-helpers.ts
+++ b/webui/src/components/voice/voice-app-test-helpers.ts
@@ -6,6 +6,7 @@
 import { type RealtimeItem } from "@openai/agents/realtime";
 import { vi } from "vitest";
 import { type VoiceAppProps } from "#webui/components/voice/VoiceApp";
+import { DEFAULT_TURN_DETECTION } from "#webui/hooks/settings/turn-detection-helpers";
 import { type ConversationSummary } from "#webui/lib/conversation-db";
 import { type UseSettingsReturn } from "#webui/types/settings";
 
@@ -40,6 +41,7 @@ export function makeProps(o: PropOverrides = {}): VoiceAppProps {
       savedModel: model,
       enabledTools: {},
       savedRealtimeVoice: o.savedRealtimeVoice ?? "marin",
+      savedTurnDetection: DEFAULT_TURN_DETECTION,
     } as unknown as UseSettingsReturn,
     display: {
       showTimestamps: false,

--- a/webui/src/hooks/settings/settings-helpers.ts
+++ b/webui/src/hooks/settings/settings-helpers.ts
@@ -8,6 +8,7 @@ import { decryptApiKey, encryptApiKey } from "#webui/lib/api-key-crypto";
 import {
   DEFAULT_MODELS,
   DEFAULT_REALTIME_VOICE,
+  isValidGeminiRealtimeVoice,
   isValidRealtimeVoice,
 } from "#webui/lib/constants/models";
 import { type Provider } from "#webui/types/settings";
@@ -30,13 +31,20 @@ export const VOICE_VOLUME_DEFAULT = 1.0;
 
 /**
  * Loads the saved realtime voice from localStorage, falling back to the
- * default voice when missing or invalid.
+ * default voice when missing or invalid. Accepts either an OpenAI or a Gemini
+ * voice id (the two providers share this one field); the consuming hook
+ * re-validates per active provider, so storing the other provider's voice here
+ * is harmless and lets a chosen Gemini voice survive a reload.
  * @returns A known realtime voice id
  */
 export function loadRealtimeVoice(): string {
   const stored = localStorage.getItem(REALTIME_VOICE_KEY);
 
-  if (stored && isValidRealtimeVoice(stored)) return stored;
+  if (
+    stored &&
+    (isValidRealtimeVoice(stored) || isValidGeminiRealtimeVoice(stored))
+  )
+    return stored;
 
   return DEFAULT_REALTIME_VOICE;
 }

--- a/webui/src/hooks/settings/tests/config-builders.test.ts
+++ b/webui/src/hooks/settings/tests/config-builders.test.ts
@@ -12,11 +12,15 @@ import {
   mapThinkingToRealtimeEffort,
   mapTurnDetectionToConfig,
 } from "#webui/hooks/settings/config-builders";
-import { type TurnDetectionSettings } from "#webui/hooks/settings/turn-detection-helpers";
+import {
+  DEFAULT_TURN_DETECTION,
+  type TurnDetectionSettings,
+} from "#webui/hooks/settings/turn-detection-helpers";
 
 describe("config-builders", () => {
   describe("mapTurnDetectionToConfig", () => {
     const base: TurnDetectionSettings = {
+      ...DEFAULT_TURN_DETECTION,
       mode: "server_vad",
       threshold: 0.6,
       silenceDurationMs: 300,

--- a/webui/src/hooks/settings/tests/turn-detection-helpers.test.ts
+++ b/webui/src/hooks/settings/tests/turn-detection-helpers.test.ts
@@ -8,7 +8,11 @@
  */
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  DEFAULT_GEMINI_VAD,
   DEFAULT_TURN_DETECTION,
+  GEMINI_VAD_PREFIX_MAX,
+  GEMINI_VAD_SILENCE_MAX,
+  GEMINI_VAD_SILENCE_MIN,
   loadTurnDetection,
   saveTurnDetection,
   TURN_DETECTION_SILENCE_MAX,
@@ -32,6 +36,7 @@ describe("turn-detection-helpers", () => {
 
     it("round-trips a valid settings object", () => {
       const settings: TurnDetectionSettings = {
+        ...DEFAULT_TURN_DETECTION,
         mode: "semantic_vad",
         threshold: 0.7,
         silenceDurationMs: 400,
@@ -104,6 +109,77 @@ describe("turn-detection-helpers", () => {
       expect(loaded.silenceDurationMs).toBe(
         DEFAULT_TURN_DETECTION.silenceDurationMs,
       );
+    });
+  });
+
+  describe("Gemini VAD", () => {
+    it("defaults the gemini block when absent", () => {
+      expect(loadTurnDetection().gemini).toStrictEqual(DEFAULT_GEMINI_VAD);
+    });
+
+    it("round-trips a valid gemini block", () => {
+      const gemini = {
+        startSensitivity: "high" as const,
+        endSensitivity: "high" as const,
+        silenceDurationMs: 500,
+        prefixPaddingMs: 100,
+        interruptResponse: false,
+      };
+
+      saveTurnDetection({ ...DEFAULT_TURN_DETECTION, gemini });
+      expect(loadTurnDetection().gemini).toStrictEqual(gemini);
+    });
+
+    it("falls back to defaults for unknown sensitivity values", () => {
+      localStorage.setItem(
+        KEY,
+        JSON.stringify({
+          gemini: { startSensitivity: "ludicrous", endSensitivity: 42 },
+        }),
+      );
+
+      const { gemini } = loadTurnDetection();
+
+      expect(gemini.startSensitivity).toBe(DEFAULT_GEMINI_VAD.startSensitivity);
+      expect(gemini.endSensitivity).toBe(DEFAULT_GEMINI_VAD.endSensitivity);
+    });
+
+    it("defaults gemini barge-in on, ignoring a non-boolean stored value", () => {
+      expect(loadTurnDetection().gemini.interruptResponse).toBe(true);
+
+      localStorage.setItem(
+        KEY,
+        JSON.stringify({ gemini: { interruptResponse: "nope" } }),
+      );
+      expect(loadTurnDetection().gemini.interruptResponse).toBe(true);
+    });
+
+    it("clamps gemini silence and prefix padding to their bounds", () => {
+      localStorage.setItem(
+        KEY,
+        JSON.stringify({
+          gemini: { silenceDurationMs: 99999, prefixPaddingMs: -5 },
+        }),
+      );
+
+      const { gemini } = loadTurnDetection();
+
+      expect(gemini.silenceDurationMs).toBe(GEMINI_VAD_SILENCE_MAX);
+      expect(gemini.prefixPaddingMs).toBe(0);
+    });
+
+    it("clamps a too-low gemini silence up to the min", () => {
+      localStorage.setItem(
+        KEY,
+        JSON.stringify({
+          gemini: { silenceDurationMs: -1, prefixPaddingMs: 99999 },
+        }),
+      );
+
+      const { gemini } = loadTurnDetection();
+
+      expect(gemini.silenceDurationMs).toBe(GEMINI_VAD_SILENCE_MIN);
+      expect(gemini.prefixPaddingMs).toBe(GEMINI_VAD_PREFIX_MAX);
     });
   });
 });

--- a/webui/src/hooks/settings/turn-detection-helpers.ts
+++ b/webui/src/hooks/settings/turn-detection-helpers.ts
@@ -12,6 +12,32 @@ export type TurnDetectionMode = "server_vad" | "semantic_vad";
 /** semantic_vad endpointing eagerness — higher responds sooner. */
 export type SemanticEagerness = "auto" | "low" | "medium" | "high";
 
+/** Start/end-of-speech detection sensitivity for Gemini's VAD. */
+export type SpeechSensitivity = "high" | "low";
+
+/**
+ * Gemini Live automatic-activity-detection (VAD) settings. Distinct from
+ * OpenAI's mode/threshold/eagerness model — Gemini exposes start/end-of-speech
+ * sensitivity plus padding/silence windows (maps to
+ * realtimeInputConfig.automaticActivityDetection), and barge-in via
+ * activityHandling. Nested under TurnDetectionSettings so it rides the same
+ * voice-settings plumbing without threading a second settings object.
+ */
+export interface GeminiVadSettings {
+  /** How readily the start of speech is detected. */
+  startSensitivity: SpeechSensitivity;
+  /** How readily the end of speech is detected. */
+  endSensitivity: SpeechSensitivity;
+  /** Silence (ms) after speech before the turn is considered over. */
+  silenceDurationMs: number;
+  /** Audio (ms) retained before detected speech onset. */
+  prefixPaddingMs: number;
+  /** Barge-in: when true, user speech interrupts the assistant's current
+   * response (activityHandling START_OF_ACTIVITY_INTERRUPTS); false maps to
+   * NO_INTERRUPTION. On by default — Gemini's native behavior. */
+  interruptResponse: boolean;
+}
+
 export interface TurnDetectionSettings {
   mode: TurnDetectionMode;
   /** server_vad: activation volume threshold (0–1). Higher ignores quieter input. */
@@ -24,12 +50,30 @@ export interface TurnDetectionSettings {
    * response (maps to turn_detection.interrupt_response). Off by default —
    * without headphones the assistant's own audio can self-interrupt. */
   interruptResponse: boolean;
+  /** Gemini-only VAD settings (ignored by the OpenAI path). */
+  gemini: GeminiVadSettings;
 }
 
 export const TURN_DETECTION_THRESHOLD_MIN = 0;
 export const TURN_DETECTION_THRESHOLD_MAX = 1;
 export const TURN_DETECTION_SILENCE_MIN = 100;
 export const TURN_DETECTION_SILENCE_MAX = 2000;
+
+export const GEMINI_VAD_SILENCE_MIN = 0;
+export const GEMINI_VAD_SILENCE_MAX = 2000;
+export const GEMINI_VAD_PREFIX_MIN = 0;
+export const GEMINI_VAD_PREFIX_MAX = 500;
+
+/** Gemini VAD defaults mirror the Live API's documented out-of-the-box values
+ * (~800 ms silence, ~20 ms prefix padding, low sensitivity); barge-in defaults
+ * on to match Gemini's native interrupt behavior. */
+export const DEFAULT_GEMINI_VAD: GeminiVadSettings = {
+  startSensitivity: "low",
+  endSensitivity: "low",
+  silenceDurationMs: 800,
+  prefixPaddingMs: 20,
+  interruptResponse: true,
+};
 
 /** Defaults mirror the OpenAI Realtime server_vad defaults so an untouched
  * config behaves exactly like the API's own out-of-the-box endpointing. */
@@ -39,6 +83,7 @@ export const DEFAULT_TURN_DETECTION: TurnDetectionSettings = {
   silenceDurationMs: 200,
   eagerness: "auto",
   interruptResponse: false,
+  gemini: DEFAULT_GEMINI_VAD,
 };
 
 const VALID_MODES = new Set<TurnDetectionMode>(["server_vad", "semantic_vad"]);
@@ -48,6 +93,7 @@ const VALID_EAGERNESS = new Set<SemanticEagerness>([
   "medium",
   "high",
 ]);
+const VALID_SENSITIVITY = new Set<SpeechSensitivity>(["high", "low"]);
 
 /**
  * Loads the saved turn-detection settings from localStorage, falling back to
@@ -110,6 +156,46 @@ function normalizeTurnDetection(
       DEFAULT_TURN_DETECTION.silenceDurationMs,
       TURN_DETECTION_SILENCE_MIN,
       TURN_DETECTION_SILENCE_MAX,
+    ),
+    gemini: normalizeGeminiVad(raw.gemini),
+  };
+}
+
+/**
+ * Coerces a possibly-partial/invalid Gemini VAD object into a valid one:
+ * unknown sensitivity values fall back to defaults; numbers are clamped.
+ * @param raw - Parsed (untrusted) Gemini VAD settings, possibly undefined
+ * @returns A normalized Gemini VAD settings object
+ */
+function normalizeGeminiVad(
+  raw: Partial<GeminiVadSettings> | undefined,
+): GeminiVadSettings {
+  const g = raw ?? {};
+
+  return {
+    startSensitivity: VALID_SENSITIVITY.has(
+      g.startSensitivity as SpeechSensitivity,
+    )
+      ? (g.startSensitivity as SpeechSensitivity)
+      : DEFAULT_GEMINI_VAD.startSensitivity,
+    endSensitivity: VALID_SENSITIVITY.has(g.endSensitivity as SpeechSensitivity)
+      ? (g.endSensitivity as SpeechSensitivity)
+      : DEFAULT_GEMINI_VAD.endSensitivity,
+    interruptResponse:
+      typeof g.interruptResponse === "boolean"
+        ? g.interruptResponse
+        : DEFAULT_GEMINI_VAD.interruptResponse,
+    silenceDurationMs: clampNumber(
+      g.silenceDurationMs,
+      DEFAULT_GEMINI_VAD.silenceDurationMs,
+      GEMINI_VAD_SILENCE_MIN,
+      GEMINI_VAD_SILENCE_MAX,
+    ),
+    prefixPaddingMs: clampNumber(
+      g.prefixPaddingMs,
+      DEFAULT_GEMINI_VAD.prefixPaddingMs,
+      GEMINI_VAD_PREFIX_MIN,
+      GEMINI_VAD_PREFIX_MAX,
     ),
   };
 }

--- a/webui/src/hooks/voice/gemini/gemini-mcp-tools.ts
+++ b/webui/src/hooks/voice/gemini/gemini-mcp-tools.ts
@@ -1,0 +1,81 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type FunctionDeclaration } from "@google/genai";
+import { type Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  createConnectedMcpClient,
+  filterEnabledTools,
+} from "#webui/chat/helpers/mcp-client-helpers";
+import { callMcpToolToString } from "#webui/hooks/voice/voice-mcp-call";
+
+/** Result of creating Gemini Live function declarations from MCP. */
+export interface GeminiMcpTools {
+  /** Declarations for the Live session config (config.tools). */
+  functionDeclarations: FunctionDeclaration[];
+  /** Run a tool the model called, by name, returning a string for the
+   * functionResponse output (errors come back as a prefixed string, never a
+   * throw — same recovery policy as the OpenAI bridge). */
+  executeTool: (name: string, args: Record<string, unknown>) => Promise<string>;
+  /** The underlying MCP client (caller closes it). */
+  mcpClient: Client;
+}
+
+/**
+ * Build Gemini Live function declarations from a Producer Pal MCP server. Unlike
+ * OpenAI's SDK (which wraps each tool with its own execute()), Gemini hands back
+ * a `toolCall` with the tool name and we dispatch it ourselves — so this returns
+ * the declarations plus one executeTool(name, args) dispatcher over the same MCP
+ * client the chat UI uses. MCP tool names (with dashes) are valid Gemini
+ * function names, so no name mangling is needed.
+ *
+ * @param mcpUrl - URL of the MCP server
+ * @param enabledTools - Optional map of tool names to enabled state
+ * @returns Function declarations, the dispatcher, and the MCP client
+ */
+export async function createGeminiMcpTools(
+  mcpUrl: string,
+  enabledTools?: Record<string, boolean>,
+): Promise<GeminiMcpTools> {
+  const mcpClient = await createConnectedMcpClient(mcpUrl);
+  const toolsResult = await mcpClient.listTools();
+  const filtered = filterEnabledTools(toolsResult.tools, enabledTools);
+
+  const functionDeclarations: FunctionDeclaration[] = filtered.map((t) => ({
+    name: t.name,
+    description: t.description ?? "",
+    parametersJsonSchema: normalizeGeminiSchema(t.inputSchema),
+  }));
+
+  const executeTool = (
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<string> => callMcpToolToString(mcpClient, name, args);
+
+  return { functionDeclarations, executeTool, mcpClient };
+}
+
+/**
+ * Coerce an MCP input schema into the JSON Schema object Gemini's
+ * parametersJsonSchema expects: an object schema with properties. Passes the
+ * MCP schema through (preserving enums, nested objects, descriptions) but drops
+ * `$schema` (a meta-key Gemini's validator doesn't need) and guarantees
+ * type/properties/required defaults for a bare schema.
+ *
+ * @param raw - The raw inputSchema from MCP listTools()
+ * @returns A JSON Schema object for parametersJsonSchema
+ */
+function normalizeGeminiSchema(raw: unknown): Record<string, unknown> {
+  const schema = { ...((raw ?? {}) as Record<string, unknown>) };
+
+  delete schema.$schema;
+
+  return {
+    type: "object",
+    properties: {},
+    required: [],
+    ...schema,
+  };
+}

--- a/webui/src/hooks/voice/gemini/gemini-mic-capture.ts
+++ b/webui/src/hooks/voice/gemini/gemini-mic-capture.ts
@@ -1,0 +1,159 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Gemini Live captures mic audio as raw 16-bit PCM, 16 kHz, mono, little-endian
+// (the format sendRealtimeInput expects). Unlike OpenAI's WebRTC transport —
+// which captured, encoded, and resampled the mic for us — the WebSocket path
+// makes us do it by hand. We create the AudioContext at 16 kHz so the browser
+// resamples the mic stream for us, then an AudioWorklet batches the Float32
+// quanta into ~100 ms Int16 chunks. (Proven in the throwaway spike, Chrome +
+// Firefox.)
+
+const INPUT_SAMPLE_RATE = 16000;
+
+// AudioWorklet processor source, inlined so it survives the single-file webui
+// build (viteSingleFile) — there is no separate asset URL to addModule() at
+// runtime, so we load it from a Blob URL built from this string. It batches the
+// 128-sample render quanta to ~100 ms and converts Float32 → Int16 LE before
+// transferring the buffer to the main thread.
+const MIC_WORKLET_SOURCE = `
+const TARGET_SAMPLES = 1600; // 100 ms at 16 kHz
+class PcmRecorderProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._buf = new Float32Array(TARGET_SAMPLES);
+    this._len = 0;
+  }
+  process(inputs) {
+    const channel = inputs[0] && inputs[0][0];
+    if (!channel) return true;
+    for (let i = 0; i < channel.length; i++) {
+      this._buf[this._len++] = channel[i];
+      if (this._len === TARGET_SAMPLES) this._flush();
+    }
+    return true;
+  }
+  _flush() {
+    const pcm = new Int16Array(this._len);
+    for (let i = 0; i < this._len; i++) {
+      const s = Math.max(-1, Math.min(1, this._buf[i]));
+      pcm[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+    }
+    this.port.postMessage(pcm.buffer, [pcm.buffer]);
+    this._len = 0;
+  }
+}
+registerProcessor("pcm-recorder", PcmRecorderProcessor);
+`;
+
+export interface GeminiMicCaptureOptions {
+  /** Called with each base64-encoded 16 kHz PCM chunk (~100 ms) while unmuted. */
+  onChunk: (base64Pcm: string) => void;
+}
+
+/**
+ * Owns the mic → 16 kHz PCM input path for a Gemini Live session: getUserMedia
+ * (with the browser's echo cancellation / noise suppression / AGC on), a 16 kHz
+ * AudioContext, and the batching AudioWorklet. Muting drops chunks at the source
+ * rather than stopping the track, so the half-duplex auto-mute and the user's
+ * manual mute both reduce to setMuted().
+ */
+export class GeminiMicCapture {
+  private stream: MediaStream | null = null;
+  private ctx: AudioContext | null = null;
+  private node: AudioWorkletNode | null = null;
+  private muted = false;
+
+  /**
+   * Open the mic and start streaming PCM chunks to options.onChunk.
+   * @param options - The chunk callback
+   * @returns The actual input sample rate the browser gave us
+   */
+  async start(
+    options: GeminiMicCaptureOptions,
+  ): Promise<{ sampleRate: number }> {
+    this.stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+        channelCount: 1,
+      },
+    });
+
+    this.ctx = new AudioContext({ sampleRate: INPUT_SAMPLE_RATE });
+
+    const blobUrl = URL.createObjectURL(
+      new Blob([MIC_WORKLET_SOURCE], { type: "application/javascript" }),
+    );
+
+    try {
+      await this.ctx.audioWorklet.addModule(blobUrl);
+    } finally {
+      URL.revokeObjectURL(blobUrl);
+    }
+
+    const source = this.ctx.createMediaStreamSource(this.stream);
+
+    this.node = new AudioWorkletNode(this.ctx, "pcm-recorder");
+
+    this.node.port.onmessage = (event: MessageEvent<ArrayBuffer>) => {
+      if (this.muted) return;
+      options.onChunk(arrayBufferToBase64(event.data));
+    };
+
+    // Worklet output is unused (we read it via the port); do not connect to
+    // destination or the mic would be audible to the user.
+    source.connect(this.node);
+
+    return { sampleRate: this.ctx.sampleRate };
+  }
+
+  /**
+   * Mute/unmute by dropping chunks at the source (the track stays open so
+   * unmute is instant and the AEC reference is uninterrupted).
+   * @param muted - Whether to stop sending mic audio
+   */
+  setMuted(muted: boolean): void {
+    this.muted = muted;
+  }
+
+  /** Stop the mic, close the worklet node and AudioContext. */
+  async stop(): Promise<void> {
+    if (this.node) {
+      this.node.port.onmessage = null;
+      this.node.disconnect();
+      this.node = null;
+    }
+
+    if (this.stream) {
+      for (const track of this.stream.getTracks()) track.stop();
+      this.stream = null;
+    }
+
+    if (this.ctx) {
+      await this.ctx.close().catch(() => {});
+      this.ctx = null;
+    }
+  }
+}
+
+/**
+ * Base64-encode a PCM ArrayBuffer in chunks (apply() argument-count safe) for
+ * sendRealtimeInput.
+ * @param buffer - Raw PCM bytes
+ * @returns Base64 string
+ */
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  const CHUNK = 0x8000;
+
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+
+  return btoa(binary);
+}

--- a/webui/src/hooks/voice/gemini/gemini-pcm-player.ts
+++ b/webui/src/hooks/voice/gemini/gemini-pcm-player.ts
@@ -1,0 +1,127 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Gemini Live returns output audio as raw 16-bit PCM, 24 kHz, mono,
+// little-endian, in base64 chunks. WebRTC played OpenAI's audio for us; here we
+// schedule it by hand. The key to smooth (non-choppy) playback is scheduling
+// each chunk against a running nextStartTime cursor — NOT "now" — so chunks butt
+// up against each other with no gaps. A small lead on the first chunk of a turn
+// absorbs network jitter. This is the fix the throwaway spike validated; the
+// earlier choppy attempt scheduled every chunk at "now".
+
+const OUTPUT_SAMPLE_RATE = 24000;
+const LEAD_SECONDS = 0.12; // jitter cushion before the first chunk of a turn
+
+/**
+ * Gapless playback scheduler for Gemini's 24 kHz PCM output, with a GainNode so
+ * volume can boost above unity (mirroring the OpenAI path's voice-audio-graph)
+ * and a flush() for barge-in.
+ */
+export class GeminiPcmPlayer {
+  private ctx: AudioContext | null = null;
+  private gain: GainNode | null = null;
+  private nextStartTime = 0;
+  private sources = new Set<AudioBufferSourceNode>();
+  private volume = 1;
+
+  /** Create/resume the output context (must follow a user gesture). */
+  async resume(): Promise<void> {
+    if (!this.ctx) {
+      this.ctx = new AudioContext({ sampleRate: OUTPUT_SAMPLE_RATE });
+      this.gain = this.ctx.createGain();
+      this.gain.gain.value = this.volume;
+      this.gain.connect(this.ctx.destination);
+    }
+
+    if (this.ctx.state === "suspended") await this.ctx.resume();
+  }
+
+  /**
+   * Set output volume. Unlike an <audio> element, a GainNode can exceed unity,
+   * so this honors the >1 boost range.
+   * @param value - Gain (0 = silent, 1 = unity, >1 = boost)
+   */
+  setVolume(value: number): void {
+    this.volume = value;
+
+    if (this.gain) this.gain.gain.value = value;
+  }
+
+  /**
+   * Decode and schedule one base64 PCM chunk immediately after whatever is
+   * already queued (gapless).
+   * @param base64Pcm - Base64-encoded 24 kHz Int16 PCM
+   */
+  enqueueBase64(base64Pcm: string): void {
+    if (!this.ctx || !this.gain) return;
+    const pcm = base64ToInt16(base64Pcm);
+
+    if (pcm.length === 0) return;
+
+    const buffer = this.ctx.createBuffer(1, pcm.length, OUTPUT_SAMPLE_RATE);
+    const channel = buffer.getChannelData(0);
+
+    for (let i = 0; i < pcm.length; i++) {
+      channel[i] = (pcm[i] as number) / 32768;
+    }
+
+    const source = this.ctx.createBufferSource();
+
+    source.buffer = buffer;
+    source.connect(this.gain);
+
+    const now = this.ctx.currentTime;
+    // Drained queue (cursor in the past) → restart from now + lead for a fresh
+    // jitter cushion; otherwise butt against the previous chunk's end.
+    const startAt = Math.max(now + LEAD_SECONDS, this.nextStartTime);
+
+    source.start(startAt);
+    this.nextStartTime = startAt + buffer.duration;
+    this.sources.add(source);
+    source.onended = () => this.sources.delete(source);
+  }
+
+  /** Barge-in: stop all scheduled audio and reset the cursor. */
+  flush(): void {
+    for (const source of this.sources) {
+      try {
+        source.onended = null;
+        source.stop();
+      } catch {
+        // already stopped/ended
+      }
+    }
+
+    this.sources.clear();
+    this.nextStartTime = 0;
+  }
+
+  /** Stop playback and close the output context. */
+  async close(): Promise<void> {
+    this.flush();
+
+    if (this.ctx) {
+      await this.ctx.close().catch(() => {});
+      this.ctx = null;
+      this.gain = null;
+    }
+  }
+}
+
+/**
+ * Decode base64 PCM into Int16 samples. Guards against an odd byte length (a
+ * truncated chunk) by dropping the trailing byte so the Int16Array view is valid.
+ * @param base64Pcm - Base64-encoded little-endian Int16 PCM
+ * @returns The samples
+ */
+function base64ToInt16(base64Pcm: string): Int16Array {
+  const binary = atob(base64Pcm);
+  const evenLength = binary.length - (binary.length % 2);
+  const bytes = new Uint8Array(evenLength);
+
+  for (let i = 0; i < evenLength; i++) bytes[i] = binary.charCodeAt(i);
+
+  return new Int16Array(bytes.buffer);
+}

--- a/webui/src/hooks/voice/gemini/gemini-realtime-items.ts
+++ b/webui/src/hooks/voice/gemini/gemini-realtime-items.ts
@@ -1,0 +1,158 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type RealtimeItem } from "@openai/agents/realtime";
+
+// Gemini Live streams the conversation as incremental transcript deltas
+// (input = user speech, output = model speech) plus separate tool calls — there
+// is no ready-made history object like the OpenAI SDK's RealtimeSession. This
+// builder accumulates those deltas into the SAME RealtimeItem[] shape the rest
+// of voice mode already consumes (persistence, realtimeItemsToUIMessages), so
+// the Gemini session reuses the OpenAI transcript UI and saved-record format
+// unchanged. toRealtimeItems() returns brand-new objects each call (no shared
+// mutable state) so Preact re-renders and autosave snapshots stay correct.
+
+type Turn =
+  | { kind: "user"; id: string; text: string }
+  | { kind: "assistant"; id: string; text: string; done: boolean }
+  | {
+      kind: "tool";
+      id: string;
+      name: string;
+      args: string;
+      output: string | null;
+    };
+
+/**
+ * Accumulates Gemini Live transcript deltas + tool calls into RealtimeItem[].
+ * One instance per session; the hook calls the mutators as messages arrive and
+ * publishes toRealtimeItems() to React state.
+ */
+export class GeminiHistoryBuilder {
+  private turns: Turn[] = [];
+
+  /**
+   * Append a user-speech transcript delta to the current (or a new) user turn.
+   * @param text - Transcript delta
+   */
+  addUserTranscript(text: string): void {
+    if (!text) return;
+    this.closeAssistant();
+    const last = this.turns.at(-1);
+
+    if (last?.kind === "user") {
+      last.text += text;
+
+      return;
+    }
+
+    this.turns.push({ kind: "user", id: newId(), text });
+  }
+
+  /**
+   * Append a model-speech transcript delta to the current (or a new) turn.
+   * @param text - Transcript delta
+   */
+  addAssistantTranscript(text: string): void {
+    if (!text) return;
+    const last = this.turns.at(-1);
+
+    if (last?.kind === "assistant" && !last.done) {
+      last.text += text;
+
+      return;
+    }
+
+    this.turns.push({ kind: "assistant", id: newId(), text, done: false });
+  }
+
+  /**
+   * Record a tool call. Closes any open assistant text turn so a follow-up
+   * narration renders as a distinct bubble part (text → tool → text), matching
+   * how a multi-step assistant turn already renders in chat.
+   *
+   * @param id - The Gemini functionCall id (matched on output)
+   * @param name - Tool name
+   * @param args - Tool arguments object
+   */
+  addToolCall(id: string, name: string, args: Record<string, unknown>): void {
+    this.closeAssistant();
+    this.turns.push({
+      kind: "tool",
+      id,
+      name,
+      args: JSON.stringify(args),
+      output: null,
+    });
+  }
+
+  /**
+   * Fill in a tool call's result once it returns.
+   *
+   * @param id - The functionCall id supplied to addToolCall
+   * @param output - The tool's string output
+   */
+  setToolOutput(id: string, output: string): void {
+    const turn = this.turns.find((t) => t.kind === "tool" && t.id === id);
+
+    if (turn?.kind === "tool") turn.output = output;
+  }
+
+  /** Mark the current assistant turn complete (Gemini turnComplete / barge-in). */
+  completeTurn(): void {
+    this.closeAssistant();
+  }
+
+  /**
+   * Snapshot the accumulated turns as fresh RealtimeItem objects.
+   * @returns The synthesized history items
+   */
+  toRealtimeItems(): RealtimeItem[] {
+    return this.turns.map((t): RealtimeItem => {
+      if (t.kind === "user") {
+        return {
+          itemId: t.id,
+          type: "message",
+          role: "user",
+          status: "completed",
+          content: [{ type: "input_audio", transcript: t.text }],
+        };
+      }
+
+      if (t.kind === "assistant") {
+        return {
+          itemId: t.id,
+          type: "message",
+          role: "assistant",
+          status: t.done ? "completed" : "in_progress",
+          content: [{ type: "output_audio", transcript: t.text }],
+        };
+      }
+
+      return {
+        itemId: t.id,
+        type: "function_call",
+        status: t.output == null ? "in_progress" : "completed",
+        name: t.name,
+        arguments: t.args,
+        output: t.output,
+      };
+    });
+  }
+
+  private closeAssistant(): void {
+    const last = this.turns.at(-1);
+
+    if (last?.kind === "assistant") last.done = true;
+  }
+}
+
+/**
+ * Unique, stable id for a synthesized history item (dedup keys on itemId).
+ * @returns A unique item id
+ */
+function newId(): string {
+  return `gem-${crypto.randomUUID()}`;
+}

--- a/webui/src/hooks/voice/gemini/gemini-voice-token.ts
+++ b/webui/src/hooks/voice/gemini/gemini-voice-token.ts
@@ -1,0 +1,77 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** What the browser needs to open a Live connection. */
+export interface GeminiVoiceCredential {
+  /** The apiKey to pass to GoogleGenAI — a raw key (passthrough) or, once the
+   * route mints them, an ephemeral token. */
+  value: string;
+  /** Ephemeral tokens are only valid on the v1alpha API; a raw key is not. The
+   * hook sets httpOptions.apiVersion accordingly. */
+  ephemeral: boolean;
+}
+
+/**
+ * Fetch a Gemini Live credential from the backend proxy. Mirrors the OpenAI
+ * /voice-token flow: the browser sends its own Gemini key in a header and the
+ * server returns what to connect with. The server currently passes the key back
+ * (a localhost convenience — the key already lives in this browser for text
+ * chat); when it grows ephemeral-token minting it returns `{ ephemeral: true }`
+ * and this code path doesn't change beyond honoring that flag.
+ *
+ * @param tokenUrl - URL of the /gemini-voice-token endpoint
+ * @param geminiKey - User's Gemini API key (sent in X-Gemini-Key)
+ * @param model - Realtime model id (lets the server scope an ephemeral token)
+ * @returns The credential to open the Live connection with
+ */
+export async function fetchGeminiToken(
+  tokenUrl: string,
+  geminiKey: string,
+  model: string,
+): Promise<GeminiVoiceCredential> {
+  const response = await fetch(tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Gemini-Key": geminiKey,
+    },
+    body: JSON.stringify({ model }),
+  });
+
+  if (!response.ok) {
+    const detail = await safeJson(response);
+
+    throw new Error(
+      `Gemini voice token request failed: ${response.status} ${response.statusText}${
+        detail ? ` — ${JSON.stringify(detail)}` : ""
+      }`,
+    );
+  }
+
+  const json = (await response.json()) as {
+    value?: string;
+    ephemeral?: boolean;
+  };
+
+  if (!json.value) {
+    throw new Error("Gemini voice token response missing 'value' field");
+  }
+
+  return { value: json.value, ephemeral: json.ephemeral === true };
+}
+
+/**
+ * Best-effort JSON read; returns null on failure.
+ *
+ * @param response - Fetch response
+ * @returns Parsed JSON or null
+ */
+async function safeJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}

--- a/webui/src/hooks/voice/gemini/tests/gemini-mcp-tools.test.ts
+++ b/webui/src/hooks/voice/gemini/tests/gemini-mcp-tools.test.ts
@@ -1,0 +1,170 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  callToolMock,
+  fakeMcpClient,
+  listToolsMock,
+  mcpClientHelpersMock,
+  resetMcpClientMocks,
+} from "#webui/hooks/voice/gemini/tests/mcp-bridge-test-helpers";
+
+vi.mock(import("#webui/chat/helpers/mcp-client-helpers"), () =>
+  mcpClientHelpersMock(),
+);
+
+import { createGeminiMcpTools } from "#webui/hooks/voice/gemini/gemini-mcp-tools";
+
+afterEach(resetMcpClientMocks);
+
+const MCP_URL = "http://localhost:3350/mcp";
+
+describe("createGeminiMcpTools", () => {
+  it("maps MCP tools to function declarations, keeping dashed names", async () => {
+    listToolsMock.mockResolvedValueOnce({
+      tools: [
+        {
+          name: "ppal-read-track",
+          description: "Read a track",
+          inputSchema: {
+            $schema: "https://json-schema.org/draft/2020-12/schema",
+            type: "object",
+            properties: { trackIndex: { type: "number" } },
+            required: ["trackIndex"],
+          },
+        },
+        {
+          name: "ppal-create-clip",
+          description: "Create a clip",
+          inputSchema: { properties: {} }, // missing type + required — defaulted
+        },
+      ],
+    });
+
+    const { functionDeclarations, mcpClient } =
+      await createGeminiMcpTools(MCP_URL);
+
+    expect(mcpClient).toBe(fakeMcpClient);
+    // Gemini allows dashes in function names — no underscore mangling.
+    expect(functionDeclarations.map((d) => d.name)).toStrictEqual([
+      "ppal-read-track",
+      "ppal-create-clip",
+    ]);
+
+    const schema0 = functionDeclarations[0]!.parametersJsonSchema as Record<
+      string,
+      unknown
+    >;
+
+    expect(schema0.type).toBe("object");
+    expect(schema0.required).toStrictEqual(["trackIndex"]);
+    // $schema meta-key is stripped so Gemini's validator doesn't choke on it.
+    expect(schema0.$schema).toBeUndefined();
+
+    const schema1 = functionDeclarations[1]!.parametersJsonSchema as Record<
+      string,
+      unknown
+    >;
+
+    expect(schema1.type).toBe("object");
+    expect(schema1.required).toStrictEqual([]);
+    expect(schema1.properties).toStrictEqual({});
+  });
+
+  it("defaults the schema when a tool has no inputSchema at all", async () => {
+    listToolsMock.mockResolvedValueOnce({
+      tools: [{ name: "ppal-bare", description: "" }],
+    });
+
+    const { functionDeclarations } = await createGeminiMcpTools(MCP_URL);
+    const schema = functionDeclarations[0]!.parametersJsonSchema as Record<
+      string,
+      unknown
+    >;
+
+    expect(schema).toStrictEqual({
+      type: "object",
+      properties: {},
+      required: [],
+    });
+  });
+
+  it("filters tools using the enabledTools map", async () => {
+    listToolsMock.mockResolvedValueOnce({
+      tools: [
+        { name: "ppal-a", description: "", inputSchema: { properties: {} } },
+        { name: "ppal-b", description: "", inputSchema: { properties: {} } },
+        { name: "ppal-c", description: "", inputSchema: { properties: {} } },
+      ],
+    });
+
+    const { functionDeclarations } = await createGeminiMcpTools(MCP_URL, {
+      "ppal-a": true,
+      "ppal-b": false,
+      "ppal-c": true,
+    });
+
+    expect(functionDeclarations.map((d) => d.name)).toStrictEqual([
+      "ppal-a",
+      "ppal-c",
+    ]);
+  });
+
+  it("executeTool forwards args and returns flattened text content", async () => {
+    listToolsMock.mockResolvedValueOnce({
+      tools: [{ name: "ppal-read-live-set", description: "", inputSchema: {} }],
+    });
+    callToolMock.mockResolvedValueOnce({
+      isError: false,
+      content: [
+        { type: "text", text: "Track 1: Drums" },
+        { type: "text", text: "Track 2: Bass" },
+      ],
+    });
+
+    const { executeTool } = await createGeminiMcpTools(MCP_URL);
+    const out = await executeTool("ppal-read-live-set", { foo: "bar" });
+
+    expect(callToolMock).toHaveBeenCalledWith(
+      { name: "ppal-read-live-set", arguments: { foo: "bar" } },
+      undefined,
+      { timeout: 30_000 },
+    );
+    expect(out).toBe("Track 1: Drums\nTrack 2: Bass");
+  });
+
+  it("executeTool returns a prefixed error string on MCP isError (no throw)", async () => {
+    listToolsMock.mockResolvedValueOnce({
+      tools: [{ name: "ppal-broken", description: "", inputSchema: {} }],
+    });
+    callToolMock.mockResolvedValueOnce({
+      isError: true,
+      content: [{ type: "text", text: "trackIndex out of range" }],
+    });
+
+    const { executeTool } = await createGeminiMcpTools(MCP_URL);
+    const out = await executeTool("ppal-broken", {});
+
+    expect(out).toContain("Error from ppal-broken");
+    expect(out).toContain("trackIndex out of range");
+  });
+
+  it("executeTool returns error text on a transport-level throw", async () => {
+    listToolsMock.mockResolvedValueOnce({
+      tools: [{ name: "ppal-y", description: "", inputSchema: {} }],
+    });
+    callToolMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const { executeTool } = await createGeminiMcpTools(MCP_URL);
+    const out = await executeTool("ppal-y", {});
+
+    expect(out).toContain("Error calling ppal-y");
+    expect(out).toContain("ECONNREFUSED");
+  });
+});

--- a/webui/src/hooks/voice/gemini/tests/gemini-mic-capture.test.ts
+++ b/webui/src/hooks/voice/gemini/tests/gemini-mic-capture.test.ts
@@ -1,0 +1,138 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GeminiMicCapture } from "#webui/hooks/voice/gemini/gemini-mic-capture";
+
+// Web Audio + mic fakes (happy-dom has none). We capture the worklet node so a
+// posted PCM buffer can be pushed through onmessage and asserted.
+
+class FakeAudioWorkletNode {
+  static last: FakeAudioWorkletNode | null = null;
+  port: { onmessage: ((e: MessageEvent<ArrayBuffer>) => void) | null } = {
+    onmessage: null,
+  };
+
+  disconnect = vi.fn();
+
+  constructor() {
+    FakeAudioWorkletNode.last = this;
+  }
+}
+
+class FakeAudioContext {
+  static last: FakeAudioContext | null = null;
+  sampleRate = 16000;
+  audioWorklet = { addModule: vi.fn(async () => {}) };
+  createMediaStreamSource = vi.fn(() => ({ connect: vi.fn() }));
+  close = vi.fn(async () => {});
+  constructor() {
+    FakeAudioContext.last = this;
+  }
+}
+
+const trackStop = vi.fn();
+const getUserMedia = vi.fn(async () => ({
+  getTracks: () => [{ stop: trackStop }],
+}));
+
+beforeEach(() => {
+  FakeAudioWorkletNode.last = null;
+  trackStop.mockClear();
+  getUserMedia.mockClear();
+  vi.stubGlobal("AudioContext", FakeAudioContext);
+  vi.stubGlobal("AudioWorkletNode", FakeAudioWorkletNode);
+  vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+  vi.stubGlobal("URL", {
+    createObjectURL: vi.fn(() => "blob:fake"),
+    revokeObjectURL: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("GeminiMicCapture", () => {
+  it("opens the mic with AEC constraints and loads the worklet", async () => {
+    const capture = new GeminiMicCapture();
+    const result = await capture.start({ onChunk: vi.fn() });
+
+    expect(result.sampleRate).toBe(16000);
+    expect(getUserMedia).toHaveBeenCalledWith({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+        channelCount: 1,
+      },
+    });
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:fake");
+  });
+
+  it("base64-encodes posted PCM and forwards it to onChunk", async () => {
+    const capture = new GeminiMicCapture();
+    const onChunk = vi.fn();
+
+    await capture.start({ onChunk });
+    const buf = new Uint8Array([1, 2, 3, 4]).buffer;
+
+    FakeAudioWorkletNode.last!.port.onmessage!({
+      data: buf,
+    } as MessageEvent<ArrayBuffer>);
+
+    expect(onChunk).toHaveBeenCalledWith(btoa(String.fromCharCode(1, 2, 3, 4)));
+  });
+
+  it("drops chunks while muted, resumes when unmuted", async () => {
+    const capture = new GeminiMicCapture();
+    const onChunk = vi.fn();
+
+    await capture.start({ onChunk });
+    const post = (): void =>
+      FakeAudioWorkletNode.last!.port.onmessage!({
+        data: new Uint8Array([0, 0]).buffer,
+      } as MessageEvent<ArrayBuffer>);
+
+    capture.setMuted(true);
+    post();
+    expect(onChunk).not.toHaveBeenCalled();
+
+    capture.setMuted(false);
+    post();
+    expect(onChunk).toHaveBeenCalledTimes(1);
+  });
+
+  it("stop() ends tracks, disconnects the node, and closes the context", async () => {
+    const capture = new GeminiMicCapture();
+
+    await capture.start({ onChunk: vi.fn() });
+    const node = FakeAudioWorkletNode.last!;
+
+    await capture.stop();
+
+    expect(node.disconnect).toHaveBeenCalled();
+    expect(trackStop).toHaveBeenCalled();
+    expect(node.port.onmessage).toBeNull();
+  });
+
+  it("stop() is safe before start()", async () => {
+    const capture = new GeminiMicCapture();
+
+    await expect(capture.stop()).resolves.toBeUndefined();
+  });
+
+  it("stop() swallows a context that fails to close", async () => {
+    const capture = new GeminiMicCapture();
+
+    await capture.start({ onChunk: vi.fn() });
+    FakeAudioContext.last!.close = vi.fn(async () => {
+      throw new Error("close failed");
+    });
+
+    await expect(capture.stop()).resolves.toBeUndefined();
+  });
+});

--- a/webui/src/hooks/voice/gemini/tests/gemini-pcm-player.test.ts
+++ b/webui/src/hooks/voice/gemini/tests/gemini-pcm-player.test.ts
@@ -1,0 +1,206 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GeminiPcmPlayer } from "#webui/hooks/voice/gemini/gemini-pcm-player";
+
+// Minimal Web Audio fakes — happy-dom has no AudioContext. We capture the
+// scheduled sources so the gapless-cursor and flush behavior can be asserted.
+
+class FakeBufferSource {
+  buffer: { duration: number } | null = null;
+  onended: (() => void) | null = null;
+  connect = vi.fn();
+  start = vi.fn();
+  stop = vi.fn();
+}
+
+class FakeAudioContext {
+  static instances: FakeAudioContext[] = [];
+  currentTime = 0;
+  state: "running" | "suspended" = "suspended";
+  destination = {};
+  gain = { gain: { value: 1 }, connect: vi.fn() };
+  sources: FakeBufferSource[] = [];
+  resume = vi.fn(async () => {
+    this.state = "running";
+  });
+
+  close = vi.fn(async () => {});
+  createGain = vi.fn(() => this.gain);
+  createBuffer = vi.fn((_ch: number, length: number, rate: number) => ({
+    duration: length / rate,
+    getChannelData: () => new Float32Array(length),
+  }));
+
+  createBufferSource = vi.fn(() => {
+    const s = new FakeBufferSource();
+
+    this.sources.push(s);
+
+    return s;
+  });
+
+  constructor() {
+    FakeAudioContext.instances.push(this);
+  }
+}
+
+/**
+ * Base64 of `count` Int16 samples (all zero).
+ * @param count - Number of 16-bit samples
+ * @returns Base64-encoded PCM
+ */
+function pcmBase64(count: number): string {
+  return btoa(String.fromCharCode(...new Uint8Array(count * 2)));
+}
+
+beforeEach(() => {
+  FakeAudioContext.instances = [];
+  vi.stubGlobal("AudioContext", FakeAudioContext);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("GeminiPcmPlayer", () => {
+  it("creates and resumes a suspended output context", async () => {
+    const player = new GeminiPcmPlayer();
+
+    await player.resume();
+    const ctx = FakeAudioContext.instances[0]!;
+
+    expect(ctx.resume).toHaveBeenCalled();
+    expect(ctx.gain.connect).toHaveBeenCalledWith(ctx.destination);
+  });
+
+  it("schedules chunks gaplessly against a running cursor", async () => {
+    const player = new GeminiPcmPlayer();
+
+    await player.resume();
+    const ctx = FakeAudioContext.instances[0]!;
+
+    player.enqueueBase64(pcmBase64(2400)); // 0.1s at 24k
+    player.enqueueBase64(pcmBase64(2400));
+
+    expect(ctx.sources).toHaveLength(2);
+    const first = ctx.sources[0]!.start.mock.calls[0]![0] as number;
+    const second = ctx.sources[1]!.start.mock.calls[0]![0] as number;
+
+    // First chunk gets the lead; second butts up against the first's end.
+    expect(first).toBeCloseTo(0.12);
+    expect(second).toBeCloseTo(0.22);
+  });
+
+  it("does nothing when enqueueing before resume()", () => {
+    const player = new GeminiPcmPlayer();
+
+    expect(() => player.enqueueBase64(pcmBase64(10))).not.toThrow();
+    expect(FakeAudioContext.instances).toHaveLength(0);
+  });
+
+  it("ignores an empty decoded chunk", async () => {
+    const player = new GeminiPcmPlayer();
+
+    await player.resume();
+    player.enqueueBase64("");
+    expect(FakeAudioContext.instances[0]!.sources).toHaveLength(0);
+  });
+
+  it("applies volume live, including boost above unity", async () => {
+    const player = new GeminiPcmPlayer();
+
+    player.setVolume(1.25); // before resume: stored
+    await player.resume();
+    const ctx = FakeAudioContext.instances[0]!;
+
+    expect(ctx.gain.gain.value).toBe(1.25);
+    player.setVolume(0.5);
+    expect(ctx.gain.gain.value).toBe(0.5);
+  });
+
+  it("flush stops scheduled sources and resets the cursor", async () => {
+    const player = new GeminiPcmPlayer();
+
+    await player.resume();
+    const ctx = FakeAudioContext.instances[0]!;
+
+    player.enqueueBase64(pcmBase64(2400));
+    const source = ctx.sources[0]!;
+
+    player.flush();
+    expect(source.stop).toHaveBeenCalled();
+
+    // After flush the cursor resets, so the next chunk starts from now + lead.
+    player.enqueueBase64(pcmBase64(2400));
+    const restart = ctx.sources[1]!.start.mock.calls[0]![0] as number;
+
+    expect(restart).toBeCloseTo(0.12);
+  });
+
+  it("tolerates a source that throws on stop during flush", async () => {
+    const player = new GeminiPcmPlayer();
+
+    await player.resume();
+    const ctx = FakeAudioContext.instances[0]!;
+
+    player.enqueueBase64(pcmBase64(10));
+    ctx.sources[0]!.stop = vi.fn(() => {
+      throw new Error("already stopped");
+    });
+
+    expect(() => player.flush()).not.toThrow();
+  });
+
+  it("drops a scheduled source from the set when it ends", async () => {
+    const player = new GeminiPcmPlayer();
+
+    await player.resume();
+    const ctx = FakeAudioContext.instances[0]!;
+
+    player.enqueueBase64(pcmBase64(10));
+    // Fire onended; flush afterward should find nothing to stop.
+    ctx.sources[0]!.onended!();
+    player.flush();
+    expect(ctx.sources[0]!.stop).not.toHaveBeenCalled();
+  });
+
+  it("close flushes and closes the context (idempotent)", async () => {
+    const player = new GeminiPcmPlayer();
+
+    await player.resume();
+    const ctx = FakeAudioContext.instances[0]!;
+
+    await player.close();
+    expect(ctx.close).toHaveBeenCalled();
+
+    // Second close is a no-op (no context).
+    await expect(player.close()).resolves.toBeUndefined();
+  });
+
+  it("close swallows a context that fails to close", async () => {
+    const player = new GeminiPcmPlayer();
+
+    await player.resume();
+    FakeAudioContext.instances[0]!.close = vi.fn(async () => {
+      throw new Error("close failed");
+    });
+
+    await expect(player.close()).resolves.toBeUndefined();
+  });
+
+  it("drops a trailing odd byte when decoding base64 PCM", async () => {
+    const player = new GeminiPcmPlayer();
+
+    await player.resume();
+    const ctx = FakeAudioContext.instances[0]!;
+    // 3 bytes → 1 whole Int16 sample (trailing byte dropped).
+    const threeBytes = btoa(String.fromCharCode(1, 2, 3));
+
+    player.enqueueBase64(threeBytes);
+    expect(ctx.createBuffer).toHaveBeenCalledWith(1, 1, 24000);
+  });
+});

--- a/webui/src/hooks/voice/gemini/tests/gemini-realtime-items.test.ts
+++ b/webui/src/hooks/voice/gemini/tests/gemini-realtime-items.test.ts
@@ -1,0 +1,137 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { GeminiHistoryBuilder } from "#webui/hooks/voice/gemini/gemini-realtime-items";
+import { realtimeItemsToUIMessages } from "#webui/hooks/voice/realtime-items-to-ui-messages";
+
+describe("GeminiHistoryBuilder", () => {
+  it("accumulates user + assistant transcript deltas into messages", () => {
+    const b = new GeminiHistoryBuilder();
+
+    b.addUserTranscript("set the ");
+    b.addUserTranscript("tempo to 128");
+    b.addAssistantTranscript("Tempo ");
+    b.addAssistantTranscript("set to 128.");
+
+    const items = b.toRealtimeItems();
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_audio", transcript: "set the tempo to 128" }],
+    });
+    expect(items[1]).toMatchObject({
+      type: "message",
+      role: "assistant",
+      status: "in_progress",
+      content: [{ type: "output_audio", transcript: "Tempo set to 128." }],
+    });
+  });
+
+  it("marks the assistant turn completed on completeTurn", () => {
+    const b = new GeminiHistoryBuilder();
+
+    b.addAssistantTranscript("Hi there!");
+    b.completeTurn();
+
+    expect(b.toRealtimeItems()[0]).toMatchObject({ status: "completed" });
+  });
+
+  it("records tool calls and fills output by id, ordered text → tool → text", () => {
+    const b = new GeminiHistoryBuilder();
+
+    b.addAssistantTranscript("One moment.");
+    b.addToolCall("call-1", "ppal-update-live-set", { tempo: 128 });
+    b.setToolOutput("call-1", "Tempo updated.");
+    b.addAssistantTranscript("Done!");
+
+    const items = b.toRealtimeItems();
+
+    expect(items.map((i) => i.type)).toStrictEqual([
+      "message",
+      "function_call",
+      "message",
+    ]);
+    expect(items[1]).toMatchObject({
+      type: "function_call",
+      name: "ppal-update-live-set",
+      arguments: JSON.stringify({ tempo: 128 }),
+      output: "Tempo updated.",
+      status: "completed",
+    });
+    // A pending tool call (no output yet) is in_progress.
+    const b2 = new GeminiHistoryBuilder();
+
+    b2.addToolCall("c", "ppal-x", {});
+    expect(b2.toRealtimeItems()[0]).toMatchObject({ status: "in_progress" });
+  });
+
+  it("starts a new user turn after an assistant reply (barge-in / next turn)", () => {
+    const b = new GeminiHistoryBuilder();
+
+    b.addUserTranscript("hello");
+    b.addAssistantTranscript("hi");
+    b.addUserTranscript("what can you do");
+
+    const items = b.toRealtimeItems();
+
+    expect(items.map((i) => i.type === "message" && i.role)).toStrictEqual([
+      "user",
+      "assistant",
+      "user",
+    ]);
+    // The interrupted assistant turn is closed when the user speaks again.
+    expect(items[1]).toMatchObject({ status: "completed" });
+  });
+
+  it("ignores empty transcript deltas", () => {
+    const b = new GeminiHistoryBuilder();
+
+    b.addUserTranscript("");
+    b.addAssistantTranscript("");
+
+    expect(b.toRealtimeItems()).toHaveLength(0);
+  });
+
+  it("produces fresh objects each snapshot (no shared mutable state)", () => {
+    const b = new GeminiHistoryBuilder();
+
+    b.addAssistantTranscript("a");
+    const first = b.toRealtimeItems();
+
+    b.addAssistantTranscript("b");
+    const second = b.toRealtimeItems();
+
+    expect(first[0]).not.toBe(second[0]);
+    expect(first[0]).toMatchObject({
+      content: [{ transcript: "a" }],
+    });
+  });
+
+  it("round-trips through realtimeItemsToUIMessages into chat UIMessages", () => {
+    const b = new GeminiHistoryBuilder();
+
+    b.addUserTranscript("set tempo to 128");
+    b.addAssistantTranscript("Sure.");
+    b.addToolCall("c1", "ppal-update-live-set", { tempo: 128 });
+    b.setToolOutput("c1", "ok");
+    b.addAssistantTranscript("Done!");
+    b.completeTurn();
+
+    const messages = realtimeItemsToUIMessages(b.toRealtimeItems());
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({
+      role: "user",
+      parts: [{ type: "text", content: "set tempo to 128" }],
+    });
+    expect(messages[1]?.role).toBe("model");
+    const types = messages[1]?.parts.map((p) => p.type);
+
+    expect(types).toStrictEqual(["text", "tool", "text"]);
+  });
+});

--- a/webui/src/hooks/voice/gemini/tests/gemini-voice-token.test.ts
+++ b/webui/src/hooks/voice/gemini/tests/gemini-voice-token.test.ts
@@ -1,0 +1,88 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchGeminiToken } from "#webui/hooks/voice/gemini/gemini-voice-token";
+
+const TOKEN_URL = "http://localhost:3350/gemini-voice-token";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * Stub global fetch with a single JSON (or custom) response.
+ * @param response - The Response to resolve with
+ * @returns The fetch spy
+ */
+function stubFetch(response: Response) {
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+}
+
+describe("fetchGeminiToken", () => {
+  it("sends the key header + model and returns the credential", async () => {
+    const fetchSpy = stubFetch(
+      new Response(JSON.stringify({ value: "gem-key", ephemeral: false }), {
+        status: 200,
+      }),
+    );
+
+    const cred = await fetchGeminiToken(TOKEN_URL, "gem-key", "gemini-live");
+
+    expect(cred).toStrictEqual({ value: "gem-key", ephemeral: false });
+    const init = fetchSpy.mock.calls[0]![1]!;
+
+    expect((init.headers as Record<string, string>)["X-Gemini-Key"]).toBe(
+      "gem-key",
+    );
+    expect(JSON.parse(init.body as string)).toStrictEqual({
+      model: "gemini-live",
+    });
+  });
+
+  it("honors the ephemeral flag from the server", async () => {
+    stubFetch(
+      new Response(
+        JSON.stringify({ value: "auth_tokens/abc", ephemeral: true }),
+        {
+          status: 200,
+        },
+      ),
+    );
+
+    const cred = await fetchGeminiToken(TOKEN_URL, "k", "m");
+
+    expect(cred).toStrictEqual({ value: "auth_tokens/abc", ephemeral: true });
+  });
+
+  it("throws with detail on a non-ok response", async () => {
+    stubFetch(
+      new Response(JSON.stringify({ error: "Chat UI is disabled" }), {
+        status: 403,
+        statusText: "Forbidden",
+      }),
+    );
+
+    await expect(fetchGeminiToken(TOKEN_URL, "k", "m")).rejects.toThrow(
+      /403.*Chat UI is disabled/,
+    );
+  });
+
+  it("throws on a non-ok response whose body isn't JSON", async () => {
+    stubFetch(new Response("nope", { status: 500, statusText: "Error" }));
+
+    await expect(fetchGeminiToken(TOKEN_URL, "k", "m")).rejects.toThrow(/500/);
+  });
+
+  it("throws when the response is missing the value field", async () => {
+    stubFetch(
+      new Response(JSON.stringify({ ephemeral: false }), { status: 200 }),
+    );
+
+    await expect(fetchGeminiToken(TOKEN_URL, "k", "m")).rejects.toThrow(
+      /missing 'value'/,
+    );
+  });
+});

--- a/webui/src/hooks/voice/gemini/tests/mcp-bridge-test-helpers.ts
+++ b/webui/src/hooks/voice/gemini/tests/mcp-bridge-test-helpers.ts
@@ -1,0 +1,51 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { vi } from "vitest";
+import { type McpToolDefinition } from "#webui/chat/helpers/mcp-client-helpers";
+
+// Shared MCP-client mock scaffold for the voice tool-bridge tests (OpenAI
+// Realtime + Gemini Live). Both bridges build on the same mcp-client-helpers, so
+// they share one fake client + one vi.mock factory rather than duplicating the
+// setup in each test file.
+
+export const callToolMock = vi.fn();
+export const listToolsMock = vi.fn();
+export const closeMock = vi.fn();
+
+export const fakeMcpClient = {
+  callTool: callToolMock,
+  listTools: listToolsMock,
+  close: closeMock,
+} as unknown as Client;
+
+/**
+ * Factory for `vi.mock("#webui/chat/helpers/mcp-client-helpers")` — returns the
+ * fake client and a passthrough filterEnabledTools.
+ * @returns The mocked module shape
+ */
+export function mcpClientHelpersMock(): {
+  createConnectedMcpClient: () => Promise<Client>;
+  filterEnabledTools: (
+    tools: McpToolDefinition[],
+    enabledTools?: Record<string, boolean>,
+  ) => McpToolDefinition[];
+} {
+  return {
+    createConnectedMcpClient: vi.fn(async () => fakeMcpClient),
+    filterEnabledTools: (tools, enabledTools) =>
+      enabledTools
+        ? tools.filter((t) => enabledTools[t.name] !== false)
+        : tools,
+  };
+}
+
+/** Reset all MCP-client mocks (call from afterEach). */
+export function resetMcpClientMocks(): void {
+  callToolMock.mockReset();
+  listToolsMock.mockReset();
+  closeMock.mockReset();
+}

--- a/webui/src/hooks/voice/gemini/tests/use-gemini-voice-session-helpers.test.ts
+++ b/webui/src/hooks/voice/gemini/tests/use-gemini-voice-session-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   ActivityHandling,
   EndSensitivity,
   GoogleGenAI,
+  type LiveConnectConfig,
   type LiveServerMessage,
   type Session,
   StartSensitivity,
@@ -18,9 +19,12 @@ import { GeminiHistoryBuilder } from "#webui/hooks/voice/gemini/gemini-realtime-
 import { type GeminiPcmPlayer } from "#webui/hooks/voice/gemini/gemini-pcm-player";
 import {
   buildGeminiConfig,
+  closeQuietly,
   createGenAIClient,
   type GeminiMessageDeps,
   handleGeminiMessage,
+  openResumableGeminiSession,
+  type ResumableSessionContext,
   seedGeminiContext,
 } from "#webui/hooks/voice/gemini/use-gemini-voice-session-helpers";
 
@@ -46,6 +50,7 @@ function makeDeps(overrides: Partial<GeminiMessageDeps> = {}) {
     setAssistantSpeaking: vi.fn(),
     setAssistantThinking: vi.fn(),
     setError: vi.fn(),
+    setResumeHandle: vi.fn(),
     ...overrides,
   };
 
@@ -90,6 +95,25 @@ describe("buildGeminiConfig", () => {
     expect(
       config.speechConfig?.voiceConfig?.prebuiltVoiceConfig?.voiceName,
     ).toBe("Puck");
+  });
+
+  it("enables session resumption with an empty handle for a fresh session", () => {
+    const config = buildGeminiConfig({
+      voice: "Puck",
+      functionDeclarations: [],
+    });
+
+    expect(config.sessionResumption).toStrictEqual({});
+  });
+
+  it("passes the resumption handle when resuming a prior session", () => {
+    const config = buildGeminiConfig({
+      voice: "Puck",
+      functionDeclarations: [],
+      resumeHandle: "handle-9",
+    });
+
+    expect(config.sessionResumption).toStrictEqual({ handle: "handle-9" });
   });
 
   it("omits realtimeInputConfig when no VAD settings are given", () => {
@@ -244,6 +268,32 @@ describe("handleGeminiMessage", () => {
     expect(deps.publishHistory).not.toHaveBeenCalled();
   });
 
+  it("stores a resumable session-resumption handle", async () => {
+    const { deps } = makeDeps();
+
+    await handleGeminiMessage(
+      msg({ sessionResumptionUpdate: { resumable: true, newHandle: "h-1" } }),
+      deps,
+    );
+
+    expect(deps.setResumeHandle).toHaveBeenCalledWith("h-1");
+  });
+
+  it("ignores a non-resumable update and one with no handle", async () => {
+    const { deps } = makeDeps();
+
+    await handleGeminiMessage(
+      msg({ sessionResumptionUpdate: { resumable: false } }),
+      deps,
+    );
+    await handleGeminiMessage(
+      msg({ sessionResumptionUpdate: { resumable: true } }),
+      deps,
+    );
+
+    expect(deps.setResumeHandle).not.toHaveBeenCalled();
+  });
+
   it("runs a tool call and sends the response with matching id", async () => {
     const executeTool = vi.fn(async () => "Tempo updated.");
     const { deps, sendToolResponse } = makeDeps({ executeTool });
@@ -327,6 +377,202 @@ describe("handleGeminiMessage", () => {
 
     // No throw; thinking still toggled off.
     expect(deps.setAssistantThinking).toHaveBeenCalledWith(false);
+  });
+});
+
+/**
+ * Build a fake GenAI client whose live.connect records each call's config and
+ * callbacks and returns a shared fake session.
+ * @param closeImpl - Optional session.close implementation (defaults to a spy)
+ * @returns The fake ai, the shared session, and the recorded connect calls
+ */
+function makeFakeAi(closeImpl?: () => void) {
+  const session = {
+    close: closeImpl ? vi.fn(closeImpl) : vi.fn(),
+  } as unknown as Session;
+  const calls: {
+    config: LiveConnectConfig;
+    callbacks: Record<string, (arg?: unknown) => void>;
+  }[] = [];
+  const connect = vi.fn(
+    async (params: {
+      config: LiveConnectConfig;
+      callbacks: Record<string, (arg?: unknown) => void>;
+    }) => {
+      calls.push({ config: params.config, callbacks: params.callbacks });
+
+      return session;
+    },
+  );
+  const ai = { live: { connect } } as unknown as GoogleGenAI;
+
+  return { ai, session, connect, calls };
+}
+
+/**
+ * Build a ResumableSessionContext with sensible defaults and spy callbacks.
+ * @param ai - The fake GenAI client to drive
+ * @param over - Per-test overrides
+ * @returns A ResumableSessionContext
+ */
+function makeCtx(
+  ai: GoogleGenAI,
+  over: Partial<ResumableSessionContext> = {},
+): ResumableSessionContext {
+  const { deps } = makeDeps();
+
+  return {
+    ai,
+    model: "gemini-x",
+    voice: "Puck",
+    vad: undefined,
+    functionDeclarations: [],
+    deps,
+    resumeHandleRef: { current: null },
+    isStale: () => false,
+    isIntentionalClose: () => false,
+    onSession: vi.fn(),
+    onDrop: vi.fn(),
+    ...over,
+  };
+}
+
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+describe("openResumableGeminiSession", () => {
+  it("opens a session enabling resumption and returns it", async () => {
+    const { ai, session, calls } = makeFakeAi();
+
+    const result = await openResumableGeminiSession(makeCtx(ai));
+
+    expect(result).toBe(session);
+    expect(calls[0]!.config.sessionResumption).toStrictEqual({});
+  });
+
+  it("resumes with the stored handle after an unexpected close", async () => {
+    const { ai, calls } = makeFakeAi();
+    const ctx = makeCtx(ai, { resumeHandleRef: { current: "h-7" } });
+
+    await openResumableGeminiSession(ctx);
+    calls[0]!.callbacks.onclose?.();
+    await tick();
+
+    expect(ai.live.connect).toHaveBeenCalledTimes(2);
+    expect(calls[1]!.config.sessionResumption).toStrictEqual({ handle: "h-7" });
+    expect(ctx.onSession).toHaveBeenCalledTimes(1);
+    expect(ctx.onDrop).not.toHaveBeenCalled();
+  });
+
+  it("reports an unrecoverable drop when no handle is available", async () => {
+    const { ai, calls } = makeFakeAi();
+    const ctx = makeCtx(ai);
+
+    await openResumableGeminiSession(ctx);
+    calls[0]!.callbacks.onclose?.();
+    await tick();
+
+    expect(ai.live.connect).toHaveBeenCalledTimes(1);
+    expect(ctx.onDrop).toHaveBeenCalledWith(
+      "Connection lost. Press Talk to reconnect.",
+    );
+  });
+
+  it("reports the transport error message when erroring without a handle", async () => {
+    const { ai, calls } = makeFakeAi();
+    const ctx = makeCtx(ai);
+
+    await openResumableGeminiSession(ctx);
+    calls[0]!.callbacks.onerror?.(new Error("ws down"));
+    await tick();
+
+    expect(ctx.onDrop).toHaveBeenCalledWith("ws down");
+  });
+
+  it("handles a drop once when onerror and onclose both fire", async () => {
+    const { ai, calls } = makeFakeAi();
+    const ctx = makeCtx(ai, { resumeHandleRef: { current: "h" } });
+
+    await openResumableGeminiSession(ctx);
+    calls[0]!.callbacks.onerror?.(new Error("x"));
+    calls[0]!.callbacks.onclose?.();
+    await tick();
+
+    expect(ai.live.connect).toHaveBeenCalledTimes(2);
+    expect(ctx.onSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not resume after an intentional close", async () => {
+    const { ai, calls } = makeFakeAi();
+    const ctx = makeCtx(ai, {
+      resumeHandleRef: { current: "h" },
+      isIntentionalClose: () => true,
+    });
+
+    await openResumableGeminiSession(ctx);
+    calls[0]!.callbacks.onclose?.();
+    await tick();
+
+    expect(ai.live.connect).toHaveBeenCalledTimes(1);
+    expect(ctx.onDrop).not.toHaveBeenCalled();
+  });
+
+  it("closes a resumed session that races teardown instead of installing it", async () => {
+    // close throws to also exercise closeQuietly's swallow path.
+    const { ai, session, calls } = makeFakeAi(() => {
+      throw new Error("already closed");
+    });
+    let staleChecks = 0;
+    const ctx = makeCtx(ai, {
+      resumeHandleRef: { current: "h" },
+      // false at handleClose entry, true at resumeOrFail's post-await check.
+      isStale: () => staleChecks++ >= 1,
+    });
+
+    await openResumableGeminiSession(ctx);
+    calls[0]!.callbacks.onclose?.();
+    await tick();
+
+    expect(ctx.onSession).not.toHaveBeenCalled();
+    expect(session.close).toHaveBeenCalled();
+  });
+
+  it("reports a failed resume via onDrop", async () => {
+    const session = { close: vi.fn() } as unknown as Session;
+    let firstCallbacks!: Record<string, (arg?: unknown) => void>;
+    let n = 0;
+    const connect = vi.fn(
+      async (p: { callbacks: Record<string, (arg?: unknown) => void> }) => {
+        n++;
+
+        if (n === 1) {
+          firstCallbacks = p.callbacks;
+
+          return session;
+        }
+
+        throw new Error("resume failed");
+      },
+    );
+    const ai = { live: { connect } } as unknown as GoogleGenAI;
+    const ctx = makeCtx(ai, { resumeHandleRef: { current: "h" } });
+
+    await openResumableGeminiSession(ctx);
+    firstCallbacks.onclose?.();
+    await tick();
+
+    expect(ctx.onDrop).toHaveBeenCalledWith("resume failed");
+  });
+});
+
+describe("closeQuietly", () => {
+  it("swallows a close that throws", () => {
+    const session = {
+      close: () => {
+        throw new Error("boom");
+      },
+    } as unknown as Session;
+
+    expect(() => closeQuietly(session)).not.toThrow();
   });
 });
 

--- a/webui/src/hooks/voice/gemini/tests/use-gemini-voice-session-helpers.test.ts
+++ b/webui/src/hooks/voice/gemini/tests/use-gemini-voice-session-helpers.test.ts
@@ -1,0 +1,322 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type LiveServerMessage, type Session } from "@google/genai";
+import { type RealtimeItem } from "@openai/agents/realtime";
+import { describe, expect, it, vi } from "vitest";
+import { GeminiHistoryBuilder } from "#webui/hooks/voice/gemini/gemini-realtime-items";
+import { type GeminiPcmPlayer } from "#webui/hooks/voice/gemini/gemini-pcm-player";
+import {
+  buildGeminiConfig,
+  type GeminiMessageDeps,
+  handleGeminiMessage,
+  seedGeminiContext,
+} from "#webui/hooks/voice/gemini/use-gemini-voice-session-helpers";
+
+/**
+ * Build message-handler deps with spy-able fakes (a real history builder, a fake
+ * player, and an injectable session/tool dispatcher).
+ * @param overrides - Partial deps to override
+ * @returns The deps plus the fakes for assertions
+ */
+function makeDeps(overrides: Partial<GeminiMessageDeps> = {}) {
+  const player = {
+    flush: vi.fn(),
+    enqueueBase64: vi.fn(),
+  } as unknown as GeminiPcmPlayer;
+  const sendToolResponse = vi.fn();
+  const session = { sendToolResponse } as unknown as Session;
+  const deps: GeminiMessageDeps = {
+    builder: new GeminiHistoryBuilder(),
+    player,
+    getSession: () => session,
+    executeTool: vi.fn(async () => "tool-output"),
+    publishHistory: vi.fn(),
+    setAssistantSpeaking: vi.fn(),
+    setAssistantThinking: vi.fn(),
+    setError: vi.fn(),
+    ...overrides,
+  };
+
+  return { deps, player, sendToolResponse, session };
+}
+
+/**
+ * Cast a partial message literal to LiveServerMessage (a class with text/data
+ * getters that plain object literals can't satisfy structurally).
+ * @param partial - The message fields under test
+ * @returns The same value typed as LiveServerMessage
+ */
+function msg(partial: Partial<LiveServerMessage>): LiveServerMessage {
+  return partial as LiveServerMessage;
+}
+
+describe("buildGeminiConfig", () => {
+  it("sets audio modality, voice, tools, and transcription", () => {
+    const config = buildGeminiConfig({
+      voice: "Charon",
+      functionDeclarations: [{ name: "ppal-x" }],
+    });
+
+    expect(config.responseModalities).toStrictEqual(["AUDIO"]);
+    expect(
+      config.speechConfig?.voiceConfig?.prebuiltVoiceConfig?.voiceName,
+    ).toBe("Charon");
+    expect(config.tools).toStrictEqual([
+      { functionDeclarations: [{ name: "ppal-x" }] },
+    ]);
+    expect(config.inputAudioTranscription).toStrictEqual({});
+    expect(config.outputAudioTranscription).toStrictEqual({});
+    expect(typeof config.systemInstruction).toBe("string");
+  });
+
+  it("falls back to the default voice when none is given", () => {
+    const config = buildGeminiConfig({
+      voice: undefined,
+      functionDeclarations: [],
+    });
+
+    expect(
+      config.speechConfig?.voiceConfig?.prebuiltVoiceConfig?.voiceName,
+    ).toBe("Puck");
+  });
+});
+
+describe("handleGeminiMessage", () => {
+  it("appends input transcription to history", async () => {
+    const { deps } = makeDeps();
+
+    await handleGeminiMessage(
+      msg({ serverContent: { inputTranscription: { text: "hello" } } }),
+      deps,
+    );
+
+    expect(deps.builder.toRealtimeItems()[0]).toMatchObject({ role: "user" });
+    expect(deps.publishHistory).toHaveBeenCalled();
+  });
+
+  it("appends output transcription and enqueues audio", async () => {
+    const { deps, player } = makeDeps();
+
+    await handleGeminiMessage(
+      msg({
+        serverContent: {
+          outputTranscription: { text: "hi" },
+          modelTurn: { parts: [{ inlineData: { data: "BASE64" } }] },
+        },
+      }),
+      deps,
+    );
+
+    expect(deps.builder.toRealtimeItems()[0]).toMatchObject({
+      role: "assistant",
+    });
+    expect(player.enqueueBase64).toHaveBeenCalledWith("BASE64");
+    expect(deps.setAssistantSpeaking).toHaveBeenCalledWith(true);
+  });
+
+  it("ignores model-turn parts that carry no audio data", async () => {
+    const { deps, player } = makeDeps();
+
+    await handleGeminiMessage(
+      msg({ serverContent: { modelTurn: { parts: [{ text: "no audio" }] } } }),
+      deps,
+    );
+
+    expect(player.enqueueBase64).not.toHaveBeenCalled();
+  });
+
+  it("flushes playback and stops speaking on interruption", async () => {
+    const { deps, player } = makeDeps();
+
+    await handleGeminiMessage(
+      msg({ serverContent: { interrupted: true } }),
+      deps,
+    );
+
+    expect(player.flush).toHaveBeenCalled();
+    expect(deps.setAssistantSpeaking).toHaveBeenCalledWith(false);
+  });
+
+  it("stops speaking on turnComplete", async () => {
+    const { deps } = makeDeps();
+
+    await handleGeminiMessage(
+      msg({ serverContent: { turnComplete: true } }),
+      deps,
+    );
+
+    expect(deps.setAssistantSpeaking).toHaveBeenCalledWith(false);
+    expect(deps.publishHistory).toHaveBeenCalled();
+  });
+
+  it("ignores a message with no serverContent or toolCall", async () => {
+    const { deps } = makeDeps();
+
+    await handleGeminiMessage(msg({ setupComplete: {} }), deps);
+
+    expect(deps.publishHistory).not.toHaveBeenCalled();
+  });
+
+  it("runs a tool call and sends the response with matching id", async () => {
+    const executeTool = vi.fn(async () => "Tempo updated.");
+    const { deps, sendToolResponse } = makeDeps({ executeTool });
+
+    const message = msg({
+      toolCall: {
+        functionCalls: [
+          { id: "c1", name: "ppal-update-live-set", args: { tempo: 128 } },
+        ],
+      },
+    });
+
+    await handleGeminiMessage(message, deps);
+
+    expect(executeTool).toHaveBeenCalledWith("ppal-update-live-set", {
+      tempo: 128,
+    });
+    expect(sendToolResponse).toHaveBeenCalledWith({
+      functionResponses: [
+        {
+          id: "c1",
+          name: "ppal-update-live-set",
+          response: { output: "Tempo updated." },
+        },
+      ],
+    });
+    expect(deps.setAssistantThinking).toHaveBeenCalledWith(true);
+    expect(deps.setAssistantThinking).toHaveBeenCalledWith(false);
+  });
+
+  it("falls back to the tool name as id when none is provided", async () => {
+    const { deps, sendToolResponse } = makeDeps();
+
+    await handleGeminiMessage(
+      msg({ toolCall: { functionCalls: [{ name: "ppal-x" }] } }),
+      deps,
+    );
+
+    expect(deps.builder.toRealtimeItems()[0]).toMatchObject({
+      type: "function_call",
+      name: "ppal-x",
+    });
+    expect(sendToolResponse).toHaveBeenCalled();
+  });
+
+  it("tolerates a function call with no name (empty-string fallbacks)", async () => {
+    const executeTool = vi.fn(async () => "ok");
+    const { deps, sendToolResponse } = makeDeps({ executeTool });
+
+    await handleGeminiMessage(msg({ toolCall: { functionCalls: [{}] } }), deps);
+
+    expect(executeTool).toHaveBeenCalledWith("", {});
+    expect(sendToolResponse).toHaveBeenCalled();
+  });
+
+  it("surfaces a sendToolResponse failure via setError", async () => {
+    const { deps } = makeDeps({
+      getSession: () =>
+        ({
+          sendToolResponse: () => {
+            throw new Error("socket closed");
+          },
+        }) as unknown as Session,
+    });
+
+    await handleGeminiMessage(
+      msg({ toolCall: { functionCalls: [{ id: "c", name: "ppal-x" }] } }),
+      deps,
+    );
+
+    expect(deps.setError).toHaveBeenCalledWith("socket closed");
+  });
+
+  it("skips sendToolResponse when the session is gone", async () => {
+    const { deps } = makeDeps({ getSession: () => null });
+
+    await handleGeminiMessage(
+      msg({ toolCall: { functionCalls: [{ id: "c", name: "ppal-x" }] } }),
+      deps,
+    );
+
+    // No throw; thinking still toggled off.
+    expect(deps.setAssistantThinking).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("seedGeminiContext", () => {
+  it("is a no-op for empty or missing history", () => {
+    const sendClientContent = vi.fn();
+    const session = { sendClientContent } as unknown as Session;
+
+    seedGeminiContext(session, undefined);
+    seedGeminiContext(session, []);
+
+    expect(sendClientContent).not.toHaveBeenCalled();
+  });
+
+  it("sends prior message transcripts as a non-triggering context turn", () => {
+    const sendClientContent = vi.fn();
+    const session = { sendClientContent } as unknown as Session;
+    const history: RealtimeItem[] = [
+      {
+        itemId: "1",
+        type: "message",
+        role: "user",
+        status: "completed",
+        content: [{ type: "input_audio", transcript: "set tempo to 128" }],
+      },
+      {
+        itemId: "2",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_audio", transcript: "Done." }],
+      },
+      // function_call + system items are skipped by the transcript flattener.
+      {
+        itemId: "3",
+        type: "function_call",
+        status: "completed",
+        name: "ppal-x",
+        arguments: "{}",
+        output: "ok",
+      },
+    ];
+
+    seedGeminiContext(session, history);
+
+    expect(sendClientContent).toHaveBeenCalledTimes(1);
+    const arg = sendClientContent.mock.calls[0]![0] as {
+      turns: { parts: { text: string }[] }[];
+      turnComplete: boolean;
+    };
+
+    expect(arg.turnComplete).toBe(false);
+    const text = arg.turns[0]!.parts[0]!.text;
+
+    expect(text).toContain("User: set tempo to 128");
+    expect(text).toContain("You: Done.");
+    expect(text).not.toContain("ppal-x");
+  });
+
+  it("is a no-op when history has no usable transcript text", () => {
+    const sendClientContent = vi.fn();
+    const session = { sendClientContent } as unknown as Session;
+    const history: RealtimeItem[] = [
+      {
+        itemId: "1",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_audio", transcript: "" }],
+      },
+    ];
+
+    seedGeminiContext(session, history);
+
+    expect(sendClientContent).not.toHaveBeenCalled();
+  });
+});

--- a/webui/src/hooks/voice/gemini/tests/use-gemini-voice-session-helpers.test.ts
+++ b/webui/src/hooks/voice/gemini/tests/use-gemini-voice-session-helpers.test.ts
@@ -3,13 +3,22 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { type LiveServerMessage, type Session } from "@google/genai";
+import {
+  ActivityHandling,
+  EndSensitivity,
+  GoogleGenAI,
+  type LiveServerMessage,
+  type Session,
+  StartSensitivity,
+} from "@google/genai";
 import { type RealtimeItem } from "@openai/agents/realtime";
 import { describe, expect, it, vi } from "vitest";
+import { type GeminiVadSettings } from "#webui/hooks/settings/turn-detection-helpers";
 import { GeminiHistoryBuilder } from "#webui/hooks/voice/gemini/gemini-realtime-items";
 import { type GeminiPcmPlayer } from "#webui/hooks/voice/gemini/gemini-pcm-player";
 import {
   buildGeminiConfig,
+  createGenAIClient,
   type GeminiMessageDeps,
   handleGeminiMessage,
   seedGeminiContext,
@@ -81,6 +90,81 @@ describe("buildGeminiConfig", () => {
     expect(
       config.speechConfig?.voiceConfig?.prebuiltVoiceConfig?.voiceName,
     ).toBe("Puck");
+  });
+
+  it("omits realtimeInputConfig when no VAD settings are given", () => {
+    const config = buildGeminiConfig({
+      voice: "Puck",
+      functionDeclarations: [],
+    });
+
+    expect(config.realtimeInputConfig).toBeUndefined();
+  });
+
+  it("maps high-sensitivity VAD with barge-in on", () => {
+    const vad: GeminiVadSettings = {
+      startSensitivity: "high",
+      endSensitivity: "high",
+      silenceDurationMs: 500,
+      prefixPaddingMs: 100,
+      interruptResponse: true,
+    };
+
+    const config = buildGeminiConfig({
+      voice: "Puck",
+      functionDeclarations: [],
+      vad,
+    });
+
+    expect(config.realtimeInputConfig).toStrictEqual({
+      automaticActivityDetection: {
+        startOfSpeechSensitivity: StartSensitivity.START_SENSITIVITY_HIGH,
+        endOfSpeechSensitivity: EndSensitivity.END_SENSITIVITY_HIGH,
+        prefixPaddingMs: 100,
+        silenceDurationMs: 500,
+      },
+      activityHandling: ActivityHandling.START_OF_ACTIVITY_INTERRUPTS,
+    });
+  });
+
+  it("maps low-sensitivity VAD with barge-in off to NO_INTERRUPTION", () => {
+    const vad: GeminiVadSettings = {
+      startSensitivity: "low",
+      endSensitivity: "low",
+      silenceDurationMs: 800,
+      prefixPaddingMs: 20,
+      interruptResponse: false,
+    };
+
+    const config = buildGeminiConfig({
+      voice: "Puck",
+      functionDeclarations: [],
+      vad,
+    });
+
+    expect(config.realtimeInputConfig).toStrictEqual({
+      automaticActivityDetection: {
+        startOfSpeechSensitivity: StartSensitivity.START_SENSITIVITY_LOW,
+        endOfSpeechSensitivity: EndSensitivity.END_SENSITIVITY_LOW,
+        prefixPaddingMs: 20,
+        silenceDurationMs: 800,
+      },
+      activityHandling: ActivityHandling.NO_INTERRUPTION,
+    });
+  });
+});
+
+describe("createGenAIClient", () => {
+  it("builds a client for a raw key (default API version)", () => {
+    const client = createGenAIClient({ value: "raw-key", ephemeral: false });
+
+    expect(client).toBeInstanceOf(GoogleGenAI);
+  });
+
+  it("builds a client for an ephemeral token (v1alpha)", () => {
+    const client = createGenAIClient({ value: "ephemeral", ephemeral: true });
+
+    expect(client).toBeInstanceOf(GoogleGenAI);
   });
 });
 

--- a/webui/src/hooks/voice/gemini/tests/use-gemini-voice-session.test.ts
+++ b/webui/src/hooks/voice/gemini/tests/use-gemini-voice-session.test.ts
@@ -1,0 +1,432 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @vitest-environment happy-dom
+ */
+import { act, renderHook } from "@testing-library/preact";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- hoisted doubles (vi.mock factories can only see vi.hoisted values) ---
+const h = vi.hoisted(() => {
+  const fakeSession = {
+    sendRealtimeInput: vi.fn(),
+    sendToolResponse: vi.fn(),
+    sendClientContent: vi.fn(),
+    close: vi.fn(),
+  };
+
+  const state: {
+    callbacks: Record<string, (arg?: unknown) => void>;
+    connectParams: { model?: string; config?: unknown } | null;
+    genaiOptions: unknown;
+    onChunk: ((data: string) => void) | null;
+  } = { callbacks: {}, connectParams: null, genaiOptions: null, onChunk: null };
+
+  const liveConnect = vi.fn(
+    async (params: {
+      model: string;
+      callbacks: Record<string, (arg?: unknown) => void>;
+      config: unknown;
+    }) => {
+      state.callbacks = params.callbacks;
+      state.connectParams = params;
+      params.callbacks.onopen?.();
+
+      return fakeSession;
+    },
+  );
+
+  class FakeGoogleGenAI {
+    live = { connect: liveConnect };
+    constructor(options: unknown) {
+      state.genaiOptions = options;
+    }
+  }
+
+  class FakeMic {
+    static last: FakeMic | null = null;
+    setMuted = vi.fn();
+    stop = vi.fn(async () => {});
+    start = vi.fn(async (opts: { onChunk: (data: string) => void }) => {
+      state.onChunk = opts.onChunk;
+
+      return { sampleRate: 16000 };
+    });
+
+    constructor() {
+      FakeMic.last = this;
+    }
+  }
+
+  class FakePlayer {
+    static last: FakePlayer | null = null;
+    setVolume = vi.fn();
+    resume = vi.fn(async () => {});
+    flush = vi.fn();
+    enqueueBase64 = vi.fn();
+    close = vi.fn(async () => {});
+    constructor() {
+      FakePlayer.last = this;
+    }
+  }
+
+  const mcpClose = vi.fn(async () => {});
+  const executeTool = vi.fn(async () => "tool-out");
+  const createGeminiMcpTools = vi.fn(async () => ({
+    functionDeclarations: [{ name: "ppal-x" }],
+    executeTool,
+    mcpClient: { close: mcpClose },
+  }));
+
+  const fetchGeminiToken = vi.fn(async () => ({
+    value: "gem-key",
+    ephemeral: false,
+  }));
+
+  return {
+    fakeSession,
+    state,
+    liveConnect,
+    FakeGoogleGenAI,
+    FakeMic,
+    FakePlayer,
+    mcpClose,
+    executeTool,
+    createGeminiMcpTools,
+    fetchGeminiToken,
+  };
+});
+
+// `as never` lets the structural fakes stand in for the real module exports
+// (classes with private fields can't be matched structurally) — same pattern as
+// use-voice-session.test.ts.
+vi.mock(import("@google/genai"), () => ({
+  GoogleGenAI: h.FakeGoogleGenAI as never,
+  Modality: { AUDIO: "AUDIO" } as never,
+}));
+vi.mock(import("#webui/hooks/voice/gemini/gemini-mic-capture"), () => ({
+  GeminiMicCapture: h.FakeMic as never,
+}));
+vi.mock(import("#webui/hooks/voice/gemini/gemini-pcm-player"), () => ({
+  GeminiPcmPlayer: h.FakePlayer as never,
+}));
+vi.mock(import("#webui/hooks/voice/gemini/gemini-mcp-tools"), () => ({
+  createGeminiMcpTools: h.createGeminiMcpTools as never,
+}));
+vi.mock(import("#webui/hooks/voice/gemini/gemini-voice-token"), () => ({
+  fetchGeminiToken: h.fetchGeminiToken as never,
+}));
+
+import { useGeminiVoiceSession } from "#webui/hooks/voice/gemini/use-gemini-voice-session";
+
+const PARAMS = {
+  mcpUrl: "http://localhost:3350/mcp",
+  voiceTokenUrl: "http://localhost:3350/gemini-voice-token",
+  geminiKey: "gem-key" as string | null,
+  model: "gemini-3.1-flash-live-preview",
+  voice: "Puck",
+  volume: 1,
+};
+
+/**
+ * Render the hook and run a successful connect().
+ * @param overrides - Param overrides
+ * @returns The renderHook result
+ */
+async function renderConnected(overrides: Partial<typeof PARAMS> = {}) {
+  const view = renderHook((p: typeof PARAMS) => useGeminiVoiceSession(p), {
+    initialProps: { ...PARAMS, ...overrides },
+  });
+
+  await act(async () => {
+    await view.result.current.connect();
+  });
+
+  return view;
+}
+
+beforeEach(() => {
+  h.fetchGeminiToken.mockResolvedValue({ value: "gem-key", ephemeral: false });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  h.FakeMic.last = null;
+  h.FakePlayer.last = null;
+  h.state.callbacks = {};
+  h.state.onChunk = null;
+});
+
+describe("useGeminiVoiceSession", () => {
+  it("errors without a key and never opens a session", async () => {
+    const { result } = renderHook(() =>
+      useGeminiVoiceSession({ ...PARAMS, geminiKey: null }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toMatch(/Gemini API key/);
+    expect(h.liveConnect).not.toHaveBeenCalled();
+  });
+
+  it("connects: opens session with config, starts mic, sets status", async () => {
+    const { result } = await renderConnected();
+
+    expect(result.current.status).toBe("connected");
+    expect(result.current.activeVoice).toBe("Puck");
+    expect(h.FakePlayer.last!.resume).toHaveBeenCalled();
+    expect(h.FakeMic.last!.start).toHaveBeenCalled();
+    const params = h.state.connectParams!;
+
+    expect(params.model).toBe("gemini-3.1-flash-live-preview");
+    expect(h.state.genaiOptions).toStrictEqual({ apiKey: "gem-key" });
+  });
+
+  it("uses v1alpha httpOptions for an ephemeral credential", async () => {
+    h.fetchGeminiToken.mockResolvedValueOnce({
+      value: "auth_tokens/x",
+      ephemeral: true,
+    });
+
+    await renderConnected();
+
+    expect(h.state.genaiOptions).toStrictEqual({
+      apiKey: "auth_tokens/x",
+      httpOptions: { apiVersion: "v1alpha" },
+    });
+  });
+
+  it("leaves activeVoice null when no voice is provided", async () => {
+    const { result } = await renderConnected({ voice: undefined });
+
+    expect(result.current.status).toBe("connected");
+    expect(result.current.activeVoice).toBeNull();
+  });
+
+  it("ignores a second connect() while already connected", async () => {
+    const { result } = await renderConnected();
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(h.liveConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders incoming transcripts into history", async () => {
+    const { result } = await renderConnected();
+
+    await act(async () => {
+      h.state.callbacks.onmessage?.({
+        serverContent: { inputTranscription: { text: "hello there" } },
+      });
+    });
+
+    expect(result.current.history[0]).toMatchObject({
+      role: "user",
+      content: [{ transcript: "hello there" }],
+    });
+  });
+
+  it("forwards mic chunks to sendRealtimeInput", async () => {
+    await renderConnected();
+
+    h.state.onChunk?.("BASE64PCM");
+
+    expect(h.fakeSession.sendRealtimeInput).toHaveBeenCalledWith({
+      audio: { data: "BASE64PCM", mimeType: "audio/pcm;rate=16000" },
+    });
+  });
+
+  it("runs a tool call through the session (covers getSession)", async () => {
+    await renderConnected();
+
+    await act(async () => {
+      h.state.callbacks.onmessage?.({
+        toolCall: { functionCalls: [{ id: "c1", name: "ppal-x", args: {} }] },
+      });
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(h.executeTool).toHaveBeenCalledWith("ppal-x", {});
+    expect(h.fakeSession.sendToolResponse).toHaveBeenCalled();
+  });
+
+  it("toggleMute drives the mic and flips isMuted", async () => {
+    const { result } = await renderConnected();
+
+    await act(async () => {
+      await result.current.toggleMute();
+    });
+
+    expect(result.current.isMuted).toBe(true);
+    expect(h.FakeMic.last!.setMuted).toHaveBeenCalledWith(true);
+
+    await act(async () => {
+      await result.current.toggleMute();
+    });
+
+    expect(result.current.isMuted).toBe(false);
+  });
+
+  it("toggleMute is a no-op when idle", async () => {
+    const { result } = renderHook(() => useGeminiVoiceSession(PARAMS));
+
+    await act(async () => {
+      await result.current.toggleMute();
+    });
+
+    expect(result.current.isMuted).toBe(false);
+  });
+
+  it("interrupt flushes playback and clears speaking", async () => {
+    const { result } = await renderConnected();
+
+    await act(async () => {
+      result.current.interrupt();
+    });
+
+    expect(h.FakePlayer.last!.flush).toHaveBeenCalled();
+    expect(result.current.assistantSpeaking).toBe(false);
+  });
+
+  it("interrupt is safe before connect (no player)", () => {
+    const { result } = renderHook(() => useGeminiVoiceSession(PARAMS));
+
+    expect(() => act(() => result.current.interrupt())).not.toThrow();
+  });
+
+  it("retryResponse clears the error banner", async () => {
+    const { result } = renderHook(() =>
+      useGeminiVoiceSession({ ...PARAMS, geminiKey: null }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    expect(result.current.error).not.toBeNull();
+
+    await act(async () => {
+      result.current.retryResponse();
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("resetHistory clears the transcript", async () => {
+    const { result } = await renderConnected();
+
+    await act(async () => {
+      h.state.callbacks.onmessage?.({
+        serverContent: { inputTranscription: { text: "hi" } },
+      });
+    });
+    expect(result.current.history).toHaveLength(1);
+
+    await act(async () => {
+      result.current.resetHistory();
+    });
+    expect(result.current.history).toHaveLength(0);
+  });
+
+  it("disconnect tears everything down and goes idle", async () => {
+    const { result } = await renderConnected();
+    const mic = h.FakeMic.last!;
+    const player = h.FakePlayer.last!;
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(result.current.status).toBe("idle");
+    expect(mic.stop).toHaveBeenCalled();
+    expect(player.close).toHaveBeenCalled();
+    expect(h.fakeSession.close).toHaveBeenCalled();
+    expect(h.mcpClose).toHaveBeenCalled();
+  });
+
+  it("surfaces an unexpected close as a lost connection", async () => {
+    const { result } = await renderConnected();
+
+    await act(async () => {
+      h.state.callbacks.onclose?.();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toMatch(/Connection lost/);
+  });
+
+  it("surfaces a transport error", async () => {
+    const { result } = await renderConnected();
+
+    await act(async () => {
+      h.state.callbacks.onerror?.(new Error("ws boom"));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe("ws boom");
+  });
+
+  it("catches a connect failure and cleans up", async () => {
+    h.fetchGeminiToken.mockRejectedValueOnce(new Error("token denied"));
+
+    const { result } = await renderConnected();
+
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toBe("token denied");
+    expect(h.mcpClose).toHaveBeenCalled();
+  });
+
+  it("defaults volume to unity when none is provided", async () => {
+    await renderConnected({ volume: undefined });
+
+    expect(h.FakePlayer.last!.setVolume).toHaveBeenCalledWith(1);
+  });
+
+  it("pushes live volume changes to the player", async () => {
+    const view = await renderConnected();
+    const player = h.FakePlayer.last!;
+
+    player.setVolume.mockClear();
+    view.rerender({ ...PARAMS, volume: 0.5 });
+
+    expect(player.setVolume).toHaveBeenCalledWith(0.5);
+  });
+
+  it("bails and closes the session if torn down during connect", async () => {
+    // Suspend the token fetch, unmount mid-connect, then let it resolve.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+
+    h.fetchGeminiToken.mockReturnValueOnce(
+      gate.then(() => ({ value: "gem-key", ephemeral: false })),
+    );
+
+    const { result, unmount } = renderHook(() => useGeminiVoiceSession(PARAMS));
+    let connectPromise!: Promise<void>;
+
+    await act(async () => {
+      connectPromise = result.current.connect();
+      await Promise.resolve();
+    });
+
+    unmount();
+    await act(async () => {
+      release();
+      await connectPromise;
+    });
+
+    // Torn down before the session opened: no live session leaked.
+    expect(h.liveConnect).not.toHaveBeenCalled();
+    expect(h.mcpClose).toHaveBeenCalled();
+  });
+});

--- a/webui/src/hooks/voice/gemini/tests/use-gemini-voice-session.test.ts
+++ b/webui/src/hooks/voice/gemini/tests/use-gemini-voice-session.test.ts
@@ -362,6 +362,32 @@ describe("useGeminiVoiceSession", () => {
     expect(result.current.error).toMatch(/Connection lost/);
   });
 
+  it("captures a resumption handle and silently resumes after a drop", async () => {
+    const { result } = await renderConnected();
+
+    await act(async () => {
+      h.state.callbacks.onmessage?.({
+        sessionResumptionUpdate: { resumable: true, newHandle: "handle-1" },
+      });
+    });
+
+    await act(async () => {
+      h.state.callbacks.onclose?.();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(h.liveConnect).toHaveBeenCalledTimes(2);
+    expect(result.current.status).toBe("connected");
+    expect(result.current.error).toBeNull();
+    const cfg = h.state.connectParams!.config as {
+      sessionResumption?: { handle?: string };
+    };
+
+    expect(cfg.sessionResumption?.handle).toBe("handle-1");
+    // The mic and player are reused across a resume, not rebuilt.
+    expect(h.FakeMic.last!.start).toHaveBeenCalledTimes(1);
+  });
+
   it("surfaces a transport error", async () => {
     const { result } = await renderConnected();
 

--- a/webui/src/hooks/voice/gemini/use-gemini-voice-session-helpers.ts
+++ b/webui/src/hooks/voice/gemini/use-gemini-voice-session-helpers.ts
@@ -1,0 +1,228 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import {
+  type FunctionDeclaration,
+  type LiveConnectConfig,
+  type LiveServerMessage,
+  Modality,
+  type Session,
+} from "@google/genai";
+import { type RealtimeItem } from "@openai/agents/realtime";
+import { type GeminiPcmPlayer } from "#webui/hooks/voice/gemini/gemini-pcm-player";
+import { type GeminiHistoryBuilder } from "#webui/hooks/voice/gemini/gemini-realtime-items";
+import { extractErrorMessage } from "#webui/hooks/voice/use-voice-session-helpers";
+import { DEFAULT_GEMINI_REALTIME_VOICE } from "#webui/lib/constants/models";
+
+/** Mic input format Gemini Live expects (raw 16-bit PCM, 16 kHz, mono, LE). */
+export const GEMINI_INPUT_MIME_TYPE = "audio/pcm;rate=16000";
+
+export const GEMINI_AGENT_INSTRUCTIONS = [
+  "You are Producer Pal, an AI music production assistant working with the user in Ableton Live.",
+  "Always speak and respond in English. Interpret all user audio as English, even if a short utterance sounds ambiguous.",
+  "Before responding to the user's first request, call the ppal-connect tool to load the latest Producer Pal skills and current project context.",
+  "Keep voice responses brief and conversational. When tool calls take a moment, you may narrate what you are doing so the user knows you are working.",
+].join(" ");
+
+/**
+ * Build the Live API session config: audio-out, the system instruction, the
+ * MCP function declarations, the selected voice, and input/output transcription
+ * (off by default on Gemini — we need both to render the transcript UI).
+ *
+ * @param opts - Voice id and the MCP function declarations
+ * @param opts.voice - Prebuilt Gemini voice name (defaults to Puck)
+ * @param opts.functionDeclarations - MCP tools as Gemini declarations
+ * @returns The LiveConnectConfig
+ */
+export function buildGeminiConfig(opts: {
+  voice: string | undefined;
+  functionDeclarations: FunctionDeclaration[];
+}): LiveConnectConfig {
+  return {
+    responseModalities: [Modality.AUDIO],
+    systemInstruction: GEMINI_AGENT_INSTRUCTIONS,
+    tools: [{ functionDeclarations: opts.functionDeclarations }],
+    speechConfig: {
+      voiceConfig: {
+        prebuiltVoiceConfig: {
+          voiceName: opts.voice ?? DEFAULT_GEMINI_REALTIME_VOICE,
+        },
+      },
+    },
+    inputAudioTranscription: {},
+    outputAudioTranscription: {},
+  };
+}
+
+/** Dependencies handleGeminiMessage needs from the hook. */
+export interface GeminiMessageDeps {
+  builder: GeminiHistoryBuilder;
+  player: GeminiPcmPlayer;
+  /** The live session (for sendToolResponse); null after teardown. */
+  getSession: () => Session | null;
+  executeTool: (name: string, args: Record<string, unknown>) => Promise<string>;
+  /** Push the builder's current items to React state. */
+  publishHistory: () => void;
+  setAssistantSpeaking: (value: boolean) => void;
+  setAssistantThinking: (value: boolean) => void;
+  setError: (value: string | null) => void;
+}
+
+/**
+ * Translate one Live server message into transcript/audio/tool side effects.
+ * The WebSocket transport hands us raw deltas — transcripts, audio chunks, tool
+ * calls, and turn/interrupt signals — which we fold into the history builder,
+ * the gapless player, and the UI flags. The OpenAI SDK did all of this
+ * internally; here it is explicit.
+ *
+ * @param message - The Live server message
+ * @param deps - Builder, player, tool dispatcher, and UI setters
+ */
+export async function handleGeminiMessage(
+  message: LiveServerMessage,
+  deps: GeminiMessageDeps,
+): Promise<void> {
+  const sc = message.serverContent;
+
+  if (sc) {
+    if (sc.interrupted) {
+      // Barge-in: drop queued audio and close the open model turn.
+      deps.player.flush();
+      deps.builder.completeTurn();
+      deps.setAssistantSpeaking(false);
+      deps.publishHistory();
+    }
+
+    if (sc.inputTranscription?.text) {
+      deps.builder.addUserTranscript(sc.inputTranscription.text);
+      deps.publishHistory();
+    }
+
+    if (sc.outputTranscription?.text) {
+      deps.builder.addAssistantTranscript(sc.outputTranscription.text);
+      deps.publishHistory();
+    }
+
+    for (const part of sc.modelTurn?.parts ?? []) {
+      const data = part.inlineData?.data;
+
+      if (data) {
+        deps.player.enqueueBase64(data);
+        deps.setAssistantSpeaking(true);
+      }
+    }
+
+    if (sc.turnComplete) {
+      deps.builder.completeTurn();
+      deps.setAssistantSpeaking(false);
+      deps.publishHistory();
+    }
+  }
+
+  if (message.toolCall) {
+    await handleGeminiToolCall(message.toolCall, deps);
+  }
+}
+
+/**
+ * Run each function call the model requested through the MCP dispatcher and send
+ * the results back with matching ids. Errors come back from executeTool as a
+ * string (never a throw), so a failing tool is reported to the model as output
+ * it can recover from rather than wedging the session.
+ *
+ * @param toolCall - The server tool-call message
+ * @param deps - Builder, tool dispatcher, session accessor, and UI setters
+ */
+async function handleGeminiToolCall(
+  toolCall: NonNullable<LiveServerMessage["toolCall"]>,
+  deps: GeminiMessageDeps,
+): Promise<void> {
+  deps.setAssistantThinking(true);
+
+  const functionResponses = [];
+
+  for (const fc of toolCall.functionCalls ?? []) {
+    const name = fc.name ?? "";
+    const id = fc.id ?? name;
+    const args = fc.args ?? {};
+
+    deps.builder.addToolCall(id, name, args);
+    deps.publishHistory();
+
+    const output = await deps.executeTool(name, args);
+
+    deps.builder.setToolOutput(id, output);
+    deps.publishHistory();
+    functionResponses.push({ id: fc.id, name, response: { output } });
+  }
+
+  try {
+    deps.getSession()?.sendToolResponse({ functionResponses });
+  } catch (err) {
+    deps.setError(extractErrorMessage(err));
+  }
+
+  deps.setAssistantThinking(false);
+}
+
+/**
+ * Seed prior conversation context onto a fresh Gemini session so continuing a
+ * saved voice chat keeps the model's memory. Unlike the OpenAI SDK's
+ * updateHistory, Gemini has no item-replay API — we send the saved transcript
+ * as a single text turn (turnComplete:false so it becomes context without
+ * triggering a spoken reply). Tool calls and audio bytes are not replayable, so
+ * only message transcripts are carried.
+ *
+ * @param session - The connected Live session
+ * @param initialHistory - Saved history to seed, or undefined
+ */
+export function seedGeminiContext(
+  session: Pick<Session, "sendClientContent">,
+  initialHistory: RealtimeItem[] | undefined,
+): void {
+  if (!initialHistory || initialHistory.length === 0) return;
+  const transcript = transcriptText(initialHistory);
+
+  if (!transcript) return;
+
+  session.sendClientContent({
+    turns: [
+      {
+        role: "user",
+        parts: [
+          {
+            text: `Here is the transcript of our conversation so far, for context. Do not respond to it; just continue from here.\n\n${transcript}`,
+          },
+        ],
+      },
+    ],
+    turnComplete: false,
+  });
+}
+
+/**
+ * Flatten saved message items into a "Speaker: text" transcript for seeding.
+ *
+ * @param items - Saved history items
+ * @returns Newline-joined transcript, or empty string
+ */
+function transcriptText(items: RealtimeItem[]): string {
+  const lines: string[] = [];
+
+  for (const item of items) {
+    if (item.type !== "message") continue;
+    if (item.role === "system") continue;
+    const text = item.content
+      .map((c) =>
+        "text" in c ? c.text : "transcript" in c ? (c.transcript ?? "") : "",
+      )
+      .filter(Boolean)
+      .join(" ");
+
+    if (text) lines.push(`${item.role === "user" ? "User" : "You"}: ${text}`);
+  }
+
+  return lines.join("\n");
+}

--- a/webui/src/hooks/voice/gemini/use-gemini-voice-session-helpers.ts
+++ b/webui/src/hooks/voice/gemini/use-gemini-voice-session-helpers.ts
@@ -4,15 +4,22 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import {
+  ActivityHandling,
+  EndSensitivity,
   type FunctionDeclaration,
+  GoogleGenAI,
   type LiveConnectConfig,
   type LiveServerMessage,
   Modality,
+  type RealtimeInputConfig,
   type Session,
+  StartSensitivity,
 } from "@google/genai";
 import { type RealtimeItem } from "@openai/agents/realtime";
+import { type GeminiVadSettings } from "#webui/hooks/settings/turn-detection-helpers";
 import { type GeminiPcmPlayer } from "#webui/hooks/voice/gemini/gemini-pcm-player";
 import { type GeminiHistoryBuilder } from "#webui/hooks/voice/gemini/gemini-realtime-items";
+import { type GeminiVoiceCredential } from "#webui/hooks/voice/gemini/gemini-voice-token";
 import { extractErrorMessage } from "#webui/hooks/voice/use-voice-session-helpers";
 import { DEFAULT_GEMINI_REALTIME_VOICE } from "#webui/lib/constants/models";
 
@@ -28,19 +35,22 @@ export const GEMINI_AGENT_INSTRUCTIONS = [
 
 /**
  * Build the Live API session config: audio-out, the system instruction, the
- * MCP function declarations, the selected voice, and input/output transcription
- * (off by default on Gemini — we need both to render the transcript UI).
+ * MCP function declarations, the selected voice, input/output transcription
+ * (off by default on Gemini — we need both to render the transcript UI), and the
+ * VAD/turn-detection config when provided.
  *
- * @param opts - Voice id and the MCP function declarations
+ * @param opts - Voice id, the MCP function declarations, and optional VAD config
  * @param opts.voice - Prebuilt Gemini voice name (defaults to Puck)
  * @param opts.functionDeclarations - MCP tools as Gemini declarations
+ * @param opts.vad - Gemini VAD settings; when omitted, Live API defaults apply
  * @returns The LiveConnectConfig
  */
 export function buildGeminiConfig(opts: {
   voice: string | undefined;
   functionDeclarations: FunctionDeclaration[];
+  vad?: GeminiVadSettings;
 }): LiveConnectConfig {
-  return {
+  const config: LiveConnectConfig = {
     responseModalities: [Modality.AUDIO],
     systemInstruction: GEMINI_AGENT_INSTRUCTIONS,
     tools: [{ functionDeclarations: opts.functionDeclarations }],
@@ -54,6 +64,55 @@ export function buildGeminiConfig(opts: {
     inputAudioTranscription: {},
     outputAudioTranscription: {},
   };
+
+  if (opts.vad) config.realtimeInputConfig = buildRealtimeInputConfig(opts.vad);
+
+  return config;
+}
+
+/**
+ * Map the UI VAD settings to Gemini's realtimeInputConfig: start/end-of-speech
+ * sensitivity, silence + prefix-padding windows, and barge-in via
+ * activityHandling (NO_INTERRUPTION when barge-in is off).
+ *
+ * @param vad - Gemini VAD settings
+ * @returns The realtimeInputConfig payload
+ */
+function buildRealtimeInputConfig(vad: GeminiVadSettings): RealtimeInputConfig {
+  return {
+    automaticActivityDetection: {
+      startOfSpeechSensitivity:
+        vad.startSensitivity === "high"
+          ? StartSensitivity.START_SENSITIVITY_HIGH
+          : StartSensitivity.START_SENSITIVITY_LOW,
+      endOfSpeechSensitivity:
+        vad.endSensitivity === "high"
+          ? EndSensitivity.END_SENSITIVITY_HIGH
+          : EndSensitivity.END_SENSITIVITY_LOW,
+      prefixPaddingMs: vad.prefixPaddingMs,
+      silenceDurationMs: vad.silenceDurationMs,
+    },
+    activityHandling: vad.interruptResponse
+      ? ActivityHandling.START_OF_ACTIVITY_INTERRUPTS
+      : ActivityHandling.NO_INTERRUPTION,
+  };
+}
+
+/**
+ * Construct the GoogleGenAI client for a Live session. Ephemeral tokens are only
+ * valid on the v1alpha API, so the API version is pinned accordingly; a raw key
+ * uses the default version.
+ *
+ * @param credential - The Gemini voice credential (raw key or ephemeral token)
+ * @returns A configured GoogleGenAI client
+ */
+export function createGenAIClient(
+  credential: GeminiVoiceCredential,
+): GoogleGenAI {
+  return new GoogleGenAI({
+    apiKey: credential.value,
+    ...(credential.ephemeral ? { httpOptions: { apiVersion: "v1alpha" } } : {}),
+  });
 }
 
 /** Dependencies handleGeminiMessage needs from the hook. */

--- a/webui/src/hooks/voice/gemini/use-gemini-voice-session-helpers.ts
+++ b/webui/src/hooks/voice/gemini/use-gemini-voice-session-helpers.ts
@@ -36,19 +36,23 @@ export const GEMINI_AGENT_INSTRUCTIONS = [
 /**
  * Build the Live API session config: audio-out, the system instruction, the
  * MCP function declarations, the selected voice, input/output transcription
- * (off by default on Gemini — we need both to render the transcript UI), and the
- * VAD/turn-detection config when provided.
+ * (off by default on Gemini — we need both to render the transcript UI), the
+ * VAD/turn-detection config when provided, and session resumption (always on, so
+ * the server issues handles we can reconnect with after the ~10–15 min cap).
  *
  * @param opts - Voice id, the MCP function declarations, and optional VAD config
  * @param opts.voice - Prebuilt Gemini voice name (defaults to Puck)
  * @param opts.functionDeclarations - MCP tools as Gemini declarations
  * @param opts.vad - Gemini VAD settings; when omitted, Live API defaults apply
+ * @param opts.resumeHandle - Prior session's resumption handle; omit for a fresh
+ *   session (still enables resumption so the server starts issuing handles)
  * @returns The LiveConnectConfig
  */
 export function buildGeminiConfig(opts: {
   voice: string | undefined;
   functionDeclarations: FunctionDeclaration[];
   vad?: GeminiVadSettings;
+  resumeHandle?: string;
 }): LiveConnectConfig {
   const config: LiveConnectConfig = {
     responseModalities: [Modality.AUDIO],
@@ -63,6 +67,7 @@ export function buildGeminiConfig(opts: {
     },
     inputAudioTranscription: {},
     outputAudioTranscription: {},
+    sessionResumption: opts.resumeHandle ? { handle: opts.resumeHandle } : {},
   };
 
   if (opts.vad) config.realtimeInputConfig = buildRealtimeInputConfig(opts.vad);
@@ -115,6 +120,120 @@ export function createGenAIClient(
   });
 }
 
+/** Connection state + lifecycle callbacks openResumableGeminiSession needs. */
+export interface ResumableSessionContext {
+  /** The GenAI client (carries the credential and API version). */
+  ai: GoogleGenAI;
+  /** Gemini Live model id. */
+  model: string;
+  /** Prebuilt voice name, or undefined for the default. */
+  voice: string | undefined;
+  /** VAD/turn-detection settings, or undefined for Live API defaults. */
+  vad: GeminiVadSettings | undefined;
+  /** MCP tools exposed to the model. */
+  functionDeclarations: FunctionDeclaration[];
+  /** Message-handler deps (history builder, player, tool loop, UI setters). */
+  deps: GeminiMessageDeps;
+  /** Holds the latest server-issued resumption handle (null before the first). */
+  resumeHandleRef: { current: string | null };
+  /** True once teardown bumped the connect generation. */
+  isStale: () => boolean;
+  /** True when we initiated the close (disconnect/cleanup). */
+  isIntentionalClose: () => boolean;
+  /** Install a freshly (re)connected session as the active one. */
+  onSession: (session: Session) => void;
+  /** Report an unrecoverable drop (no handle, or a failed resume). */
+  onDrop: (message: string) => void;
+}
+
+/**
+ * Open a Gemini Live session that transparently resumes after a server-initiated
+ * drop. The Live API caps connection duration (~10–15 min) and periodically
+ * issues resumption handles (captured by handleGeminiMessage); when the socket
+ * closes or errors and a handle is available, this reconnects with it and swaps
+ * the new session in without tearing down the mic, player, MCP client, or
+ * transcript. A per-session `dropHandled` flag collapses the onerror+onclose pair
+ * a dead socket fires (and ignores a late callback from a session we've already
+ * replaced) so one drop triggers exactly one resume.
+ *
+ * @param ctx - Connection state and lifecycle callbacks
+ * @returns The connected Live session
+ */
+export async function openResumableGeminiSession(
+  ctx: ResumableSessionContext,
+): Promise<Session> {
+  let dropHandled = false;
+
+  const handleClose = (fallback: string): void => {
+    if (dropHandled || ctx.isIntentionalClose() || ctx.isStale()) return;
+    dropHandled = true;
+    void resumeOrFail(ctx, fallback);
+  };
+
+  return await ctx.ai.live.connect({
+    model: ctx.model,
+    callbacks: {
+      onopen: () => {},
+      onmessage: (m) => void handleGeminiMessage(m, ctx.deps),
+      onerror: (e) =>
+        handleClose(extractErrorMessage(e) || "Voice connection error."),
+      onclose: () => handleClose("Connection lost. Press Talk to reconnect."),
+    },
+    config: buildGeminiConfig({
+      voice: ctx.voice,
+      functionDeclarations: ctx.functionDeclarations,
+      vad: ctx.vad,
+      resumeHandle: ctx.resumeHandleRef.current ?? undefined,
+    }),
+  });
+}
+
+/**
+ * Resume the session from the stored handle, or report an unrecoverable drop.
+ * Without a handle (none issued yet) there is nothing to resume, so the drop is
+ * surfaced with the original message. A resume that races teardown closes the
+ * fresh session instead of leaking it.
+ *
+ * @param ctx - Connection state and lifecycle callbacks
+ * @param fallbackMessage - Drop message used when no handle is available
+ */
+async function resumeOrFail(
+  ctx: ResumableSessionContext,
+  fallbackMessage: string,
+): Promise<void> {
+  if (!ctx.resumeHandleRef.current) {
+    ctx.onDrop(fallbackMessage);
+
+    return;
+  }
+
+  try {
+    const session = await openResumableGeminiSession(ctx);
+
+    if (ctx.isStale() || ctx.isIntentionalClose()) {
+      closeQuietly(session);
+
+      return;
+    }
+
+    ctx.onSession(session);
+  } catch (err) {
+    ctx.onDrop(extractErrorMessage(err));
+  }
+}
+
+/**
+ * Close a session, swallowing any error (best-effort teardown).
+ * @param session - The session to close
+ */
+export function closeQuietly(session: Session): void {
+  try {
+    session.close();
+  } catch {
+    // best-effort
+  }
+}
+
 /** Dependencies handleGeminiMessage needs from the hook. */
 export interface GeminiMessageDeps {
   builder: GeminiHistoryBuilder;
@@ -127,6 +246,8 @@ export interface GeminiMessageDeps {
   setAssistantSpeaking: (value: boolean) => void;
   setAssistantThinking: (value: boolean) => void;
   setError: (value: string | null) => void;
+  /** Store the latest server-issued session-resumption handle. */
+  setResumeHandle: (handle: string) => void;
 }
 
 /**
@@ -143,6 +264,12 @@ export async function handleGeminiMessage(
   message: LiveServerMessage,
   deps: GeminiMessageDeps,
 ): Promise<void> {
+  const resumption = message.sessionResumptionUpdate;
+
+  if (resumption?.resumable && resumption.newHandle) {
+    deps.setResumeHandle(resumption.newHandle);
+  }
+
   const sc = message.serverContent;
 
   if (sc) {

--- a/webui/src/hooks/voice/gemini/use-gemini-voice-session.ts
+++ b/webui/src/hooks/voice/gemini/use-gemini-voice-session.ts
@@ -14,11 +14,11 @@ import { GeminiPcmPlayer } from "#webui/hooks/voice/gemini/gemini-pcm-player";
 import { GeminiHistoryBuilder } from "#webui/hooks/voice/gemini/gemini-realtime-items";
 import { fetchGeminiToken } from "#webui/hooks/voice/gemini/gemini-voice-token";
 import {
-  buildGeminiConfig,
+  closeQuietly,
   createGenAIClient,
   GEMINI_INPUT_MIME_TYPE,
   type GeminiMessageDeps,
-  handleGeminiMessage,
+  openResumableGeminiSession,
   seedGeminiContext,
 } from "#webui/hooks/voice/gemini/use-gemini-voice-session-helpers";
 import {
@@ -52,7 +52,10 @@ export interface UseGeminiVoiceSessionParams {
  * 24 kHz PCM out gaplessly, GeminiHistoryBuilder synthesizes the transcript, and
  * the MCP tool loop is explicit. Reentrancy is guarded the same way (a
  * connecting flag plus a generation counter that a teardown bumps so a connect()
- * resumed after teardown bails instead of leaking a socket + mic).
+ * resumed after teardown bails instead of leaking a socket + mic). The Live API
+ * caps a connection at ~10–15 min; session resumption (in
+ * openResumableGeminiSession) reconnects with the server-issued handle on an
+ * unexpected drop, keeping the mic/player/MCP/transcript so long chats survive.
  *
  * @param params - Hook parameters
  * @returns Voice session state and controls
@@ -80,6 +83,9 @@ export function useGeminiVoiceSession(
   const connectGenRef = useRef(0);
   const intentionalCloseRef = useRef(false);
   const isMutedRef = useRef(false);
+  // Latest server-issued resumption handle; reset per fresh connect so a new
+  // Talk starts a new session rather than resuming the previous one.
+  const resumeHandleRef = useRef<string | null>(null);
 
   const [status, setStatus] = useState<VoiceStatus>("idle");
   const [error, setError] = useState<string | null>(null);
@@ -151,6 +157,7 @@ export function useGeminiVoiceSession(
       const stale = (): boolean => connectGenRef.current !== myGen;
 
       intentionalCloseRef.current = false;
+      resumeHandleRef.current = null;
       setStatus("connecting");
       setError(null);
       setHistory([]);
@@ -191,6 +198,9 @@ export function useGeminiVoiceSession(
           setAssistantSpeaking,
           setAssistantThinking,
           setError,
+          setResumeHandle: (handle) => {
+            resumeHandleRef.current = handle;
+          },
         };
 
         const handleDrop = (message: string): void => {
@@ -203,29 +213,24 @@ export function useGeminiVoiceSession(
 
         const ai = createGenAIClient(credential);
 
-        const session = await ai.live.connect({
+        const session = await openResumableGeminiSession({
+          ai,
           model,
-          callbacks: {
-            onopen: () => {},
-            onmessage: (m) => void handleGeminiMessage(m, deps),
-            onerror: (e) =>
-              handleDrop(extractErrorMessage(e) || "Voice connection error."),
-            onclose: () =>
-              handleDrop("Connection lost. Press Talk to reconnect."),
+          voice,
+          vad: turnDetection,
+          functionDeclarations,
+          deps,
+          resumeHandleRef,
+          isStale: stale,
+          isIntentionalClose: () => intentionalCloseRef.current,
+          onSession: (s) => {
+            sessionRef.current = s;
           },
-          config: buildGeminiConfig({
-            voice,
-            functionDeclarations,
-            vad: turnDetection,
-          }),
+          onDrop: handleDrop,
         });
 
         if (stale()) {
-          try {
-            session.close();
-          } catch {
-            // best-effort
-          }
+          closeQuietly(session);
 
           return void (await cleanup());
         }

--- a/webui/src/hooks/voice/gemini/use-gemini-voice-session.ts
+++ b/webui/src/hooks/voice/gemini/use-gemini-voice-session.ts
@@ -3,10 +3,11 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { GoogleGenAI, type Session } from "@google/genai";
+import { type Session } from "@google/genai";
 import { type Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { type RealtimeItem } from "@openai/agents/realtime";
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import { type GeminiVadSettings } from "#webui/hooks/settings/turn-detection-helpers";
 import { createGeminiMcpTools } from "#webui/hooks/voice/gemini/gemini-mcp-tools";
 import { GeminiMicCapture } from "#webui/hooks/voice/gemini/gemini-mic-capture";
 import { GeminiPcmPlayer } from "#webui/hooks/voice/gemini/gemini-pcm-player";
@@ -14,6 +15,7 @@ import { GeminiHistoryBuilder } from "#webui/hooks/voice/gemini/gemini-realtime-
 import { fetchGeminiToken } from "#webui/hooks/voice/gemini/gemini-voice-token";
 import {
   buildGeminiConfig,
+  createGenAIClient,
   GEMINI_INPUT_MIME_TYPE,
   type GeminiMessageDeps,
   handleGeminiMessage,
@@ -37,6 +39,8 @@ export interface UseGeminiVoiceSessionParams {
   voice?: string;
   /** Output playback volume (live; applied to the GainNode immediately). */
   volume?: number;
+  /** Gemini VAD/turn-detection settings; read at connect (next Stop → Talk). */
+  turnDetection?: GeminiVadSettings;
 }
 
 /**
@@ -64,6 +68,7 @@ export function useGeminiVoiceSession(
     enabledTools,
     voice,
     volume,
+    turnDetection,
   } = params;
 
   const sessionRef = useRef<Session | null>(null);
@@ -196,12 +201,7 @@ export function useGeminiVoiceSession(
           });
         };
 
-        const ai = new GoogleGenAI({
-          apiKey: credential.value,
-          ...(credential.ephemeral
-            ? { httpOptions: { apiVersion: "v1alpha" } }
-            : {}),
-        });
+        const ai = createGenAIClient(credential);
 
         const session = await ai.live.connect({
           model,
@@ -213,7 +213,11 @@ export function useGeminiVoiceSession(
             onclose: () =>
               handleDrop("Connection lost. Press Talk to reconnect."),
           },
-          config: buildGeminiConfig({ voice, functionDeclarations }),
+          config: buildGeminiConfig({
+            voice,
+            functionDeclarations,
+            vad: turnDetection,
+          }),
         });
 
         if (stale()) {
@@ -263,6 +267,7 @@ export function useGeminiVoiceSession(
       enabledTools,
       voice,
       volume,
+      turnDetection,
       cleanup,
     ],
   );

--- a/webui/src/hooks/voice/gemini/use-gemini-voice-session.ts
+++ b/webui/src/hooks/voice/gemini/use-gemini-voice-session.ts
@@ -1,0 +1,331 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { GoogleGenAI, type Session } from "@google/genai";
+import { type Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { type RealtimeItem } from "@openai/agents/realtime";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import { createGeminiMcpTools } from "#webui/hooks/voice/gemini/gemini-mcp-tools";
+import { GeminiMicCapture } from "#webui/hooks/voice/gemini/gemini-mic-capture";
+import { GeminiPcmPlayer } from "#webui/hooks/voice/gemini/gemini-pcm-player";
+import { GeminiHistoryBuilder } from "#webui/hooks/voice/gemini/gemini-realtime-items";
+import { fetchGeminiToken } from "#webui/hooks/voice/gemini/gemini-voice-token";
+import {
+  buildGeminiConfig,
+  GEMINI_INPUT_MIME_TYPE,
+  type GeminiMessageDeps,
+  handleGeminiMessage,
+  seedGeminiContext,
+} from "#webui/hooks/voice/gemini/use-gemini-voice-session-helpers";
+import {
+  type UseVoiceSessionReturn,
+  type VoiceStatus,
+} from "#webui/hooks/voice/use-voice-session";
+import { extractErrorMessage } from "#webui/hooks/voice/use-voice-session-helpers";
+
+export interface UseGeminiVoiceSessionParams {
+  mcpUrl: string;
+  /** URL of the /gemini-voice-token proxy endpoint. */
+  voiceTokenUrl: string;
+  geminiKey: string | null;
+  /** Gemini Live model id for the session. */
+  model: string;
+  enabledTools?: Record<string, boolean>;
+  /** Prebuilt Gemini voice name; locked at connect (applied on next Stop → Talk). */
+  voice?: string;
+  /** Output playback volume (live; applied to the GainNode immediately). */
+  volume?: number;
+}
+
+/**
+ * Gemini Live counterpart to useVoiceSession (OpenAI). Returns the identical
+ * UseVoiceSessionReturn contract so use-voice-mode-state can drive either
+ * backend interchangeably. Where the OpenAI hook leans on @openai/agents
+ * (RealtimeSession owns audio, history, and the tool loop), this drives a raw
+ * WebSocket: GeminiMicCapture streams 16 kHz PCM in, GeminiPcmPlayer schedules
+ * 24 kHz PCM out gaplessly, GeminiHistoryBuilder synthesizes the transcript, and
+ * the MCP tool loop is explicit. Reentrancy is guarded the same way (a
+ * connecting flag plus a generation counter that a teardown bumps so a connect()
+ * resumed after teardown bails instead of leaking a socket + mic).
+ *
+ * @param params - Hook parameters
+ * @returns Voice session state and controls
+ */
+export function useGeminiVoiceSession(
+  params: UseGeminiVoiceSessionParams,
+): UseVoiceSessionReturn {
+  const {
+    mcpUrl,
+    voiceTokenUrl,
+    geminiKey,
+    model,
+    enabledTools,
+    voice,
+    volume,
+  } = params;
+
+  const sessionRef = useRef<Session | null>(null);
+  const micRef = useRef<GeminiMicCapture | null>(null);
+  const playerRef = useRef<GeminiPcmPlayer | null>(null);
+  const mcpClientRef = useRef<Client | null>(null);
+  const builderRef = useRef<GeminiHistoryBuilder | null>(null);
+  const connectingRef = useRef(false);
+  const connectGenRef = useRef(0);
+  const intentionalCloseRef = useRef(false);
+  const isMutedRef = useRef(false);
+
+  const [status, setStatus] = useState<VoiceStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [history, setHistory] = useState<RealtimeItem[]>([]);
+  const [isMuted, setIsMuted] = useState(false);
+  const [assistantSpeaking, setAssistantSpeaking] = useState(false);
+  const [assistantThinking, setAssistantThinking] = useState(false);
+  const [activeVoice, setActiveVoice] = useState<string | null>(null);
+
+  const cleanup = useCallback(async () => {
+    intentionalCloseRef.current = true;
+    const session = sessionRef.current;
+    const mcp = mcpClientRef.current;
+    const mic = micRef.current;
+    const player = playerRef.current;
+
+    sessionRef.current = null;
+    mcpClientRef.current = null;
+    micRef.current = null;
+    playerRef.current = null;
+    builderRef.current = null;
+    connectingRef.current = false;
+    // Invalidate any connect() suspended on an await so it bails on resume.
+    connectGenRef.current++;
+
+    await mic?.stop();
+    await player?.close();
+
+    try {
+      session?.close();
+    } catch {
+      // best-effort
+    }
+
+    try {
+      await mcp?.close();
+    } catch {
+      // best-effort
+    }
+
+    setAssistantSpeaking(false);
+    setAssistantThinking(false);
+    setActiveVoice(null);
+    setIsMuted(false);
+    isMutedRef.current = false;
+  }, []);
+
+  const connect = useCallback(
+    async (initialHistory?: RealtimeItem[]) => {
+      // connectingRef alone guards reentrancy: it's set true here and only
+      // cleared by cleanup() (disconnect/error), so it stays true while
+      // connected too. Deliberately NOT reading sessionRef.current here —
+      // reading it before the awaits and assigning it after would trip the
+      // require-atomic-updates rule (which the OpenAI hook suppresses; we avoid
+      // needing a suppression instead).
+      if (connectingRef.current) return;
+
+      if (!geminiKey) {
+        setStatus("error");
+        setError(
+          "Configure your Gemini API key in the chat UI settings first.",
+        );
+
+        return;
+      }
+
+      connectingRef.current = true;
+      const myGen = connectGenRef.current;
+      const stale = (): boolean => connectGenRef.current !== myGen;
+
+      intentionalCloseRef.current = false;
+      setStatus("connecting");
+      setError(null);
+      setHistory([]);
+      const builder = new GeminiHistoryBuilder();
+
+      builderRef.current = builder;
+
+      try {
+        const { functionDeclarations, executeTool, mcpClient } =
+          await createGeminiMcpTools(mcpUrl, enabledTools);
+
+        mcpClientRef.current = mcpClient;
+        if (stale()) return void (await cleanup());
+
+        const credential = await fetchGeminiToken(
+          voiceTokenUrl,
+          geminiKey,
+          model,
+        );
+
+        if (stale()) return void (await cleanup());
+
+        const player = new GeminiPcmPlayer();
+
+        player.setVolume(volume ?? 1);
+        await player.resume();
+        playerRef.current = player;
+
+        const deps: GeminiMessageDeps = {
+          builder,
+          player,
+          getSession: () => sessionRef.current,
+          executeTool,
+          publishHistory: () => {
+            if (builderRef.current === builder)
+              setHistory(builder.toRealtimeItems());
+          },
+          setAssistantSpeaking,
+          setAssistantThinking,
+          setError,
+        };
+
+        const handleDrop = (message: string): void => {
+          if (intentionalCloseRef.current) return;
+          void cleanup().then(() => {
+            setStatus("error");
+            setError(message);
+          });
+        };
+
+        const ai = new GoogleGenAI({
+          apiKey: credential.value,
+          ...(credential.ephemeral
+            ? { httpOptions: { apiVersion: "v1alpha" } }
+            : {}),
+        });
+
+        const session = await ai.live.connect({
+          model,
+          callbacks: {
+            onopen: () => {},
+            onmessage: (m) => void handleGeminiMessage(m, deps),
+            onerror: (e) =>
+              handleDrop(extractErrorMessage(e) || "Voice connection error."),
+            onclose: () =>
+              handleDrop("Connection lost. Press Talk to reconnect."),
+          },
+          config: buildGeminiConfig({ voice, functionDeclarations }),
+        });
+
+        if (stale()) {
+          try {
+            session.close();
+          } catch {
+            // best-effort
+          }
+
+          return void (await cleanup());
+        }
+
+        sessionRef.current = session;
+
+        const mic = new GeminiMicCapture();
+
+        micRef.current = mic;
+        mic.setMuted(isMutedRef.current);
+        await mic.start({
+          onChunk: (data) => {
+            try {
+              sessionRef.current?.sendRealtimeInput({
+                audio: { data, mimeType: GEMINI_INPUT_MIME_TYPE },
+              });
+            } catch {
+              // a chunk racing teardown — drop it
+            }
+          },
+        });
+
+        if (stale()) return void (await cleanup());
+
+        seedGeminiContext(session, initialHistory);
+        setActiveVoice(voice ?? null);
+        setStatus("connected");
+      } catch (err) {
+        setStatus("error");
+        setError(extractErrorMessage(err));
+        await cleanup();
+      }
+    },
+    [
+      mcpUrl,
+      voiceTokenUrl,
+      geminiKey,
+      model,
+      enabledTools,
+      voice,
+      volume,
+      cleanup,
+    ],
+  );
+
+  const disconnect = useCallback(async () => {
+    setStatus("disconnecting");
+    await cleanup();
+    setStatus("idle");
+  }, [cleanup]);
+
+  const toggleMute = useCallback(async () => {
+    const mic = micRef.current;
+
+    if (!mic) return;
+    const next = !isMuted;
+
+    mic.setMuted(next);
+    isMutedRef.current = next;
+    setIsMuted(next);
+  }, [isMuted]);
+
+  // Manual interrupt: flush local playback and close the open model turn. (Gemini
+  // also auto-interrupts on barge-in via server VAD; this is the explicit button.)
+  const interrupt = useCallback(() => {
+    playerRef.current?.flush();
+
+    if (builderRef.current) {
+      builderRef.current.completeTurn();
+      setHistory(builderRef.current.toRealtimeItems());
+    }
+
+    setAssistantSpeaking(false);
+  }, []);
+
+  // Gemini responds automatically and has no OpenAI-style rate-limit retry, so
+  // this just clears any error banner to satisfy the shared contract.
+  const retryResponse = useCallback(() => setError(null), []);
+
+  const resetHistory = useCallback(() => {
+    builderRef.current = sessionRef.current ? new GeminiHistoryBuilder() : null;
+    setHistory([]);
+  }, []);
+
+  useEffect(() => {
+    playerRef.current?.setVolume(volume ?? 1);
+  }, [volume]);
+
+  useEffect(() => () => void cleanup(), [cleanup]);
+
+  return {
+    status,
+    error,
+    history,
+    isMuted,
+    assistantSpeaking,
+    assistantThinking,
+    rateLimitedUntil: null,
+    connect,
+    disconnect,
+    toggleMute,
+    interrupt,
+    retryResponse,
+    resetHistory,
+    activeVoice,
+  };
+}

--- a/webui/src/hooks/voice/realtime-mcp-tools.ts
+++ b/webui/src/hooks/voice/realtime-mcp-tools.ts
@@ -10,18 +10,13 @@ import {
   createConnectedMcpClient,
   filterEnabledTools,
 } from "#webui/chat/helpers/mcp-client-helpers";
+import { callMcpToolToString } from "#webui/hooks/voice/voice-mcp-call";
 
 /** Result of creating Realtime SDK tools from MCP */
 export interface RealtimeMcpTools {
   tools: Tool[];
   mcpClient: Client;
 }
-
-// Cap how long a voice tool call can run. The MCP SDK's default is 60s; a stuck
-// Live operation would otherwise block the voice turn that long with no
-// feedback. On timeout the SDK rejects with an McpError, which is caught below
-// and returned to the model as a normal tool-error string so it can recover.
-const VOICE_TOOL_TIMEOUT_MS = 30_000;
 
 /**
  * Build OpenAI Realtime SDK tools from a Producer Pal MCP server. Each tool's
@@ -50,59 +45,16 @@ export async function createRealtimeMcpTools(
       // OpenAI's strict-mode JSON schema does not accept.
       parameters: normalizeJsonSchema(t.inputSchema),
       strict: false,
-      execute: async (args: unknown) => {
-        try {
-          const result = await mcpClient.callTool(
-            {
-              name: t.name,
-              arguments: args as Record<string, unknown>,
-            },
-            undefined,
-            { timeout: VOICE_TOOL_TIMEOUT_MS },
-          );
-
-          const content = result.content as Array<{
-            type: string;
-            text?: string;
-          }>;
-
-          const text = extractMcpText(content);
-
-          // Return MCP errors as a normal tool output (prefixed) instead of
-          // throwing. The Realtime SDK's default error-handling can leave the
-          // voice session in a broken state — returning the error text as the
-          // function output lets the model see it and respond naturally.
-          if (result.isError) {
-            return `Error from ${t.name}: ${text}`;
-          }
-
-          return text;
-        } catch (err) {
-          // Same rationale for transport/network errors raised by the MCP client.
-          const message = err instanceof Error ? err.message : String(err);
-
-          return `Error calling ${t.name}: ${message}`;
-        }
-      },
+      execute: async (args: unknown) =>
+        await callMcpToolToString(
+          mcpClient,
+          t.name,
+          (args ?? {}) as Record<string, unknown>,
+        ),
     }),
   );
 
   return { tools, mcpClient };
-}
-
-/**
- * Extract text content from an MCP content array.
- *
- * @param content - MCP content items (text, image, etc.)
- * @returns Concatenated text from all text content items
- */
-function extractMcpText(
-  content: Array<{ type: string; text?: string }>,
-): string {
-  return content
-    .filter((c): c is { type: "text"; text: string } => c.type === "text")
-    .map((c) => c.text)
-    .join("\n");
 }
 
 type JsonObjectSchemaNonStrict = {

--- a/webui/src/hooks/voice/tests/realtime-mcp-tools.test.ts
+++ b/webui/src/hooks/voice/tests/realtime-mcp-tools.test.ts
@@ -6,36 +6,23 @@
 /**
  * @vitest-environment happy-dom
  */
-import { type Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { type McpToolDefinition } from "#webui/chat/helpers/mcp-client-helpers";
+import {
+  callToolMock,
+  fakeMcpClient,
+  listToolsMock,
+  mcpClientHelpersMock,
+  resetMcpClientMocks,
+} from "#webui/hooks/voice/gemini/tests/mcp-bridge-test-helpers";
 
-const callToolMock = vi.fn();
-const listToolsMock = vi.fn();
-const closeMock = vi.fn();
-
-const fakeMcpClient = {
-  callTool: callToolMock,
-  listTools: listToolsMock,
-  close: closeMock,
-} as unknown as Client;
-
-vi.mock(import("#webui/chat/helpers/mcp-client-helpers"), () => ({
-  createConnectedMcpClient: vi.fn(async () => fakeMcpClient),
-  filterEnabledTools: (
-    tools: McpToolDefinition[],
-    enabledTools?: Record<string, boolean>,
-  ): McpToolDefinition[] =>
-    enabledTools ? tools.filter((t) => enabledTools[t.name] !== false) : tools,
-}));
+vi.mock(import("#webui/chat/helpers/mcp-client-helpers"), () =>
+  mcpClientHelpersMock(),
+);
 
 import { createRealtimeMcpTools } from "#webui/hooks/voice/realtime-mcp-tools";
 
-afterEach(() => {
-  callToolMock.mockReset();
-  listToolsMock.mockReset();
-  closeMock.mockReset();
-});
+afterEach(resetMcpClientMocks);
 
 const MCP_URL = "http://localhost:3350/mcp";
 

--- a/webui/src/hooks/voice/tests/use-voice-session-config.test.ts
+++ b/webui/src/hooks/voice/tests/use-voice-session-config.test.ts
@@ -57,7 +57,10 @@ vi.mock(import("#webui/hooks/voice/realtime-mcp-tools"), () => ({
 
 import { mapThinkingToRealtimeEffort } from "#webui/hooks/settings/config-builders";
 import { VOICE_SPEED_DEFAULT } from "#webui/hooks/settings/settings-helpers";
-import { type TurnDetectionSettings } from "#webui/hooks/settings/turn-detection-helpers";
+import {
+  DEFAULT_TURN_DETECTION,
+  type TurnDetectionSettings,
+} from "#webui/hooks/settings/turn-detection-helpers";
 import { useVoiceSession } from "#webui/hooks/voice/use-voice-session";
 import { OPENAI_REALTIME_MODEL } from "#webui/lib/constants/models";
 
@@ -114,6 +117,7 @@ async function connectAndReadAudio(
 describe("useVoiceSession turn-detection config", () => {
   it("maps server_vad turnDetection into audio.input", async () => {
     const turnDetection: TurnDetectionSettings = {
+      ...DEFAULT_TURN_DETECTION,
       mode: "server_vad",
       threshold: 0.7,
       silenceDurationMs: 350,

--- a/webui/src/hooks/voice/use-voice-mode-reporting.ts
+++ b/webui/src/hooks/voice/use-voice-mode-reporting.ts
@@ -33,13 +33,17 @@ interface UseVoiceModeReportingParams {
    * model (e.g. opening a voice convo from history while saved is GPT-5). */
   savedModel: string;
   savedProvider: Provider;
+  /** The provider backing the active voice session ("openai" | "gemini"). Drives
+   * the header brand label and the saved-vs-active divergence check, so a Gemini
+   * session shows "Google" and isn't flagged as diverging from saved. */
+  activeProvider: Provider;
 }
 
 /**
  * Reports the active voice session's lock + delete handlers up to App and
- * builds the HeaderInfo. Voice mode's conversation lock is static (always
- * realtime/openai) but only meaningful when a record is loaded — the lock
- * notice should be invisible on a fresh session.
+ * builds the HeaderInfo. Voice mode's conversation lock is a realtime model on
+ * the active provider (OpenAI or Gemini) but only meaningful when a record is
+ * loaded — the lock notice should be invisible on a fresh session.
  *
  * @param params - reporting inputs
  * @returns The computed HeaderInfo
@@ -57,6 +61,7 @@ export function useVoiceModeReporting(
     activeModel,
     savedModel,
     savedProvider,
+    activeProvider,
   } = params;
   const hasActiveVoiceConv = persistence.activeConversationId != null;
   // Read delete handlers via a ref so the effect's deps stay stable —
@@ -83,7 +88,7 @@ export function useVoiceModeReporting(
     setModeContext({
       conversationLock: {
         activeModel: hasActiveVoiceConv ? activeModel : null,
-        activeProvider: hasActiveVoiceConv ? "openai" : null,
+        activeProvider: hasActiveVoiceConv ? activeProvider : null,
         activeSmallModelMode: hasActiveVoiceConv ? false : null,
       },
       onDeleteAllConversations: () => void handlersRef.current.deleteAll(),
@@ -91,11 +96,17 @@ export function useVoiceModeReporting(
         void handlersRef.current.deleteUnbookmarked(),
       activeVoice,
     });
-  }, [hasActiveVoiceConv, setModeContext, activeVoice, activeModel]);
+  }, [
+    hasActiveVoiceConv,
+    setModeContext,
+    activeVoice,
+    activeModel,
+    activeProvider,
+  ]);
 
   return {
     activeModel,
-    activeProvider: "openai",
+    activeProvider,
     model: savedModel,
     provider: savedProvider,
     enabledToolsCount,

--- a/webui/src/hooks/voice/use-voice-mode-state.ts
+++ b/webui/src/hooks/voice/use-voice-mode-state.ts
@@ -9,12 +9,21 @@ import { useConversationTransfer } from "#webui/hooks/chat/use-conversation-tran
 import { type PreferencesSettings } from "#webui/hooks/use-preferences-settings";
 import { useClearViewingModeOnReset } from "#webui/hooks/view-state/use-clear-viewing-mode-on-reset";
 import { type ViewState } from "#webui/hooks/view-state/use-view-state";
+import { useGeminiVoiceSession } from "#webui/hooks/voice/gemini/use-gemini-voice-session";
 import { realtimeItemsToUIMessages } from "#webui/hooks/voice/realtime-items-to-ui-messages";
 import { useVoiceModeReporting } from "#webui/hooks/voice/use-voice-mode-reporting";
 import { useVoicePersistence } from "#webui/hooks/voice/use-voice-persistence";
 import { mergeVoiceHistory } from "#webui/hooks/voice/use-voice-persistence-helpers";
 import { useVoiceSession } from "#webui/hooks/voice/use-voice-session";
-import { resolveRealtimeModel } from "#webui/lib/constants/models";
+import {
+  DEFAULT_GEMINI_REALTIME_VOICE,
+  DEFAULT_REALTIME_VOICE,
+  isGeminiRealtimeModelId,
+  isValidGeminiRealtimeVoice,
+  isValidRealtimeVoice,
+  realtimeProvider,
+  resolveRealtimeModel,
+} from "#webui/lib/constants/models";
 import { type ConversationRecord } from "#webui/lib/conversation-db";
 import { type UseSettingsReturn } from "#webui/types/settings";
 import { isFirefox } from "#webui/utils/browser-detect";
@@ -59,17 +68,46 @@ export function useVoiceModeState(params: UseVoiceModeStateParams) {
     () => mcpUrl.replace(/\/mcp$/, "/voice-token"),
     [mcpUrl],
   );
+  const geminiTokenUrl = useMemo(
+    () => mcpUrl.replace(/\/mcp$/, "/gemini-voice-token"),
+    [mcpUrl],
+  );
+  // Which realtime backend the saved selection runs on. Voice is OpenAI OR
+  // Gemini; the inactive backend's hook stays idle (its key is null below).
+  const backend = realtimeProvider(settings.savedProvider, settings.savedModel);
+  const isGemini = backend === "gemini";
   const openAiKey =
     settings.provider === "openai" && settings.apiKey ? settings.apiKey : null;
+  const geminiKey =
+    settings.provider === "gemini" && settings.apiKey ? settings.apiKey : null;
   // The realtime model the active voice session runs on (the saved selection
-  // when it's realtime, else the default). Threaded into the session, ephemeral
-  // token, saved record, and header lock so a non-default realtime model isn't
-  // mislabeled as the default.
+  // when it's realtime, else the provider default). Threaded into the session,
+  // ephemeral token, saved record, and header lock so a non-default realtime
+  // model isn't mislabeled as the default.
   const realtimeModel = resolveRealtimeModel(
     settings.savedProvider,
     settings.savedModel,
   );
+  // OpenAI and Gemini have disjoint voice sets but share one saved field, so
+  // validate per-provider at the point of use: a voice valid for the active
+  // backend passes through, anything else (a leftover cross-provider id) falls
+  // back to that backend's default. Keeps the wrong voice id from ever reaching
+  // a session (which would error).
+  const openAiVoiceId = isValidRealtimeVoice(settings.savedRealtimeVoice)
+    ? settings.savedRealtimeVoice
+    : DEFAULT_REALTIME_VOICE;
+  const geminiVoiceId = isValidGeminiRealtimeVoice(settings.savedRealtimeVoice)
+    ? settings.savedRealtimeVoice
+    : DEFAULT_GEMINI_REALTIME_VOICE;
+  // The voice the active backend will actually use — drives the header/controls
+  // "pending change" comparison so it reflects the real (validated) voice.
+  const activeVoiceId = isGemini ? geminiVoiceId : openAiVoiceId;
+  // Firefox can't drive OpenAI's WebRTC transport, but Gemini's WebSocket path
+  // works there — so the unsupported-browser block only applies to OpenAI.
   const firefoxDetected = useMemo(() => isFirefox(), []);
+  const isUnsupportedBrowser = firefoxDetected && !isGemini;
+  const voiceKey = isGemini ? geminiKey : openAiKey;
+  const voiceProviderName = isGemini ? "Gemini" : "OpenAI";
   const historyPanelOpen = viewState.historyPanelOpen;
   const setHistoryPanelOpen = useCallback(
     (updater: (open: boolean) => boolean) => {
@@ -78,19 +116,33 @@ export function useVoiceModeState(params: UseVoiceModeStateParams) {
     [historyPanelOpen, setViewState],
   );
 
-  const voice = useVoiceSession({
+  // Both backend hooks are always called (rules of hooks); the inactive one gets
+  // a null key, so its connect() short-circuits and it never opens a socket/mic.
+  // App routes to VoiceApp only for a realtime selection, so `backend` picks the
+  // live one here.
+  const openAiVoice = useVoiceSession({
     mcpUrl,
     voiceTokenUrl,
     openAiKey,
     model: realtimeModel,
     enabledTools: settings.enabledTools,
-    voice: settings.savedRealtimeVoice,
+    voice: openAiVoiceId,
     speed: settings.savedVoiceSpeed,
     // Live (not saved): volume changes take effect during the active session.
     volume: settings.voiceVolume,
     thinking: settings.savedThinking,
     turnDetection: settings.savedTurnDetection,
   });
+  const geminiVoiceSession = useGeminiVoiceSession({
+    mcpUrl,
+    voiceTokenUrl: geminiTokenUrl,
+    geminiKey,
+    model: realtimeModel,
+    enabledTools: settings.enabledTools,
+    voice: geminiVoiceId,
+    volume: settings.voiceVolume,
+  });
+  const voice = isGemini ? geminiVoiceSession : openAiVoice;
 
   // When a Settings bulk delete removes the in-progress live record, tear the
   // session down too (mirrors the sidebar delete-active path) so the deleted
@@ -171,6 +223,11 @@ export function useVoiceModeState(params: UseVoiceModeStateParams) {
   // session model for a fresh session. The live session still runs on
   // realtimeModel; only the displayed/saved label tracks the record.
   const headerModel = persistence.activeRecordModel ?? realtimeModel;
+  // Derive the brand from the header model itself (not the saved selection) so a
+  // saved Gemini record reads "Google" even if the user later switched provider.
+  const headerProvider = isGeminiRealtimeModelId(headerModel)
+    ? "gemini"
+    : "openai";
 
   const headerInfo = useVoiceModeReporting({
     persistence,
@@ -182,6 +239,7 @@ export function useVoiceModeState(params: UseVoiceModeStateParams) {
     activeModel: headerModel,
     savedModel: settings.savedModel,
     savedProvider: settings.savedProvider,
+    activeProvider: headerProvider,
   });
 
   return {
@@ -189,8 +247,16 @@ export function useVoiceModeState(params: UseVoiceModeStateParams) {
     persistence,
     transfer,
     messages,
-    openAiKey,
-    firefoxDetected,
+    /** Active backend's API key (OpenAI or Gemini), or null when unconfigured. */
+    voiceKey,
+    /** Name of the active voice provider, for key-required messaging. */
+    voiceProviderName,
+    /** Validated voice id the active backend uses (provider-aware), for the
+     * controls' pending-change comparison. */
+    activeVoiceId,
+    /** True only when the browser can't drive the active backend (Firefox +
+     * OpenAI WebRTC; Gemini's WebSocket works in Firefox). */
+    isUnsupportedBrowser,
     historyPanelOpen,
     setHistoryPanelOpen,
     isConnected,

--- a/webui/src/hooks/voice/use-voice-mode-state.ts
+++ b/webui/src/hooks/voice/use-voice-mode-state.ts
@@ -141,6 +141,7 @@ export function useVoiceModeState(params: UseVoiceModeStateParams) {
     enabledTools: settings.enabledTools,
     voice: geminiVoiceId,
     volume: settings.voiceVolume,
+    turnDetection: settings.savedTurnDetection.gemini,
   });
   const voice = isGemini ? geminiVoiceSession : openAiVoice;
 

--- a/webui/src/hooks/voice/use-voice-session.ts
+++ b/webui/src/hooks/voice/use-voice-session.ts
@@ -72,7 +72,7 @@ interface UseVoiceSessionParams {
   turnDetection?: TurnDetectionSettings;
 }
 
-interface UseVoiceSessionReturn {
+export interface UseVoiceSessionReturn {
   status: VoiceStatus;
   error: string | null;
   history: RealtimeItem[];

--- a/webui/src/hooks/voice/voice-mcp-call.ts
+++ b/webui/src/hooks/voice/voice-mcp-call.ts
@@ -1,0 +1,69 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+// Cap how long a voice tool call can run. The MCP SDK's default is 60s; a stuck
+// Live operation would otherwise block the voice turn that long with no
+// feedback. On timeout the SDK rejects with an McpError, which is caught below
+// and returned to the model as a normal tool-error string so it can recover.
+export const VOICE_TOOL_TIMEOUT_MS = 30_000;
+
+/**
+ * Call an MCP tool and return its result as a string, never throwing. Shared by
+ * both voice tool bridges (OpenAI Realtime and Gemini Live): each provider wraps
+ * tools differently, but the call + result-flattening + error-as-output policy
+ * is identical. MCP errors (isError) and transport/network throws are returned
+ * as a prefixed string rather than thrown — the realtime models recover from a
+ * tool-output error far better than from a protocol-level failure (which can
+ * wedge the session).
+ *
+ * @param mcpClient - Connected MCP client
+ * @param name - Tool name to call
+ * @param args - Tool arguments
+ * @returns Flattened text output, or an "Error from/calling …" string
+ */
+export async function callMcpToolToString(
+  mcpClient: Client,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  try {
+    const result = await mcpClient.callTool(
+      { name, arguments: args },
+      undefined,
+      {
+        timeout: VOICE_TOOL_TIMEOUT_MS,
+      },
+    );
+
+    const content = result.content as Array<{ type: string; text?: string }>;
+    const text = extractMcpText(content);
+
+    if (result.isError) return `Error from ${name}: ${text}`;
+
+    return text;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    return `Error calling ${name}: ${message}`;
+  }
+}
+
+/**
+ * Extract and join text content from an MCP content array, dropping non-text
+ * items (images, etc.).
+ *
+ * @param content - MCP content items
+ * @returns Concatenated text from all text content items
+ */
+export function extractMcpText(
+  content: Array<{ type: string; text?: string }>,
+): string {
+  return content
+    .filter((c): c is { type: "text"; text: string } => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
+}

--- a/webui/src/lib/constants/models.test.ts
+++ b/webui/src/lib/constants/models.test.ts
@@ -5,10 +5,14 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  GEMINI_MODELS,
+  GEMINI_REALTIME_MODEL,
   OPENAI_MODELS,
   OPENAI_REALTIME_MODEL,
+  isGeminiRealtimeModelId,
   isRealtimeModelId,
   isRealtimeSelection,
+  realtimeProvider,
   resolveRealtimeModel,
 } from "#webui/lib/constants/models";
 
@@ -24,7 +28,32 @@ describe("isRealtimeSelection", () => {
     expect(isRealtimeSelection("openrouter", OPENAI_REALTIME_MODEL)).toBe(
       false,
     );
+    // gemini provider with the OpenAI id must NOT route to Gemini voice — the
+    // Gemini heuristic excludes "realtime" precisely so this stays false.
     expect(isRealtimeSelection("gemini", OPENAI_REALTIME_MODEL)).toBe(false);
+  });
+
+  it("returns true for the Gemini realtime model under the gemini provider", () => {
+    expect(isRealtimeSelection("gemini", GEMINI_REALTIME_MODEL)).toBe(true);
+  });
+
+  it("treats a free-text Gemini live model under gemini as realtime (Other...)", () => {
+    expect(isRealtimeSelection("gemini", "gemini-2.0-flash-live-001")).toBe(
+      true,
+    );
+    expect(
+      isRealtimeSelection(
+        "gemini",
+        "gemini-2.5-flash-native-audio-preview-12-2025",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not route the Gemini realtime model under a non-gemini provider", () => {
+    expect(isRealtimeSelection("openai", GEMINI_REALTIME_MODEL)).toBe(false);
+    expect(isRealtimeSelection("openrouter", GEMINI_REALTIME_MODEL)).toBe(
+      false,
+    );
   });
 
   it("returns false for standard chat models", () => {
@@ -78,6 +107,28 @@ describe("isRealtimeModelId", () => {
   });
 });
 
+describe("isGeminiRealtimeModelId", () => {
+  it("matches Gemini live / native-audio ids, not 'realtime' ids", () => {
+    expect(isGeminiRealtimeModelId("gemini-3.1-flash-live-preview")).toBe(true);
+    expect(isGeminiRealtimeModelId("gemini-2.0-flash-live-001")).toBe(true);
+    expect(
+      isGeminiRealtimeModelId("gemini-2.5-flash-native-audio-preview-12-2025"),
+    ).toBe(true);
+    // Must NOT match OpenAI's "realtime" naming — guards foreign-id routing.
+    expect(isGeminiRealtimeModelId("gpt-realtime-2")).toBe(false);
+  });
+
+  it("does not match standard Gemini chat ids", () => {
+    expect(isGeminiRealtimeModelId("gemini-3.5-flash")).toBe(false);
+    expect(isGeminiRealtimeModelId("gemini-3.1-pro-preview")).toBe(false);
+  });
+
+  it("returns false for null or undefined", () => {
+    expect(isGeminiRealtimeModelId(null)).toBe(false);
+    expect(isGeminiRealtimeModelId(undefined)).toBe(false);
+  });
+});
+
 describe("resolveRealtimeModel", () => {
   it("returns the saved model when it is a realtime selection", () => {
     expect(resolveRealtimeModel("openai", "gpt-4o-realtime-preview")).toBe(
@@ -85,6 +136,9 @@ describe("resolveRealtimeModel", () => {
     );
     expect(resolveRealtimeModel("openai", OPENAI_REALTIME_MODEL)).toBe(
       OPENAI_REALTIME_MODEL,
+    );
+    expect(resolveRealtimeModel("gemini", GEMINI_REALTIME_MODEL)).toBe(
+      GEMINI_REALTIME_MODEL,
     );
   });
 
@@ -97,6 +151,34 @@ describe("resolveRealtimeModel", () => {
       OPENAI_REALTIME_MODEL,
     );
     expect(resolveRealtimeModel("openai", null)).toBe(OPENAI_REALTIME_MODEL);
+  });
+
+  it("falls back to the Gemini realtime model under the gemini provider", () => {
+    // A non-realtime Gemini selection still resolves to a Gemini voice model,
+    // not the OpenAI default.
+    expect(resolveRealtimeModel("gemini", "gemini-3.5-flash")).toBe(
+      GEMINI_REALTIME_MODEL,
+    );
+    expect(resolveRealtimeModel("gemini", null)).toBe(GEMINI_REALTIME_MODEL);
+  });
+});
+
+describe("realtimeProvider", () => {
+  it("returns the backend for a realtime selection, else null", () => {
+    expect(realtimeProvider("openai", OPENAI_REALTIME_MODEL)).toBe("openai");
+    expect(realtimeProvider("gemini", GEMINI_REALTIME_MODEL)).toBe("gemini");
+    expect(realtimeProvider("openai", "gpt-5.5")).toBeNull();
+    expect(realtimeProvider("anthropic", "claude-sonnet-4-6")).toBeNull();
+    expect(realtimeProvider("gemini", "gemini-3.5-flash")).toBeNull();
+  });
+});
+
+describe("GEMINI_MODELS", () => {
+  it("includes the realtime model with kind marker", () => {
+    const entry = GEMINI_MODELS.find((m) => m.value === GEMINI_REALTIME_MODEL);
+
+    expect(entry).toBeDefined();
+    expect(entry?.kind).toBe("realtime");
   });
 });
 

--- a/webui/src/lib/constants/models.ts
+++ b/webui/src/lib/constants/models.ts
@@ -26,6 +26,46 @@ export const OTHER_MODEL_OPTION = {
 export const OPENAI_REALTIME_MODEL = "gpt-realtime-2";
 
 /**
+ * Gemini's recommended Live API model (audio-to-audio, low latency). Used as
+ * the realtime fallback when the saved Gemini selection isn't itself a realtime
+ * model, mirroring OPENAI_REALTIME_MODEL for the OpenAI side.
+ */
+export const GEMINI_REALTIME_MODEL = "gemini-3.1-flash-live-preview";
+
+/**
+ * Prebuilt voices for the Gemini Live API (distinct from OpenAI's
+ * REALTIME_VOICES). The voice is set in the session config at connect time.
+ */
+export const GEMINI_REALTIME_VOICES = [
+  { value: "Puck", label: "Puck" },
+  { value: "Charon", label: "Charon" },
+  { value: "Kore", label: "Kore" },
+  { value: "Fenrir", label: "Fenrir" },
+  { value: "Aoede", label: "Aoede" },
+  { value: "Leda", label: "Leda" },
+  { value: "Orus", label: "Orus" },
+  { value: "Zephyr", label: "Zephyr" },
+] as const;
+
+export type GeminiRealtimeVoice =
+  (typeof GEMINI_REALTIME_VOICES)[number]["value"];
+
+export const DEFAULT_GEMINI_REALTIME_VOICE: GeminiRealtimeVoice = "Puck";
+
+/**
+ * Validates that a string is a known Gemini realtime voice id. Used when loading
+ * a saved voice to guard against an OpenAI voice id (e.g. "marin") left over
+ * from a provider switch.
+ * @param value - Candidate voice id
+ * @returns True if the value is one of GEMINI_REALTIME_VOICES
+ */
+export function isValidGeminiRealtimeVoice(
+  value: string,
+): value is GeminiRealtimeVoice {
+  return GEMINI_REALTIME_VOICES.some((v) => v.value === value);
+}
+
+/**
  * Voice options accepted by OpenAI's Realtime API. Recommended by OpenAI:
  * `marin` or `cedar` for best audio quality. Once the model has emitted audio
  * in a session, the voice is locked for that session — we can change it
@@ -65,10 +105,15 @@ export const ANTHROPIC_MODELS = [
   OTHER_MODEL_OPTION,
 ];
 
-export const GEMINI_MODELS = [
+export const GEMINI_MODELS: ModelPresetItem[] = [
   { value: "gemini-3.5-flash", label: "Gemini 3.5 Flash" },
   { value: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro" },
   { value: "gemini-3.1-flash-lite", label: "Gemini 3.1 Flash-Lite" },
+  {
+    value: GEMINI_REALTIME_MODEL,
+    label: "Gemini 3.1 Flash Live (Voice)",
+    kind: "realtime",
+  },
   OTHER_MODEL_OPTION,
 ];
 
@@ -177,6 +222,13 @@ export const PROVIDER_MODELS: Partial<
 };
 
 const REALTIME_MODEL_ID = /realtime/i;
+// Gemini's realtime/voice models don't carry "realtime" — they're named with
+// "-live-" (gemini-3.1-flash-live-preview, gemini-2.0-flash-live-001) or
+// "native-audio" (gemini-2.5-flash-native-audio-*). Deliberately excludes
+// "realtime" so a foreign OpenAI id (gpt-realtime-2) under the gemini provider
+// does NOT route to Gemini voice. Lets a free-text "Other..." Gemini live model
+// enable voice without a preset for every id.
+const GEMINI_REALTIME_MODEL_ID = /(-live-|native-audio)/i;
 
 /**
  * Heuristic: does a model id name a realtime (voice) model? OpenAI's realtime
@@ -188,6 +240,19 @@ const REALTIME_MODEL_ID = /realtime/i;
  */
 export function isRealtimeModelId(model: string | null | undefined): boolean {
   return model != null && REALTIME_MODEL_ID.test(model);
+}
+
+/**
+ * Heuristic counterpart to isRealtimeModelId for Gemini's naming (-live- /
+ * native-audio / realtime). Lets a free-text "Other..." Gemini live model route
+ * to voice.
+ * @param model - Candidate model id
+ * @returns True if the id looks like a Gemini realtime model
+ */
+export function isGeminiRealtimeModelId(
+  model: string | null | undefined,
+): boolean {
+  return model != null && GEMINI_REALTIME_MODEL_ID.test(model);
 }
 
 /**
@@ -212,7 +277,11 @@ export function isRealtimeSelection(
       (m) => m.value === model && m.kind === "realtime",
     ) ?? false;
 
-  return isPreset || (provider === "openai" && isRealtimeModelId(model));
+  return (
+    isPreset ||
+    (provider === "openai" && isRealtimeModelId(model)) ||
+    (provider === "gemini" && isGeminiRealtimeModelId(model))
+  );
 }
 
 /**
@@ -229,7 +298,24 @@ export function resolveRealtimeModel(
   model: string | null | undefined,
 ): string {
   // isRealtimeSelection is false for null/undefined, so model is a string here.
-  return isRealtimeSelection(provider, model)
-    ? (model as string)
-    : OPENAI_REALTIME_MODEL;
+  if (isRealtimeSelection(provider, model)) return model as string;
+
+  return provider === "gemini" ? GEMINI_REALTIME_MODEL : OPENAI_REALTIME_MODEL;
+}
+
+/**
+ * Which voice backend a (provider, model) realtime selection runs on. Returns
+ * null when the selection isn't a realtime model at all. Lets the voice-mode
+ * layer pick the OpenAI vs Gemini session hook without re-deriving the rule.
+ * @param provider - The saved provider
+ * @param model - The saved model id
+ * @returns "openai" | "gemini" for a realtime selection, else null
+ */
+export function realtimeProvider(
+  provider: Provider,
+  model: string | null | undefined,
+): "openai" | "gemini" | null {
+  if (!isRealtimeSelection(provider, model)) return null;
+
+  return provider === "gemini" ? "gemini" : "openai";
 }

--- a/webui/src/lib/constants/models.ts
+++ b/webui/src/lib/constants/models.ts
@@ -35,16 +35,41 @@ export const GEMINI_REALTIME_MODEL = "gemini-3.1-flash-live-preview";
 /**
  * Prebuilt voices for the Gemini Live API (distinct from OpenAI's
  * REALTIME_VOICES). The voice is set in the session config at connect time.
+ * Labels include Google's tonal descriptor. All 30 are empirically verified to
+ * produce audio on gemini-3.1-flash-live-preview; Puck is listed first as the
+ * default. Source: Gemini TTS voice catalog (ai.google.dev).
  */
 export const GEMINI_REALTIME_VOICES = [
-  { value: "Puck", label: "Puck" },
-  { value: "Charon", label: "Charon" },
-  { value: "Kore", label: "Kore" },
-  { value: "Fenrir", label: "Fenrir" },
-  { value: "Aoede", label: "Aoede" },
-  { value: "Leda", label: "Leda" },
-  { value: "Orus", label: "Orus" },
-  { value: "Zephyr", label: "Zephyr" },
+  { value: "Puck", label: "Puck (Upbeat)" },
+  { value: "Zephyr", label: "Zephyr (Bright)" },
+  { value: "Charon", label: "Charon (Informative)" },
+  { value: "Kore", label: "Kore (Firm)" },
+  { value: "Fenrir", label: "Fenrir (Excitable)" },
+  { value: "Leda", label: "Leda (Youthful)" },
+  { value: "Orus", label: "Orus (Firm)" },
+  { value: "Aoede", label: "Aoede (Breezy)" },
+  { value: "Callirrhoe", label: "Callirrhoe (Easy-going)" },
+  { value: "Autonoe", label: "Autonoe (Bright)" },
+  { value: "Enceladus", label: "Enceladus (Breathy)" },
+  { value: "Iapetus", label: "Iapetus (Clear)" },
+  { value: "Umbriel", label: "Umbriel (Easy-going)" },
+  { value: "Algieba", label: "Algieba (Smooth)" },
+  { value: "Despina", label: "Despina (Smooth)" },
+  { value: "Erinome", label: "Erinome (Clear)" },
+  { value: "Algenib", label: "Algenib (Gravelly)" },
+  { value: "Rasalgethi", label: "Rasalgethi (Informative)" },
+  { value: "Laomedeia", label: "Laomedeia (Upbeat)" },
+  { value: "Achernar", label: "Achernar (Soft)" },
+  { value: "Alnilam", label: "Alnilam (Firm)" },
+  { value: "Schedar", label: "Schedar (Even)" },
+  { value: "Gacrux", label: "Gacrux (Mature)" },
+  { value: "Pulcherrima", label: "Pulcherrima (Forward)" },
+  { value: "Achird", label: "Achird (Friendly)" },
+  { value: "Zubenelgenubi", label: "Zubenelgenubi (Casual)" },
+  { value: "Vindemiatrix", label: "Vindemiatrix (Gentle)" },
+  { value: "Sadachbia", label: "Sadachbia (Lively)" },
+  { value: "Sadaltager", label: "Sadaltager (Knowledgeable)" },
+  { value: "Sulafat", label: "Sulafat (Warm)" },
 ] as const;
 
 export type GeminiRealtimeVoice =


### PR DESCRIPTION
Adds **Gemini Live** (`gemini-3.1-flash-live-preview`) as a realtime/voice provider alongside OpenAI's `gpt-realtime-2`. Select the Gemini provider + "Gemini 3.1 Flash Live (Voice)" model, paste a Gemini key, and voice mode works — verified in-app (voice switching works, OpenAI path unaffected).

## Architecture

**Parallel hook, not a shared-transport refactor.** `useGeminiVoiceSession` returns the same `UseVoiceSessionReturn` contract; `use-voice-mode-state` calls both hooks and selects by provider. The inactive hook gets a null key and stays idle, so the OpenAI WebRTC lifecycle is **untouched** (zero regression risk).

Where WebRTC handled the audio subsystem for OpenAI, the Gemini WebSocket path rebuilds it by hand:
- **Input** — `getUserMedia` → 16 kHz `AudioContext` → `AudioWorklet` (worklet source inlined + loaded via a Blob URL so it survives the single-file `viteSingleFile` webui build).
- **Output** — gapless 24 kHz PCM scheduler (running cursor + jitter lead) with barge-in flush.
- **Tools** — MCP → Gemini `FunctionDeclaration[]`, sharing a new `voice-mcp-call.ts` the OpenAI bridge was refactored onto (DRY).
- **History** — transcripts + tool calls synthesized into the same `RealtimeItem[]` shape, so persistence and the transcript UI are reused unchanged.

Gemini code is isolated in `webui/src/hooks/voice/gemini/`.

## Notable bits
- `models.ts`: realtime preset, Gemini voices, provider-aware `resolveRealtimeModel` / `isRealtimeSelection` / `realtimeProvider`.
- `/gemini-voice-token` route: raw-key passthrough (localhost/own-key); ephemeral v1alpha `auth_tokens` minting is seamed for later.
- Provider-aware UI: Gemini voice picker, Firefox-works-on-Gemini, provider-aware key-required + header brand ("Google") labels.

## Known follow-ups (deferred, non-blocking)
- **Session resumption** — long Gemini sessions drop at ~10–15 min (degrades gracefully to "press Talk to reconnect"; saved transcript reseeds context).
- **Ephemeral tokens** — server-only upgrade from the current passthrough.
- **Docs** — voice guide still says OpenAI-only / Firefox-unsupported.

## Checks
`npm run check` (lint, typecheck, format, duplication, 6466 tests, coverage 100% functions / 95.52% branches), `npm run check:build`, and `npm run ui:build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)