### PR TITLE
test: increase statement and branch coverage; raise thresholds

### DIFF
--- a/src/live-api-adapter/tests/live-api-extensions-path-indices.test.ts
+++ b/src/live-api-adapter/tests/live-api-extensions-path-indices.test.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -51,6 +52,32 @@ describe("LiveAPI extensions - path index extensions", () => {
       const track = LiveAPI.from(livePath.track(42));
 
       expect(track.trackIndex).toBe(42);
+    });
+  });
+
+  describe("category", () => {
+    it("should return 'regular' for a track path", () => {
+      const track = LiveAPI.from(livePath.track(3));
+
+      expect(track.category).toBe("regular");
+    });
+
+    it("should return 'return' for a return track path", () => {
+      const returnTrack = LiveAPI.from(livePath.returnTrack(0));
+
+      expect(returnTrack.category).toBe("return");
+    });
+
+    it("should return 'master' for the master track path", () => {
+      const master = LiveAPI.from(livePath.masterTrack());
+
+      expect(master.category).toBe("master");
+    });
+
+    it("should return null for a non-track path", () => {
+      const scene = LiveAPI.from(livePath.scene(2));
+
+      expect(scene.category).toBe(null);
     });
   });
 

--- a/src/mcp-server/rpc/node-request-protocol.test.ts
+++ b/src/mcp-server/rpc/node-request-protocol.test.ts
@@ -127,6 +127,23 @@ describe("node-request-protocol", () => {
     expect(response.error).toBe("kaboom");
   });
 
+  it("returns failure when handler throws a non-Error value", async () => {
+    registerNodeRoute("boom-string", () => {
+      const nonError: unknown = "plain string failure";
+
+      throw nonError;
+    });
+
+    const request = JSON.stringify({ route: "boom-string", args: {} });
+
+    await handleNodeRequest("req-4b", request);
+
+    const response = parseSentResponse();
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBe("plain string failure");
+  });
+
   it("returns failure when handler rejects", async () => {
     registerNodeRoute("rejects", () => Promise.reject(new Error("nope")));
 

--- a/src/shared/tests/version-check.test.ts
+++ b/src/shared/tests/version-check.test.ts
@@ -91,6 +91,13 @@ describe("checkForUpdate", () => {
     expect(result).toStrictEqual({ version: "2.0.0" });
   });
 
+  it("returns version when tag_name has no v prefix", async () => {
+    mockFetchResponse({ tag_name: "2.0.0" });
+    const result = await checkForUpdate("1.0.0");
+
+    expect(result).toStrictEqual({ version: "2.0.0" });
+  });
+
   it("returns null when the current version matches latest", async () => {
     mockFetchResponse({ tag_name: "v1.0.0" });
     expect(await checkForUpdate("1.0.0")).toBeNull();

--- a/src/tools/actions/delete/tests/delete-device-errors.test.ts
+++ b/src/tools/actions/delete/tests/delete-device-errors.test.ts
@@ -80,6 +80,28 @@ describe("deleteObject device path error cases", () => {
     );
   });
 
+  it("should warn and skip when device path has no parent segment", () => {
+    const consoleSpy = vi.spyOn(console, "warn");
+
+    // A device path that begins with "devices N" has nothing before the last
+    // "devices" match, so the extracted parent path is empty.
+    registerMockObject("orphan-device", {
+      path: "devices 0",
+      type: "Device",
+    });
+
+    const result = deleteObject({ ids: "orphan-device", type: "device" });
+
+    expect(result).toStrictEqual({
+      id: "orphan-device",
+      type: "device",
+      deleted: false,
+    });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'delete: could not extract parent path from device "orphan-device" (path="devices 0"), skipping',
+    );
+  });
+
   it("should warn when direct device path does not exist", () => {
     const consoleSpy = vi.spyOn(console, "warn");
 

--- a/src/tools/clip/arrangement/arrangement-operations.test.ts
+++ b/src/tools/clip/arrangement/arrangement-operations.test.ts
@@ -1,0 +1,127 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as console from "#src/shared/v8-max-console.ts";
+import { handleArrangementLengthOperation } from "./arrangement-operations.ts";
+import * as helpers from "./helpers/arrangement-operations-helpers.ts";
+
+interface MockClipOptions {
+  id?: string;
+  path?: string;
+  props?: Record<string, number>;
+}
+
+function createMockClip({
+  id = "789",
+  path = "live_set tracks 0 arrangement_clips 0",
+  props = {},
+}: MockClipOptions = {}): LiveAPI {
+  const merged: Record<string, number> = {
+    is_arrangement_clip: 1,
+    start_time: 0,
+    end_time: 8,
+    ...props,
+  };
+
+  return {
+    id,
+    path,
+    getProperty: vi.fn((prop: string) => merged[prop]),
+  } as unknown as LiveAPI;
+}
+
+describe("handleArrangementLengthOperation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("warns and skips for a session clip", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const clip = createMockClip({ props: { is_arrangement_clip: 0 } });
+
+    const result = handleArrangementLengthOperation({
+      clip,
+      isAudioClip: false,
+      arrangementLengthBeats: 16,
+      context: { holdingAreaStartBeats: 40000 },
+    });
+
+    expect(result).toStrictEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ignored for session clip"),
+    );
+  });
+
+  it("warns and skips for a take-lane clip", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const clip = createMockClip({
+      path: "live_set tracks 0 take_lanes 1 arrangement_clips 0",
+    });
+
+    const result = handleArrangementLengthOperation({
+      clip,
+      isAudioClip: false,
+      arrangementLengthBeats: 16,
+      context: { holdingAreaStartBeats: 40000 },
+    });
+
+    expect(result).toStrictEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ignored for take-lane clip"),
+    );
+  });
+
+  it("delegates to handleArrangementLengthening when target length is longer", () => {
+    const lengtheningSpy = vi
+      .spyOn(helpers, "handleArrangementLengthening")
+      .mockReturnValue([{ id: "789" }]);
+    const clip = createMockClip({ props: { start_time: 0, end_time: 8 } });
+
+    const result = handleArrangementLengthOperation({
+      clip,
+      isAudioClip: true,
+      arrangementLengthBeats: 16,
+      context: { holdingAreaStartBeats: 40000 },
+    });
+
+    expect(lengtheningSpy).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual([{ id: "789" }]);
+  });
+
+  it("delegates to handleArrangementShortening when target length is shorter", () => {
+    const shorteningSpy = vi
+      .spyOn(helpers, "handleArrangementShortening")
+      .mockImplementation(() => {});
+    const clip = createMockClip({ props: { start_time: 0, end_time: 8 } });
+
+    const result = handleArrangementLengthOperation({
+      clip,
+      isAudioClip: false,
+      arrangementLengthBeats: 4,
+      context: { holdingAreaStartBeats: 40000 },
+    });
+
+    expect(shorteningSpy).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual([]);
+  });
+
+  it("does nothing when target length equals current length", () => {
+    const lengtheningSpy = vi.spyOn(helpers, "handleArrangementLengthening");
+    const shorteningSpy = vi.spyOn(helpers, "handleArrangementShortening");
+    const clip = createMockClip({ props: { start_time: 0, end_time: 8 } });
+
+    const result = handleArrangementLengthOperation({
+      clip,
+      isAudioClip: false,
+      arrangementLengthBeats: 8,
+      context: { holdingAreaStartBeats: 40000 },
+    });
+
+    expect(lengtheningSpy).not.toHaveBeenCalled();
+    expect(shorteningSpy).not.toHaveBeenCalled();
+    expect(result).toStrictEqual([]);
+  });
+});

--- a/src/tools/clip/update/tests/arrangement/update-clip-splitting.test.ts
+++ b/src/tools/clip/update/tests/arrangement/update-clip-splitting.test.ts
@@ -1,19 +1,27 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Smoke tests for update-clip splitting integration.
  * Comprehensive splitting tests are in arrangement-splitting.test.ts
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   type RegisteredMockObject,
   registerMockObject,
   lookupMockObject,
+  clearMockRegistry,
 } from "#src/test/mocks/mock-registry.ts";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
-import { setupClipSplittingMocks } from "#src/tools/shared/arrangement/tests/arrangement-splitting-test-helpers.ts";
+import * as console from "#src/shared/v8-max-console.ts";
+import {
+  createSplittingCallMock,
+  setupClipSplittingMocks,
+  setupSplittingClipBaseMocks,
+  setupSplittingClipGetMock,
+} from "#src/tools/shared/arrangement/tests/arrangement-splitting-test-helpers.ts";
 import { updateClip } from "#src/tools/clip/update/update-clip.ts";
 
 function expectDuplicateCalled(trackMock: RegisteredMockObject): void {
@@ -107,5 +115,34 @@ describe("updateClip - splitting smoke tests", () => {
     const resultIds = results.map((r) => r.id);
 
     expect(resultIds).not.toContain("0");
+  });
+
+  it("should warn and skip splitting for a take-lane clip", async () => {
+    const clipId = "take_lane_clip";
+    const consoleSpy = vi.spyOn(console, "warn");
+
+    // A take-lane arrangement clip cannot be split via
+    // duplicate_clip_to_arrangement, so it is warned-and-skipped.
+    clearMockRegistry();
+    setupSplittingClipBaseMocks(clipId, {
+      path: livePath.track(0).takeLane(0).arrangementClip(0),
+    });
+    setupSplittingClipGetMock(clipId);
+    createSplittingCallMock();
+
+    const result = await updateClip(
+      {
+        ids: clipId,
+        split: "2|1",
+      },
+      { holdingAreaStartBeats: 40000 },
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("split parameter ignored for take-lane clip"),
+    );
+    const results = Array.isArray(result) ? result : [result];
+
+    expect(results.map((r) => r.id)).toContain(clipId);
   });
 });

--- a/src/tools/track/read/tests/read-track-basic.test.ts
+++ b/src/tools/track/read/tests/read-track-basic.test.ts
@@ -431,6 +431,50 @@ describe("readTrack", () => {
 
     expect(result.instrument).toBeUndefined();
   });
+
+  it("returns empty sessionClips for a return track when session-clips is included", () => {
+    registerMockObject("return1", {
+      path: livePath.returnTrack(0),
+      type: "Track",
+      properties: {
+        has_midi_input: 0,
+        name: "Return Track",
+        clip_slots: [],
+        arrangement_clips: [],
+        devices: [],
+      },
+    });
+
+    const result = readTrack({
+      trackIndex: 0,
+      trackType: "return",
+      include: ["session-clips"],
+    });
+
+    expect(result.sessionClips).toStrictEqual([]);
+  });
+
+  it("returns empty arrangementClips for a return track when arrangement-clips is included", () => {
+    registerMockObject("return1", {
+      path: livePath.returnTrack(0),
+      type: "Track",
+      properties: {
+        has_midi_input: 0,
+        name: "Return Track",
+        clip_slots: [],
+        arrangement_clips: [],
+        devices: [],
+      },
+    });
+
+    const result = readTrack({
+      trackIndex: 0,
+      trackType: "return",
+      include: ["arrangement-clips"],
+    });
+
+    expect(result.arrangementClips).toStrictEqual([]);
+  });
 });
 
 function expectedSoloedMidiTrackResult(): Record<string, unknown> {

--- a/src/tools/track/update/tests/update-track-mixer.test.ts
+++ b/src/tools/track/update/tests/update-track-mixer.test.ts
@@ -262,6 +262,48 @@ describe("updateTrack - mixer properties", () => {
     expect(leftSplitParam1.set).toHaveBeenCalledWith("value", -1);
     expect(rightSplitParam1.set).toHaveBeenCalledWith("value", 1);
   });
+
+  it("should skip gain when the volume parameter does not exist", () => {
+    // Mixer exists but its volume child does not.
+    registerMockObject("id 0", {
+      path: `${livePath.track(0).mixerDevice()} volume`,
+    });
+
+    updateTrack({ ids: "123", gainDb: -6 });
+
+    expect(volumeParam1.set).not.toHaveBeenCalled();
+  });
+
+  it("should skip pan when the panning parameter does not exist", () => {
+    // Mixer exists but its panning child does not.
+    registerMockObject("id 0", {
+      path: `${livePath.track(0).mixerDevice()} panning`,
+    });
+
+    updateTrack({ ids: "123", pan: 0.5 });
+
+    expect(panningParam1.set).not.toHaveBeenCalled();
+  });
+
+  it("should skip split panning when split parameters do not exist", () => {
+    // Mixer is in split mode but the split stereo children do not exist.
+    mixer1.get.mockImplementation((prop: string) => {
+      if (prop === "panning_mode") return [1]; // Split mode
+
+      return [0];
+    });
+    const leftSplitParam1 = registerMockObject("id 0", {
+      path: `${livePath.track(0).mixerDevice()} left_split_stereo`,
+    });
+    const rightSplitParam1 = registerMockObject("id 0", {
+      path: `${livePath.track(0).mixerDevice()} right_split_stereo`,
+    });
+
+    updateTrack({ ids: "123", leftPan: -0.75, rightPan: 0.5 });
+
+    expect(leftSplitParam1.set).not.toHaveBeenCalled();
+    expect(rightSplitParam1.set).not.toHaveBeenCalled();
+  });
 });
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import preact from "@preact/preset-vite";
@@ -107,8 +108,8 @@ export default defineConfig({
 
       // IMPORTANT: Do NOT let test coverage drop:
       thresholds: {
-        statements: 99,
-        branches: 95.5,
+        statements: 99.2,
+        branches: 95.8,
         functions: 100,
         lines: 99.4,
       },


### PR DESCRIPTION
## Summary

Increases statement and branch test coverage by adding targeted tests for previously-uncovered warn-and-skip and edge-case branches, then raises the coverage thresholds to track the new results.

### Coverage results

| Metric | Before | After | New threshold |
|---|---|---|---|
| Statements | 99.25% | **99.30%** | 99 → **99.2** |
| Branches | 95.83% | **95.99%** | 95.5 → **95.8** |
| Functions | 100% | 100% | 100 |
| Lines | 99.51% | 99.56% | 99.4 |

Each raised threshold sits at the highest 0.1% increment that is at least 0.1% below the resulting coverage (e.g. 95.99% → 95.8).

### Tests added

- **arrangement-operations** — new direct test for `handleArrangementLengthOperation`: session-clip and take-lane warn-and-skip paths plus the lengthen/shorten/no-op dispatch (file went from 88% → 100%)
- **delete** — empty device parent-path warn path
- **update-track mixer** — missing `volume` / `panning` / split-stereo child params (the `.exists()` false branches)
- **read-track** — empty session/arrangement clips for non-regular (return) tracks
- **update-clip splitting** — take-lane clip warn-and-skip
- **live-api-extensions** — `category` getter for regular/return/master plus the null fallthrough
- **version-check** — `tag_name` without a `v` prefix
- **node-request-protocol** — handler throwing a non-Error value (`String(error)` branch)

### Validation

- `npm run check` — lint, typecheck, format, 7479 tests pass; coverage thresholds met
- `npm run check:build` — production bundles + docs site build successfully

https://claude.ai/code/session_016k7A3xJBS52Asvwv6SvGPv

---
_Generated by [Claude Code](https://claude.ai/code/session_016k7A3xJBS52Asvwv6SvGPv)_