### PR TITLE
bar|beat: switch `t` and `@step` to absolute note values (experiment)

### DIFF
--- a/dev/specs/BarBeat-Spec.md
+++ b/dev/specs/BarBeat-Spec.md
@@ -14,10 +14,13 @@ A precise, stateful music notation format for MIDI sequencing in Ableton Live.
 
 - **Start Time (`bar|beat`)** Time position that emits buffered notes.
   - `bar` – 1-based bar number (integer, required)
-  - `beat` – 1-based beat number within bar (float for sub-beat precision)
-  - **Repeat patterns**: `beat x times @ step` generates multiple positions
-    - Example: `1|1x4@1` → beats 1,2,3,4
-    - Example: `1|1x3@1/3` → triplets at 1, 4/3, 5/3
+  - `beat` – 1-based beat number within bar, **meter-relative** (float for
+    sub-beat precision)
+  - **Repeat patterns**: `beat x times @ step` generates multiple positions.
+    `step` is an absolute note value with the same form as `t` (see Duration).
+    - Example: `1|1x4@/4` → 4 positions a quarter note apart: beats 1,2,3,4 in
+      4/4
+    - Example: `1|1x3@/12` → eighth-note triplets at beats 1, 4/3, 5/3 in 4/4
   - Notes are emitted ONLY at time positions
   - Buffered pitches persist and re-emit at subsequent time positions
   - Requires whitespace separation from following elements
@@ -40,12 +43,21 @@ A precise, stateful music notation format for MIDI sequencing in Ableton Live.
 
 - **Duration (`t`)**
   - Sets duration for following notes until changed
-  - Beat-only format: `t2.5` (2.5 beats), `t3/4` (0.75 beats), `t/4` (0.25
-    beats - numerator defaults to 1)
-  - Bar:beat format: `t2:1.5` (2 bars + 1.5 beats), `t1:3/4` (1 bar + 0.75
-    beats), `t1:/4` (1 bar + 0.25 beats)
-  - Default: 1.0
+  - **Absolute note value**: written as a fraction of a whole note,
+    `t<numerator>/<denominator>`. Numerator defaults to 1 (`t/4` == `t1/4`).
+    Denominator is **mandatory** — bare integers (`t1`), decimals (`t0.5`), and
+    mixed numbers (`t1+1/2`) are invalid and raise a parser error
+  - Common values: `t/1` whole, `t/2` half, `t/4` quarter, `t/8` eighth, `t/16`
+    sixteenth, `t3/8` dotted quarter, `t5/4` five quarter notes
+  - Tuplets: `t/3` half-note triplet, `t/6` quarter triplet, `t/12` eighth
+    triplet, `t/24` sixteenth triplet (denominator = how many fit in a whole
+    note)
+  - Meter-independent: `t/4` is always one quarter note, in 4/4, 6/8, 5/4, etc.
+  - Default: `t/4` (one quarter note)
   - Requires whitespace separation from following elements
+  - NOTE: clip `length` and arrangement durations use a separate `bar:beat`
+    format (e.g., `"4:0"` = 4 bars) elsewhere in the tool API — that format is
+    NOT this one, and is unchanged
 
 - **Note (`C4`, `Eb2`, `F#3`, etc.)**
   - Note names follow standard pitch notation using:
@@ -219,52 +231,56 @@ Repeat patterns generate sequences of beat positions using the syntax
 bar|{start}x{times}@{step}
 ```
 
-- **start**: Starting beat position (supports decimals, fractions, and mixed
-  numbers)
+- **start**: Starting beat position (meter-relative; supports decimals,
+  fractions, and mixed numbers)
 - **times**: Number of repetitions (positive integer)
-- **step**: Interval between repetitions (supports decimals, fractions, mixed
-  numbers, and optional numerator: `/3` = `1/3`)
+- **step**: Interval between repetitions, **same form as `t`** — absolute note
+  value as a fraction of a whole note, denominator mandatory, numerator defaults
+  to 1 (`@/4` == `@1/4`). Bare integers (`@1`), decimals (`@0.5`), and mixed
+  numbers (`@1+1/2`) are invalid and raise a parser error
 
 The `@` symbol reads as "at intervals" and semantically connects to bar copy
 operations.
 
 ### Examples
 
-**Whole beats:**
+**Quarter notes:**
 
 ```
-1|1x4@1          // Beats 1,2,3,4
+1|1x4@/4         // 4 positions a quarter apart: beats 1,2,3,4 in 4/4
 ```
 
 **Triplets:**
 
 ```
-1|1x3@1/3        // Beats 1, 4/3, 5/3 (every third)
-1|1x3@/3         // Same as above (numerator defaults to 1)
-1|3x3@1/3        // Beats 3, 10/3, 11/3
+1|1x3@/12        // eighth-note triplet (3 in a quarter): beats 1, 4/3, 5/3 in 4/4
+1|1x3@/6         // quarter-note triplet (3 in a half): beats 1, 5/3, 7/3 in 4/4
+1|3x3@/12        // eighth-note triplet starting at beat 3
 ```
 
 **16th notes:**
 
 ```
-1|4x4@1/4        // Four 16ths on beat 4: 4, 17/4, 18/4, 19/4
-1|4x4@/4         // Same as above (numerator defaults to 1)
-1|1x16@1/4       // Full bar of 16ths
-1|1x16@/4        // Same as above (numerator defaults to 1)
+1|4x4@/16        // four 16ths on beat 4: 4, 17/4, 18/4, 19/4
+1|1x16@/16       // 16 sixteenths spanning one quarter note
 ```
 
 **Eighth notes:**
 
 ```
-1|1x8@1/2        // Eight 8ths: 1, 3/2, 2, 5/2, ..., 9/2
-1|1x8@0.5        // Same as above (decimal notation)
+1|1x8@/8         // eight 8ths: 1, 3/2, 2, 5/2, ..., 9/2 in 4/4
 ```
 
-**Mixed numbers:**
+**Mixed-number starts (positions stay meter-relative):**
 
 ```
-1|2+1/3x3@1/3    // Start at 2+1/3: 2+1/3, 2+2/3, 3
-1|1x4@1+1/2      // Steps of 1.5: 1, 2.5, 4, 5.5
+1|2+1/3x3@/12    // start at 2+1/3, three eighth-note-triplet steps
+```
+
+**Step omitted** (defaults to the current duration):
+
+```
+t/8 C1 1|1x4     // 4 eighths starting at 1|1 (step defaults to t value)
 ```
 
 ### Behavior
@@ -272,19 +288,19 @@ operations.
 **Bar overflow**: Patterns naturally overflow into subsequent bars:
 
 ```
-1|3x6@1          // 3,4,5,6,7,8 → 1|3, 1|4, 2|1, 2|2, 2|3, 2|4
+1|3x6@/4         // 3,4,5,6,7,8 → 1|3, 1|4, 2|1, 2|2, 2|3, 2|4 in 4/4
 ```
 
 **Mixing with regular beats**: Combine repeat patterns with explicit beats:
 
 ```
-C1 1|1x4@1,3.5   // Beats 1,2,3,4,3.5 (beat 3.5 listed explicitly)
+C1 1|1x4@/4,3.5  // Beats 1,2,3,4,3.5 (beat 3.5 listed explicitly)
 ```
 
 **Multiple patterns**: Use multiple repeat patterns in one beat list:
 
 ```
-C1 1|1x2@1,3x2@0.5  // Beats 1,2,3,3.5
+C1 1|1x2@/4,3x2@/8  // Beats 1,2,3,3.5 in 4/4
 ```
 
 ### Interaction with Other Features
@@ -292,19 +308,19 @@ C1 1|1x2@1,3x2@0.5  // Beats 1,2,3,3.5
 **Pitch buffering**: All buffered pitches emit at each expanded position:
 
 ```
-C3 D3 E3 1|1x4@1    // C3, D3, E3 at each of beats 1,2,3,4
+C3 D3 E3 1|1x4@/4   // C3, D3, E3 at each of beats 1,2,3,4
 ```
 
 **State parameters**: Velocity, duration, probability apply to all positions:
 
 ```
-v80 t0.5 C1 1|1x4@1 // All four notes have v80 and t0.5
+v80 t/8 C1 1|1x4@/4 // All four notes have v80 and an eighth-note duration
 ```
 
 **Bar copy**: Repeat patterns work with bar copy operations:
 
 ```
-C1 1|1x4@1          // Bar 1: kick on every beat
+C1 1|1x4@/4         // Bar 1: kick on every beat
 @2=1                // Bar 2: copy of bar 1
 ```
 
@@ -533,47 +549,45 @@ C1 1|1 1|2 1|3 1|4
 C1 1|1 1|3  D1 1|2 1|4
 
 // Simple melody with state changes
-v100 t1.0 C3 1|1 D3 1|2 E3 1|3 F3 1|4
-v80 t2.0 G3 2|1
+v100 t/4 C3 1|1 D3 1|2 E3 1|3 F3 1|4   // quarter notes
+v80 t/2 G3 2|1                          // half note
 
-// Sub-beat timing with floating points
-v100 t0.25 C3 1|1 D3 1|1.5 E3 1|2.25 F3 1|3.75
+// Sub-beat timing with floating points (positions stay decimal)
+v100 t/16 C3 1|1 D3 1|1.5 E3 1|2.25 F3 1|3.75
 
-// Duration examples - beat-only format
-t2.5 C3 1|1    // 2.5 beats duration (decimal)
-t3/4 C3 1|1    // 0.75 beats duration (fraction)
-t/4 C3 1|1     // 0.25 beats duration (numerator defaults to 1)
-t1/3 C3 1|1,4/3,5/3  // Triplet eighth notes
-t/3 C3 1|1,4/3,5/3   // Same as above (numerator defaults to 1)
+// Duration examples — absolute note values
+t/2 C3 1|1       // half note (2 quarters)
+t/4 C3 1|1       // quarter note (default)
+t/8 C3 1|1       // eighth note
+t/16 C3 1|1      // sixteenth note
+t3/8 C3 1|1      // dotted quarter (3 eighths)
+t3/16 C3 1|1     // dotted eighth (3 sixteenths)
+t/12 C3 1|1,4/3,5/3   // eighth-note triplets (3 per quarter)
+t/6 C3 1|1,5/3,7/3    // quarter-note triplets (3 per half)
+t/1 C3 1|1       // whole note (4 quarters)
+t2/1 C3 1|1      // 2 whole notes (8 quarters)
+t5/4 C3 1|1      // 5 quarter notes (e.g. fills a 5/4 bar)
 
-// Duration examples - bar:beat format
-t2:0 C3 1|1    // 2 bar duration (whole note in 4/4)
-t1:0 C3 1|1    // 1 bar duration (half note in 4/4)
-t2:1.5 C3 1|1  // 2 bars + 1.5 beats
-t1:3/4 C3 1|1  // 1 bar + 0.75 beats
-t1:/4 C3 1|1   // 1 bar + 0.25 beats (numerator defaults to 1)
-
-// Repeat patterns - whole beats
-C1 1|1x4@1     // Kick on every beat (repeat syntax)
+// Repeat patterns - quarter-note step
+C1 1|1x4@/4    // Kick on every beat (repeat syntax)
 C1 1|1,2,3,4   // Same as above (comma-separated beats still supported)
 
 // Repeat patterns - triplets
-t1/3 C3 1|1x3@1/3           // Triplet eighth notes
-t/3 C3 1|1x3@/3             // Same as above (numerator defaults to 1)
-t1/3 C3 1|1x3@1/3 1|2x3@1/3  // Two sets of triplets
+t/12 C3 1|1x3@/12            // eighth-note triplets (3 per quarter)
+t/12 C3 1|1x3 1|2x3          // step defaults to t, two sets of triplets
 
 // Repeat patterns - 16th notes
-t1/4 Gb1 1|1x16@1/4  // Full bar of hi-hat 16ths
-t/4 Gb1 1|1x16@/4    // Same as above (numerator defaults to 1)
+t/16 Gb1 1|1x16@/16    // 16 sixteenths spanning a quarter note
+t/16 Gb1 1|1x16        // same — step defaults to t value
 
 // Repeat patterns - mixed with regular beats
-C1 1|1x4@1 D1 1|2,4  // Kick on all beats, snare on 2 & 4
+C1 1|1x4@/4 D1 1|2,4   // Kick on all beats, snare on 2 & 4
 
 // Repeat patterns - bar overflow
-C3 1|3x6@1  // Starts beat 3, overflows into bar 2
+C3 1|3x6@/4  // Starts beat 3, overflows into bar 2 in 4/4
 
 // Drum pattern with probability and velocity variation
-v100 t0.25 p1.0 C1 v80-100 p0.8 Gb1 1|1
+v100 t/16 p1.0 C1 v80-100 p0.8 Gb1 1|1
 p0.6 Gb1 1|1.5
 v90 p1.0 D1 v100 p0.9 Gb1 1|2
 
@@ -627,7 +641,7 @@ type Element =
   | { bar: number, beat: number | RepeatPattern }                    // Time position
   | { velocity: number }                                             // Single velocity (0-127)
   | { velocityMin: number, velocityMax: number }                     // Velocity range (0-127)
-  | { duration: number }                                             // Duration in beats
+  | { duration: number }                                             // Duration as a fraction of a whole note (e.g., 1/4 = quarter)
   | { probability: number }                                          // Probability (0.0-1.0)
   | { barCopy: number, sourcePrevious: true }                        // @N= (copy previous)
   | { barCopy: number, sourceBar: number }                           // @N=M (copy bar M)
@@ -638,9 +652,9 @@ type Element =
   | { clearBuffer: true }                                            // @clear (clear copy buffer)
 
 type RepeatPattern = {
-  start: number,   // Starting beat position
+  start: number,   // Starting beat position (meter-relative)
   times: number,   // Number of repetitions (integer)
-  step: number     // Step size (supports fractions)
+  step: number     // Step size as a fraction of a whole note (null when @step omitted)
 }
 ```
 
@@ -678,8 +692,10 @@ grammar AST to return an array of note events:
   for time signature)
   - Example: In 4/4, bar 2 beat 3 = `(2-1) * 4 + (3-1) = 6.0` beats
   - Example: In 3/4, bar 2 beat 3 = `((2-1) * 3 + (3-1)) * (4/4) = 5.0` beats
-- **duration**: Converted from beat duration to Ableton beats (accounts for time
-  signature)
+- **duration**: The grammar emits durations as a fraction of a whole note
+  (meter-independent); the interpreter then converts to Ableton beats (= quarter
+  notes). A `t/4` becomes `1.0` in any meter; `t/8` becomes `0.5`; a `t3/8`
+  (dotted quarter) becomes `1.5`
 - **velocity**: Base velocity (0-127)
   - `v0` notes appear in output with `velocity: 0` for deletion purposes
   - Tools filter v0 notes before sending to Live API (see Note Deletion section)

--- a/dev/specs/BarBeat-Spec.md
+++ b/dev/specs/BarBeat-Spec.md
@@ -262,7 +262,7 @@ operations.
 
 ```
 1|4x4@/16        // four 16ths on beat 4: 4, 17/4, 18/4, 19/4
-1|1x16@/16       // 16 sixteenths spanning one quarter note
+1|1x16@/16       // 16 sixteenths = 4 quarters (a full bar in 4/4)
 ```
 
 **Eighth notes:**
@@ -577,7 +577,7 @@ t/12 C3 1|1x3@/12            // eighth-note triplets (3 per quarter)
 t/12 C3 1|1x3 1|2x3          // step defaults to t, two sets of triplets
 
 // Repeat patterns - 16th notes
-t/16 Gb1 1|1x16@/16    // 16 sixteenths spanning a quarter note
+t/16 Gb1 1|1x16@/16    // 16 sixteenths = 4 quarters (a full bar in 4/4)
 t/16 Gb1 1|1x16        // same — step defaults to t value
 
 // Repeat patterns - mixed with regular beats

--- a/src/notation/barbeat/barbeat-config.ts
+++ b/src/notation/barbeat/barbeat-config.ts
@@ -1,10 +1,56 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 export const DEFAULT_VELOCITY = 100;
-export const DEFAULT_DURATION = 1;
 export const DEFAULT_TIME: { bar: number; beat: number } = { bar: 1, beat: 1 };
 export const DEFAULT_BEATS_PER_BAR = 4;
 export const DEFAULT_PROBABILITY = 1.0;
 export const DEFAULT_VELOCITY_DEVIATION = 0;
+
+/**
+ * Default `t` duration as a fraction of a whole note (quarter note = 1/4).
+ * Under the absolute-note-value semantics, the default is always a quarter
+ * note regardless of meter.
+ */
+export const DEFAULT_DURATION_WHOLE_NOTE_FRACTION = 1 / 4;
+
+/**
+ * Default duration in musical beats for a given time signature.
+ * A quarter note in N/D meter is D/4 musical beats: 1 in 4/4, 2 in 6/8, 0.5 in 2/2.
+ * @param timeSigDenominator - Time signature denominator (defaults to 4)
+ * @returns Default duration expressed in musical beats
+ */
+export function defaultDurationMusicalBeats(
+  timeSigDenominator: number | undefined,
+): number {
+  return DEFAULT_DURATION_WHOLE_NOTE_FRACTION * (timeSigDenominator ?? 4);
+}
+
+/**
+ * Convert an absolute duration/step (fraction of a whole note) to musical beats.
+ * 1 whole note = D musical beats in N/D meter.
+ * @param wholeNoteFraction - Value as a fraction of a whole note (e.g., 1/4 = quarter)
+ * @param timeSigDenominator - Time signature denominator (defaults to 4)
+ * @returns Value expressed in musical beats
+ */
+export function wholeNoteFractionToMusicalBeats(
+  wholeNoteFraction: number,
+  timeSigDenominator: number | undefined,
+): number {
+  return wholeNoteFraction * (timeSigDenominator ?? 4);
+}
+
+/**
+ * Convert musical beats to a fraction of a whole note.
+ * @param musicalBeats - Value in musical beats
+ * @param timeSigDenominator - Time signature denominator (defaults to 4)
+ * @returns Value as a fraction of a whole note
+ */
+export function musicalBeatsToWholeNoteFraction(
+  musicalBeats: number,
+  timeSigDenominator: number | undefined,
+): number {
+  return musicalBeats / (timeSigDenominator ?? 4);
+}

--- a/src/notation/barbeat/barbeat-format-notation.test.ts
+++ b/src/notation/barbeat/barbeat-format-notation.test.ts
@@ -25,6 +25,7 @@ describe("bar|beat formatNotation() re-export shim", () => {
   });
 
   it("formats notes with state changes", () => {
+    // 0.5 quarter = /8 whole; 2 quarter = /2 whole
     const notes = [
       createNote({ velocity: 80, duration: 0.5, probability: 0.8 }),
       createNote({
@@ -37,7 +38,7 @@ describe("bar|beat formatNotation() re-export shim", () => {
     ] as NoteEvent[];
 
     expect(formatNotation(notes)).toBe(
-      "v80 t/2 p0.8 C3 1|1 v120 t2 p0.6 D3 1|2",
+      "v80 t/8 p0.8 C3 1|1 v120 t/2 p0.6 D3 1|2",
     );
   });
 
@@ -46,7 +47,8 @@ describe("bar|beat formatNotation() re-export shim", () => {
   });
 
   it("round-trips with interpretNotation", () => {
-    const original = "1|1 p0.8 v80-120 t0.5 C3 D3 1|2.25 v120 p1.0 t2 E3 F3";
+    // t/8 = eighth; t/2 = half
+    const original = "1|1 p0.8 v80-120 t/8 C3 D3 1|2.25 v120 p1.0 t/2 E3 F3";
     const parsed = interpretNotation(original);
     const formatted = formatNotation(parsed);
     const reparsed = interpretNotation(formatted);

--- a/src/notation/barbeat/barbeat-test-fixtures.ts
+++ b/src/notation/barbeat/barbeat-test-fixtures.ts
@@ -37,7 +37,7 @@ export const drumPatternNotes: NoteEvent[] = [
 ] as NoteEvent[];
 
 export const drumPatternNotation =
-  "t/4 C1 v80-100 p0.8 Gb1 1|1 p0.6 Gb1 1|1.5 v90 p1 D1 v100 p0.9 Gb1 1|2";
+  "t/16 C1 v80-100 p0.8 Gb1 1|1 p0.6 Gb1 1|1.5 v90 p1 D1 v100 p0.9 Gb1 1|2";
 
 /**
  * Sort notes by start_time (with epsilon tolerance), then pitch for comparison.

--- a/src/notation/barbeat/interpreter/barbeat-interpreter.ts
+++ b/src/notation/barbeat/interpreter/barbeat-interpreter.ts
@@ -4,18 +4,16 @@
 
 import { applyV0Deletions } from "#src/notation/barbeat/barbeat-apply-v0-deletions.ts";
 import {
-  DEFAULT_DURATION,
   DEFAULT_PROBABILITY,
   DEFAULT_TIME,
   DEFAULT_VELOCITY,
   DEFAULT_VELOCITY_DEVIATION,
+  defaultDurationMusicalBeats,
+  wholeNoteFractionToMusicalBeats,
 } from "#src/notation/barbeat/barbeat-config.ts";
 import * as parser from "#src/notation/barbeat/parser/barbeat-parser.ts";
 import { type ASTElement } from "#src/notation/barbeat/parser/barbeat-parser.ts";
-import {
-  barBeatDurationToMusicalBeats,
-  parseBeatsPerBar,
-} from "#src/notation/barbeat/time/barbeat-time.ts";
+import { parseBeatsPerBar } from "#src/notation/barbeat/time/barbeat-time.ts";
 import { formatParserError } from "#src/notation/peggy-error-formatter.ts";
 import { type PeggySyntaxError } from "#src/notation/peggy-parser-types.ts";
 import * as console from "#src/shared/v8-max-console.ts";
@@ -87,24 +85,22 @@ function processVelocityRangeUpdate(
 }
 
 /**
- * Process a duration update
+ * Process a duration update.
+ * The grammar emits the duration as a fraction of a whole note (e.g., 1/4 for
+ * a quarter); convert to musical beats based on the time signature denominator.
  * @param element - AST element with duration value
  * @param state - Interpreter state
- * @param timeSigNumerator - Time signature numerator
+ * @param timeSigDenominator - Time signature denominator
  */
 function processDurationUpdate(
   element: ASTElement,
   state: InterpreterState,
-  timeSigNumerator: number | undefined,
+  timeSigDenominator: number | undefined,
 ): void {
-  if (typeof element.duration === "string") {
-    state.currentDuration = barBeatDurationToMusicalBeats(
-      element.duration,
-      timeSigNumerator,
-    );
-  } else {
-    state.currentDuration = element.duration as number;
-  }
+  state.currentDuration = wholeNoteFractionToMusicalBeats(
+    element.duration as number,
+    timeSigDenominator,
+  );
 
   handlePropertyUpdate(state, (pitchState: PitchState) => {
     pitchState.duration = state.currentDuration;
@@ -197,6 +193,7 @@ function processTimePosition(
     element as TimeElement,
     state,
     beatsPerBar,
+    timeSigDenominator,
   );
 
   handlePitchEmission(
@@ -219,7 +216,6 @@ function processTimePosition(
  * @param element - AST element to process
  * @param state - Interpreter state
  * @param beatsPerBar - Beats per bar
- * @param timeSigNumerator - Time signature numerator
  * @param timeSigDenominator - Time signature denominator
  * @param notesByBar - Notes by bar cache
  * @param events - Output events array
@@ -228,7 +224,6 @@ function processElementInLoop(
   element: ASTElement,
   state: InterpreterState,
   beatsPerBar: number,
-  timeSigNumerator: number | undefined,
   timeSigDenominator: number | undefined,
   notesByBar: Map<number, BarCopyNote[]>,
   events: NoteEvent[],
@@ -286,7 +281,7 @@ function processElementInLoop(
   ) {
     processVelocityRangeUpdate(element, state);
   } else if (element.duration !== undefined) {
-    processDurationUpdate(element, state, timeSigNumerator);
+    processDurationUpdate(element, state, timeSigDenominator);
   } else if (element.probability !== undefined) {
     processProbabilityUpdate(element, state);
   }
@@ -306,7 +301,7 @@ export function interpretNotation(
     return [];
   }
 
-  const { timeSigNumerator, timeSigDenominator } = options;
+  const { timeSigDenominator } = options;
   const beatsPerBar = parseBeatsPerBar(options);
 
   try {
@@ -319,7 +314,7 @@ export function interpretNotation(
     const state: InterpreterState = {
       currentTime: DEFAULT_TIME,
       currentVelocity: DEFAULT_VELOCITY,
-      currentDuration: DEFAULT_DURATION,
+      currentDuration: defaultDurationMusicalBeats(timeSigDenominator),
       currentProbability: DEFAULT_PROBABILITY,
       currentVelocityMin: null,
       currentVelocityMax: null,
@@ -335,7 +330,6 @@ export function interpretNotation(
         element,
         state,
         beatsPerBar,
-        timeSigNumerator,
         timeSigDenominator,
         notesByBar,
         events,

--- a/src/notation/barbeat/interpreter/helpers/barbeat-interpreter-pitch-helpers.ts
+++ b/src/notation/barbeat/interpreter/helpers/barbeat-interpreter-pitch-helpers.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Adam Murray
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import { wholeNoteFractionToMusicalBeats } from "#src/notation/barbeat/barbeat-config.ts";
 import * as console from "#src/shared/v8-max-console.ts";
 import { assertDefined } from "#src/tools/shared/utils.ts";
 import { type NoteEvent, type BarCopyNote } from "../../../types.ts";
@@ -23,11 +24,14 @@ export interface TimeElement {
 }
 
 /**
- * Expand a repeat pattern into multiple beat positions
+ * Expand a repeat pattern into multiple beat positions.
+ * The parser emits `pattern.step` as a fraction of a whole note; convert to
+ * musical beats here so it can be added to positions (also in musical beats).
  * @param pattern - Repeat pattern to expand
  * @param currentBar - Current bar number
- * @param beatsPerBar - Beats per bar
- * @param currentDuration - Current note duration
+ * @param beatsPerBar - Beats per bar (musical beats)
+ * @param currentDuration - Current note duration in musical beats (used when @step is omitted)
+ * @param timeSigDenominator - Time signature denominator (for step unit conversion)
  * @returns Array of time positions
  */
 function expandRepeatPattern(
@@ -35,9 +39,13 @@ function expandRepeatPattern(
   currentBar: number,
   beatsPerBar: number,
   currentDuration: number,
+  timeSigDenominator: number | undefined,
 ): TimePosition[] {
   const { start, times, step: stepValue } = pattern;
-  const step = stepValue ?? currentDuration;
+  const step =
+    stepValue == null
+      ? currentDuration
+      : wholeNoteFractionToMusicalBeats(stepValue, timeSigDenominator);
 
   if (times > 100) {
     console.warn(
@@ -168,13 +176,15 @@ function emitPitchesAtPositions(
  * Calculate positions from time element
  * @param element - Time element
  * @param state - Interpreter state
- * @param beatsPerBar - Beats per bar
+ * @param beatsPerBar - Beats per bar (musical beats)
+ * @param timeSigDenominator - Time signature denominator
  * @returns Array of time positions
  */
 export function calculatePositions(
   element: TimeElement,
   state: InterpreterState,
   beatsPerBar: number,
+  timeSigDenominator: number | undefined,
 ): TimePosition[] {
   // bar is always defined when this function is called (checked at barbeat-interpreter.ts dispatch)
   const bar = element.bar as number;
@@ -185,6 +195,7 @@ export function calculatePositions(
       bar,
       beatsPerBar,
       state.currentDuration,
+      timeSigDenominator,
     );
   }
 

--- a/src/notation/barbeat/interpreter/tests/barbeat-interpreter-beat-lists.test.ts
+++ b/src/notation/barbeat/interpreter/tests/barbeat-interpreter-beat-lists.test.ts
@@ -43,7 +43,8 @@ describe("bar|beat interpretNotation() - comma-separated beat lists", () => {
   });
 
   it("applies state to all emitted notes in beat list", () => {
-    const result = interpretNotation("v80 t0.25 p0.8 C1 1|1,2,3,4");
+    // t/16 = sixteenth = 0.25 quarter
+    const result = interpretNotation("v80 t/16 p0.8 C1 1|1,2,3,4");
     const stateOverrides = { duration: 0.25, velocity: 80, probability: 0.8 };
 
     expect(result).toStrictEqual(

--- a/src/notation/barbeat/interpreter/tests/barbeat-interpreter-comments.test.ts
+++ b/src/notation/barbeat/interpreter/tests/barbeat-interpreter-comments.test.ts
@@ -72,8 +72,9 @@ multi-line comment */ D3 1|1`);
   });
 
   it("handles comments between state changes", () => {
+    // t/8 = eighth = 0.5 quarter
     const result = interpretNotation(
-      "v100 // set velocity\nt0.5 // set duration\nC3 1|1 // play note",
+      "v100 // set velocity\nt/8 // set duration\nC3 1|1 // play note",
     );
 
     expect(result).toStrictEqual([createNote({ duration: 0.5 })]);
@@ -87,7 +88,7 @@ multi-line comment */ D3 1|1`);
 
   it("handles drum pattern with comments", () => {
     const result = interpretNotation(`
-        v100 t0.25 p1.0 C1 // kick drum
+        v100 t/16 p1.0 C1 // kick drum
         v80-100 p0.8 Gb1 1|1 // hi-hat with variation
         p0.6 Gb1 1|1.5 // ghost hi-hat
         v90 p1.0 D1 // snare

--- a/src/notation/barbeat/interpreter/tests/barbeat-interpreter-copy-advanced.test.ts
+++ b/src/notation/barbeat/interpreter/tests/barbeat-interpreter-copy-advanced.test.ts
@@ -126,8 +126,9 @@ describe("bar|beat interpretNotation() - advanced bar copy", () => {
       });
 
       it("preserves note properties in tiled copy", () => {
+        // t/8 = eighth = 0.5; t/16 = sixteenth = 0.25
         const result = interpretNotation(
-          "v80 t0.5 p0.8 C3 1|1 v90 t0.25 p0.9 D3 2|1 @3-6=1-2",
+          "v80 t/8 p0.8 C3 1|1 v90 t/16 p0.9 D3 2|1 @3-6=1-2",
         );
 
         // Bar 3 should have C3 with original properties
@@ -152,6 +153,7 @@ describe("bar|beat interpretNotation() - advanced bar copy", () => {
       });
 
       it("handles tiling with different time signatures", () => {
+        // Default duration is a quarter note regardless of meter — 1 Ableton beat in 6/8
         const result = interpretNotation("C3 1|1 D3 2|1 @3-4=1-2", {
           timeSigNumerator: 6,
           timeSigDenominator: 8,
@@ -161,11 +163,11 @@ describe("bar|beat interpretNotation() - advanced bar copy", () => {
         expect(result).toHaveLength(4);
         // Bar 3: C3 at 6.0 beats
         expect(result[2]).toStrictEqual(
-          createNote({ start_time: 6.0, duration: 0.5 }),
+          createNote({ start_time: 6.0, duration: 1 }),
         );
         // Bar 4: D3 at 9.0 beats
         expect(result[3]).toStrictEqual(
-          createNote({ pitch: 62, start_time: 9.0, duration: 0.5 }),
+          createNote({ pitch: 62, start_time: 9.0, duration: 1 }),
         );
       });
     });

--- a/src/notation/barbeat/interpreter/tests/barbeat-interpreter-copy-range.test.ts
+++ b/src/notation/barbeat/interpreter/tests/barbeat-interpreter-copy-range.test.ts
@@ -34,7 +34,8 @@ describe("bar|beat interpretNotation() - bar copy range operations", () => {
       ]);
     });
     it("preserves note properties in range copy", () => {
-      const result = interpretNotation("v80 t0.5 p0.8 C3 1|1 @2-3=");
+      // t/8 = eighth = 0.5 quarter
+      const result = interpretNotation("v80 t/8 p0.8 C3 1|1 @2-3=");
 
       expect(result).toStrictEqual([
         createNote({ duration: 0.5, velocity: 80, probability: 0.8 }),
@@ -53,15 +54,16 @@ describe("bar|beat interpretNotation() - bar copy range operations", () => {
       ]);
     });
     it("handles range copy with different time signatures", () => {
+      // Default duration is a quarter note regardless of meter — 1 Ableton beat in 6/8
       const result = interpretNotation("C3 1|1 @2-3=", {
         timeSigNumerator: 6,
         timeSigDenominator: 8,
       });
 
       expect(result).toStrictEqual([
-        createNote({ duration: 0.5 }),
-        createNote({ start_time: 3.0, duration: 0.5 }),
-        createNote({ start_time: 6.0, duration: 0.5 }),
+        createNote({ duration: 1 }),
+        createNote({ start_time: 3.0, duration: 1 }),
+        createNote({ start_time: 6.0, duration: 1 }),
       ]);
     });
     it("can chain range copies with regular copies", () => {

--- a/src/notation/barbeat/interpreter/tests/barbeat-interpreter-copy.test.ts
+++ b/src/notation/barbeat/interpreter/tests/barbeat-interpreter-copy.test.ts
@@ -73,7 +73,8 @@ describe("bar|beat interpretNotation() - bar copy operations", () => {
       ]);
     });
     it("preserves note properties (velocity, duration, probability)", () => {
-      const result = interpretNotation("v80 t0.5 p0.7 C3 1|1 @2=1");
+      // t/8 = eighth = 0.5 quarter
+      const result = interpretNotation("v80 t/8 p0.7 C3 1|1 @2=1");
 
       expect(result).toStrictEqual([
         createNote({ duration: 0.5, velocity: 80, probability: 0.7 }), // Bar 1
@@ -97,14 +98,15 @@ describe("bar|beat interpretNotation() - bar copy operations", () => {
       ]);
     });
     it("handles 6/8 time signature correctly", () => {
+      // Default duration is a quarter note regardless of meter — 1 Ableton beat in 6/8
       const result = interpretNotation("C3 1|1 @2=1", {
         timeSigNumerator: 6,
         timeSigDenominator: 8,
       });
 
       expect(result).toStrictEqual([
-        createNote({ duration: 0.5 }), // Bar 1 (6/8 time = 3 quarter notes per bar)
-        createNote({ start_time: 3, duration: 0.5 }), // Bar 2 (3 quarter notes later)
+        createNote({ duration: 1 }), // Bar 1 (6/8 = 3 quarter notes per bar)
+        createNote({ start_time: 3, duration: 1 }), // Bar 2 (3 quarter notes later)
       ]);
     });
     it("handles multiple notes at different beats", () => {
@@ -174,25 +176,25 @@ describe("bar|beat interpretNotation() - bar copy operations", () => {
       expect(result).toHaveLength(6);
 
       // Verify bar 1 notes (beats 1 and 4)
-      expect(result).toContainEqual(createNote({ pitch: 36, duration: 0.5 })); // Bar 1 beat 1
+      expect(result).toContainEqual(createNote({ pitch: 36, duration: 1 })); // Bar 1 beat 1
       expect(result).toContainEqual(
-        createNote({ pitch: 36, start_time: 1.5, duration: 0.5 }),
+        createNote({ pitch: 36, start_time: 1.5, duration: 1 }),
       ); // Bar 1 beat 4
 
       // Verify bar 2 notes (beats 7 and 10 overflow from bar 1)
       expect(result).toContainEqual(
-        createNote({ pitch: 36, start_time: 3.0, duration: 0.5 }),
+        createNote({ pitch: 36, start_time: 3.0, duration: 1 }),
       ); // Bar 2 beat 1
       expect(result).toContainEqual(
-        createNote({ pitch: 36, start_time: 4.5, duration: 0.5 }),
+        createNote({ pitch: 36, start_time: 4.5, duration: 1 }),
       ); // Bar 2 beat 4
 
       // Verify bar 3 has ONLY the 2 notes from bar 1
       expect(result).toContainEqual(
-        createNote({ pitch: 36, start_time: 6.0, duration: 0.5 }),
+        createNote({ pitch: 36, start_time: 6.0, duration: 1 }),
       ); // Bar 3 beat 1
       expect(result).toContainEqual(
-        createNote({ pitch: 36, start_time: 7.5, duration: 0.5 }),
+        createNote({ pitch: 36, start_time: 7.5, duration: 1 }),
       ); // Bar 3 beat 4
 
       // Verify bar 4 does NOT have notes (bug would copy bar 2's notes)

--- a/src/notation/barbeat/interpreter/tests/barbeat-interpreter-core.test.ts
+++ b/src/notation/barbeat/interpreter/tests/barbeat-interpreter-core.test.ts
@@ -77,8 +77,9 @@ describe("bar|beat interpretNotation() - core functionality", () => {
     ]);
   });
 
-  it("handles duration state changes", () => {
-    const result = interpretNotation("t0.5 C3 t2.0 D3 E3 1|1");
+  it("handles duration state changes (absolute note values)", () => {
+    // t/8 = eighth note = 0.5 quarter; t/2 = half note = 2 quarters (Ableton beats)
+    const result = interpretNotation("t/8 C3 t/2 D3 E3 1|1");
 
     expect(result).toStrictEqual([
       createNote({ duration: 0.5 }),
@@ -87,79 +88,64 @@ describe("bar|beat interpretNotation() - core functionality", () => {
     ]);
   });
 
-  it("handles bar:beat duration format in 4/4 (NEW)", () => {
-    const result = interpretNotation("t2:1.5 C3 1|1", {
+  it("handles whole-note family durations in 4/4", () => {
+    const result = interpretNotation("t/1 C3 1|1", {
       timeSigNumerator: 4,
       timeSigDenominator: 4,
     });
 
-    // 2 bars (8 beats) + 1.5 beats = 9.5 Ableton beats in 4/4
-    expect(result).toStrictEqual([createNote({ duration: 9.5 })]);
+    // t/1 = whole note = 4 quarters
+    expect(result).toStrictEqual([createNote({ duration: 4 })]);
   });
 
-  it("handles bar:beat duration with fractions (NEW)", () => {
-    const result = interpretNotation("t1:3/4 C3 1|1", {
+  it("handles multi-whole-note durations (t5/4 in 4/4 = 5 quarters)", () => {
+    const result = interpretNotation("t5/4 C3 1|1", {
       timeSigNumerator: 4,
       timeSigDenominator: 4,
     });
 
-    // 1 bar (4 beats) + 0.75 beats = 4.75 Ableton beats
-    expect(result).toStrictEqual([createNote({ duration: 4.75 })]);
+    expect(result).toStrictEqual([createNote({ duration: 5 })]);
   });
 
-  it("handles beat-only decimal duration (NEW)", () => {
-    const result = interpretNotation("t2.5 C3 1|1", {
+  it("handles fractional sub-quarter durations (t3/16 = dotted eighth)", () => {
+    const result = interpretNotation("t3/16 C3 1|1", {
       timeSigNumerator: 4,
       timeSigDenominator: 4,
     });
 
-    // 2.5 beats in 4/4 = 2.5 Ableton beats
-    expect(result).toStrictEqual([createNote({ duration: 2.5 })]);
-  });
-
-  it("handles beat-only fractional duration (NEW)", () => {
-    const result = interpretNotation("t3/4 C3 1|1", {
-      timeSigNumerator: 4,
-      timeSigDenominator: 4,
-    });
-
-    // 3/4 beats in 4/4 = 0.75 Ableton beats
+    // 3/16 of a whole note = 0.75 quarter notes (dotted eighth)
     expect(result).toStrictEqual([createNote({ duration: 0.75 })]);
   });
 
-  it("handles bar:beat duration in 6/8 time (NEW)", () => {
-    const result = interpretNotation("t1:2 C3 1|1", {
+  it("treats t/4 as a quarter regardless of meter (6/8)", () => {
+    const result = interpretNotation("t/4 C3 1|1", {
       timeSigNumerator: 6,
       timeSigDenominator: 8,
     });
 
-    // 1 bar (6 eighth notes) + 2 eighth notes = 8 eighth notes = 4 quarter notes
-    expect(result).toStrictEqual([createNote({ duration: 4.0 })]);
+    // t/4 always = 1 quarter note = 1 Ableton beat, even in 6/8
+    expect(result).toStrictEqual([createNote({ duration: 1 })]);
   });
 
-  it("handles duration with + operator in bar:beat format (NEW)", () => {
-    const result = interpretNotation("t1:2+1/3 C3 1|1", {
+  it("meter-fill: t3/4 fills a 6/8 bar (6 eighths = 3 quarters)", () => {
+    const result = interpretNotation("t3/4 C3 1|1", {
+      timeSigNumerator: 6,
+      timeSigDenominator: 8,
+    });
+
+    expect(result).toStrictEqual([createNote({ duration: 3 })]);
+  });
+
+  it("triplet durations: t/12 = eighth-note triplet, t/6 = quarter-note triplet", () => {
+    const result = interpretNotation("t/12 C3 1|1 t/6 D3 1|2", {
       timeSigNumerator: 4,
       timeSigDenominator: 4,
     });
 
-    expect(result).toHaveLength(1);
-    expect(result[0]!.pitch).toBe(60);
-    expect(result[0]!.start_time).toBe(0);
-    expect(result[0]!.duration).toBeCloseTo(6 + 1 / 3, 10); // 1 bar (4 beats) + 2+1/3 beats = 6+1/3 beats
-    expect(result[0]!.velocity).toBe(100);
-    expect(result[0]!.probability).toBe(1.0);
-    expect(result[0]!.velocity_deviation).toBe(0);
-  });
-
-  it("handles beat-only duration with + operator (NEW)", () => {
-    const result = interpretNotation("t2+3/4 C3 1|1", {
-      timeSigNumerator: 4,
-      timeSigDenominator: 4,
-    });
-
-    // 2+3/4 beats in 4/4 = 2.75 Ableton beats
-    expect(result).toStrictEqual([createNote({ duration: 2.75 })]);
+    // t/12 = 1/3 quarter, t/6 = 2/3 quarter
+    expect(result).toHaveLength(2);
+    expect(result[0]!.duration).toBeCloseTo(1 / 3, 10);
+    expect(result[1]!.duration).toBeCloseTo(2 / 3, 10);
   });
 
   it("handles beat positions with + operator (NEW)", () => {
@@ -187,15 +173,16 @@ describe("bar|beat interpretNotation() - core functionality", () => {
     expect(result[1]!.velocity_deviation).toBe(0);
   });
 
-  it("handles mixed duration formats (NEW)", () => {
-    const result = interpretNotation("t2:0 C3 1|1 t1.5 D3 1|2 t3/4 E3 1|3", {
+  it("handles changing durations across notes", () => {
+    // t2/1 = 2 whole = 8 quarters; t3/8 = dotted quarter = 1.5 quarters; t3/16 = dotted eighth = 0.75
+    const result = interpretNotation("t2/1 C3 1|1 t3/8 D3 1|2 t3/16 E3 1|3", {
       timeSigNumerator: 4,
       timeSigDenominator: 4,
     });
 
-    expect(result[0]!.duration).toBe(8); // 2 bars = 8 beats
-    expect(result[1]!.duration).toBe(1.5); // 1.5 beats
-    expect(result[2]!.duration).toBe(0.75); // 3/4 beats
+    expect(result[0]!.duration).toBe(8);
+    expect(result[1]!.duration).toBe(1.5);
+    expect(result[2]!.duration).toBe(0.75);
   });
 
   it("handles sub-beat timing", () => {
@@ -208,8 +195,9 @@ describe("bar|beat interpretNotation() - core functionality", () => {
   });
 
   it("handles complex state combinations", () => {
+    // t/16 = sixteenth = 0.25; t/4 = quarter = 1
     const result = interpretNotation(
-      "v100 t0.25 p0.9 C3 D3 1|1 v80-120 t1.0 p0.7 E3 F3 1|2",
+      "v100 t/16 p0.9 C3 D3 1|1 v80-120 t/4 p0.7 E3 F3 1|2",
     );
 
     expect(result).toStrictEqual([
@@ -238,7 +226,8 @@ describe("bar|beat interpretNotation() - core functionality", () => {
     expect(result).toStrictEqual(drumPatternNotes);
   });
   it("maintains state across multiple bar boundaries", () => {
-    const result = interpretNotation("v80 t0.5 p0.8 C3 1|1 D3 3|2 E3 5|1");
+    // t/8 = eighth = 0.5 quarter
+    const result = interpretNotation("v80 t/8 p0.8 C3 1|1 D3 3|2 E3 5|1");
 
     expect(result).toStrictEqual([
       createNote({ duration: 0.5, velocity: 80, probability: 0.8 }), // bar 1, beat 1
@@ -284,8 +273,9 @@ describe("bar|beat interpretNotation() - core functionality", () => {
   });
 
   it("handles mixed order of state changes", () => {
+    // t/8 = eighth = 0.5; t/4 = quarter = 1.0
     const result = interpretNotation(
-      "t0.5 v80 p0.7 C3 1|1 v100 t1.0 p1.0 D3 2|1",
+      "t/8 v80 p0.7 C3 1|1 v100 t/4 p1.0 D3 2|1",
     );
 
     expect(result).toStrictEqual([
@@ -341,7 +331,7 @@ describe("bar|beat interpretNotation() - core functionality", () => {
 
   it("warns when repeat time position has no pitches", () => {
     // Repeat pattern with no pitches (multiple positions)
-    interpretNotation("1|1x3@1");
+    interpretNotation("1|1x3@/4");
 
     expect(outlet).toHaveBeenCalledWith(
       1,

--- a/src/notation/barbeat/interpreter/tests/barbeat-interpreter-patterns.test.ts
+++ b/src/notation/barbeat/interpreter/tests/barbeat-interpreter-patterns.test.ts
@@ -8,8 +8,8 @@ import { interpretNotation } from "#src/notation/barbeat/interpreter/barbeat-int
 
 describe("bar|beat interpretNotation() - pattern features", () => {
   describe("repeat patterns (x{times}@{step})", () => {
-    it("expands basic repeat pattern with whole step", () => {
-      const result = interpretNotation("C1 1|1x4@1");
+    it("expands basic repeat pattern with quarter-note step (@/4)", () => {
+      const result = interpretNotation("C1 1|1x4@/4");
 
       expect(result).toStrictEqual([
         createNote({ pitch: 36 }),
@@ -19,8 +19,8 @@ describe("bar|beat interpretNotation() - pattern features", () => {
       ]);
     });
 
-    it("expands repeat pattern with fractional step (triplets)", () => {
-      const result = interpretNotation("C3 1|1x3@1/3", {
+    it("expands repeat pattern with eighth-triplet step (@/12)", () => {
+      const result = interpretNotation("C3 1|1x3@/12", {
         timeSigNumerator: 4,
         timeSigDenominator: 4,
       });
@@ -31,8 +31,8 @@ describe("bar|beat interpretNotation() - pattern features", () => {
       expect(result[2]!.start_time).toBeCloseTo(2 / 3, 10);
     });
 
-    it("expands repeat pattern with decimal step", () => {
-      const result = interpretNotation("Gb1 1|1x8@0.5");
+    it("expands repeat pattern with eighth-note step (@/8)", () => {
+      const result = interpretNotation("Gb1 1|1x8@/8");
 
       expect(result).toHaveLength(8);
       expect(result[0]!.start_time).toBeCloseTo(0, 10);
@@ -40,8 +40,9 @@ describe("bar|beat interpretNotation() - pattern features", () => {
       expect(result[7]!.start_time).toBeCloseTo(3.5, 10);
     });
 
-    it("expands repeat pattern with mixed number step", () => {
-      const result = interpretNotation("C1 1|1x4@1+1/2");
+    it("expands repeat pattern with dotted-quarter step (@3/8)", () => {
+      // 3/8 of a whole note = 1.5 quarter notes (dotted quarter)
+      const result = interpretNotation("C1 1|1x4@3/8");
 
       expect(result).toHaveLength(4);
       expect(result[0]!.start_time).toBeCloseTo(0, 10);
@@ -50,8 +51,8 @@ describe("bar|beat interpretNotation() - pattern features", () => {
       expect(result[3]!.start_time).toBeCloseTo(4.5, 10);
     });
 
-    it("expands repeat pattern with mixed number start", () => {
-      const result = interpretNotation("C3 1|2+1/3x3@1/3", {
+    it("expands repeat pattern with mixed-number start (positions still meter-relative)", () => {
+      const result = interpretNotation("C3 1|2+1/3x3@/12", {
         timeSigNumerator: 4,
         timeSigDenominator: 4,
       });
@@ -63,7 +64,7 @@ describe("bar|beat interpretNotation() - pattern features", () => {
     });
 
     it("handles repeat pattern overflowing into next bar", () => {
-      const result = interpretNotation("C1 1|3x6@1");
+      const result = interpretNotation("C1 1|3x6@/4");
 
       expect(result).toHaveLength(6);
       expect(result[0]!.start_time).toBe(2); // bar 1, beat 3
@@ -75,7 +76,7 @@ describe("bar|beat interpretNotation() - pattern features", () => {
     });
 
     it("handles repeat pattern with explicit bar", () => {
-      const result = interpretNotation("C1 1|1 D1 1|2x2@1");
+      const result = interpretNotation("C1 1|1 D1 1|2x2@/4");
 
       expect(result).toHaveLength(3);
       expect(result[0]!.pitch).toBe(36); // C1 at 1|1
@@ -84,7 +85,7 @@ describe("bar|beat interpretNotation() - pattern features", () => {
     });
 
     it("emits multiple pitches at each expanded position", () => {
-      const result = interpretNotation("C3 D3 E3 1|1x4@1");
+      const result = interpretNotation("C3 D3 E3 1|1x4@/4");
 
       expect(result).toHaveLength(12); // 3 pitches × 4 positions
       // Check first position (beat 1)
@@ -98,7 +99,7 @@ describe("bar|beat interpretNotation() - pattern features", () => {
     });
 
     it("applies state changes to all expanded positions", () => {
-      const result = interpretNotation("v80 t0.5 C1 1|1x4@1");
+      const result = interpretNotation("v80 t/8 C1 1|1x4@/4");
 
       expect(result).toHaveLength(4);
       expect(result.every((note) => note.velocity === 80)).toBe(true);
@@ -106,7 +107,7 @@ describe("bar|beat interpretNotation() - pattern features", () => {
     });
 
     it("uses current duration when step is omitted", () => {
-      const result = interpretNotation("t0.5 C1 1|1x4");
+      const result = interpretNotation("t/8 C1 1|1x4");
 
       expect(result).toHaveLength(4);
       expect(result[0]!.start_time).toBe(0); // 1|1
@@ -116,7 +117,7 @@ describe("bar|beat interpretNotation() - pattern features", () => {
       expect(result.every((note) => note.duration === 0.5)).toBe(true);
     });
 
-    it("uses default duration when step is omitted and no duration set", () => {
+    it("uses default duration (quarter) when step is omitted and no duration set", () => {
       const result = interpretNotation("C1 1|1x3");
 
       expect(result).toHaveLength(3);
@@ -127,7 +128,7 @@ describe("bar|beat interpretNotation() - pattern features", () => {
     });
 
     it("handles repeat pattern mixed with regular beats", () => {
-      const result = interpretNotation("C1 1|1x2@1,3.5");
+      const result = interpretNotation("C1 1|1x2@/4,3.5");
 
       expect(result).toHaveLength(3);
       expect(result[0]!.start_time).toBe(0); // 1|1
@@ -136,7 +137,7 @@ describe("bar|beat interpretNotation() - pattern features", () => {
     });
 
     it("handles multiple repeat patterns in same beat list", () => {
-      const result = interpretNotation("C1 1|1x2@1,3x2@0.5");
+      const result = interpretNotation("C1 1|1x2@/4,3x2@/8");
 
       expect(result).toHaveLength(4);
       expect(result[0]!.start_time).toBe(0); // 1|1
@@ -146,7 +147,7 @@ describe("bar|beat interpretNotation() - pattern features", () => {
     });
 
     it("works with bar copy operations", () => {
-      const result = interpretNotation("C1 1|1x4@1 @2=1");
+      const result = interpretNotation("C1 1|1x4@/4 @2=1");
 
       expect(result).toHaveLength(8);
       // Bar 1
@@ -158,7 +159,7 @@ describe("bar|beat interpretNotation() - pattern features", () => {
     });
 
     it("emits warning for excessive repeat times", () => {
-      interpretNotation("C1 1|1x101@1");
+      interpretNotation("C1 1|1x101@/4");
       expect(outlet).toHaveBeenCalledWith(
         1,
         expect.stringContaining("101 notes, which may be excessive"),
@@ -166,7 +167,7 @@ describe("bar|beat interpretNotation() - pattern features", () => {
     });
 
     it("does not warn about buffered pitches when emitted via repeat pattern", () => {
-      const result = interpretNotation("t.5 C1 1|1x8");
+      const result = interpretNotation("t/8 C1 1|1x8");
 
       // Should emit 8 notes
       expect(result).toHaveLength(8);
@@ -181,7 +182,7 @@ describe("bar|beat interpretNotation() - pattern features", () => {
     });
 
     it("does not warn about buffered pitches when emitted then bar copied", () => {
-      const result = interpretNotation("t.5 C1 1|1x8 @2=");
+      const result = interpretNotation("t/8 C1 1|1x8 @2=");
 
       // Should emit 8 notes in bar 1 and copy to bar 2 (16 total)
       expect(result).toHaveLength(16);
@@ -299,13 +300,13 @@ describe("bar|beat interpretNotation() - pattern features", () => {
     });
 
     it("v0 deletions work with different time signatures", () => {
+      // Default duration is a quarter note regardless of meter — in 6/8 that's 1 Ableton beat
       const result = interpretNotation("C3 D3 1|1 v0 C3 1|1", {
         timeSigNumerator: 6,
         timeSigDenominator: 8,
       });
 
-      // In 6/8 time, each beat is an 8th note, so beats are 0.5 apart in Ableton beats
-      expect(result).toStrictEqual([createNote({ pitch: 62, duration: 0.5 })]);
+      expect(result).toStrictEqual([createNote({ pitch: 62, duration: 1 })]);
     });
 
     it("complex scenario: v0 deletions with bar copies and multiple notes", () => {
@@ -340,7 +341,8 @@ describe("bar|beat interpretNotation() - pattern features", () => {
     });
 
     it("v0 preserves note properties like duration, probability", () => {
-      const result = interpretNotation("t2 p0.8 C3 1|1 t0.5 p1.0 v0 C3 1|1");
+      // t/2 = half = 2 quarters; t/8 = eighth = 0.5
+      const result = interpretNotation("t/2 p0.8 C3 1|1 t/8 p1.0 v0 C3 1|1");
 
       expect(result).toStrictEqual([]);
     });

--- a/src/notation/barbeat/interpreter/tests/barbeat-interpreter-timesig.test.ts
+++ b/src/notation/barbeat/interpreter/tests/barbeat-interpreter-timesig.test.ts
@@ -27,14 +27,15 @@ describe("bar|beat interpretNotation() - time signatures", () => {
     ]);
   });
   it("converts time signatures with half-note denominators correctly", () => {
+    // Default duration is a quarter note regardless of meter — 1 Ableton beat in 2/2
     const result = interpretNotation("C3 1|1 D3 1|2", {
       timeSigNumerator: 2,
       timeSigDenominator: 2,
     });
 
     expect(result).toStrictEqual([
-      createNote({ duration: 2 }),
-      createNote({ pitch: 62, start_time: 2, duration: 2 }),
+      createNote({ duration: 1 }),
+      createNote({ pitch: 62, start_time: 2, duration: 1 }),
     ]);
   });
   it("prefers timeSigNumerator/timeSigDenominator over beatsPerBar", () => {
@@ -50,14 +51,15 @@ describe("bar|beat interpretNotation() - time signatures", () => {
     ]);
   });
   it("converts time signatures with different denominators correctly", () => {
+    // Default duration is a quarter note regardless of meter — 1 Ableton beat in 6/8
     const result = interpretNotation("C3 1|1 D3 1|3", {
       timeSigNumerator: 6,
       timeSigDenominator: 8,
     });
 
     expect(result).toStrictEqual([
-      createNote({ duration: 0.5 }),
-      createNote({ pitch: 62, start_time: 1, duration: 0.5 }),
+      createNote({ duration: 1 }),
+      createNote({ pitch: 62, start_time: 1, duration: 1 }),
     ]);
   });
   it("throws error when only timeSigNumerator is provided", () => {

--- a/src/notation/barbeat/interpreter/tests/barbeat-interpreter-timing.test.ts
+++ b/src/notation/barbeat/interpreter/tests/barbeat-interpreter-timing.test.ts
@@ -88,7 +88,8 @@ describe("bar|beat interpretNotation() - timing features", () => {
     });
 
     it("handles duration updates after time", () => {
-      const result = interpretNotation("C4 1|1 t0.5 1|2 t0.25 1|3");
+      // Default = quarter (1); t/8 = eighth (0.5); t/16 = sixteenth (0.25)
+      const result = interpretNotation("C4 1|1 t/8 1|2 t/16 1|3");
 
       expect(result).toHaveLength(3);
       expect(result[0]!.duration).toBe(1);

--- a/src/notation/barbeat/parser/barbeat-grammar.peggy
+++ b/src/notation/barbeat/parser/barbeat-grammar.peggy
@@ -54,14 +54,19 @@ beatList "beat list"
   }
 
 beatSpec "beat specification"
-  = start:oneOrMoreFloat "x" times:oneOrMoreInt step:("@" unsignedFloat)? {
-      const stepValue = step ? step[1] : null;
-      if (stepValue === 0) {
+  = start:oneOrMoreFloat "x" times:oneOrMoreInt step:stepInterval? {
+      if (step === 0) {
         throw new Error("Repeat step size must be greater than 0");
       }
-      return { start, times, step: stepValue };
+      return { start, times, step: step ?? null };
     }
   / oneOrMoreFloat
+
+stepInterval
+  = "@" frac:unsignedFraction { return frac; }
+  / "@" bad:badAbsoluteValue {
+      throw new Error(`step intervals need a denominator: @/4 = quarter, @/8 = eighth, @/12 = eighth triplet. Got @${bad}`);
+    }
 
 probability "probability value"
   = "p" val:unsignedDecimal {
@@ -89,12 +94,18 @@ velocity "velocity value"
   }
 
 duration "duration value"
-  = "t" bars:unsignedInt ":" beats:unsignedFloat {
-    return { duration: `${bars}:${beats}` };  // String for bar:beat format
+  = "t" frac:unsignedFraction {
+    return { duration: frac };  // Fraction of a whole note (e.g., 1/4 = quarter)
   }
-  / "t" val:unsignedFloat {
-    return { duration: val };  // Number for beat-only (existing)
+  / "t" bad:badAbsoluteValue {
+    throw new Error(`durations need a denominator: t/4 = quarter, t/8 = eighth, t/12 = eighth triplet. Got t${bad}`);
   }
+
+// Matches values that LOOK like a duration/step but lack the required denominator.
+// Used only to produce a targeted error message — never returns a value.
+badAbsoluteValue
+  = unsignedMixedNumber { return text(); }
+  / unsignedDecimal { return text(); }
 
 pitch "note pitch"
   = pitchClass:pitchClass octave:signedInt {

--- a/src/notation/barbeat/parser/generated-barbeat-parser.d.ts
+++ b/src/notation/barbeat/parser/generated-barbeat-parser.d.ts
@@ -39,7 +39,7 @@ export interface ASTElement {
   velocity?: number;
   velocityMin?: number;
   velocityMax?: number;
-  duration?: number | string;
+  duration?: number;
   probability?: number;
   pitch?: number;
   bar?: number;

--- a/src/notation/barbeat/parser/tests/barbeat-parser-basic.test.ts
+++ b/src/notation/barbeat/parser/tests/barbeat-parser-basic.test.ts
@@ -21,10 +21,10 @@ describe("BarBeatScript Parser - basic tests", () => {
     });
 
     it("parses mixed elements (state + notes)", () => {
-      expect(parser.parse("1|1 v100 t0.5 p0.8 C3 D3")).toStrictEqual([
+      expect(parser.parse("1|1 v100 t/2 p0.8 C3 D3")).toStrictEqual([
         { bar: 1, beat: 1 },
         { velocity: 100 },
-        { duration: 0.5 },
+        { duration: 1 / 2 },
         { probability: 0.8 },
         { pitch: 60 },
         { pitch: 62 },
@@ -32,10 +32,10 @@ describe("BarBeatScript Parser - basic tests", () => {
     });
 
     it("parses state-only input", () => {
-      expect(parser.parse("2|3 v80 t0.25 p0.9")).toStrictEqual([
+      expect(parser.parse("2|3 v80 t/16 p0.9")).toStrictEqual([
         { bar: 2, beat: 3 },
         { velocity: 80 },
-        { duration: 0.25 },
+        { duration: 1 / 16 },
         { probability: 0.9 },
       ]);
     });

--- a/src/notation/barbeat/parser/tests/barbeat-parser-beat-lists.test.ts
+++ b/src/notation/barbeat/parser/tests/barbeat-parser-beat-lists.test.ts
@@ -110,9 +110,9 @@ describe("BarBeatScript Parser - beat lists", () => {
       ]);
     });
 
-    it("parses mixed fractional and decimal notation throughout", () => {
+    it("parses mixed fractional and decimal notation throughout (positions stay decimal/mixed)", () => {
       expect(
-        parser.parse("t1/4 C3 1|1,5/4,3/2,7/4 t0.5 D3 1|2,2.5,3,3.5"),
+        parser.parse("t1/4 C3 1|1,5/4,3/2,7/4 t/2 D3 1|2,2.5,3,3.5"),
       ).toStrictEqual([
         { duration: 1 / 4 },
         { pitch: 60 },
@@ -120,7 +120,7 @@ describe("BarBeatScript Parser - beat lists", () => {
         { bar: 1, beat: 5 / 4 },
         { bar: 1, beat: 3 / 2 },
         { bar: 1, beat: 7 / 4 },
-        { duration: 0.5 },
+        { duration: 1 / 2 },
         { pitch: 62 },
         { bar: 1, beat: 2 },
         { bar: 1, beat: 2.5 },

--- a/src/notation/barbeat/parser/tests/barbeat-parser-duration.test.ts
+++ b/src/notation/barbeat/parser/tests/barbeat-parser-duration.test.ts
@@ -1,144 +1,98 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
 import * as parser from "../barbeat-parser.ts";
 
 describe("BarBeatScript Parser - duration", () => {
-  it("parses floating-point durations", () => {
-    expect(parser.parse("t0.25 C3 t1.0 D3")).toStrictEqual([
-      { duration: 0.25 },
+  it("parses fractional durations (numerator + denominator)", () => {
+    expect(parser.parse("t1/4 C3 t3/8 D3 t5/4 E3")).toStrictEqual([
+      { duration: 1 / 4 },
       { pitch: 60 },
-      { duration: 1.0 },
+      { duration: 3 / 8 },
       { pitch: 62 },
+      { duration: 5 / 4 },
+      { pitch: 64 },
     ]);
   });
 
-  it("parses fractional durations", () => {
-    expect(parser.parse("t1/3 C3 t2/3 D3 t4/3 E3")).toStrictEqual([
+  it("parses fractional duration with optional numerator (defaults to 1)", () => {
+    expect(parser.parse("t/4 C3 t/8 D3 t/16 E3")).toStrictEqual([
+      { duration: 1 / 4 },
+      { pitch: 60 },
+      { duration: 1 / 8 },
+      { pitch: 62 },
+      { duration: 1 / 16 },
+      { pitch: 64 },
+    ]);
+  });
+
+  it("parses triplet/tuplet denominators", () => {
+    expect(parser.parse("t/3 C3 t/6 D3 t/12 E3 t/20 F3")).toStrictEqual([
       { duration: 1 / 3 },
       { pitch: 60 },
-      { duration: 2 / 3 },
+      { duration: 1 / 6 },
       { pitch: 62 },
-      { duration: 4 / 3 },
+      { duration: 1 / 12 },
       { pitch: 64 },
-    ]);
-  });
-
-  it("parses mixed decimal and fractional durations", () => {
-    expect(parser.parse("t0.5 C3 t1/2 D3 t1.5 E3 t3/2 F3")).toStrictEqual([
-      { duration: 0.5 },
-      { pitch: 60 },
-      { duration: 1 / 2 },
-      { pitch: 62 },
-      { duration: 1.5 },
-      { pitch: 64 },
-      { duration: 3 / 2 },
+      { duration: 1 / 20 },
       { pitch: 65 },
     ]);
   });
 
-  it("parses quintuplet durations", () => {
-    expect(parser.parse("t1/5 C3 t2/5 D3")).toStrictEqual([
-      { duration: 1 / 5 },
-      { pitch: 60 },
-      { duration: 2 / 5 },
-      { pitch: 62 },
-    ]);
-  });
-
-  it("parses zero duration with fraction notation", () => {
+  it("parses zero numerator", () => {
     expect(parser.parse("t0/1 C3")).toStrictEqual([
       { duration: 0 },
       { pitch: 60 },
     ]);
   });
 
-  it("parses fractional duration with optional numerator (defaults to 1)", () => {
-    expect(parser.parse("t/4 C3")).toStrictEqual([
+  it("parses whole-note family", () => {
+    expect(parser.parse("t/1 C3 t/2 D3 t/4 E3 t/8 F3 t/16 G3")).toStrictEqual([
+      { duration: 1 },
+      { pitch: 60 },
+      { duration: 1 / 2 },
+      { pitch: 62 },
       { duration: 1 / 4 },
-      { pitch: 60 },
-    ]);
-    expect(parser.parse("t/8 C3")).toStrictEqual([
+      { pitch: 64 },
       { duration: 1 / 8 },
-      { pitch: 60 },
-    ]);
-    expect(parser.parse("t/3 C3")).toStrictEqual([
-      { duration: 1 / 3 },
-      { pitch: 60 },
+      { pitch: 65 },
+      { duration: 1 / 16 },
+      { pitch: 67 },
     ]);
   });
 
-  it("parses bar:beat duration format (NEW)", () => {
-    expect(parser.parse("t2:1.5 C3")).toStrictEqual([
-      { duration: "2:1.5" },
-      { pitch: 60 },
-    ]);
-    expect(parser.parse("t1:0 C3")).toStrictEqual([
-      { duration: "1:0" },
-      { pitch: 60 },
-    ]);
-    expect(parser.parse("t0:2 C3")).toStrictEqual([
-      { duration: "0:2" },
-      { pitch: 60 },
-    ]);
+  it("rejects bare-integer durations with denominator-required error", () => {
+    expect(() => parser.parse("t1 C3")).toThrow(
+      /durations need a denominator.*Got t1/,
+    );
+    expect(() => parser.parse("t4 C3")).toThrow(
+      /durations need a denominator.*Got t4/,
+    );
   });
 
-  it("parses bar:beat duration with fractions (NEW)", () => {
-    expect(parser.parse("t1:3/4 C3")).toStrictEqual([
-      { duration: "1:0.75" },
-      { pitch: 60 },
-    ]);
-    expect(parser.parse("t2:1/3 C3")).toStrictEqual([
-      { duration: `2:${1 / 3}` },
-      { pitch: 60 },
-    ]);
+  it("rejects decimal durations with denominator-required error", () => {
+    expect(() => parser.parse("t0.5 C3")).toThrow(
+      /durations need a denominator.*Got t0\.5/,
+    );
+    expect(() => parser.parse("t2.5 C3")).toThrow(
+      /durations need a denominator.*Got t2\.5/,
+    );
+    expect(() => parser.parse("t.25 C3")).toThrow(
+      /durations need a denominator.*Got t\.25/,
+    );
   });
 
-  it("parses bar:beat duration with fractions (optional numerator)", () => {
-    expect(parser.parse("t1:/4 C3")).toStrictEqual([
-      { duration: "1:0.25" },
-      { pitch: 60 },
-    ]);
-    expect(parser.parse("t0:/3 C3")).toStrictEqual([
-      { duration: `0:${1 / 3}` },
-      { pitch: 60 },
-    ]);
+  it("rejects mixed-number durations with denominator-required error", () => {
+    expect(() => parser.parse("t1+1/2 C3")).toThrow(
+      /durations need a denominator.*Got t1\+1\/2/,
+    );
   });
 
-  it("parses bar:beat duration with + operator", () => {
-    expect(parser.parse("t1:2+1/3 C3")).toStrictEqual([
-      { duration: `1:${2 + 1 / 3}` },
-      { pitch: 60 },
-    ]);
-    expect(parser.parse("t0:3+3/4 C3")).toStrictEqual([
-      { duration: `0:${3 + 3 / 4}` },
-      { pitch: 60 },
-    ]);
-  });
-
-  it("parses beat-only duration with + operator", () => {
-    expect(parser.parse("t2+3/4 C3")).toStrictEqual([
-      { duration: 2 + 3 / 4 },
-      { pitch: 60 },
-    ]);
-    expect(parser.parse("t1+1/2 C3")).toStrictEqual([
-      { duration: 1 + 1 / 2 },
-      { pitch: 60 },
-    ]);
-  });
-
-  it("distinguishes between beat-only and bar:beat formats", () => {
-    // Beat-only: number
-    expect(parser.parse("t2.5 C3")).toStrictEqual([
-      { duration: 2.5 },
-      { pitch: 60 },
-    ]);
-    // Bar:beat: string
-    expect(parser.parse("t2:0.5 C3")).toStrictEqual([
-      { duration: "2:0.5" },
-      { pitch: 60 },
-    ]);
+  it("rejects bar:beat duration form", () => {
+    expect(() => parser.parse("t2:1.5 C3")).toThrow();
+    expect(() => parser.parse("t1:0 C3")).toThrow();
   });
 });

--- a/src/notation/barbeat/parser/tests/barbeat-parser-edge-cases.test.ts
+++ b/src/notation/barbeat/parser/tests/barbeat-parser-edge-cases.test.ts
@@ -27,13 +27,6 @@ describe("BarBeatScript Parser - edge cases", () => {
       expect(parser.parse("1|1.")).toStrictEqual([{ bar: 1, beat: 1 }]);
     });
 
-    it("handles decimal-only floats in duration", () => {
-      expect(parser.parse("t.25 C3")).toStrictEqual([
-        { duration: 0.25 },
-        { pitch: 60 },
-      ]);
-    });
-
     it("handles decimal-only floats in probability", () => {
       expect(parser.parse("p.5 C3")).toStrictEqual([
         { probability: 0.5 },
@@ -42,9 +35,9 @@ describe("BarBeatScript Parser - edge cases", () => {
     });
 
     it("handles various float formats", () => {
-      expect(parser.parse("p0.5 t1.25 v64")).toStrictEqual([
+      expect(parser.parse("p0.5 t5/16 v64")).toStrictEqual([
         { probability: 0.5 },
-        { duration: 1.25 },
+        { duration: 5 / 16 },
         { velocity: 64 },
       ]);
     });

--- a/src/notation/barbeat/parser/tests/barbeat-parser-features.test.ts
+++ b/src/notation/barbeat/parser/tests/barbeat-parser-features.test.ts
@@ -129,8 +129,8 @@ describe("BarBeatScript Parser - parser features", () => {
       expect(() => parser.parse("t")).toThrow();
     });
 
-    it("handles zero values correctly", () => {
-      expect(parser.parse("1|1 v0 p0.0 t0.0 C0")).toStrictEqual([
+    it("handles zero values correctly (duration via 0/1 fraction)", () => {
+      expect(parser.parse("1|1 v0 p0.0 t0/1 C0")).toStrictEqual([
         { bar: 1, beat: 1 },
         { velocity: 0 },
         { probability: 0.0 },
@@ -140,11 +140,11 @@ describe("BarBeatScript Parser - parser features", () => {
     });
 
     it("handles maximum values correctly", () => {
-      expect(parser.parse("999|999.999 v127 p1.0 t999.999 G8")).toStrictEqual([
+      expect(parser.parse("999|999.999 v127 p1.0 t999/1 G8")).toStrictEqual([
         { bar: 999, beat: 999.999 },
         { velocity: 127 },
         { probability: 1.0 },
-        { duration: 999.999 },
+        { duration: 999 },
         { pitch: 127 },
       ]);
     });
@@ -153,7 +153,7 @@ describe("BarBeatScript Parser - parser features", () => {
   describe("integration", () => {
     it("handles real-world drum pattern example with probability and velocity range", () => {
       const input = `
-        1|1 v100 t0.25 p1.0 C1 v80-100 p0.8 Gb1
+        1|1 v100 t/16 p1.0 C1 v80-100 p0.8 Gb1
         1|1.5 p0.6 Gb1
         2|2 v90 p1.0 D1
         v100 p0.9 Gb1
@@ -162,7 +162,7 @@ describe("BarBeatScript Parser - parser features", () => {
       expect(parser.parse(input)).toStrictEqual([
         { bar: 1, beat: 1 },
         { velocity: 100 },
-        { duration: 0.25 },
+        { duration: 1 / 16 },
         { probability: 1.0 },
         { pitch: 36 },
         { velocityMin: 80, velocityMax: 100 },

--- a/src/notation/barbeat/parser/tests/barbeat-parser-time.test.ts
+++ b/src/notation/barbeat/parser/tests/barbeat-parser-time.test.ts
@@ -59,15 +59,12 @@ describe("BarBeatScript Parser - time declarations", () => {
     ]);
   });
 
-  it("parses repeat pattern with whole step", () => {
-    expect(parser.parse("1|1x4@1")).toStrictEqual([
-      { bar: 1, beat: { start: 1, times: 4, step: 1 } },
-    ]);
-  });
-
-  it("parses repeat pattern with fractional step", () => {
+  it("parses repeat pattern with fractional step (numerator + denominator)", () => {
     expect(parser.parse("1|1x3@1/3")).toStrictEqual([
       { bar: 1, beat: { start: 1, times: 3, step: 1 / 3 } },
+    ]);
+    expect(parser.parse("1|1x4@3/4")).toStrictEqual([
+      { bar: 1, beat: { start: 1, times: 4, step: 3 / 4 } },
     ]);
   });
 
@@ -80,19 +77,7 @@ describe("BarBeatScript Parser - time declarations", () => {
     ]);
   });
 
-  it("parses repeat pattern with decimal step", () => {
-    expect(parser.parse("1|3x4@0.25")).toStrictEqual([
-      { bar: 1, beat: { start: 3, times: 4, step: 0.25 } },
-    ]);
-  });
-
-  it("parses repeat pattern with mixed number step", () => {
-    expect(parser.parse("1|1x4@1+1/2")).toStrictEqual([
-      { bar: 1, beat: { start: 1, times: 4, step: 1.5 } },
-    ]);
-  });
-
-  it("parses repeat pattern with mixed number start", () => {
+  it("parses repeat pattern with mixed number start (positions still meter-relative)", () => {
     expect(parser.parse("1|2+1/3x3@1/3")).toStrictEqual([
       { bar: 1, beat: { start: 2 + 1 / 3, times: 3, step: 1 / 3 } },
     ]);
@@ -105,21 +90,42 @@ describe("BarBeatScript Parser - time declarations", () => {
   });
 
   it("parses repeat pattern mixed with regular beats", () => {
-    expect(parser.parse("1|1x4@1,3.5")).toStrictEqual([
-      { bar: 1, beat: { start: 1, times: 4, step: 1 } },
+    expect(parser.parse("1|1x4@1/4,3.5")).toStrictEqual([
+      { bar: 1, beat: { start: 1, times: 4, step: 1 / 4 } },
       { bar: 1, beat: 3.5 },
     ]);
   });
 
   it("parses multiple repeat patterns in beat list", () => {
-    expect(parser.parse("1|1x2@1,3x2@0.5")).toStrictEqual([
-      { bar: 1, beat: { start: 1, times: 2, step: 1 } },
-      { bar: 1, beat: { start: 3, times: 2, step: 0.5 } },
+    expect(parser.parse("1|1x2@1/4,3x2@/8")).toStrictEqual([
+      { bar: 1, beat: { start: 1, times: 2, step: 1 / 4 } },
+      { bar: 1, beat: { start: 3, times: 2, step: 1 / 8 } },
     ]);
   });
 
-  it("rejects repeat pattern with step=0", () => {
+  it("rejects bare-integer step intervals with denominator-required error", () => {
+    expect(() => parser.parse("1|1x4@1")).toThrow(
+      /step intervals need a denominator.*Got @1/,
+    );
     expect(() => parser.parse("1|1x4@0")).toThrow(
+      /step intervals need a denominator.*Got @0/,
+    );
+  });
+
+  it("rejects decimal step intervals with denominator-required error", () => {
+    expect(() => parser.parse("1|3x4@0.25")).toThrow(
+      /step intervals need a denominator.*Got @0\.25/,
+    );
+  });
+
+  it("rejects mixed-number step intervals with denominator-required error", () => {
+    expect(() => parser.parse("1|1x4@1+1/2")).toThrow(
+      /step intervals need a denominator.*Got @1\+1\/2/,
+    );
+  });
+
+  it("rejects step size of zero (e.g. @0/1)", () => {
+    expect(() => parser.parse("1|1x4@0/1")).toThrow(
       "Repeat step size must be greater than 0",
     );
   });

--- a/src/notation/barbeat/serializer/barbeat-serializer.ts
+++ b/src/notation/barbeat/serializer/barbeat-serializer.ts
@@ -45,7 +45,7 @@ export function formatNotation(
 
   const timeGroups = groupNotesByTime(sortedNotes, config);
   const batches = findMergeBatches(timeGroups);
-  const state = createInitialState();
+  const state = createInitialState(config.timeSigDenominator);
   const elements: string[] = [];
 
   for (const batch of batches) {

--- a/src/notation/barbeat/serializer/helpers/barbeat-serializer-drum.ts
+++ b/src/notation/barbeat/serializer/helpers/barbeat-serializer-drum.ts
@@ -7,10 +7,11 @@ import { type NoteEvent } from "#src/notation/types.ts";
 import {
   DEFAULT_PROBABILITY,
   DEFAULT_VELOCITY_DEVIATION,
+  musicalBeatsToWholeNoteFraction,
 } from "../../barbeat-config.ts";
 import {
+  formatAbsoluteDuration,
   formatBeatPosition,
-  formatUnsignedValue,
 } from "./barbeat-serializer-fractions.ts";
 import {
   calculateBarBeat,
@@ -46,7 +47,7 @@ export function formatDrumNotation(
   config: FormatConfig,
 ): string {
   const pitchGroups = groupByPitch(sortedNotes);
-  const state = createInitialState();
+  const state = createInitialState(config.timeSigDenominator);
   const elements: string[] = [];
 
   for (const { pitch, notes } of pitchGroups) {
@@ -68,7 +69,12 @@ export function formatDrumNotation(
       );
       elements.push(pitchName(pitch));
       elements.push(
-        ...formatPositions(run.positions, state.duration, config.beatsPerBar),
+        ...formatPositions(
+          run.positions,
+          state.duration,
+          config.beatsPerBar,
+          config.timeSigDenominator,
+        ),
       );
     }
   }
@@ -152,16 +158,22 @@ function sameState(a: NoteEvent, b: NoteEvent): boolean {
  * Format beat positions, using repeat patterns when shorter.
  * Groups positions by bar for comma merging, then checks for repeat patterns.
  * @param positions - Bar|beat positions to format
- * @param currentDuration - Current duration state for step omission
+ * @param currentDuration - Current duration state in musical beats (for step omission)
  * @param beatsPerBar - Beats per bar for absolute beat calculation
+ * @param timeSigDenominator - Time signature denominator (for step fraction conversion)
  * @returns Formatted position strings
  */
 function formatPositions(
   positions: Position[],
   currentDuration: number,
   beatsPerBar: number,
+  timeSigDenominator: number | undefined,
 ): string[] {
-  const repeat = detectRepeatPattern(positions, beatsPerBar);
+  const repeat = detectRepeatPattern(
+    positions,
+    beatsPerBar,
+    timeSigDenominator,
+  );
 
   if (repeat) {
     return [formatRepeat(repeat, currentDuration, positions[0] as Position)];
@@ -173,18 +185,23 @@ function formatPositions(
 /** Repeat pattern info */
 interface RepeatInfo {
   count: number;
+  /** Step in musical beats (for comparison against currentDuration). */
   step: number;
+  /** Step pre-formatted as an absolute fraction string (e.g., "/4"). */
+  stepStr: string;
 }
 
 /**
  * Detect evenly-spaced repeat pattern in positions (3+ positions required)
  * @param positions - Bar|beat positions
  * @param beatsPerBar - Beats per bar
+ * @param timeSigDenominator - Time signature denominator (for step fraction conversion)
  * @returns Repeat info or null
  */
 function detectRepeatPattern(
   positions: Position[],
   beatsPerBar: number,
+  timeSigDenominator: number | undefined,
 ): RepeatInfo | null {
   if (positions.length < 3) return null;
 
@@ -204,33 +221,36 @@ function detectRepeatPattern(
     }
   }
 
+  const stepStr = formatAbsoluteDuration(
+    musicalBeatsToWholeNoteFraction(step, timeSigDenominator),
+  );
+
   // Check that repeat format is actually shorter than listing positions
   const repeatStr = formatRepeatLength(
     positions[0] as Position,
     positions.length,
-    step,
+    stepStr,
   );
   const listStr = formatBarBeatPositions(positions).join(" ");
 
   if (repeatStr >= listStr.length) return null;
 
-  return { count: positions.length, step };
+  return { count: positions.length, step, stepStr };
 }
 
 /**
  * Estimate length of a repeat pattern string
  * @param start - Start position
  * @param count - Repeat count
- * @param step - Step size
+ * @param stepStr - Pre-formatted step string
  * @returns Estimated string length
  */
 function formatRepeatLength(
   start: Position,
   count: number,
-  step: number,
+  stepStr: string,
 ): number {
   const startStr = `${start.bar}|${formatBeatPosition(start.beat)}`;
-  const stepStr = formatUnsignedValue(step);
 
   // bar|beatx{count}@{step} or bar|beatx{count}
   return startStr.length + 1 + count.toString().length + 1 + stepStr.length;
@@ -239,9 +259,9 @@ function formatRepeatLength(
 /**
  * Format a repeat pattern string
  * @param repeat - Repeat info
- * @param currentDuration - Current duration (omit step if equal)
+ * @param currentDuration - Current duration in musical beats (omit @step if equal)
  * @param start - Start position
- * @returns Repeat pattern string like "1|1x8@2"
+ * @returns Repeat pattern string like "1|1x8@/4"
  */
 function formatRepeat(
   repeat: RepeatInfo,
@@ -252,7 +272,7 @@ function formatRepeat(
   const stepSuffix =
     Math.abs(repeat.step - currentDuration) <= 0.001
       ? ""
-      : `@${formatUnsignedValue(repeat.step)}`;
+      : `@${repeat.stepStr}`;
 
   return `${startStr}x${repeat.count}${stepSuffix}`;
 }

--- a/src/notation/barbeat/serializer/helpers/barbeat-serializer-fractions.ts
+++ b/src/notation/barbeat/serializer/helpers/barbeat-serializer-fractions.ts
@@ -29,34 +29,44 @@ export function formatBeatPosition(value: number): string {
 }
 
 /**
- * Format an unsigned value for durations and repeat steps.
- * Can be < 1 (parser: unsignedFloat). Supports /4 shorthand (numerator=1 implied).
- * Fractions are required when decimal representation is lossy (e.g., 1/3 → 0.333).
- * @param value - Duration or step value (>= 0)
- * @returns Formatted value string
+ * Format an absolute duration/step value as a `<num>/<den>` fraction of a whole note.
+ * Used for `t` durations and `@step` intervals in bar|beat notation.
+ * Always emits the fraction form (numerator omitted when 1).
+ * @param wholeNoteFraction - Value as a fraction of a whole note (e.g., 1/4 = quarter)
+ * @returns Formatted value string (e.g., "/4", "3/8", "/12", "5/4")
  */
-export function formatUnsignedValue(value: number): string {
-  if (value % 1 === 0) return value.toString();
+export function formatAbsoluteDuration(wholeNoteFraction: number): string {
+  if (wholeNoteFraction === 0) return "0/1";
 
-  if (value < 1) {
-    const fraction = findFraction(value);
+  // Try musically clean denominators first (powers of 2), then triplet family,
+  // then less common tuplets. Smallest matching denominator wins.
+  for (const den of ABSOLUTE_DURATION_DENOMINATORS) {
+    const num = wholeNoteFraction * den;
 
-    if (fraction) {
-      // Use /den shorthand when numerator is 1
-      const fractionStr =
-        fraction.num === 1
-          ? `/${fraction.den}`
-          : `${fraction.num}/${fraction.den}`;
+    if (Math.abs(num - Math.round(num)) < EPSILON && Math.round(num) > 0) {
+      const numRounded = Math.round(num);
 
-      return preferFractionOrDecimal(fractionStr, value);
+      return numRounded === 1 ? `/${den}` : `${numRounded}/${den}`;
     }
-
-    return formatDecimal(value);
   }
 
-  // value >= 1 with fractional part
-  return formatMixedNumber(value) ?? formatDecimal(value);
+  // Fallback: any value we couldn't reduce to a clean fraction (unusual).
+  // Use a high-resolution denominator and accept slight rounding.
+  const fallbackDen = 64;
+  const fallbackNum = Math.max(1, Math.round(wholeNoteFraction * fallbackDen));
+
+  return fallbackNum === 1
+    ? `/${fallbackDen}`
+    : `${fallbackNum}/${fallbackDen}`;
 }
+
+/**
+ * Denominators tried when reducing an absolute duration to a fraction.
+ * Order: powers of 2 (most common note values), triplets, then quintuplets.
+ */
+const ABSOLUTE_DURATION_DENOMINATORS = [
+  1, 2, 4, 8, 16, 32, 3, 6, 12, 24, 5, 10, 20,
+];
 
 /**
  * Choose between a fraction string and decimal, preferring decimal when it's

--- a/src/notation/barbeat/serializer/helpers/barbeat-serializer-state.ts
+++ b/src/notation/barbeat/serializer/helpers/barbeat-serializer-state.ts
@@ -6,14 +6,15 @@
 import { type NoteEvent } from "#src/notation/types.ts";
 import { midiToNoteName } from "#src/shared/pitch.ts";
 import {
-  DEFAULT_DURATION,
   DEFAULT_PROBABILITY,
   DEFAULT_VELOCITY,
   DEFAULT_VELOCITY_DEVIATION,
+  defaultDurationMusicalBeats,
+  musicalBeatsToWholeNoteFraction,
 } from "../../barbeat-config.ts";
 import {
+  formatAbsoluteDuration,
   formatDecimal,
-  formatUnsignedValue,
 } from "./barbeat-serializer-fractions.ts";
 import { type TimeGroup } from "./barbeat-serializer-grouping.ts";
 
@@ -26,14 +27,18 @@ export interface SerializerState {
 }
 
 /**
- * Create initial serializer state with default values
+ * Create initial serializer state with default values.
+ * The default duration depends on time signature (quarter note in any meter).
+ * @param timeSigDenominator - Time signature denominator
  * @returns Fresh serializer state
  */
-export function createInitialState(): SerializerState {
+export function createInitialState(
+  timeSigDenominator: number | undefined,
+): SerializerState {
   return {
     velocity: DEFAULT_VELOCITY,
     velocityDeviation: DEFAULT_VELOCITY_DEVIATION,
-    duration: DEFAULT_DURATION,
+    duration: defaultDurationMusicalBeats(timeSigDenominator),
     probability: DEFAULT_PROBABILITY,
   };
 }
@@ -168,9 +173,10 @@ function emitVelocityChange(
 
 /**
  * Emit duration change if different from current state.
- * Converts Ableton beats to notation beats when time signature is specified.
+ * Converts Ableton beats (quarter notes) into notation's musical beats for
+ * change detection, and into a whole-note fraction for emission (e.g., /4).
  * @param note - Note to check
- * @param state - Current state (mutated, tracks notation beats)
+ * @param state - Current state (mutated, tracks notation in musical beats)
  * @param elements - Output array
  * @param timeSigDenominator - Time signature denominator for conversion
  */
@@ -180,15 +186,21 @@ function emitDurationChange(
   elements: string[],
   timeSigDenominator: number | undefined,
 ): void {
-  // Convert from Ableton beats to notation beats
-  const notationDuration =
+  // Convert Ableton beats (= quarter notes) to musical beats for state tracking
+  const musicalBeats =
     timeSigDenominator != null
       ? note.duration * (timeSigDenominator / 4)
       : note.duration;
 
-  if (Math.abs(notationDuration - state.duration) > 0.001) {
-    elements.push(`t${formatUnsignedValue(notationDuration)}`);
-    state.duration = notationDuration;
+  if (Math.abs(musicalBeats - state.duration) > 0.001) {
+    // Emit as an absolute note value (fraction of a whole note)
+    const wholeNoteFraction = musicalBeatsToWholeNoteFraction(
+      musicalBeats,
+      timeSigDenominator,
+    );
+
+    elements.push(`t${formatAbsoluteDuration(wholeNoteFraction)}`);
+    state.duration = musicalBeats;
   }
 }
 

--- a/src/notation/barbeat/serializer/tests/barbeat-serializer-core.test.ts
+++ b/src/notation/barbeat/serializer/tests/barbeat-serializer-core.test.ts
@@ -78,13 +78,14 @@ describe("formatNotation() core", () => {
   });
 
   it("formats notes with duration changes", () => {
+    // 0.5 quarter = 1/8 whole → t/8; 2 quarter = 1/2 whole → t/2
     const notes = [
       createNote({ duration: 0.5 }),
       createNote({ pitch: 62, duration: 2.0 }),
       createNote({ pitch: 64, duration: 2.0 }),
     ] as NoteEvent[];
 
-    expect(formatNotation(notes)).toBe("t/2 C3 t2 D3 E3 1|1");
+    expect(formatNotation(notes)).toBe("t/8 C3 t/2 D3 E3 1|1");
   });
 
   it("formats sub-beat timing", () => {
@@ -258,7 +259,7 @@ describe("formatNotation() core", () => {
 
     expect(parsed).toStrictEqual(
       interpretNotation(
-        "t0.25 C1 v80-100 p0.8 Gb1 1|1 p0.6 Gb1 1|1.5 v90 p1 D1 v100 p0.9 Gb1 1|2",
+        "t/16 C1 v80-100 p0.8 Gb1 1|1 p0.6 Gb1 1|1.5 v90 p1 D1 v100 p0.9 Gb1 1|2",
       ),
     );
   });
@@ -286,11 +287,12 @@ describe("formatNotation() per-note state in chords", () => {
   });
 
   it("emits per-note state for mixed properties", () => {
+    // 2 quarter = 1/2 whole → t/2; 1 quarter → t/4
     const notes = [
       createNote({ velocity: 80, duration: 2 }),
       createNote({ pitch: 64, velocity: 80, duration: 1 }),
     ] as NoteEvent[];
 
-    expect(formatNotation(notes)).toBe("v80 t2 C3 t1 E3 1|1");
+    expect(formatNotation(notes)).toBe("v80 t/2 C3 t/4 E3 1|1");
   });
 });

--- a/src/notation/barbeat/serializer/tests/barbeat-serializer-drum.test.ts
+++ b/src/notation/barbeat/serializer/tests/barbeat-serializer-drum.test.ts
@@ -40,7 +40,7 @@ describe("drum mode serializer", () => {
     const result = formatNotation(notes, { drumMode: true });
 
     // C1 (kick) positions grouped and comma-merged, then D1 (snare)
-    expect(result).toBe("t/4 C1 1|1,2 v90 D1 1|1.5,2.5");
+    expect(result).toBe("t/16 C1 1|1,2 v90 D1 1|1.5,2.5");
   });
 
   it("comma-merges beats within same bar", () => {
@@ -53,7 +53,7 @@ describe("drum mode serializer", () => {
 
     const result = formatNotation(notes, { drumMode: true });
 
-    expect(result).toBe("t/4 C1 1|1,3 v90 D1 1|2,4");
+    expect(result).toBe("t/16 C1 1|1,3 v90 D1 1|2,4");
   });
 
   it("detects repeat patterns (3+ evenly spaced)", () => {
@@ -70,7 +70,7 @@ describe("drum mode serializer", () => {
     const result = formatNotation(notes, { drumMode: true });
 
     // Step equals duration (0.25), so @step is omitted
-    expect(result).toBe("v80 t/4 Gb1 1|1x16");
+    expect(result).toBe("v80 t/16 Gb1 1|1x16");
   });
 
   it("does not use repeat pattern for non-uniform spacing", () => {
@@ -113,7 +113,7 @@ describe("drum mode serializer", () => {
 
     // Both notes have same state (undefined probability defaults equal),
     // so they should merge into comma format with no probability prefix
-    expect(result).toBe("v80 t/4 C1 1|1,2");
+    expect(result).toBe("v80 t/16 C1 1|1,2");
   });
 
   it("includes @step when step differs from duration", () => {
@@ -128,7 +128,8 @@ describe("drum mode serializer", () => {
 
     const result = formatNotation(notes, { drumMode: true });
 
-    expect(result).toBe("t/4 C1 1|1x8@2");
+    // Duration 0.25 quarter = /16; step 2 quarters = /2
+    expect(result).toBe("t/16 C1 1|1x8@/2");
   });
 
   it("splits into state runs when velocity changes", () => {
@@ -142,7 +143,7 @@ describe("drum mode serializer", () => {
     const result = formatNotation(notes, { drumMode: true });
 
     // Two state runs for Gb1: v80 then v100
-    expect(result).toBe("v80 t/4 Gb1 1|1,1.5 v100 Gb1 1|2,2.5");
+    expect(result).toBe("v80 t/16 Gb1 1|1,1.5 v100 Gb1 1|2,2.5");
   });
 
   it("handles single-note pitch groups", () => {
@@ -153,7 +154,7 @@ describe("drum mode serializer", () => {
 
     const result = formatNotation(notes, { drumMode: true });
 
-    expect(result).toBe("t/4 C1 1|1 Db2 1|1");
+    expect(result).toBe("t/16 C1 1|1 Db2 1|1");
   });
 
   it("preserves pitch order by first occurrence", () => {
@@ -165,7 +166,7 @@ describe("drum mode serializer", () => {
     const result = formatNotation(notes, { drumMode: true });
 
     // D1 appears first because it has the earlier start_time
-    expect(result).toBe("v90 t/4 D1 1|1 v100 C1 1|1.5");
+    expect(result).toBe("v90 t/16 D1 1|1 v100 C1 1|1.5");
   });
 
   it("handles multi-bar positions", () => {
@@ -178,15 +179,15 @@ describe("drum mode serializer", () => {
 
     const result = formatNotation(notes, { drumMode: true });
 
-    expect(result).toBe("t/4 C1 1|1 2|1 v90 D1 1|3 2|3");
+    expect(result).toBe("t/16 C1 1|1 2|1 v90 D1 1|3 2|3");
   });
 
   it("uses fraction formatting for positions and steps", () => {
-    // Triplet hi-hat: every 1/3 beat
+    // Triplet hi-hat: every 1/3 of a quarter note (eighth-note triplet spacing)
     const notes: NoteEvent[] = Array.from({ length: 6 }, (_, i) =>
       createNote({
         pitch: 42,
-        start_time: (i * 4) / 3 / 4, // 1/3 of a beat
+        start_time: i * (1 / 3),
         duration: 1 / 3,
         velocity: 80,
       }),
@@ -194,8 +195,8 @@ describe("drum mode serializer", () => {
 
     const result = formatNotation(notes, { drumMode: true });
 
-    // Duration 1/3 → t/3, step 1/3 → omitted (equals duration)
-    expect(result).toBe("v80 t/3 Gb1 1|1x6");
+    // 1/3 quarter = 1/12 whole → t/12, step equals duration so @step is omitted
+    expect(result).toBe("v80 t/12 Gb1 1|1x6");
   });
 
   describe("round-trip tests", () => {

--- a/src/notation/barbeat/serializer/tests/barbeat-serializer-fractions.test.ts
+++ b/src/notation/barbeat/serializer/tests/barbeat-serializer-fractions.test.ts
@@ -5,9 +5,9 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  formatAbsoluteDuration,
   formatBeatPosition,
   formatDecimal,
-  formatUnsignedValue,
 } from "../helpers/barbeat-serializer-fractions.ts";
 
 describe("formatBeatPosition", () => {
@@ -81,47 +81,46 @@ describe("formatBeatPosition", () => {
   });
 });
 
-describe("formatUnsignedValue", () => {
-  it("formats integers as-is", () => {
-    expect(formatUnsignedValue(0)).toBe("0");
-    expect(formatUnsignedValue(1)).toBe("1");
-    expect(formatUnsignedValue(4)).toBe("4");
+describe("formatAbsoluteDuration", () => {
+  it("formats common note values with /den shorthand", () => {
+    expect(formatAbsoluteDuration(1)).toBe("/1"); // whole
+    expect(formatAbsoluteDuration(1 / 2)).toBe("/2"); // half
+    expect(formatAbsoluteDuration(1 / 4)).toBe("/4"); // quarter
+    expect(formatAbsoluteDuration(1 / 8)).toBe("/8"); // eighth
+    expect(formatAbsoluteDuration(1 / 16)).toBe("/16"); // sixteenth
+    expect(formatAbsoluteDuration(1 / 32)).toBe("/32"); // thirty-second
   });
 
-  it("formats common sub-beat durations with /den shorthand", () => {
-    expect(formatUnsignedValue(0.25)).toBe("/4");
-    expect(formatUnsignedValue(0.5)).toBe("/2");
-    expect(formatUnsignedValue(1 / 3)).toBe("/3");
-    expect(formatUnsignedValue(1 / 6)).toBe("/6");
-    expect(formatUnsignedValue(0.125)).toBe("/8");
-    expect(formatUnsignedValue(1 / 16)).toBe("/16");
-    expect(formatUnsignedValue(1 / 12)).toBe("/12");
+  it("formats triplet/tuplet denominators", () => {
+    expect(formatAbsoluteDuration(1 / 3)).toBe("/3"); // half-note triplet
+    expect(formatAbsoluteDuration(1 / 6)).toBe("/6"); // quarter-note triplet
+    expect(formatAbsoluteDuration(1 / 12)).toBe("/12"); // eighth-note triplet
+    expect(formatAbsoluteDuration(1 / 24)).toBe("/24"); // sixteenth-note triplet
+    expect(formatAbsoluteDuration(1 / 20)).toBe("/20"); // sixteenth quintuplet
   });
 
-  it("formats non-unit fractions < 1", () => {
-    expect(formatUnsignedValue(0.75)).toBe("3/4");
-    expect(formatUnsignedValue(2 / 3)).toBe("2/3");
-    expect(formatUnsignedValue(3 / 8)).toBe("3/8");
-    expect(formatUnsignedValue(5 / 6)).toBe("5/6");
+  it("formats non-unit numerators", () => {
+    expect(formatAbsoluteDuration(3 / 8)).toBe("3/8"); // dotted quarter
+    expect(formatAbsoluteDuration(3 / 4)).toBe("3/4"); // dotted half / 3 quarters
+    expect(formatAbsoluteDuration(3 / 16)).toBe("3/16"); // dotted eighth
+    expect(formatAbsoluteDuration(2 / 3)).toBe("2/3"); // 2 half-note triplets
+    expect(formatAbsoluteDuration(5 / 4)).toBe("5/4"); // 5 quarter notes (5/4 bar)
+    expect(formatAbsoluteDuration(5 / 8)).toBe("5/8"); // 5 eighth notes
   });
 
-  it("uses fraction for mixed number durations when lossy or equal", () => {
-    // 1+1/3 — 1/3 is lossy → fraction required
-    expect(formatUnsignedValue(1 + 1 / 3)).toBe("1+1/3");
-    // 2+2/3 — 2/3 is lossy → fraction required
-    expect(formatUnsignedValue(2 + 2 / 3)).toBe("2+2/3");
+  it("formats values >= 1 (multi-whole-note durations)", () => {
+    expect(formatAbsoluteDuration(2)).toBe("2/1"); // 2 whole notes
+    expect(formatAbsoluteDuration(4)).toBe("4/1"); // 4 whole notes
   });
 
-  it("prefers decimal when shorter and lossless for >= 1 values", () => {
-    // 1.5 (3 chars) < 1+1/2 (5 chars) and lossless → decimal
-    expect(formatUnsignedValue(1.5)).toBe("1.5");
-    // 2.25 (4 chars) < 2+1/4 (5 chars) and lossless → decimal
-    expect(formatUnsignedValue(2.25)).toBe("2.25");
+  it("prefers smallest denominator", () => {
+    // 1/2 reduces from 2/4, 4/8, etc. — should always pick the smallest
+    expect(formatAbsoluteDuration(0.5)).toBe("/2");
+    expect(formatAbsoluteDuration(0.25)).toBe("/4");
   });
 
-  it("falls back to decimal for non-fraction values", () => {
-    expect(formatUnsignedValue(0.123)).toBe("0.123");
-    expect(formatUnsignedValue(1.789)).toBe("1.789");
+  it("formats zero", () => {
+    expect(formatAbsoluteDuration(0)).toBe("0/1");
   });
 });
 

--- a/src/notation/barbeat/serializer/tests/barbeat-serializer-merge.test.ts
+++ b/src/notation/barbeat/serializer/tests/barbeat-serializer-merge.test.ts
@@ -64,7 +64,8 @@ describe("comma merging", () => {
       createNote({ duration: 1, start_time: 1 }),
     ] as NoteEvent[];
 
-    expect(formatNotation(notes)).toBe("t/2 C3 1|1 t1 C3 1|2");
+    // 0.5 quarter = /8 whole; 1 quarter = /4 whole
+    expect(formatNotation(notes)).toBe("t/8 C3 1|1 t/4 C3 1|2");
   });
 
   it("does not merge notes with different probabilities", () => {
@@ -139,7 +140,8 @@ describe("comma merging", () => {
       createNote({ velocity: 80, duration: 0.5, start_time: 2 }),
     ] as NoteEvent[];
 
-    expect(formatNotation(notes)).toBe("v80 t/2 C3 1|1,2,3");
+    // 0.5 quarter = /8 whole
+    expect(formatNotation(notes)).toBe("v80 t/8 C3 1|1,2,3");
   });
 
   it("merges repeated chord progression pattern", () => {

--- a/src/notation/barbeat/serializer/tests/barbeat-serializer-roundtrip.test.ts
+++ b/src/notation/barbeat/serializer/tests/barbeat-serializer-roundtrip.test.ts
@@ -181,7 +181,8 @@ describe("round-trip: serialize → parse → interpret", () => {
   });
 
   it("round-trips from notation string", () => {
-    const original = "v80-120 t/2 C3 D3 1|2.25 v120 p0.8 t2 E3 F3 1|3";
+    // t/2 = half note; t2/1 = 2 whole notes
+    const original = "v80-120 t/2 C3 D3 1|2.25 v120 p0.8 t2/1 E3 F3 1|3";
     const parsed = interpretNotation(original);
     const formatted = formatNotation(parsed);
     const reparsed = interpretNotation(formatted);

--- a/src/skills/basic.ts
+++ b/src/skills/basic.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 export const skills = `# Producer Pal Skills
@@ -8,18 +9,18 @@ export const skills = `# Producer Pal Skills
 
 Pitches: C0-G8 with # or b for sharps/flats (C#3, Bb2). C3 = middle C
 Format: [v<vel>] [t<dur>] [p<prob>] pitch(es) bar|beat
-- v: velocity 0-127 (default 100). t: duration in beats (default 1). p: probability 0-1 (default 1). Persist until changed
-- Fraction beats: t/4 = quarter beat, t3/4, 1|2+1/3 for triplets
+- v: velocity 0-127 (default 100). t: duration as an absolute note value (default t/4 = quarter). p: probability 0-1 (default 1). Persist until changed
+- Durations REQUIRE a denominator: t/4 = quarter, t/8 = eighth, t/16 = sixteenth, t/12 = eighth triplet. t3/8 = dotted quarter. Bare integers or decimals are invalid
 
-### Melody (one note per beat across 2 bars)
+### Melody (one quarter note per beat across 2 bars)
 \`\`\`
 C3 1|1 D3 1|2 E3 1|3 F#3 1|4
 G3 2|1 A3 2|2 G#3 2|3 E3 2|4
 \`\`\`
 
-### Chords (set duration with t, t4 = 4 beats = full bar in 4/4)
+### Chords (set duration with t, t/1 = whole note = 4 quarters)
 \`\`\`
-t4
+t/1
 C3 E3 G3 1|1
 D3 F3 A3 2|1
 E3 G3 B3 3|1
@@ -30,11 +31,11 @@ F3 A3 C4 4|1
 \`\`\`
 C1 1|1,3 2|1,3 3|1,3 4|1,3  # kick
 D1 1|2,4 2|2,4 3|2,4 4|2,4  # snare
-t/4 Gb1 1|1.5x4@1 2|1.5x4@1 3|1.5x4@1 4|1.5x4@1  # hats (4 per bar, step 1 beat)
+t/16 Gb1 1|1.5x4@/4 2|1.5x4@/4 3|1.5x4@/4 4|1.5x4@/4  # hats (4 per bar, quarter-note step)
 \`\`\`
 
 ## Rules
 - Set clip lengths explicitly (e.g., 4:0 for 4 bars)
-- Positions use | (bar|beat). Durations use : (bar:beat) or plain beats (4, 2.5)
+- Positions use | (bar|beat). \`t\` durations and \`@step\` intervals are absolute note values (a quarter is a quarter in any meter)
 - If the user references a track, get its trackIndex and id - never guess
 `;

--- a/src/skills/basic.ts
+++ b/src/skills/basic.ts
@@ -18,7 +18,7 @@ C3 1|1 D3 1|2 E3 1|3 F#3 1|4
 G3 2|1 A3 2|2 G#3 2|3 E3 2|4
 \`\`\`
 
-### Chords (set duration with t, t/1 = whole note = 4 quarters)
+### Chords (set duration with t, t/1 = 4 quarters)
 \`\`\`
 t/1
 C3 E3 G3 1|1

--- a/src/skills/standard.ts
+++ b/src/skills/standard.ts
@@ -42,9 +42,9 @@ export const skills = `# Producer Pal Skills
 
 ## Time in Ableton Live
 
-- Positions: bar|beat (1-indexed). Examples: 1|1, 2|3.5, 1|2+1/3
-- Durations: beats (2.5, 3/4, /4) or bar:beat (1:2, 4:0)
-- Fractional beats: decimals (2.5), fractions (5/2), mixed (2+1/3). Numerator defaults to 1 (/4 = 1/4)
+- Positions: bar|beat (1-indexed, meter-relative). Examples: 1|1, 2|3.5, 1|2+1/3
+- Durations and \`@step\` intervals: absolute note values, written as fractions of a whole note (denominator mandatory). \`t/4\` = quarter, \`t/8\` = eighth, \`t/16\` = sixteenth, \`t/12\` = eighth triplet, \`t3/8\` = dotted quarter. A quarter is a quarter in any meter
+- Clip \`length\` and arrangement durations use a separate bar:beat format (e.g., "4:0" = 4 bars) and are NOT absolute note values
 
 ## MIDI Syntax
 
@@ -57,12 +57,12 @@ Create MIDI clips using the bar|beat notation syntax:
   - time positions are relative to clip start
   - the beat in bar|beat can be a comma-separated (no whitespace) list or repeat pattern
   - **Repeat patterns**: \`{bar|beat}x{count}[@{step}]\` generates sequences. count = how many notes
-    - step (in beats) defaults to duration (legato). step > duration = gaps; step < duration = overlap
-    - \`1|1x4@1\` → beats 1,2,3,4; \`t0.5 1|1x4\` → 1, 1.5, 2, 2.5 (step defaults to t value)
-    - \`1|1x3@/3\` → triplets; \`t/4 1|1x16\` → 16 notes at 16th-note spacing (x16 = count, t/4 = spacing)
+    - \`@step\` is an absolute note value (same form as \`t\`). Defaults to the current duration (legato)
+    - \`1|1x4@/4\` → 4 notes a quarter apart; \`t/8 1|1x4\` → 4 eighths (step defaults to t value)
+    - \`1|1x3@/12\` → eighth-note triplets (1/12 whole = 1/3 quarter); \`t/16 1|1x16\` → 16 sixteenths in a quarter-note span
 - v<velocity>: 0-127 (default: v100). Range v80-120 randomizes per note for humanization
   - \`v0\` deletes earlier notes at same pitch/time (**deletes until disabled** with non-zero v)
-- t<duration>: Note length (default: 1.0). Beats: t2.5, t3/4, t/4. Bar:beat: t2:1.5, t1:/4
+- t<duration>: Note length as a fraction of a whole note. Default: \`t/4\` (quarter). REQUIRES denominator — \`t1\`, \`t2.5\`, \`t0.5\` are invalid; write \`t/4\`, \`t5/8\`, \`t/8\` instead. \`t/12\` = eighth triplet, \`t/6\` = quarter triplet
 - p<chance>: Probability from 0.0 to 1.0 (default: 1.0 = always)
 - Notes: C0-G8 with # or b for sharps/flats (C#3, Bb2). C3 = middle C
 - **Stateful**: v/t/p and pitch persist until changed — set once, applies to all following notes
@@ -82,9 +82,9 @@ Audio params ignored when updating MIDI clips.
 C#3 F3 G#3 1|1 // chord at bar 1 beat 1
 C3 E3 G3 1|1,2,3,4 // same chord on every beat
 C1 1|1,3 2|1,2,3 // same pitch across bars (NOT 1|1,3,2|1,2,3)
-t0.25 C3 1|1.75 // 16th note at beat 1.75
-t1/3 C3 1|1x3 // triplets: 3 notes across 1 beat (step = duration)
-t/4 Gb1 1|1x16 // full bar of 16th note hi-hats
+t/16 C3 1|1.75 // 16th note at beat 1.75
+t/12 C3 1|1x3 // eighth-note triplets: 3 notes filling one quarter (step = duration)
+t/16 Gb1 1|1x16 // 16 sixteenths spanning a quarter note (1|1x16@/16 is the same)
 C3 D3 1|1 v0 C3 1|1 // delete earlier C3 (D3 remains)
 C3 D3 1|1 @2=1 v0 D3 2|1 // bar copy then delete D3 from bar 2
 v90-110 C1 1|1,3 D1 1|2,4 // humanized drum pattern

--- a/src/skills/standard.ts
+++ b/src/skills/standard.ts
@@ -43,7 +43,7 @@ export const skills = `# Producer Pal Skills
 ## Time in Ableton Live
 
 - Positions: bar|beat (1-indexed, meter-relative). Examples: 1|1, 2|3.5, 1|2+1/3
-- Durations and \`@step\` intervals: absolute note values, written as fractions of a whole note (denominator mandatory). \`t/4\` = quarter, \`t/8\` = eighth, \`t/16\` = sixteenth, \`t/12\` = eighth triplet, \`t3/8\` = dotted quarter. A quarter is a quarter in any meter
+- Durations and \`@step\` intervals: absolute note values (denominator mandatory). \`t/4\` = quarter, \`t/8\` = eighth, \`t/16\` = sixteenth, \`t/12\` = eighth triplet (3 in a quarter), \`t3/8\` = dotted quarter (3 eighths). A quarter is a quarter in any meter
 - Clip \`length\` and arrangement durations use a separate bar:beat format (e.g., "4:0" = 4 bars) and are NOT absolute note values
 
 ## MIDI Syntax
@@ -59,10 +59,10 @@ Create MIDI clips using the bar|beat notation syntax:
   - **Repeat patterns**: \`{bar|beat}x{count}[@{step}]\` generates sequences. count = how many notes
     - \`@step\` is an absolute note value (same form as \`t\`). Defaults to the current duration (legato)
     - \`1|1x4@/4\` → 4 notes a quarter apart; \`t/8 1|1x4\` → 4 eighths (step defaults to t value)
-    - \`1|1x3@/12\` → eighth-note triplets (1/12 whole = 1/3 quarter); \`t/16 1|1x16\` → 16 sixteenths in a quarter-note span
+    - \`1|1x3@/12\` → eighth-note triplets (3 in a quarter); \`t/16 1|1x16\` → 16 sixteenths spanning 4 quarters (a full bar in 4/4)
 - v<velocity>: 0-127 (default: v100). Range v80-120 randomizes per note for humanization
   - \`v0\` deletes earlier notes at same pitch/time (**deletes until disabled** with non-zero v)
-- t<duration>: Note length as a fraction of a whole note. Default: \`t/4\` (quarter). REQUIRES denominator — \`t1\`, \`t2.5\`, \`t0.5\` are invalid; write \`t/4\`, \`t5/8\`, \`t/8\` instead. \`t/12\` = eighth triplet, \`t/6\` = quarter triplet
+- t<duration>: Note length as an absolute note value. Default: \`t/4\` (quarter). REQUIRES denominator — \`t1\`, \`t2.5\`, \`t0.5\` are invalid; write \`t/4\`, \`t5/8\`, \`t/8\` instead. \`t/12\` = eighth triplet (3 in a quarter), \`t/6\` = quarter triplet (3 in a half)
 - p<chance>: Probability from 0.0 to 1.0 (default: 1.0 = always)
 - Notes: C0-G8 with # or b for sharps/flats (C#3, Bb2). C3 = middle C
 - **Stateful**: v/t/p and pitch persist until changed — set once, applies to all following notes
@@ -84,7 +84,7 @@ C3 E3 G3 1|1,2,3,4 // same chord on every beat
 C1 1|1,3 2|1,2,3 // same pitch across bars (NOT 1|1,3,2|1,2,3)
 t/16 C3 1|1.75 // 16th note at beat 1.75
 t/12 C3 1|1x3 // eighth-note triplets: 3 notes filling one quarter (step = duration)
-t/16 Gb1 1|1x16 // 16 sixteenths spanning a quarter note (1|1x16@/16 is the same)
+t/16 Gb1 1|1x16 // 16 sixteenths = 4 quarters, a full bar in 4/4 (1|1x16@/16 is the same)
 C3 D3 1|1 v0 C3 1|1 // delete earlier C3 (D3 remains)
 C3 D3 1|1 @2=1 v0 D3 2|1 // bar copy then delete D3 from bar 2
 v90-110 C1 1|1,3 D1 1|2,4 // humanized drum pattern

--- a/src/test/test-data-builders.ts
+++ b/src/test/test-data-builders.ts
@@ -37,7 +37,7 @@ export const createNote = (overrides: NoteOverrides = {}): Note => ({
 
 /**
  * Expected notes from the standard drum pattern test fixture:
- * "v100 t0.25 p1.0 C1 v80-100 p0.8 Gb1 1|1 p0.6 Gb1 1|1.5 v90 p1.0 D1 v100 p0.9 Gb1 1|2"
+ * "v100 t/16 p1.0 C1 v80-100 p0.8 Gb1 1|1 p0.6 Gb1 1|1.5 v90 p1.0 D1 v100 p0.9 Gb1 1|2"
  * @returns Array of expected note objects
  */
 export function expectedDrumPatternNotes(): Note[] {

--- a/src/tools/clip/create/tests/create-clip-advanced.test.ts
+++ b/src/tools/clip/create/tests/create-clip-advanced.test.ts
@@ -50,7 +50,7 @@ describe("createClip - advanced features", () => {
 
     await createClip({
       slot: "0/0",
-      notes: "t2 C3 1|1 t3 D3 1|3", // Last note starts at beat 2 (0-based), rounds up to 1 bar = 4 beats
+      notes: "t/2 C3 1|1 t3/4 D3 1|3", // Last note starts at beat 2 (0-based), rounds up to 1 bar = 4 beats
     });
 
     expectClipCreated(clipSlot, 4);

--- a/src/tools/clip/create/tests/create-clip-basic.test.ts
+++ b/src/tools/clip/create/tests/create-clip-basic.test.ts
@@ -82,8 +82,9 @@ describe("createClip - basic validation and time signatures", () => {
       notes: "C3 1|1 D3 2|1",
     });
 
-    // In 6/8, beat 2|1 should be 3 Ableton beats (6 musical beats * 4/8 = 3 Ableton beats)
-    expectNotesAdded(clip, [note(60, 0, 0.5), note(62, 3, 0.5)]);
+    // In 6/8, beat 2|1 = 3 Ableton beats (6 musical beats * 4/8). Default duration
+    // is a quarter note (meter-independent), so 1 Ableton beat.
+    expectNotesAdded(clip, [note(60, 0, 1), note(62, 3, 1)]);
   });
 
   it("should create clip with specified length", async () => {
@@ -121,7 +122,7 @@ describe("createClip - basic validation and time signatures", () => {
 
     await createClip({
       slot: "0/0",
-      notes: "t2 C3 1|1 t1.5 D3 1|4", // Last note starts at beat 3 (0-based), rounds up to 1 bar = 4 beats
+      notes: "t/2 C3 1|1 t3/8 D3 1|4", // Last note starts at beat 3 (0-based), rounds up to 1 bar = 4 beats
     });
 
     expectClipCreated(clipSlot, 4);
@@ -132,14 +133,16 @@ describe("createClip - basic validation and time signatures", () => {
       liveSet: { signature_numerator: 6, signature_denominator: 8 },
     });
 
+    // t/2 = half note = 2 quarters; t3/8 = dotted quarter = 1.5 quarters.
+    // Durations are absolute (meter-independent) under new semantics.
     await createClip({
       slot: "0/0",
-      notes: "t2 C3 1|1 t1.5 D3 1|2", // Last note starts at beat 1 (0.5 Ableton beats), rounds up to 1 bar
+      notes: "t/2 C3 1|1 t3/8 D3 1|2", // Last note starts at beat 1 (0.5 Ableton beats), rounds up to 1 bar
     });
 
     expectClipCreated(clipSlot, 3); // 1 bar in 6/8 = 3 Ableton beats
-    // LiveAPI durations are in quarter notes, so halved from the notation string
-    expectNotesAdded(clip, [note(60, 0, 1), note(62, 0.5, 0.75)]);
+    // Live durations are in quarter notes; absolute durations don't change with meter
+    expectNotesAdded(clip, [note(60, 0, 2), note(62, 0.5, 1.5)]);
   });
 
   it("should create 1-bar clip when empty in 4/4 time", async () => {

--- a/src/tools/clip/read/tests/read-clip-core.test.ts
+++ b/src/tools/clip/read/tests/read-clip-core.test.ts
@@ -40,7 +40,9 @@ describe("readClip", () => {
       expectedStart: "1|3", // 1 Ableton beat = 2 musical beats = bar 1 beat 3 in 6/8
       expectedEnd: "2|5", // end_marker (5 beats = 2|5 in 6/8)
       expectedLength: "1:2", // 1 bar + 2 beats (4 Ableton beats in 6/8)
-      expectedNotes: "t2 C3 1|1 D3 1|3 E3 1|5", // Real bar|beat output in 6/8 (t2 = duration in 8th-note beats)
+      // Notes default to 1 Ableton beat = a quarter note. The new notation
+      // default is also a quarter (`t/4`), so no `t` prefix is emitted.
+      expectedNotes: "C3 1|1 D3 1|3 E3 1|5",
     },
   ])(
     "returns clip information when a valid MIDI clip exists ($timeSig time)",
@@ -150,9 +152,10 @@ describe("readClip", () => {
 
     expectGetNotesExtendedCall(clip, 3);
 
-    // In 6/8 time with Ableton's quarter-note beats, beat 3 should be bar 2 beat 1
-    // t2 emitted because 1 Ableton beat = 2 eighth-note beats (notation default is 1)
-    expect(result.notes).toBe("t2 C3 1|1 D3 2|1 E3 2|2");
+    // In 6/8 time with Ableton's quarter-note beats, beat 3 should be bar 2 beat 1.
+    // Notes have default duration of 1 Ableton beat (= a quarter note), which
+    // matches the new notation default (`t/4`), so no `t` prefix is emitted.
+    expect(result.notes).toBe("C3 1|1 D3 2|1 E3 2|2");
     expect(result.timeSignature).toBe("6/8");
     expect(result).toHaveLength("1:0"); // 3 Ableton beats = 1 bar in 6/8
   });

--- a/src/tools/clip/read/tests/read-clip-edge-cases.test.ts
+++ b/src/tools/clip/read/tests/read-clip-edge-cases.test.ts
@@ -120,7 +120,7 @@ describe("readClip", () => {
       end: "2|2", // end_marker (5 beats = 2|2)
       length: "1:0",
       triggered: true,
-      notes: "t/4 C1 1|1,3 v90 D1 1|2,4",
+      notes: "t/16 C1 1|1,3 v90 D1 1|2,4",
     });
   });
 

--- a/src/tools/clip/update/tests/update-clip-basic.test.ts
+++ b/src/tools/clip/update/tests/update-clip-basic.test.ts
@@ -169,7 +169,8 @@ describe("updateClip - Basic operations", () => {
 
     const result = await updateClip({
       ids: "123",
-      notes: "v80 t2 C4 1|1 v120 t1 D4 1|3",
+      // t/2 = half = 2 quarters; t/4 = quarter
+      notes: "v80 t/2 C4 1|1 v120 t/4 D4 1|3",
       noteUpdateMode: "replace",
     });
 
@@ -200,11 +201,12 @@ describe("updateClip - Basic operations", () => {
       noteUpdateMode: "replace",
     });
 
-    // In 6/8 time, bar 2 beat 1 should be 3 Ableton beats (6 musical beats * 4/8 = 3 Ableton beats)
+    // In 6/8 time, bar 2 beat 1 = 3 Ableton beats (6 musical beats * 4/8).
+    // Default duration is a quarter note regardless of meter (1 Ableton beat).
     expect(mocks.clip123.call).toHaveBeenCalledWith("add_new_notes", {
       notes: [
-        createNote({ duration: 0.5 }),
-        createNote({ pitch: 62, start_time: 3, duration: 0.5 }),
+        createNote({ duration: 1 }),
+        createNote({ pitch: 62, start_time: 3, duration: 1 }),
       ],
     });
 
@@ -241,7 +243,7 @@ describe("updateClip - Basic operations", () => {
     const result = await updateClip({
       ids: "123",
       notes:
-        "v100 t0.25 p1.0 C1 v80-100 p0.8 Gb1 1|1 p0.6 Gb1 1|1.5 v90 p1.0 D1 v100 p0.9 Gb1 1|2",
+        "v100 t/16 p1.0 C1 v80-100 p0.8 Gb1 1|1 p0.6 Gb1 1|1.5 v90 p1.0 D1 v100 p0.9 Gb1 1|2",
       noteUpdateMode: "replace",
     });
 


### PR DESCRIPTION
## Summary

Experimental change to make `t` durations and `@step` intervals in bar|beat notation align with the music-notation prior that LLMs are trained on. A `t/4` now means a quarter note in any meter, not 1/4 of a meter-relative beat.

Motivation: months of eval data show small models consistently write `t/4` *meaning* a quarter note and silently get a sixteenth note. This change makes the notation agree with the prior instead of fighting it.

## Scope

**In:** the `t` duration and `@step` repeat interval in bar|beat notation (grammar, interpreter, serializer, skills).

**Out (untouched):**
- Bar|beat positions (`1|2.5`, `1|2+1/3`) — still meter-relative
- Clip `length` / `arrangementLength` bar:beat format (`"4:0"`)
- Transforms DSL durations / oscillator periods
- Dev specs, docs site, eval scenarios — deferred to a follow-up

## Key changes

- **Grammar:** `t<num>/<den>` and `@<num>/<den>` only; denominator mandatory, numerator defaults to 1. `t<bar>:<beat>` form removed. Targeted error message on `t1`/`t0.5`/`t1+1/2` etc. that names the fix inline
- **Default duration:** now a quarter note in every meter (1 Ableton beat in 4/4, 2 in 6/8, 0.5 in 2/2). Previously the default silently varied with the meter denominator
- **Serializer:** always emits the `n/d` fraction form; smallest matching denominator wins (powers of 2 → triplets → quintuplets)
- **Skills (basic + standard):** rewritten in absolute-note-value vocabulary; examples teach quarter-counting, not meter-matching

## Validation

This is an experiment. The next step is to run the SLM matrix on `dev` vs. this branch and compare:
- duration-error rate (the bug this is fixing — expected to drop)
- parse-error rate (expected to rise as a tradeoff — banning decimals/integers makes the bug visible instead of silent)
- final correctness (the actual win condition; even if parse errors rise)

Triplets are the weakest spot of the change (no strong model prior for `/12`, `/6`, etc.) — worth watching closely.

## Test plan

- [x] `npm run check` — 6620 tests pass, lint/typecheck/format clean, coverage above thresholds
- [x] `npm run check:build` — production artifacts + docs site build successfully
- [ ] Manual round-trip spot-check in the chat UI (a few prompts that exercise melodies, drums, triplets, non-4/4)
- [ ] SLM eval matrix comparison before/after, for triplets specifically and overall

🤖 Generated with [Claude Code](https://claude.com/claude-code)