### PR TITLE
Manual conversation compaction in chat

### DIFF
--- a/webui/src/chat/sdk/client.ts
+++ b/webui/src/chat/sdk/client.ts
@@ -15,6 +15,7 @@ import {
 } from "ai";
 import { type MessageOverrides } from "#webui/hooks/chat/use-chat-types";
 import { getMcpUrl } from "#webui/utils/mcp-url";
+import { summarizeHistory } from "./compaction";
 import { createMcpTools } from "./mcp-tools";
 import { createStreamErrorSignal } from "./stream-with-error-signal";
 import { type ChatClientConfig, type ChatMessage, toTokenUsage } from "./types";
@@ -52,6 +53,16 @@ export class ChatSdkClient {
     const { tools } = await createMcpTools(mcpUrl, this.config.enabledTools);
 
     this.tools = tools;
+  }
+
+  /**
+   * Summarize a slice of chat history into a single compaction summary,
+   * using this conversation's model with no tools.
+   * @param history - Messages to compact (oldest first)
+   * @returns The compaction summary text
+   */
+  async summarize(history: ChatMessage[]): Promise<string> {
+    return await summarizeHistory(this.config.model, history);
   }
 
   /**

--- a/webui/src/chat/sdk/client.ts
+++ b/webui/src/chat/sdk/client.ts
@@ -303,15 +303,29 @@ function handleStreamPart(
  * Assistant messages with tool calls produce two ModelMessages:
  * 1. assistant message with text + tool-call parts
  * 2. tool message with tool-result parts
+ *
+ * Consecutive user turns are merged into one. A compaction summary is a
+ * synthetic user message, so the next real user message would otherwise sit
+ * directly after it — Gemini and Mistral reject two user turns in a row (only
+ * Anthropic/OpenAI tolerate it). Folding them into a single user turn keeps the
+ * wire format valid for every provider while the UI still renders them
+ * separately (the divider plus the user bubble).
  * @param history - Chat history to convert
  * @returns Array of ModelMessage for streamText
  */
-function buildModelMessages(history: ChatMessage[]): ModelMessage[] {
+export function buildModelMessages(history: ChatMessage[]): ModelMessage[] {
   const messages: ModelMessage[] = [];
 
   for (const msg of history) {
     if (msg.role === "user") {
-      messages.push({ role: "user", content: msg.content });
+      const last = messages.at(-1);
+
+      if (last?.role === "user" && typeof last.content === "string") {
+        last.content = `${last.content}\n\n${msg.content}`;
+      } else {
+        messages.push({ role: "user", content: msg.content });
+      }
+
       continue;
     }
 

--- a/webui/src/chat/sdk/compaction.ts
+++ b/webui/src/chat/sdk/compaction.ts
@@ -1,0 +1,91 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { generateText, type LanguageModel } from "ai";
+import { type ChatMessage } from "./types";
+
+/**
+ * System prompt for conversation compaction. Tuned for Producer Pal: preserve
+ * musical intent and decisions over raw tool-result data (live state can be
+ * re-read with tools), and keep concrete notation examples as written so a
+ * small model keeps using the same dialect after compaction.
+ */
+export const COMPACTION_PROMPT = `You are compacting a conversation between a user and an AI music-composition assistant for Ableton Live, so it can continue under a smaller context window.
+
+Write a dense summary that lets the assistant pick up exactly where it left off. Preserve:
+- The user's musical goals and aesthetic direction.
+- Concrete decisions: key, scale, tempo, time signature, track and clip names, arrangement structure.
+- What has been built so far, and what is still pending or requested.
+- Concrete examples of any notation or syntax the assistant used (e.g. bar|beat note strings), exactly as written — these teach the assistant the dialect to keep using.
+
+The current Live Set state can always be re-read with the tools, so capture intent and decisions rather than copying large tool-result dumps. Write the summary as notes to your future self, not as a message to the user. Do not add any commentary before or after the summary.`;
+
+const SUMMARIZE_INSTRUCTION =
+  "Summarize the conversation transcript above following your instructions.";
+
+/**
+ * Summarize a slice of chat history into a single compaction summary string,
+ * using the conversation's own model with no tools. The slice is rendered to a
+ * plain-text transcript rather than replayed as structured turns, which
+ * sidesteps provider role-ordering rules for arbitrary slices (e.g. one ending
+ * on a tool result).
+ * @param model - The conversation's language model
+ * @param history - Chat messages to compact (oldest first)
+ * @returns The compaction summary text
+ */
+export async function summarizeHistory(
+  model: LanguageModel,
+  history: ChatMessage[],
+): Promise<string> {
+  const transcript = renderTranscript(history);
+  const { text } = await generateText({
+    model,
+    system: COMPACTION_PROMPT,
+    messages: [
+      { role: "user", content: `${transcript}\n\n${SUMMARIZE_INSTRUCTION}` },
+    ],
+  });
+
+  return text.trim();
+}
+
+/**
+ * Render chat history to a plain-text transcript for summarization, including
+ * tool calls and results so the summary reflects what the assistant actually
+ * did.
+ * @param history - Chat messages to render (oldest first)
+ * @returns Plain-text transcript
+ */
+export function renderTranscript(history: ChatMessage[]): string {
+  const lines: string[] = [];
+
+  for (const msg of history) {
+    if (msg.isError) continue;
+
+    if (msg.role === "user") {
+      lines.push(`USER: ${msg.content}`);
+      continue;
+    }
+
+    if (msg.content) {
+      lines.push(`ASSISTANT: ${msg.content}`);
+    }
+
+    for (const call of msg.toolCalls ?? []) {
+      lines.push(`ASSISTANT called ${call.name}(${JSON.stringify(call.args)})`);
+    }
+
+    for (const result of msg.toolResults ?? []) {
+      const value =
+        typeof result.result === "string"
+          ? result.result
+          : JSON.stringify(result.result);
+
+      lines.push(`TOOL ${result.name} => ${value}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/webui/src/chat/sdk/formatter.ts
+++ b/webui/src/chat/sdk/formatter.ts
@@ -28,6 +28,20 @@ function addReasoning(reasoning: string | undefined, parts: UIPart[]): void {
 }
 
 /**
+ * Add a user message's content to parts. Compaction summaries become a single
+ * compaction part (rendered as a divider); normal user text becomes text.
+ * @param msg - User message
+ * @param parts - Parts array to add to
+ */
+function addUserParts(msg: ChatMessage, parts: UIPart[]): void {
+  if (msg.isCompactionSummary) {
+    parts.push({ type: "compaction", content: msg.content });
+  } else {
+    addTextContent(parts, msg.content);
+  }
+}
+
+/**
  * Add tool calls matched with their results to parts.
  * @param msg - AI SDK message containing tool calls and results
  * @param parts - Parts array to add to
@@ -94,7 +108,7 @@ export function formatChatMessages(history: ChatMessage[]): UIMessage[] {
     }
 
     if (msg.role === "user") {
-      addTextContent(currentMessage.parts, msg.content);
+      addUserParts(msg, currentMessage.parts);
     } else if (msg.isError) {
       currentMessage.parts.push({
         type: "error",

--- a/webui/src/chat/sdk/tests/client.test.ts
+++ b/webui/src/chat/sdk/tests/client.test.ts
@@ -28,7 +28,11 @@ vi.mock(import("#webui/utils/mcp-url"), () => ({
 }));
 
 import { generateText, streamText } from "ai";
-import { ChatSdkClient, detectToolLimitReached } from "#webui/chat/sdk/client";
+import {
+  buildModelMessages,
+  ChatSdkClient,
+  detectToolLimitReached,
+} from "#webui/chat/sdk/client";
 
 const MAX_TOOL_STEPS = 10;
 
@@ -536,10 +540,10 @@ describe("ChatSdkClient", () => {
 
       const callArgs = await sendWithHistory(chatHistory, "Try again");
 
-      // 2 messages: user, new user (error skipped)
-      expect(callArgs.messages).toHaveLength(2);
-      expect(callArgs.messages[0].content).toBe("Hi");
-      expect(callArgs.messages[1].content).toBe("Try again");
+      // Skipping the error leaves two user turns adjacent, which Gemini/Mistral
+      // reject — they merge into a single user message.
+      expect(callArgs.messages).toHaveLength(1);
+      expect(callArgs.messages[0].content).toBe("Hi\n\nTry again");
     });
 
     it("converts history with tool calls to model messages", async () => {
@@ -712,5 +716,64 @@ describe("ChatSdkClient.summarize", () => {
 
     expect(result).toBe("the summary");
     expect(generateText).toHaveBeenCalledOnce();
+  });
+});
+
+describe("buildModelMessages", () => {
+  it("merges consecutive user turns into a single user message", () => {
+    // A compaction summary (synthetic user message) followed by the next real
+    // user message: Gemini and Mistral reject two user turns in a row.
+    const result = buildModelMessages([
+      {
+        role: "user",
+        content: "summary of earlier turns",
+        isCompactionSummary: true,
+      },
+      { role: "user", content: "now add a bass line" },
+    ]);
+
+    expect(result).toStrictEqual([
+      {
+        role: "user",
+        content: "summary of earlier turns\n\nnow add a bass line",
+      },
+    ]);
+  });
+
+  it("keeps alternating turns separate", () => {
+    const result = buildModelMessages([
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1" },
+      { role: "user", content: "u2" },
+    ]);
+
+    expect(result).toStrictEqual([
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1" },
+      { role: "user", content: "u2" },
+    ]);
+  });
+
+  it("does not merge a user turn across a tool-result message", () => {
+    // An assistant turn with tool calls emits an assistant message plus a tool
+    // message, so a following user turn must not fold into the earlier user.
+    const result = buildModelMessages([
+      { role: "user", content: "u1" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "1", name: "read-song", args: {} }],
+        toolResults: [{ id: "1", name: "read-song", args: {}, result: "ok" }],
+      },
+      { role: "user", content: "u2" },
+    ]);
+
+    expect(result.map((m) => m.role)).toStrictEqual([
+      "user",
+      "assistant",
+      "tool",
+      "user",
+    ]);
+    expect(result.at(-1)).toStrictEqual({ role: "user", content: "u2" });
   });
 });

--- a/webui/src/chat/sdk/tests/client.test.ts
+++ b/webui/src/chat/sdk/tests/client.test.ts
@@ -13,6 +13,7 @@ vi.mock(import("ai"), async (importOriginal) => {
   return {
     ...actual,
     streamText: vi.fn(),
+    generateText: vi.fn(),
   };
 });
 
@@ -26,7 +27,7 @@ vi.mock(import("#webui/utils/mcp-url"), () => ({
   getMcpUrl: vi.fn(() => "http://localhost:3000/mcp"),
 }));
 
-import { streamText } from "ai";
+import { generateText, streamText } from "ai";
 import { ChatSdkClient, detectToolLimitReached } from "#webui/chat/sdk/client";
 
 const MAX_TOOL_STEPS = 10;
@@ -697,5 +698,19 @@ describe("detectToolLimitReached", () => {
 
   it("returns false for an error finishReason at the limit", () => {
     expect(detectToolLimitReached(MAX_TOOL_STEPS, "error")).toBe(false);
+  });
+});
+
+describe("ChatSdkClient.summarize", () => {
+  it("returns a trimmed summary from the model", async () => {
+    (generateText as ReturnType<typeof vi.fn>).mockResolvedValue({
+      text: "  the summary  ",
+    });
+
+    const client = new ChatSdkClient("key", createConfig());
+    const result = await client.summarize([{ role: "user", content: "hi" }]);
+
+    expect(result).toBe("the summary");
+    expect(generateText).toHaveBeenCalledOnce();
   });
 });

--- a/webui/src/chat/sdk/tests/compaction.test.ts
+++ b/webui/src/chat/sdk/tests/compaction.test.ts
@@ -1,0 +1,84 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type LanguageModel, generateText } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { type ChatMessage } from "#webui/chat/sdk/types";
+
+vi.mock(import("ai"), async (importOriginal) => {
+  const actual = await importOriginal();
+
+  return { ...actual, generateText: vi.fn() };
+});
+
+import {
+  COMPACTION_PROMPT,
+  renderTranscript,
+  summarizeHistory,
+} from "#webui/chat/sdk/compaction";
+
+const model = { modelId: "test" } as unknown as LanguageModel;
+
+describe("renderTranscript", () => {
+  it("renders user and assistant text turns", () => {
+    const history: ChatMessage[] = [
+      { role: "user", content: "make a beat" },
+      { role: "assistant", content: "on it" },
+    ];
+
+    expect(renderTranscript(history)).toBe(
+      "USER: make a beat\nASSISTANT: on it",
+    );
+  });
+
+  it("renders tool calls and results, stringifying non-string results", () => {
+    const history: ChatMessage[] = [
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "1", name: "read-song", args: { x: 1 } }],
+        toolResults: [
+          { id: "1", name: "read-song", args: {}, result: { tempo: 120 } },
+          { id: "2", name: "note", args: {}, result: "ok" },
+        ],
+      },
+    ];
+
+    const out = renderTranscript(history);
+
+    expect(out).toContain('ASSISTANT called read-song({"x":1})');
+    expect(out).toContain('TOOL read-song => {"tempo":120}');
+    expect(out).toContain("TOOL note => ok");
+  });
+
+  it("skips error messages", () => {
+    const history: ChatMessage[] = [
+      { role: "assistant", content: "boom", isError: true },
+      { role: "user", content: "hi" },
+    ];
+
+    expect(renderTranscript(history)).toBe("USER: hi");
+  });
+});
+
+describe("summarizeHistory", () => {
+  it("summarizes the transcript with the compaction prompt and trims", async () => {
+    (generateText as ReturnType<typeof vi.fn>).mockResolvedValue({
+      text: "  the summary  ",
+    });
+
+    const result = await summarizeHistory(model, [
+      { role: "user", content: "hi" },
+    ]);
+
+    expect(result).toBe("the summary");
+
+    const call = (generateText as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+
+    expect(call.system).toBe(COMPACTION_PROMPT);
+    expect(call.messages[0].content).toContain("USER: hi");
+    expect(call.messages[0].content).toContain("Summarize the conversation");
+  });
+});

--- a/webui/src/chat/sdk/tests/formatter.test.ts
+++ b/webui/src/chat/sdk/tests/formatter.test.ts
@@ -298,4 +298,15 @@ describe("formatChatMessages", () => {
     expect(result).toHaveLength(1);
     expect(result[0]!.parts.every((p) => p.type !== "step-usage")).toBe(true);
   });
+
+  it("formats a compaction summary as a compaction part", () => {
+    const history: ChatMessage[] = [
+      { role: "user", content: "Earlier summary", isCompactionSummary: true },
+    ];
+    const result = formatChatMessages(history);
+
+    expect(result[0]!.parts).toStrictEqual([
+      { type: "compaction", content: "Earlier summary" },
+    ]);
+  });
 });

--- a/webui/src/chat/sdk/types.ts
+++ b/webui/src/chat/sdk/types.ts
@@ -39,6 +39,8 @@ export interface ChatMessage {
   thinkingOverride?: string;
   temperatureOverride?: number;
   showThoughtsOverride?: boolean;
+  /** True for a synthetic compaction summary that replaces older turns */
+  isCompactionSummary?: boolean;
 }
 
 /** Token usage summary extracted from LanguageModelUsage */

--- a/webui/src/components/ChatApp.tsx
+++ b/webui/src/components/ChatApp.tsx
@@ -64,12 +64,15 @@ export function ChatApp(props: ChatAppProps) {
   return (
     <ChatScreen
       messages={chat.messages}
-      isAssistantResponding={chat.isAssistantResponding}
+      isAssistantResponding={chat.isAssistantResponding || chat.isCompacting}
       rateLimitState={chat.rateLimitState}
       toolLimitReached={chat.toolLimitReached}
       handleSend={wrappedHandleSend}
       handleRetry={chat.handleRetry}
       handleEdit={chat.handleEdit}
+      handleCompact={chat.compact}
+      onUndoCompaction={chat.undoCompaction}
+      canUndoCompaction={chat.canUndoCompaction}
       headerInfo={headerInfo}
       activeThinking={chat.activeThinking}
       defaultThinking={settings.thinking}

--- a/webui/src/components/chat/ChatScreen.tsx
+++ b/webui/src/components/chat/ChatScreen.tsx
@@ -31,6 +31,9 @@ interface ChatScreenProps {
   handleSend: (message: string, options?: MessageOverrides) => Promise<void>;
   handleRetry: (messageIndex: number) => Promise<void>;
   handleEdit: (messageIndex: number, newMessage: string) => Promise<void>;
+  handleCompact?: (messageIndex: number) => Promise<void>;
+  onUndoCompaction?: () => void;
+  canUndoCompaction?: boolean;
   headerInfo: HeaderInfo;
   activeThinking: string | null;
   defaultThinking: string;
@@ -57,6 +60,9 @@ interface ChatScreenProps {
  * @param props.handleSend - Send message handler
  * @param props.handleRetry - Retry message handler
  * @param props.handleEdit - Edit message handler
+ * @param props.handleCompact - Compact-up-to-here handler
+ * @param props.onUndoCompaction - Undo the last compaction
+ * @param props.canUndoCompaction - Whether the last compaction can be undone
  * @param props.headerInfo - Header display state
  * @param props.activeThinking - Locked thinking level from conversation
  * @param props.defaultThinking - Default thinking level from settings
@@ -80,6 +86,9 @@ export function ChatScreen(props: ChatScreenProps) {
     handleSend,
     handleRetry,
     handleEdit,
+    handleCompact,
+    onUndoCompaction,
+    canUndoCompaction,
     headerInfo,
     mcpStatus,
     mcpError,
@@ -124,6 +133,9 @@ export function ChatScreen(props: ChatScreenProps) {
             isAssistantResponding={isAssistantResponding}
             handleRetry={handleRetry}
             handleEdit={handleEdit}
+            handleCompact={handleCompact}
+            onUndoCompaction={onUndoCompaction}
+            canUndoCompaction={canUndoCompaction}
             showTimestamps={showTimestamps}
             showTokenUsage={showTokenUsage}
             requestedModel={headerInfo.activeModel}

--- a/webui/src/components/chat/MessageList.tsx
+++ b/webui/src/components/chat/MessageList.tsx
@@ -2,29 +2,11 @@
 // Copyright (C) 2026 Adam Murray
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { Fragment, type VNode } from "preact";
 import { useEffect, useRef, useState } from "preact/hooks";
-import { isModelMismatch } from "#webui/chat/helpers/model-identity";
-import { type TokenUsage } from "#webui/chat/sdk/types";
-import { ErrorBoundary } from "#webui/components/ErrorBoundary";
-import {
-  calcNewContentTokens,
-  compactNumber,
-} from "#webui/lib/utils/compact-number";
-import {
-  formatTimestampDate,
-  formatTimestampTime,
-} from "#webui/lib/utils/format-timestamp";
 import { type UIMessage } from "#webui/types/messages";
-import { AssistantMessage } from "./assistant/AssistantMessage";
-import {
-  RenderErrorFallback,
-  SafeMarkdown,
-} from "./assistant/message-list-helpers";
+import { CompactionDivider } from "./assistant/CompactionDivider";
+import { MessageRow } from "./assistant/MessageRow";
 import { ActivityIndicator } from "./controls/ActivityIndicator";
-import { RetryButton } from "./controls/RetryButton";
-import { EditButton } from "./EditButton";
-import { UserMessageEditor } from "./UserMessageEditor";
 
 const STILL_THINKING_DELAY_MS = 4000;
 
@@ -33,6 +15,10 @@ interface MessageListProps {
   isAssistantResponding: boolean;
   handleRetry: (messageIndex: number) => Promise<void>;
   handleEdit: (messageIndex: number, newMessage: string) => Promise<void>;
+  /** Compact-up-to-here; omitted in surfaces that don't support compaction (voice/demo) */
+  handleCompact?: (messageIndex: number) => Promise<void>;
+  onUndoCompaction?: () => void;
+  canUndoCompaction?: boolean;
   showTimestamps: boolean;
   showTokenUsage: boolean;
   requestedModel?: string | null;
@@ -45,7 +31,11 @@ interface MessageListProps {
  * @param {boolean} root0.isAssistantResponding - Whether assistant is responding
  * @param {Function} root0.handleRetry - Retry callback
  * @param {Function} root0.handleEdit - Edit and fork callback
+ * @param {Function} root0.handleCompact - Compact-up-to-here callback
+ * @param {Function} root0.onUndoCompaction - Undo the last compaction
+ * @param {boolean} root0.canUndoCompaction - Whether the last compaction can be undone
  * @param {boolean} root0.showTimestamps - Whether to show timestamps
+ * @param {boolean} root0.showTokenUsage - Whether to show token usage
  * @param {string} [root0.requestedModel] - Requested model ID for mismatch detection
  * @returns {JSX.Element} Message list
  */
@@ -54,6 +44,9 @@ export function MessageList({
   isAssistantResponding,
   handleRetry,
   handleEdit,
+  handleCompact,
+  onUndoCompaction,
+  canUndoCompaction = false,
   showTimestamps,
   showTokenUsage,
   requestedModel,
@@ -89,77 +82,39 @@ export function MessageList({
       {messages.map((message, originalIdx) => {
         if (!hasContent(message)) return null;
 
-        const isUser = message.role === "user";
-        const canRetry = message.role === "model" && !isAssistantResponding;
-        const previousUserMessageIdx = canRetry
-          ? findPreviousUserMessageIndex(messages, originalIdx)
-          : -1;
-        const showRetry = canRetry && previousUserMessageIdx >= 0;
-        const canEdit = isUser && !isAssistantResponding;
-        const isEditing = editingIndex === originalIdx;
-        const timestamp = renderTimestamp(message.timestamp, showTimestamps);
-        const prevModelUsage = !isUser
-          ? getPrevModelUsage(messages, originalIdx)
-          : undefined;
+        const compactionPart = message.parts.find(
+          (p) => p.type === "compaction",
+        );
+
+        if (compactionPart?.type === "compaction") {
+          return (
+            <CompactionDivider
+              key={originalIdx}
+              summary={compactionPart.content}
+              canUndo={canUndoCompaction}
+              onUndo={onUndoCompaction}
+            />
+          );
+        }
 
         return (
-          <Fragment key={originalIdx}>
-            {isUser && timestamp}
-            <div
-              className={`${
-                isUser
-                  ? "text-black bg-blue-100 dark:text-white dark:bg-blue-900/80 shadow-sm dark:shadow-white/10 dark:border dark:border-blue-700/40"
-                  : "col-span-2 bg-zinc-50 dark:bg-zinc-800 shadow-sm dark:shadow-white/10 dark:border dark:border-zinc-700"
-              } min-w-0 rounded-lg py-0.5 px-3`}
-              data-testid={isUser ? undefined : "assistant-message-bubble"}
-            >
-              {!isUser && (
-                <ErrorBoundary fallback={<RenderErrorFallback />}>
-                  <AssistantBubble
-                    message={message}
-                    isAssistantResponding={isAssistantResponding}
-                    showTokenUsage={showTokenUsage}
-                    requestedModel={requestedModel}
-                    prevModelUsage={prevModelUsage}
-                  />
-                </ErrorBoundary>
-              )}
-              {isUser && isEditing && (
-                <UserMessageEditor
-                  text={editText}
-                  onTextChange={setEditText}
-                  onSave={() => {
-                    void handleEdit(originalIdx, editText);
-                    setEditingIndex(null);
-                  }}
-                  onCancel={() => setEditingIndex(null)}
-                />
-              )}
-              {isUser && !isEditing && (
-                <ErrorBoundary fallback={<RenderErrorFallback />}>
-                  <SafeMarkdown content={formatUserContent(message)} />
-                </ErrorBoundary>
-              )}
-            </div>
-            {isUser ? (
-              canEdit && !isEditing ? (
-                <EditButton
-                  onClick={() => {
-                    setEditingIndex(originalIdx);
-                    setEditText(formatUserContent(message));
-                  }}
-                />
-              ) : (
-                <div />
-              )
-            ) : (
-              <RightGutter
-                timestamp={timestamp}
-                showRetry={showRetry}
-                onRetry={() => void handleRetry(previousUserMessageIdx)}
-              />
-            )}
-          </Fragment>
+          <MessageRow
+            key={originalIdx}
+            message={message}
+            originalIdx={originalIdx}
+            messages={messages}
+            isAssistantResponding={isAssistantResponding}
+            showTimestamps={showTimestamps}
+            showTokenUsage={showTokenUsage}
+            requestedModel={requestedModel}
+            handleRetry={handleRetry}
+            handleEdit={handleEdit}
+            handleCompact={handleCompact}
+            editingIndex={editingIndex}
+            setEditingIndex={setEditingIndex}
+            editText={editText}
+            setEditText={setEditText}
+          />
         );
       })}
 
@@ -205,140 +160,13 @@ function useScrollOnUserMessage(
 }
 
 /**
- * Checks if message has any parts to display. This checks for the presence of
- * parts, not whether parts have non-empty content — messages with parts: []
- * are system messages that shouldn't be rendered.
+ * Checks if message has any parts to display. Messages with parts: [] are
+ * system messages that shouldn't be rendered.
  * @param {UIMessage} message - Message to check
  * @returns {boolean} Whether the message has displayable parts
  */
-/**
- * Renders assistant message content with model mismatch label and usage.
- * @param props - Component props
- * @param props.message - The model message
- * @param props.isAssistantResponding - Whether assistant is responding
- * @param props.showTokenUsage - Whether to show token usage
- * @param props.requestedModel - Requested model for mismatch detection
- * @param props.prevModelUsage - Previous model message's last usage
- * @returns Assistant bubble content
- */
-function AssistantBubble({
-  message,
-  isAssistantResponding,
-  showTokenUsage,
-  requestedModel,
-  prevModelUsage,
-}: {
-  message: UIMessage;
-  isAssistantResponding: boolean;
-  showTokenUsage: boolean;
-  requestedModel?: string | null;
-  prevModelUsage?: TokenUsage;
-}) {
-  return (
-    <>
-      <ModelMismatchLabel
-        requestedModel={requestedModel}
-        responseModel={message.responseModel}
-      />
-      <AssistantMessage
-        parts={message.parts}
-        isResponding={isAssistantResponding}
-        showTokenUsage={showTokenUsage}
-        prevStepUsage={prevModelUsage}
-      />
-      {showTokenUsage && (
-        <TokenUsageLabel
-          usage={message.usage}
-          prevUsage={getLastStepUsage(message) ?? prevModelUsage}
-        />
-      )}
-    </>
-  );
-}
-
 function hasContent(message: UIMessage): boolean {
   return message.parts.length > 0;
-}
-
-/**
- * Right gutter for AI messages: timestamp at top, retry button at bottom.
- * @param props - Component props
- * @param props.timestamp - Timestamp element
- * @param props.showRetry - Whether to show retry button
- * @param props.onRetry - Retry callback
- * @returns Gutter element
- */
-function RightGutter({
-  timestamp,
-  showRetry,
-  onRetry,
-}: {
-  timestamp: VNode;
-  showRetry: boolean;
-  onRetry: () => void;
-}) {
-  return (
-    <div className="flex flex-col items-start self-stretch">
-      {timestamp}
-      {showRetry && (
-        <div className="mt-auto">
-          <RetryButton onClick={onRetry} />
-        </div>
-      )}
-    </div>
-  );
-}
-
-/**
- * Renders a timestamp element for a message
- * @param {number} timestamp - Unix timestamp in milliseconds
- * @param {boolean} visible - Whether timestamp should be visible
- * @returns {JSX.Element} Timestamp element
- */
-function renderTimestamp(timestamp: number, visible: boolean) {
-  return (
-    <div
-      className={`text-[9px] leading-tight text-zinc-400 dark:text-zinc-600 whitespace-nowrap ${visible ? "" : "invisible"}`}
-      data-testid="message-timestamp"
-    >
-      <div>{formatTimestampDate(timestamp)}</div>
-      <div>{formatTimestampTime(timestamp)}</div>
-    </div>
-  );
-}
-
-/**
- * Finds previous user message index for retry
- * @param {UIMessage[]} messages - Messages array
- * @param {number} currentIdx - Current message index
- * @returns {number} Previous user message index or -1
- */
-function findPreviousUserMessageIndex(
-  messages: UIMessage[],
-  currentIdx: number,
-): number {
-  for (let i = currentIdx - 1; i >= 0; i--) {
-    if (messages[i]?.role === "user") return i;
-  }
-
-  return -1;
-}
-
-/**
- * Formats user message content as string
- * @param {UIMessage} message - User message to format
- * @returns {string} Concatenated text content
- */
-function formatUserContent(message: UIMessage): string {
-  return message.parts
-    .map((part) => {
-      if ("content" in part) {
-        return part.content;
-      }
-
-      return "";
-    })
-    .join("");
 }
 
 /**
@@ -369,95 +197,4 @@ function StreamingFooter({
       </div>
     </>
   );
-}
-
-/**
- * Shows a label when the API responded with a different model than requested.
- * @param props - Component props
- * @param props.requestedModel - Model ID that was requested
- * @param props.responseModel - Model ID from the API response
- * @returns Label element or null
- */
-function ModelMismatchLabel({
-  requestedModel,
-  responseModel,
-}: {
-  requestedModel?: string | null;
-  responseModel?: string;
-}) {
-  if (!responseModel || !requestedModel) return null;
-  if (!isModelMismatch(requestedModel, responseModel)) return null;
-
-  return (
-    <div className="text-xs text-zinc-400 dark:text-zinc-500 pt-1 text-right">
-      responded as {responseModel}
-    </div>
-  );
-}
-
-/**
- * Compact token usage display for assistant messages.
- * @param props - Component props
- * @param props.usage - Token usage data
- * @param props.prevUsage - Previous step's usage for new content calculation
- * @returns Label element or null
- */
-function TokenUsageLabel({
-  usage,
-  prevUsage,
-}: {
-  usage?: TokenUsage;
-  prevUsage?: TokenUsage;
-}) {
-  if (!usage) return null;
-
-  const newContent = calcNewContentTokens(
-    usage.inputTokens ?? 0,
-    prevUsage?.inputTokens,
-    prevUsage?.outputTokens,
-  );
-
-  return (
-    <div className="text-xs text-zinc-400 dark:text-zinc-500 pb-1 text-right">
-      tokens: {compactNumber(usage.inputTokens ?? 0)}
-      {newContent != null && ` (${compactNumber(newContent)} new)`} →{" "}
-      {compactNumber(usage.outputTokens ?? 0)}
-      {(usage.reasoningTokens ?? 0) > 0 &&
-        ` (${compactNumber(usage.reasoningTokens ?? 0)} reasoning)`}
-    </div>
-  );
-}
-
-/**
- * Get the last usage from the previous model message.
- * @param messages - All messages
- * @param currentIdx - Current message index
- * @returns Previous model message's last usage
- */
-function getPrevModelUsage(
-  messages: UIMessage[],
-  currentIdx: number,
-): TokenUsage | undefined {
-  for (let i = currentIdx - 1; i >= 0; i--) {
-    const msg = messages[i];
-
-    if (msg?.role !== "model") continue;
-
-    return getLastStepUsage(msg) ?? msg.usage;
-  }
-
-  return undefined;
-}
-
-/**
- * Get the last step-usage part's usage within a message.
- * @param message - Message to search
- * @returns Last step-usage part's usage, or undefined
- */
-function getLastStepUsage(message: UIMessage): TokenUsage | undefined {
-  const part = message.parts.findLast((p) => p.type === "step-usage");
-
-  if (part?.type === "step-usage") return part.usage;
-
-  return undefined;
 }

--- a/webui/src/components/chat/assistant/CompactionDivider.tsx
+++ b/webui/src/components/chat/assistant/CompactionDivider.tsx
@@ -1,0 +1,59 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { useState } from "preact/hooks";
+import { SafeMarkdown } from "./message-list-helpers";
+
+interface CompactionDividerProps {
+  summary: string;
+  canUndo: boolean;
+  onUndo?: () => void;
+}
+
+/**
+ * Renders a compaction summary as a divider in the transcript, with a toggle to
+ * view the generated summary and an undo action while it is still available.
+ * @param {CompactionDividerProps} root0 - Component props
+ * @param {string} root0.summary - The generated compaction summary text
+ * @param {boolean} root0.canUndo - Whether the compaction can still be undone
+ * @param {() => void} root0.onUndo - Undo callback
+ * @returns {JSX.Element} - React component
+ */
+export function CompactionDivider({
+  summary,
+  canUndo,
+  onUndo,
+}: CompactionDividerProps) {
+  const [showSummary, setShowSummary] = useState(false);
+
+  return (
+    <div className="col-span-3 my-2" data-testid="compaction-divider">
+      <div className="flex items-center gap-2 text-xs text-zinc-400 dark:text-zinc-500">
+        <div className="flex-1 border-t border-zinc-200 dark:border-zinc-700" />
+        <span>🗜 Conversation compacted</span>
+        <button
+          onClick={() => setShowSummary((v) => !v)}
+          className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
+        >
+          {showSummary ? "hide summary" : "view summary"}
+        </button>
+        {canUndo && onUndo && (
+          <button
+            onClick={onUndo}
+            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
+          >
+            undo
+          </button>
+        )}
+        <div className="flex-1 border-t border-zinc-200 dark:border-zinc-700" />
+      </div>
+      {showSummary && (
+        <div className="mt-2 rounded bg-zinc-50 dark:bg-zinc-800 p-3 text-sm">
+          <SafeMarkdown content={summary} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webui/src/components/chat/assistant/MessageRow.tsx
+++ b/webui/src/components/chat/assistant/MessageRow.tsx
@@ -1,0 +1,377 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type VNode } from "preact";
+import { isModelMismatch } from "#webui/chat/helpers/model-identity";
+import { type TokenUsage } from "#webui/chat/sdk/types";
+import { CompactButton } from "#webui/components/chat/controls/CompactButton";
+import { RetryButton } from "#webui/components/chat/controls/RetryButton";
+import { EditButton } from "#webui/components/chat/EditButton";
+import { UserMessageEditor } from "#webui/components/chat/UserMessageEditor";
+import { ErrorBoundary } from "#webui/components/ErrorBoundary";
+import {
+  calcNewContentTokens,
+  compactNumber,
+} from "#webui/lib/utils/compact-number";
+import {
+  formatTimestampDate,
+  formatTimestampTime,
+} from "#webui/lib/utils/format-timestamp";
+import { type UIMessage } from "#webui/types/messages";
+import { AssistantMessage } from "./AssistantMessage";
+import { RenderErrorFallback, SafeMarkdown } from "./message-list-helpers";
+
+interface MessageRowProps {
+  message: UIMessage;
+  originalIdx: number;
+  messages: UIMessage[];
+  isAssistantResponding: boolean;
+  showTimestamps: boolean;
+  showTokenUsage: boolean;
+  requestedModel?: string | null;
+  handleRetry: (messageIndex: number) => Promise<void>;
+  handleEdit: (messageIndex: number, newMessage: string) => Promise<void>;
+  handleCompact?: (messageIndex: number) => Promise<void>;
+  editingIndex: number | null;
+  setEditingIndex: (index: number | null) => void;
+  editText: string;
+  setEditText: (text: string) => void;
+}
+
+/**
+ * Renders a single chat row, delegating to the user or assistant variant.
+ * @param {MessageRowProps} props - Row props
+ * @returns {JSX.Element} The rendered row
+ */
+export function MessageRow(props: MessageRowProps) {
+  return props.message.role === "user" ? (
+    <UserRow {...props} />
+  ) : (
+    <AssistantRow {...props} />
+  );
+}
+
+/**
+ * Renders a user message bubble with timestamp and edit affordance.
+ * @param {MessageRowProps} props - Row props
+ * @returns {JSX.Element} The user row
+ */
+function UserRow({
+  message,
+  originalIdx,
+  showTimestamps,
+  isAssistantResponding,
+  handleEdit,
+  editingIndex,
+  setEditingIndex,
+  editText,
+  setEditText,
+}: MessageRowProps) {
+  const isEditing = editingIndex === originalIdx;
+  const canEdit = !isAssistantResponding;
+  const timestamp = renderTimestamp(message.timestamp, showTimestamps);
+
+  return (
+    <>
+      {timestamp}
+      <div className="text-black bg-blue-100 dark:text-white dark:bg-blue-900/80 shadow-sm dark:shadow-white/10 dark:border dark:border-blue-700/40 min-w-0 rounded-lg py-0.5 px-3">
+        {isEditing ? (
+          <UserMessageEditor
+            text={editText}
+            onTextChange={setEditText}
+            onSave={() => {
+              void handleEdit(originalIdx, editText);
+              setEditingIndex(null);
+            }}
+            onCancel={() => setEditingIndex(null)}
+          />
+        ) : (
+          <ErrorBoundary fallback={<RenderErrorFallback />}>
+            <SafeMarkdown content={formatUserContent(message)} />
+          </ErrorBoundary>
+        )}
+      </div>
+      {canEdit && !isEditing ? (
+        <EditButton
+          onClick={() => {
+            setEditingIndex(originalIdx);
+            setEditText(formatUserContent(message));
+          }}
+        />
+      ) : (
+        <div />
+      )}
+    </>
+  );
+}
+
+/**
+ * Renders an assistant message bubble with the retry/compact gutter.
+ * @param {MessageRowProps} props - Row props
+ * @returns {JSX.Element} The assistant row
+ */
+function AssistantRow({
+  message,
+  originalIdx,
+  messages,
+  isAssistantResponding,
+  showTimestamps,
+  showTokenUsage,
+  requestedModel,
+  handleRetry,
+  handleCompact,
+}: MessageRowProps) {
+  const canRetry = !isAssistantResponding;
+  const previousUserMessageIdx = canRetry
+    ? findPreviousUserMessageIndex(messages, originalIdx)
+    : -1;
+  const timestamp = renderTimestamp(message.timestamp, showTimestamps);
+  const prevModelUsage = getPrevModelUsage(messages, originalIdx);
+
+  return (
+    <>
+      <div
+        className="col-span-2 bg-zinc-50 dark:bg-zinc-800 shadow-sm dark:shadow-white/10 dark:border dark:border-zinc-700 min-w-0 rounded-lg py-0.5 px-3"
+        data-testid="assistant-message-bubble"
+      >
+        <ErrorBoundary fallback={<RenderErrorFallback />}>
+          <AssistantBubble
+            message={message}
+            isAssistantResponding={isAssistantResponding}
+            showTokenUsage={showTokenUsage}
+            requestedModel={requestedModel}
+            prevModelUsage={prevModelUsage}
+          />
+        </ErrorBoundary>
+      </div>
+      <RightGutter
+        timestamp={timestamp}
+        showRetry={canRetry && previousUserMessageIdx >= 0}
+        onRetry={() => void handleRetry(previousUserMessageIdx)}
+        showCompact={canRetry && handleCompact != null}
+        onCompact={() => {
+          if (handleCompact) void handleCompact(originalIdx);
+        }}
+      />
+    </>
+  );
+}
+
+/**
+ * Renders assistant message content with model mismatch label and usage.
+ * @param props - Component props
+ * @param props.message - The model message
+ * @param props.isAssistantResponding - Whether assistant is responding
+ * @param props.showTokenUsage - Whether to show token usage
+ * @param props.requestedModel - Requested model for mismatch detection
+ * @param props.prevModelUsage - Previous model message's last usage
+ * @returns Assistant bubble content
+ */
+function AssistantBubble({
+  message,
+  isAssistantResponding,
+  showTokenUsage,
+  requestedModel,
+  prevModelUsage,
+}: {
+  message: UIMessage;
+  isAssistantResponding: boolean;
+  showTokenUsage: boolean;
+  requestedModel?: string | null;
+  prevModelUsage?: TokenUsage;
+}) {
+  return (
+    <>
+      <ModelMismatchLabel
+        requestedModel={requestedModel}
+        responseModel={message.responseModel}
+      />
+      <AssistantMessage
+        parts={message.parts}
+        isResponding={isAssistantResponding}
+        showTokenUsage={showTokenUsage}
+        prevStepUsage={prevModelUsage}
+      />
+      {showTokenUsage && (
+        <TokenUsageLabel
+          usage={message.usage}
+          prevUsage={getLastStepUsage(message) ?? prevModelUsage}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * Right gutter for AI messages: timestamp at top, compact + retry at bottom.
+ * @param props - Component props
+ * @param props.timestamp - Timestamp element
+ * @param props.showRetry - Whether to show retry button
+ * @param props.onRetry - Retry callback
+ * @param props.showCompact - Whether to show the compact button
+ * @param props.onCompact - Compact-up-to-here callback
+ * @returns Gutter element
+ */
+function RightGutter({
+  timestamp,
+  showRetry,
+  onRetry,
+  showCompact,
+  onCompact,
+}: {
+  timestamp: VNode;
+  showRetry: boolean;
+  onRetry: () => void;
+  showCompact: boolean;
+  onCompact: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-start self-stretch">
+      {timestamp}
+      {(showCompact || showRetry) && (
+        <div className="mt-auto flex flex-col">
+          {showCompact && <CompactButton onClick={onCompact} />}
+          {showRetry && <RetryButton onClick={onRetry} />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Shows a label when the API responded with a different model than requested.
+ * @param props - Component props
+ * @param props.requestedModel - Model ID that was requested
+ * @param props.responseModel - Model ID from the API response
+ * @returns Label element or null
+ */
+function ModelMismatchLabel({
+  requestedModel,
+  responseModel,
+}: {
+  requestedModel?: string | null;
+  responseModel?: string;
+}) {
+  if (!responseModel || !requestedModel) return null;
+  if (!isModelMismatch(requestedModel, responseModel)) return null;
+
+  return (
+    <div className="text-xs text-zinc-400 dark:text-zinc-500 pt-1 text-right">
+      responded as {responseModel}
+    </div>
+  );
+}
+
+/**
+ * Compact token usage display for assistant messages.
+ * @param props - Component props
+ * @param props.usage - Token usage data
+ * @param props.prevUsage - Previous step's usage for new content calculation
+ * @returns Label element or null
+ */
+function TokenUsageLabel({
+  usage,
+  prevUsage,
+}: {
+  usage?: TokenUsage;
+  prevUsage?: TokenUsage;
+}) {
+  if (!usage) return null;
+
+  const newContent = calcNewContentTokens(
+    usage.inputTokens ?? 0,
+    prevUsage?.inputTokens,
+    prevUsage?.outputTokens,
+  );
+
+  return (
+    <div className="text-xs text-zinc-400 dark:text-zinc-500 pb-1 text-right">
+      tokens: {compactNumber(usage.inputTokens ?? 0)}
+      {newContent != null && ` (${compactNumber(newContent)} new)`} →{" "}
+      {compactNumber(usage.outputTokens ?? 0)}
+      {(usage.reasoningTokens ?? 0) > 0 &&
+        ` (${compactNumber(usage.reasoningTokens ?? 0)} reasoning)`}
+    </div>
+  );
+}
+
+/**
+ * Renders a timestamp element for a message.
+ * @param {number} timestamp - Unix timestamp in milliseconds
+ * @param {boolean} visible - Whether timestamp should be visible
+ * @returns {JSX.Element} Timestamp element
+ */
+function renderTimestamp(timestamp: number, visible: boolean) {
+  return (
+    <div
+      className={`text-[9px] leading-tight text-zinc-400 dark:text-zinc-600 whitespace-nowrap ${visible ? "" : "invisible"}`}
+      data-testid="message-timestamp"
+    >
+      <div>{formatTimestampDate(timestamp)}</div>
+      <div>{formatTimestampTime(timestamp)}</div>
+    </div>
+  );
+}
+
+/**
+ * Finds previous user message index for retry.
+ * @param {UIMessage[]} messages - Messages array
+ * @param {number} currentIdx - Current message index
+ * @returns {number} Previous user message index or -1
+ */
+function findPreviousUserMessageIndex(
+  messages: UIMessage[],
+  currentIdx: number,
+): number {
+  for (let i = currentIdx - 1; i >= 0; i--) {
+    if (messages[i]?.role === "user") return i;
+  }
+
+  return -1;
+}
+
+/**
+ * Formats user message content as string.
+ * @param {UIMessage} message - User message to format
+ * @returns {string} Concatenated text content
+ */
+function formatUserContent(message: UIMessage): string {
+  return message.parts
+    .map((part) => ("content" in part ? part.content : ""))
+    .join("");
+}
+
+/**
+ * Get the last usage from the previous model message.
+ * @param messages - All messages
+ * @param currentIdx - Current message index
+ * @returns Previous model message's last usage
+ */
+function getPrevModelUsage(
+  messages: UIMessage[],
+  currentIdx: number,
+): TokenUsage | undefined {
+  for (let i = currentIdx - 1; i >= 0; i--) {
+    const msg = messages[i];
+
+    if (msg?.role !== "model") continue;
+
+    return getLastStepUsage(msg) ?? msg.usage;
+  }
+
+  return undefined;
+}
+
+/**
+ * Get the last step-usage part's usage within a message.
+ * @param message - Message to search
+ * @returns Last step-usage part's usage, or undefined
+ */
+function getLastStepUsage(message: UIMessage): TokenUsage | undefined {
+  const part = message.parts.findLast((p) => p.type === "step-usage");
+
+  if (part?.type === "step-usage") return part.usage;
+
+  return undefined;
+}

--- a/webui/src/components/chat/controls/CompactButton.tsx
+++ b/webui/src/components/chat/controls/CompactButton.tsx
@@ -1,0 +1,27 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+interface CompactButtonProps {
+  onClick: () => void;
+}
+
+/**
+ * Button to compact the conversation up to and including this message.
+ * @param {CompactButtonProps} root0 - Component props
+ * @param {() => void} root0.onClick - Click handler callback
+ * @returns {JSX.Element} - React component
+ */
+export function CompactButton({ onClick }: CompactButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 text-sm size-7 flex items-center justify-center rounded hover:bg-zinc-200 dark:hover:bg-zinc-700"
+      title="Compact the conversation up to here"
+      aria-label="Compact the conversation up to here"
+    >
+      🗜
+    </button>
+  );
+}

--- a/webui/src/components/chat/controls/tests/CompactButton.test.tsx
+++ b/webui/src/components/chat/controls/tests/CompactButton.test.tsx
@@ -1,0 +1,26 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @vitest-environment happy-dom
+ */
+import { fireEvent, render, screen } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+import { CompactButton } from "#webui/components/chat/controls/CompactButton";
+
+describe("CompactButton", () => {
+  it("calls onClick when clicked", () => {
+    const onClick = vi.fn();
+
+    render(<CompactButton onClick={onClick} />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /compact the conversation up to here/i,
+      }),
+    );
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/webui/src/components/chat/tests/CompactionDivider.test.tsx
+++ b/webui/src/components/chat/tests/CompactionDivider.test.tsx
@@ -1,0 +1,59 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @vitest-environment happy-dom
+ */
+import { fireEvent, render, screen } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  import("#webui/components/chat/assistant/message-list-helpers"),
+  () => ({
+    SafeMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
+    RenderErrorFallback: () => <div />,
+  }),
+);
+
+import { CompactionDivider } from "#webui/components/chat/assistant/CompactionDivider";
+
+describe("CompactionDivider", () => {
+  it("toggles the summary visibility", () => {
+    render(
+      <CompactionDivider
+        summary="my summary"
+        canUndo={false}
+        onUndo={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("my summary")).toBeNull();
+    fireEvent.click(screen.getByText("view summary"));
+    expect(screen.getByText("my summary")).toBeTruthy();
+    fireEvent.click(screen.getByText("hide summary"));
+    expect(screen.queryByText("my summary")).toBeNull();
+  });
+
+  it("hides the undo action when undo is unavailable", () => {
+    render(<CompactionDivider summary="s" canUndo={false} onUndo={vi.fn()} />);
+
+    expect(screen.queryByText("undo")).toBeNull();
+  });
+
+  it("hides the undo action when no onUndo handler is provided", () => {
+    render(<CompactionDivider summary="s" canUndo={true} />);
+
+    expect(screen.queryByText("undo")).toBeNull();
+  });
+
+  it("calls onUndo when undo is clicked", () => {
+    const onUndo = vi.fn();
+
+    render(<CompactionDivider summary="s" canUndo={true} onUndo={onUndo} />);
+    fireEvent.click(screen.getByText("undo"));
+
+    expect(onUndo).toHaveBeenCalledOnce();
+  });
+});

--- a/webui/src/components/chat/tests/MessageList.test.tsx
+++ b/webui/src/components/chat/tests/MessageList.test.tsx
@@ -616,4 +616,54 @@ describe("MessageList", () => {
       expect(screen.getByText(/5.1K new/)).toBeDefined();
     });
   });
+
+  describe("compaction", () => {
+    it("shows a compact button on assistant messages when handleCompact is set", () => {
+      const handleCompact = vi.fn();
+
+      render(
+        <MessageList
+          messages={[createUserMessage("hi", 0), createModelMessage("yo", 1)]}
+          isAssistantResponding={false}
+          handleRetry={vi.fn()}
+          handleEdit={vi.fn()}
+          handleCompact={handleCompact}
+          showTimestamps={false}
+          showTokenUsage={false}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: /compact the conversation up to here/i,
+        }),
+      );
+
+      expect(handleCompact).toHaveBeenCalledWith(1);
+    });
+
+    it("renders a divider for a compaction summary message", () => {
+      const summaryMsg: UIMessage = {
+        role: "user",
+        parts: [{ type: "compaction", content: "sum" }],
+        rawHistoryIndex: 0,
+        timestamp: Date.now(),
+      };
+
+      render(
+        <MessageList
+          messages={[summaryMsg]}
+          isAssistantResponding={false}
+          handleRetry={vi.fn()}
+          handleEdit={vi.fn()}
+          showTimestamps={false}
+          showTokenUsage={false}
+          canUndoCompaction
+          onUndoCompaction={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId("compaction-divider")).toBeTruthy();
+    });
+  });
 });

--- a/webui/src/hooks/chat/adapter.ts
+++ b/webui/src/hooks/chat/adapter.ts
@@ -233,4 +233,8 @@ export const chatAdapter: ChatAdapter<
   createUserMessage(text: string): ChatMessage {
     return { role: "user", content: text };
   },
+
+  createCompactionSummary(summary: string): ChatMessage {
+    return { role: "user", content: summary, isCompactionSummary: true };
+  },
 };

--- a/webui/src/hooks/chat/tests/adapter.test.ts
+++ b/webui/src/hooks/chat/tests/adapter.test.ts
@@ -530,4 +530,16 @@ describe("chatAdapter", () => {
       expect(result[1]!.role).toBe("model");
     });
   });
+
+  describe("createCompactionSummary", () => {
+    it("creates a flagged synthetic user message", () => {
+      const msg = chatAdapter.createCompactionSummary("a summary");
+
+      expect(msg).toStrictEqual({
+        role: "user",
+        content: "a summary",
+        isCompactionSummary: true,
+      });
+    });
+  });
 });

--- a/webui/src/hooks/chat/tests/use-chat-test-helpers.ts
+++ b/webui/src/hooks/chat/tests/use-chat-test-helpers.ts
@@ -36,6 +36,11 @@ export class MockChatClient implements ChatClient<TestMessage> {
     // Initialization logic
   });
 
+  summarize = vi.fn(
+    async (history: TestMessage[]): Promise<string> =>
+      `Summary of ${history.length} messages`,
+  );
+
   /**
    * Simulates sending a message and streaming responses
    * @param message - User message to send
@@ -118,6 +123,10 @@ export function createMockAdapter(): ChatAdapter<
 
     createUserMessage: vi.fn(
       (text: string): TestMessage => ({ role: "user", content: text }),
+    ),
+
+    createCompactionSummary: vi.fn(
+      (summary: string): TestMessage => ({ role: "user", content: summary }),
     ),
   };
 

--- a/webui/src/hooks/chat/tests/use-compaction.test.ts
+++ b/webui/src/hooks/chat/tests/use-compaction.test.ts
@@ -1,0 +1,183 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @vitest-environment happy-dom
+ */
+import { act, renderHook } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+import { useCompaction } from "#webui/hooks/chat/use-compaction";
+import {
+  createMockAdapter,
+  MockChatClient,
+  type TestMessage,
+} from "#webui/hooks/chat/tests/use-chat-test-helpers";
+import { type UIMessage } from "#webui/types/messages";
+
+function ui(role: "user" | "model", rawHistoryIndex: number): UIMessage {
+  return {
+    role,
+    parts: [{ type: "text", content: "x" }],
+    rawHistoryIndex,
+    timestamp: 0,
+  };
+}
+
+interface SetupOptions {
+  chatHistory?: TestMessage[];
+  messages?: UIMessage[];
+  isAssistantResponding?: boolean;
+  noClient?: boolean;
+}
+
+function setup(opts: SetupOptions = {}) {
+  const client = new MockChatClient();
+
+  client.chatHistory = opts.chatHistory ?? [
+    { role: "user", content: "u1" },
+    { role: "assistant", content: "a1" },
+  ];
+
+  const clientRef = { current: opts.noClient ? null : client };
+  const adapter = createMockAdapter();
+  const setMessages = vi.fn();
+  const autoSave = vi.fn();
+  const messages = opts.messages ?? [ui("user", 0), ui("model", 1)];
+
+  const { result } = renderHook(() =>
+    useCompaction({
+      clientRef,
+      adapter,
+      autoSaveRef: { current: autoSave },
+      messages,
+      isAssistantResponding: opts.isAssistantResponding ?? false,
+      setMessages,
+    }),
+  );
+
+  return { result, client, clientRef, adapter, setMessages, autoSave };
+}
+
+describe("useCompaction", () => {
+  it("compacts the whole conversation when the last message is targeted", async () => {
+    const { result, client, setMessages, autoSave } = setup();
+
+    await act(async () => {
+      await result.current.compact(1);
+    });
+
+    expect(client.summarize).toHaveBeenCalledWith([
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1" },
+    ]);
+    expect(client.chatHistory).toStrictEqual([
+      { role: "user", content: "Summary of 2 messages" },
+    ]);
+    expect(setMessages).toHaveBeenCalled();
+    expect(autoSave).toHaveBeenCalled();
+    expect(result.current.canUndoCompaction).toBe(true);
+  });
+
+  it("drops the tail when an earlier message is targeted", async () => {
+    const { result, client } = setup({
+      chatHistory: [
+        { role: "user", content: "u1" },
+        { role: "assistant", content: "a1" },
+        { role: "user", content: "u2" },
+        { role: "assistant", content: "a2" },
+      ],
+      messages: [ui("user", 0), ui("model", 1), ui("user", 2), ui("model", 3)],
+    });
+
+    await act(async () => {
+      await result.current.compact(1);
+    });
+
+    expect(client.summarize).toHaveBeenCalledWith([
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1" },
+    ]);
+    expect(client.chatHistory).toHaveLength(1);
+  });
+
+  it("does nothing while the assistant is responding", async () => {
+    const { result, client, setMessages } = setup({
+      isAssistantResponding: true,
+    });
+
+    await act(async () => {
+      await result.current.compact(1);
+    });
+
+    expect(client.summarize).not.toHaveBeenCalled();
+    expect(setMessages).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there is no active client", async () => {
+    const { result, setMessages } = setup({ noClient: true });
+
+    await act(async () => {
+      await result.current.compact(0);
+    });
+
+    expect(setMessages).not.toHaveBeenCalled();
+    expect(result.current.canUndoCompaction).toBe(false);
+  });
+
+  it("surfaces an error message when summarization fails", async () => {
+    const { result, client, adapter, setMessages } = setup();
+
+    client.summarize.mockRejectedValueOnce(new Error("boom"));
+
+    await act(async () => {
+      await result.current.compact(1);
+    });
+
+    expect(adapter.createErrorMessage).toHaveBeenCalled();
+    expect(setMessages).toHaveBeenCalled();
+    expect(result.current.isCompacting).toBe(false);
+  });
+
+  it("restores the pre-compaction history on undo", async () => {
+    const { result, client } = setup();
+    const original = [...client.chatHistory];
+
+    await act(async () => {
+      await result.current.compact(1);
+    });
+    await act(async () => {
+      result.current.undoCompaction();
+    });
+
+    expect(client.chatHistory).toStrictEqual(original);
+    expect(result.current.canUndoCompaction).toBe(false);
+  });
+
+  it("undo is a no-op when there is no snapshot", async () => {
+    const { result, client, setMessages } = setup();
+    const before = client.chatHistory;
+
+    await act(async () => {
+      result.current.undoCompaction();
+    });
+
+    expect(client.chatHistory).toBe(before);
+    expect(setMessages).not.toHaveBeenCalled();
+  });
+
+  it("invalidateCompactionUndo clears the undo availability", async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.compact(1);
+    });
+    expect(result.current.canUndoCompaction).toBe(true);
+
+    await act(async () => {
+      result.current.invalidateCompactionUndo();
+    });
+    expect(result.current.canUndoCompaction).toBe(false);
+  });
+});

--- a/webui/src/hooks/chat/use-chat-types.ts
+++ b/webui/src/hooks/chat/use-chat-types.ts
@@ -26,6 +26,11 @@ export interface ChatClient<TMessage> {
     signal: AbortSignal,
     overrides?: MessageOverrides,
   ) => AsyncIterable<TMessage[]>;
+  /**
+   * Summarize a slice of history into a compaction summary string. Optional:
+   * clients that don't support compaction may omit it.
+   */
+  summarize?: (history: TMessage[]) => Promise<string>;
 }
 
 /**
@@ -60,6 +65,9 @@ export interface ChatAdapter<
 
   /** Create initial user message for error display */
   createUserMessage: (text: string) => TMessage;
+
+  /** Create a synthetic compaction summary message */
+  createCompactionSummary: (summary: string) => TMessage;
 }
 
 /** Model/provider/behavior settings persisted with a conversation */
@@ -92,9 +100,17 @@ export interface UseChatReturn {
   rateLimitState: RateLimitState | null;
   /** True when the last response stopped at the tool-call step limit */
   toolLimitReached: boolean;
+  /** True while a compaction summary is being generated */
+  isCompacting: boolean;
+  /** True when the most recent compaction can still be undone (in-memory) */
+  canUndoCompaction: boolean;
   handleSend: (message: string, options?: MessageOverrides) => Promise<void>;
   handleRetry: (mergedMessageIndex: number) => Promise<void>;
   handleEdit: (mergedMessageIndex: number, newMessage: string) => Promise<void>;
+  /** Compact the conversation up to and including the given UI message */
+  compact: (mergedMessageIndex: number) => Promise<void>;
+  /** Restore the pre-compaction history (while still available) */
+  undoCompaction: () => void;
   clearConversation: () => void;
   stopResponse: () => void;
   getChatHistory: () => unknown[];

--- a/webui/src/hooks/chat/use-chat.ts
+++ b/webui/src/hooks/chat/use-chat.ts
@@ -19,6 +19,7 @@ import {
   type UseChatProps,
   type UseChatReturn,
 } from "./use-chat-types";
+import { useCompaction } from "./use-compaction";
 
 /**
  * Generic chat hook that works with any provider via an adapter
@@ -70,6 +71,21 @@ export function useChat<
     setRateLimitState,
   });
 
+  const {
+    isCompacting,
+    canUndoCompaction,
+    compact,
+    undoCompaction,
+    invalidateCompactionUndo,
+  } = useCompaction({
+    clientRef,
+    adapter,
+    autoSaveRef,
+    messages,
+    isAssistantResponding,
+    setMessages,
+  });
+
   const clearConversation = useCallback(() => {
     setMessages([]);
     clientRef.current = null;
@@ -77,8 +93,9 @@ export function useChat<
     clearSettings();
     setRateLimitState(null);
     setToolLimitReached(false);
+    invalidateCompactionUndo();
     abortRetry();
-  }, [clearSettings, abortRetry]);
+  }, [clearSettings, abortRetry, invalidateCompactionUndo]);
 
   const getChatHistory = useCallback(
     (): unknown[] =>
@@ -94,8 +111,9 @@ export function useChat<
       restoreSettings(lockedSettings);
       setRateLimitState(null);
       setToolLimitReached(false);
+      invalidateCompactionUndo();
     },
-    [adapter, restoreSettings],
+    [adapter, restoreSettings, invalidateCompactionUndo],
   );
 
   const stopResponse = useCallback(() => {
@@ -208,6 +226,9 @@ export function useChat<
 
       if (!userMessage) return;
 
+      // Continuing the conversation invalidates the compaction undo snapshot.
+      invalidateCompactionUndo();
+
       const userMessageEntry = adapter.createUserMessage(userMessage);
 
       if (!apiKey) {
@@ -255,7 +276,14 @@ export function useChat<
         });
       }, userMessageEntry);
     },
-    [apiKey, adapter, initializeChat, runWithChat, executeWithRetry],
+    [
+      apiKey,
+      adapter,
+      initializeChat,
+      runWithChat,
+      executeWithRetry,
+      invalidateCompactionUndo,
+    ],
   );
 
   const forkConversation = useCallback(
@@ -271,6 +299,8 @@ export function useChat<
         clientRef.current?.chatHistory ?? pendingHistoryRef.current;
 
       if (!history) return;
+
+      invalidateCompactionUndo();
 
       await runWithChat(async () => {
         const slicedHistory = history.slice(0, rawIndex);
@@ -294,7 +324,14 @@ export function useChat<
         });
       });
     },
-    [apiKey, messages, initializeChat, runWithChat, executeWithRetry],
+    [
+      apiKey,
+      messages,
+      initializeChat,
+      runWithChat,
+      executeWithRetry,
+      invalidateCompactionUndo,
+    ],
   );
 
   const handleRetry = useCallback(
@@ -338,9 +375,13 @@ export function useChat<
     ...active,
     rateLimitState,
     toolLimitReached,
+    isCompacting,
+    canUndoCompaction,
     handleSend,
     handleRetry,
     handleEdit,
+    compact,
+    undoCompaction,
     clearConversation,
     stopResponse,
     getChatHistory,

--- a/webui/src/hooks/chat/use-compaction.ts
+++ b/webui/src/hooks/chat/use-compaction.ts
@@ -1,0 +1,145 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { useCallback, useRef, useState } from "preact/hooks";
+import {
+  type ChatAdapter,
+  type ChatClient,
+} from "#webui/hooks/chat/use-chat-types";
+import { type UIMessage } from "#webui/types/messages";
+
+interface UseCompactionParams<
+  TClient extends ChatClient<TMessage>,
+  TMessage,
+  TConfig,
+> {
+  clientRef: { current: TClient | null };
+  adapter: ChatAdapter<TClient, TMessage, TConfig>;
+  autoSaveRef?: { current: (() => void) | null };
+  messages: UIMessage[];
+  isAssistantResponding: boolean;
+  setMessages: (messages: UIMessage[]) => void;
+}
+
+interface UseCompactionReturn {
+  isCompacting: boolean;
+  canUndoCompaction: boolean;
+  compact: (mergedMessageIndex: number) => Promise<void>;
+  undoCompaction: () => void;
+  /** Drop the undo snapshot — called whenever the conversation moves on. */
+  invalidateCompactionUndo: () => void;
+}
+
+/**
+ * Manual conversation compaction: summarize the history up to (and including) a
+ * chosen UI message into a single synthetic message and continue from it,
+ * dropping everything after the cut. Requires an active client (a conversation
+ * that has been sent at least once this session).
+ * @param params - Compaction inputs from useChat
+ * @param params.clientRef - Ref to the active chat client
+ * @param params.adapter - Chat adapter (formats messages, builds the summary message)
+ * @param params.autoSaveRef - Ref to the conversation auto-save callback
+ * @param params.messages - Current UI messages (used to resolve the cut point)
+ * @param params.isAssistantResponding - Whether the assistant is currently responding
+ * @param params.setMessages - Setter for the UI messages
+ * @returns Compaction state and handlers
+ */
+export function useCompaction<
+  TClient extends ChatClient<TMessage>,
+  TMessage,
+  TConfig,
+>({
+  clientRef,
+  adapter,
+  autoSaveRef,
+  messages,
+  isAssistantResponding,
+  setMessages,
+}: UseCompactionParams<TClient, TMessage, TConfig>): UseCompactionReturn {
+  const [isCompacting, setIsCompacting] = useState(false);
+  const [canUndoCompaction, setCanUndoCompaction] = useState(false);
+  const undoRef = useRef<TMessage[] | null>(null);
+
+  // Compaction undo is in-memory and only valid until the next send/reset.
+  const invalidateCompactionUndo = useCallback(() => {
+    undoRef.current = null;
+    setCanUndoCompaction(false);
+  }, []);
+
+  // Summarize the conversation up to (and including) the given UI message into a
+  // single synthetic message and continue from it. Everything after the cut is
+  // dropped — clicking an earlier message both compacts and discards the broken
+  // tail (the small-model recovery flow).
+  const compact = useCallback(
+    async (mergedMessageIndex: number) => {
+      if (isCompacting || isAssistantResponding) return;
+
+      const client = clientRef.current;
+      const targetMessage = messages[mergedMessageIndex];
+
+      if (!client?.summarize || !targetMessage) return;
+
+      setIsCompacting(true);
+
+      try {
+        const history = client.chatHistory;
+        const nextMessage = messages[mergedMessageIndex + 1];
+        const cutEnd = nextMessage
+          ? nextMessage.rawHistoryIndex - 1
+          : history.length - 1;
+        const toCompact = history.slice(0, cutEnd + 1);
+
+        if (toCompact.length === 0) return;
+
+        const summary = await client.summarize(toCompact);
+
+        undoRef.current = history.slice();
+        client.chatHistory = [adapter.createCompactionSummary(summary)];
+        setMessages(adapter.formatMessages(client.chatHistory));
+        setCanUndoCompaction(true);
+        autoSaveRef?.current?.();
+      } catch (error) {
+        setMessages(
+          adapter.createErrorMessage(
+            error,
+            clientRef.current?.chatHistory ?? [],
+          ),
+        );
+      } finally {
+        setIsCompacting(false);
+      }
+    },
+    [
+      isCompacting,
+      isAssistantResponding,
+      messages,
+      adapter,
+      autoSaveRef,
+      clientRef,
+      setMessages,
+    ],
+  );
+
+  const undoCompaction = useCallback(() => {
+    const snapshot = undoRef.current;
+    const client = clientRef.current;
+
+    if (!snapshot || !client) return;
+
+    client.chatHistory = snapshot;
+    undoRef.current = null;
+    setCanUndoCompaction(false);
+    setMessages(adapter.formatMessages(snapshot));
+    autoSaveRef?.current?.();
+  }, [adapter, autoSaveRef, clientRef, setMessages]);
+
+  return {
+    isCompacting,
+    canUndoCompaction,
+    compact,
+    undoCompaction,
+    invalidateCompactionUndo,
+  };
+}

--- a/webui/src/types/messages.ts
+++ b/webui/src/types/messages.ts
@@ -46,12 +46,18 @@ export interface UIErrorPart {
   isError: true;
 }
 
+export interface UICompactionPart {
+  type: "compaction";
+  content: string; // the generated compaction summary
+}
+
 export type UIPart =
   | UITextPart
   | UIThoughtPart
   | UIToolPart
   | UIStepUsagePart
-  | UIErrorPart;
+  | UIErrorPart
+  | UICompactionPart;
 
 // UI Message Structure
 // This is the format used throughout the UI for rendering messages


### PR DESCRIPTION
## What

Adds **manual conversation compaction** to the chat UI. Each assistant message gets a 🗜 **"Compact up to here"** action in its gutter that summarizes the conversation through that point into a single synthetic message and continues from it, dropping anything after the cut.

Primary use case: **recover a small model that has run out of context or gone off the rails** — go back a message or two, compact from there, and the broken tail is discarded along the way. Also reclaims space in long sessions.

## How it works

- `compaction.ts`: `COMPACTION_PROMPT` + `summarizeHistory()` — one tool-less `generateText` call on the conversation's own model over a rendered transcript.
- `ChatSdkClient.summarize()` delegates to it.
- `useCompaction` hook owns `compact` / `undoCompaction` / `isCompacting` and an in-memory undo snapshot (invalidated on the next send / fork / clear / restore).
- `isCompactionSummary` flag on `ChatMessage`; a new `UICompactionPart` renders as a `CompactionDivider` with "view summary" + "undo".
- `CompactButton` in the assistant message gutter (next to retry).
- `MessageRow` extracted from `MessageList` to stay under the file/function size limits.

## Design notes

- **No `ppal-connect` pin.** Rather than keeping the large skills blob verbatim, notation rides along in the summary via the assistant's *actual in-conversation usage* of bar|beat — worked examples a small model generalizes from better than the abstract spec, and it doesn't crowd the recovered window.
- **Summary is a synthetic `user`-role message.** This is required: Anthropic and Gemini both demand the conversation *start* with a user turn, so the summary can't be an assistant message.
- **Consecutive user turns are merged at the wire boundary.** Because the summary is a user message, the next real user message would sit directly after it. Gemini and Mistral reject two user turns in a row (only Anthropic and OpenAI tolerate it — the Anthropic adapter coalesces them, OpenAI accepts natively). `buildModelMessages` now folds consecutive user turns into a single user message, so **no provider ever sees adjacent user turns**, while the UI still renders the divider and the user bubble separately. This also fixes a pre-existing case where skipping an `isError` assistant message left two user turns adjacent.

## Verification

- `npm run check`, `npm run check:build`, and `npm run ui:test` all green.
- New unit tests cover `summarizeHistory`/`renderTranscript`, `ChatSdkClient.summarize`, `useCompaction` (compact / earlier-cut / guards / error / undo / invalidate), the formatter's compaction part, the adapter factory, `CompactButton`, `CompactionDivider`, the `MessageList` compact button + divider, and `buildModelMessages` consecutive-user merging.

## Follow-up

Auto-compaction (threshold-based + context-overflow recovery) is tracked separately and reuses this core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)