### PR TITLE
test: reduce duplication by extracting shared test setup helpers

### DIFF
--- a/src/notation/transform/tests/transform-note-ops.test.ts
+++ b/src/notation/transform/tests/transform-note-ops.test.ts
@@ -11,6 +11,22 @@ import {
   createTestNotes,
 } from "./evaluator/transform-evaluator-test-helpers.ts";
 
+// Asserts a merge tolerance is rejected: the two well-separated notes pass
+// through unchanged and a warning containing `message` is emitted.
+function expectMergeWarnsAndSkips(transform: string, message: string): void {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const notes = createTestNotes([
+    { pitch: 60, start_time: 0, duration: 1 },
+    { pitch: 60, start_time: 3, duration: 1 },
+  ]);
+
+  applyTransforms(notes, transform, 4, 4);
+
+  expect(notes).toHaveLength(2);
+  expect(warn).toHaveBeenCalledWith(expect.stringContaining(message));
+  warn.mockRestore();
+}
+
 describe("note-count operations (ratchet/merge)", () => {
   describe("ratchet", () => {
     it("divides a note into N equal end-to-end pieces", () => {
@@ -377,49 +393,15 @@ describe("note-count operations (ratchet/merge)", () => {
       });
 
       it("warns and skips a non-zero bare-number tolerance", () => {
-        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-        const notes = createTestNotes([
-          { pitch: 60, start_time: 0, duration: 1 },
-          { pitch: 60, start_time: 3, duration: 1 },
-        ]);
-
-        applyTransforms(notes, "merge(0.25)", 4, 4);
-
-        expect(notes).toHaveLength(2); // passed through unchanged (not merged)
-        expect(warn).toHaveBeenCalledWith(
-          expect.stringContaining("note value"),
-        );
-        warn.mockRestore();
+        expectMergeWarnsAndSkips("merge(0.25)", "note value");
       });
 
       it("warns and skips an integer beat-count tolerance", () => {
-        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-        const notes = createTestNotes([
-          { pitch: 60, start_time: 0, duration: 1 },
-          { pitch: 60, start_time: 3, duration: 1 },
-        ]);
-
-        applyTransforms(notes, "merge(2)", 4, 4);
-
-        expect(notes).toHaveLength(2);
-        expect(warn).toHaveBeenCalledWith(
-          expect.stringContaining("note value"),
-        );
-        warn.mockRestore();
+        expectMergeWarnsAndSkips("merge(2)", "note value");
       });
 
       it("warns and skips a bar-value tolerance (Nbar not accepted)", () => {
-        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-        const notes = createTestNotes([
-          { pitch: 60, start_time: 0, duration: 1 },
-          { pitch: 60, start_time: 3, duration: 1 },
-        ]);
-
-        applyTransforms(notes, "merge(1bar)", 4, 4);
-
-        expect(notes).toHaveLength(2);
-        expect(warn).toHaveBeenCalledWith(expect.stringContaining("Nbar"));
-        warn.mockRestore();
+        expectMergeWarnsAndSkips("merge(1bar)", "Nbar");
       });
 
       it("warns about extra arguments and uses the first", () => {

--- a/src/tools/actions/delete/tests/delete-device.test.ts
+++ b/src/tools/actions/delete/tests/delete-device.test.ts
@@ -6,7 +6,6 @@
 import { describe, expect, it, vi } from "vitest";
 import * as console from "#src/shared/v8-max-console.ts";
 import "#src/live-api-adapter/live-api-extensions.ts";
-import { children } from "#src/test/mocks/mock-live-api.ts";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import {
   mockNonExistentObjects,
@@ -16,6 +15,7 @@ import {
   setupDeviceMocks,
   setupDrumChainMocks,
   setupDrumPadMocks,
+  setupNestedDrumDeviceMocks,
 } from "./delete-test-helpers.ts";
 import { deleteObject } from "../delete.ts";
 
@@ -244,34 +244,7 @@ describe("deleteObject device deletion", () => {
     });
 
     it("should delete a device nested inside a drum chain by path", () => {
-      const drumRackPath = String(livePath.track(1).device(0));
-      const chainId = "chain-1";
-      const deviceId = "nested-device";
-      const devicePath = `${String(livePath.track(1).device(0))} chains 0 devices 0`;
-      const chainPath = `${String(livePath.track(1).device(0))} chains 0`;
-
-      registerMockObject("drum-rack", {
-        path: drumRackPath,
-        type: "RackDevice",
-        properties: {
-          chains: children(chainId),
-          can_have_drum_pads: 1,
-        },
-      });
-
-      const chain = registerMockObject(chainId, {
-        path: chainPath,
-        type: "DrumChain",
-        properties: {
-          in_note: 36, // C1
-          devices: children(deviceId),
-        },
-      });
-
-      registerMockObject(deviceId, {
-        path: devicePath,
-        type: "Device",
-      });
+      const { chain, deviceId } = setupNestedDrumDeviceMocks(1);
 
       const result = deleteObject({ path: "t1/d0/pC1/c0/d0", type: "device" });
 
@@ -285,34 +258,7 @@ describe("deleteObject device deletion", () => {
     });
 
     it("should delete a device nested in a drum pad via the implicit-chain path (pC1/d0)", () => {
-      const drumRackPath = String(livePath.track(1).device(0));
-      const chainId = "chain-1";
-      const deviceId = "nested-device";
-      const devicePath = `${String(livePath.track(1).device(0))} chains 0 devices 0`;
-      const chainPath = `${String(livePath.track(1).device(0))} chains 0`;
-
-      registerMockObject("drum-rack", {
-        path: drumRackPath,
-        type: "RackDevice",
-        properties: {
-          chains: children(chainId),
-          can_have_drum_pads: 1,
-        },
-      });
-
-      const chain = registerMockObject(chainId, {
-        path: chainPath,
-        type: "DrumChain",
-        properties: {
-          in_note: 36, // C1
-          devices: children(deviceId),
-        },
-      });
-
-      registerMockObject(deviceId, {
-        path: devicePath,
-        type: "Device",
-      });
+      const { chain, deviceId } = setupNestedDrumDeviceMocks(1);
 
       // Implicit chain 0 — the form the skill recommends for clearing a pad's
       // device, and the form read-device/update-device accept.

--- a/src/tools/actions/delete/tests/delete-test-helpers.ts
+++ b/src/tools/actions/delete/tests/delete-test-helpers.ts
@@ -3,6 +3,7 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import { livePath } from "#src/shared/live-api-path-builders.ts";
 import { children } from "#src/test/mocks/mock-live-api.ts";
 import {
   type RegisteredMockObject,
@@ -186,4 +187,47 @@ export function setupDrumChainMocks({
   }
 
   return { drumRack, chain, extraPads };
+}
+
+/**
+ * Setup mocks for a device nested inside a drum rack's chain (path-based device
+ * deletion). Registers the drum rack, its chain (with the device as a child),
+ * and the nested device itself.
+ * @param trackIndex - Track index holding the drum rack device
+ * @returns The chain handle and the nested device's mock ID
+ */
+export function setupNestedDrumDeviceMocks(trackIndex: number): {
+  chain: RegisteredMockObject;
+  deviceId: string;
+} {
+  const drumRackPath = String(livePath.track(trackIndex).device(0));
+  const chainId = "chain-1";
+  const deviceId = "nested-device";
+  const devicePath = `${drumRackPath} chains 0 devices 0`;
+  const chainPath = `${drumRackPath} chains 0`;
+
+  registerMockObject("drum-rack", {
+    path: drumRackPath,
+    type: "RackDevice",
+    properties: {
+      chains: children(chainId),
+      can_have_drum_pads: 1,
+    },
+  });
+
+  const chain = registerMockObject(chainId, {
+    path: chainPath,
+    type: "DrumChain",
+    properties: {
+      in_note: 36, // C1
+      devices: children(deviceId),
+    },
+  });
+
+  registerMockObject(deviceId, {
+    path: devicePath,
+    type: "Device",
+  });
+
+  return { chain, deviceId };
 }

--- a/src/tools/actions/duplicate/helpers/tests/duplicate-helpers.test.ts
+++ b/src/tools/actions/duplicate/helpers/tests/duplicate-helpers.test.ts
@@ -12,7 +12,10 @@ import {
   duplicateClipSlot,
   duplicateClipToArrangement,
 } from "../duplicate-helpers.ts";
-import { findRoutingOptionForDuplicateNames } from "../duplicate-routing-helpers.ts";
+import {
+  findRoutingOptionForDuplicateNames,
+  type RoutingType,
+} from "../duplicate-routing-helpers.ts";
 
 interface TrackNameMapping {
   [path: string]: string;
@@ -79,6 +82,21 @@ function createMockLiveAPI(
   }
 
   return MockLiveAPI;
+}
+
+// Builds a stub source track with the given id and resolves its routing option.
+function findRouting(
+  sourceId: string,
+  targetName: string,
+  availableTypes: RoutingType[],
+): RoutingType | undefined {
+  const sourceTrack = { id: sourceId, getProperty: () => {} };
+
+  return findRoutingOptionForDuplicateNames(
+    sourceTrack as unknown as LiveAPI,
+    targetName,
+    availableTypes,
+  );
 }
 
 describe("duplicate-helpers", () => {
@@ -293,20 +311,10 @@ describe("duplicate-helpers", () => {
 
   describe("findRoutingOptionForDuplicateNames", () => {
     it("returns single match when no duplicates exist", () => {
-      const sourceTrack = {
-        id: "1",
-        getProperty: () => {},
-      };
-      const availableTypes = [
+      const result = findRouting("1", "Track 1", [
         { display_name: "Track 1", identifier: "track1" },
         { display_name: "Track 2", identifier: "track2" },
-      ];
-
-      const result = findRoutingOptionForDuplicateNames(
-        sourceTrack as unknown as LiveAPI,
-        "Track 1",
-        availableTypes,
-      );
+      ]);
 
       expect(result).toStrictEqual({
         display_name: "Track 1",
@@ -315,19 +323,9 @@ describe("duplicate-helpers", () => {
     });
 
     it("returns undefined when no matches found", () => {
-      const sourceTrack = {
-        id: "1",
-        getProperty: () => {},
-      };
-      const availableTypes = [
+      const result = findRouting("1", "Track 1", [
         { display_name: "Track 2", identifier: "track2" },
-      ];
-
-      const result = findRoutingOptionForDuplicateNames(
-        sourceTrack as unknown as LiveAPI,
-        "Track 1",
-        availableTypes,
-      );
+      ]);
 
       expect(result).toBeUndefined();
     });
@@ -336,29 +334,14 @@ describe("duplicate-helpers", () => {
       // Mock LiveAPI for global access
       (global as Record<string, unknown>).LiveAPI = createMockLiveAPI(
         ["id1", "id2", "id3"],
-        {
-          id1: "Drums",
-          id2: "Drums",
-          id3: "Bass",
-        },
+        { id1: "Drums", id2: "Drums", id3: "Bass" },
       );
 
-      const sourceTrack = {
-        id: "id1",
-        getProperty: () => {},
-      };
-
-      const availableTypes = [
+      const result = findRouting("id1", "Drums", [
         { display_name: "Drums", identifier: "drums1" },
         { display_name: "Drums", identifier: "drums2" },
         { display_name: "Bass", identifier: "bass" },
-      ];
-
-      const result = findRoutingOptionForDuplicateNames(
-        sourceTrack as unknown as LiveAPI,
-        "Drums",
-        availableTypes,
-      );
+      ]);
 
       // Should return the first "Drums" option since sourceTrack is id1 (first Drums track)
       expect(result).toStrictEqual({
@@ -370,28 +353,13 @@ describe("duplicate-helpers", () => {
     it("finds correct option for second track with duplicate name", () => {
       (global as Record<string, unknown>).LiveAPI = createMockLiveAPI(
         ["id1", "id2", "id3"],
-        {
-          id1: "Drums",
-          id2: "Drums",
-          id3: "Bass",
-        },
+        { id1: "Drums", id2: "Drums", id3: "Bass" },
       );
 
-      const sourceTrack = {
-        id: "id2",
-        getProperty: () => {},
-      };
-
-      const availableTypes = [
+      const result = findRouting("id2", "Drums", [
         { display_name: "Drums", identifier: "drums1" },
         { display_name: "Drums", identifier: "drums2" },
-      ];
-
-      const result = findRoutingOptionForDuplicateNames(
-        sourceTrack as unknown as LiveAPI,
-        "Drums",
-        availableTypes,
-      );
+      ]);
 
       // Should return the second "Drums" option since sourceTrack is id2 (second Drums track)
       expect(result).toStrictEqual({
@@ -403,27 +371,14 @@ describe("duplicate-helpers", () => {
     it("returns undefined when source track not found in duplicate list", () => {
       (global as Record<string, unknown>).LiveAPI = createMockLiveAPI(
         ["id1", "id2"],
-        {
-          id1: "Drums",
-          id2: "Drums",
-        },
+        { id1: "Drums", id2: "Drums" },
       );
 
-      const sourceTrack = {
-        id: "id999", // Non-existent track
-        getProperty: () => {},
-      };
-
-      const availableTypes = [
+      const result = findRouting("id999", "Drums", [
+        // id999: non-existent track
         { display_name: "Drums", identifier: "drums1" },
         { display_name: "Drums", identifier: "drums2" },
-      ];
-
-      const result = findRoutingOptionForDuplicateNames(
-        sourceTrack as unknown as LiveAPI,
-        "Drums",
-        availableTypes,
-      );
+      ]);
 
       expect(result).toBeUndefined();
     });

--- a/src/tools/clip/create/tests/create-clip-advanced.test.ts
+++ b/src/tools/clip/create/tests/create-clip-advanced.test.ts
@@ -25,6 +25,17 @@ vi.mock(import("#src/tools/session/select.ts"), () => ({
   select: vi.fn(),
 }));
 
+// Registers an empty clip slot (and its clip path) at track 0, the given scene.
+function registerEmptyClipSlot(sceneIndex: number): void {
+  registerMockObject(`live_set/tracks/0/clip_slots/${sceneIndex}`, {
+    path: livePath.track(0).clipSlot(sceneIndex),
+    properties: { has_clip: 0 },
+  });
+  registerMockObject(`live_set/tracks/0/clip_slots/${sceneIndex}/clip`, {
+    path: livePath.track(0).clipSlot(sceneIndex).clip(),
+  });
+}
+
 describe("createClip - advanced features", () => {
   it("should set time signature when provided", async () => {
     const { clip } = setupSessionMocks({
@@ -64,20 +75,8 @@ describe("createClip - advanced features", () => {
     setupSessionMocks({
       liveSet: { signature_numerator: 4 },
     });
-    registerMockObject("live_set/tracks/0/clip_slots/1", {
-      path: livePath.track(0).clipSlot(1),
-      properties: { has_clip: 0 },
-    });
-    registerMockObject("live_set/tracks/0/clip_slots/1/clip", {
-      path: livePath.track(0).clipSlot(1).clip(),
-    });
-    registerMockObject("live_set/tracks/0/clip_slots/2", {
-      path: livePath.track(0).clipSlot(2),
-      properties: { has_clip: 0 },
-    });
-    registerMockObject("live_set/tracks/0/clip_slots/2/clip", {
-      path: livePath.track(0).clipSlot(2).clip(),
-    });
+    registerEmptyClipSlot(1);
+    registerEmptyClipSlot(2);
 
     const singleResult = await createClip({
       slot: "0/0",
@@ -212,13 +211,7 @@ describe("createClip - advanced features", () => {
       setupSessionMocks({
         liveSet: { signature_numerator: 4, signature_denominator: 4 },
       });
-      registerMockObject("live_set/tracks/0/clip_slots/1", {
-        path: livePath.track(0).clipSlot(1),
-        properties: { has_clip: 0 },
-      });
-      registerMockObject("live_set/tracks/0/clip_slots/1/clip", {
-        path: livePath.track(0).clipSlot(1).clip(),
-      });
+      registerEmptyClipSlot(1);
 
       const result = await createClip({
         slot: "0/0,0/1",

--- a/src/tools/clip/create/tests/create-clip-session.test.ts
+++ b/src/tools/clip/create/tests/create-clip-session.test.ts
@@ -116,6 +116,22 @@ function setupSessionClip(
   return { clipSlot, clip };
 }
 
+// Sets up the live set, track 0, and `count` length-4 session clips starting at
+// scene 1 (clip ids clip_0_1, clip_0_2, ...). Returns the clip handles in order.
+function setupNumberedSessionClips(count: number): RegisteredMockObject[] {
+  setupLiveSet({ scenes: children("scene0") });
+  setupTrack(0);
+
+  return Array.from({ length: count }, (_, i) => {
+    const sceneIndex = i + 1;
+
+    return setupSessionClip(0, sceneIndex, {
+      clipId: `clip_0_${sceneIndex}`,
+      clipProperties: { length: 4 },
+    }).clip;
+  });
+}
+
 describe("createClip - session view", () => {
   it("should create a single clip with notes", async () => {
     setupLiveSet();
@@ -321,20 +337,7 @@ describe("createClip - session view", () => {
 
 describe("createClip - session view - per-clip transforms", () => {
   it("cycles clipseq() by clip.index across multiple session clips", async () => {
-    setupLiveSet({ scenes: children("scene0") });
-    setupTrack(0);
-    const { clip: clip1 } = setupSessionClip(0, 1, {
-      clipId: "clip_0_1",
-      clipProperties: { length: 4 },
-    });
-    const { clip: clip2 } = setupSessionClip(0, 2, {
-      clipId: "clip_0_2",
-      clipProperties: { length: 4 },
-    });
-    const { clip: clip3 } = setupSessionClip(0, 3, {
-      clipId: "clip_0_3",
-      clipProperties: { length: 4 },
-    });
+    const [clip1, clip2, clip3] = setupNumberedSessionClips(3);
 
     const result = await createClip({
       slot: "0/1,0/2,0/3",
@@ -344,13 +347,13 @@ describe("createClip - session view - per-clip transforms", () => {
 
     // clipseq cycles by clip.index, so each clip gets a different velocity
     // (before the fix, the transform ran once and every clip got 10).
-    expect(clip1.call).toHaveBeenCalledWith("add_new_notes", {
+    expect(clip1!.call).toHaveBeenCalledWith("add_new_notes", {
       notes: [createNote({ velocity: 10 })],
     });
-    expect(clip2.call).toHaveBeenCalledWith("add_new_notes", {
+    expect(clip2!.call).toHaveBeenCalledWith("add_new_notes", {
       notes: [createNote({ velocity: 20 })],
     });
-    expect(clip3.call).toHaveBeenCalledWith("add_new_notes", {
+    expect(clip3!.call).toHaveBeenCalledWith("add_new_notes", {
       notes: [createNote({ velocity: 30 })],
     });
 
@@ -380,16 +383,7 @@ describe("createClip - session view - per-clip transforms", () => {
   });
 
   it("exposes clip.index and clip.count to multi-clip transforms", async () => {
-    setupLiveSet({ scenes: children("scene0") });
-    setupTrack(0);
-    const { clip: clip1 } = setupSessionClip(0, 1, {
-      clipId: "clip_0_1",
-      clipProperties: { length: 4 },
-    });
-    const { clip: clip2 } = setupSessionClip(0, 2, {
-      clipId: "clip_0_2",
-      clipProperties: { length: 4 },
-    });
+    const [clip1, clip2] = setupNumberedSessionClips(2);
 
     await createClip({
       slot: "0/1,0/2",
@@ -398,10 +392,10 @@ describe("createClip - session view - per-clip transforms", () => {
     });
 
     // clip.count = 2 (the +2 base); clip.index steps the *10 term
-    expect(clip1.call).toHaveBeenCalledWith("add_new_notes", {
+    expect(clip1!.call).toHaveBeenCalledWith("add_new_notes", {
       notes: [createNote({ velocity: 2 })],
     });
-    expect(clip2.call).toHaveBeenCalledWith("add_new_notes", {
+    expect(clip2!.call).toHaveBeenCalledWith("add_new_notes", {
       notes: [createNote({ velocity: 12 })],
     });
   });

--- a/src/tools/clip/create/tests/create-clip-take-lanes.test.ts
+++ b/src/tools/clip/create/tests/create-clip-take-lanes.test.ts
@@ -29,6 +29,19 @@ function registerLiveSet(): void {
   });
 }
 
+/** Register the live set plus an empty session clip slot at track 0, scene 0. */
+function registerEmptySessionSlot(): void {
+  registerLiveSet();
+  registerMockObject("clip-slot-0-0", {
+    path: livePath.track(0).clipSlot(0),
+    properties: { has_clip: 0 },
+  });
+  registerMockObject("session-clip", {
+    path: livePath.track(0).clipSlot(0).clip(),
+    properties: { length: 4 },
+  });
+}
+
 describe("createClip take lanes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -135,15 +148,7 @@ describe("createClip take lanes", () => {
   });
 
   it("warns and ignores takeLane for session-only requests", async () => {
-    registerLiveSet();
-    registerMockObject("clip-slot-0-0", {
-      path: livePath.track(0).clipSlot(0),
-      properties: { has_clip: 0 },
-    });
-    registerMockObject("session-clip", {
-      path: livePath.track(0).clipSlot(0).clip(),
-      properties: { length: 4 },
-    });
+    registerEmptySessionSlot();
 
     await createClip({ slot: "0/0", notes: "C3", takeLane: "new" });
 
@@ -153,15 +158,7 @@ describe("createClip take lanes", () => {
   });
 
   it("warns-and-ignores an invalid takeLane for session-only requests (does not throw)", async () => {
-    registerLiveSet();
-    registerMockObject("clip-slot-0-0", {
-      path: livePath.track(0).clipSlot(0),
-      properties: { has_clip: 0 },
-    });
-    registerMockObject("session-clip", {
-      path: livePath.track(0).clipSlot(0).clip(),
-      properties: { length: 4 },
-    });
+    registerEmptySessionSlot();
 
     // "garbage" would throw if normalized; for session-only it must be dropped
     // (this await would reject if the value were still validated).

--- a/src/tools/clip/update/tests/notes/update-clip-transform-helpers.test.ts
+++ b/src/tools/clip/update/tests/notes/update-clip-transform-helpers.test.ts
@@ -36,6 +36,37 @@ function createSessionClipMock(length = 8) {
   };
 }
 
+// Mock clip that returns `existingNotes` from get_notes_extended and captures
+// every note passed to add_new_notes into the returned `addedNotes` array.
+function makeNotesMockClip<T extends object = Record<string, number>>(
+  existingNotes: object[],
+  length = 4,
+): {
+  mockClip: {
+    getProperty: ReturnType<typeof vi.fn>;
+    call: ReturnType<typeof vi.fn>;
+  };
+  addedNotes: T[];
+} {
+  const addedNotes: T[] = [];
+  const mockClip = {
+    getProperty: vi.fn((prop: string) => (prop === "length" ? length : 0)),
+    call: vi.fn((method: string, ...args: unknown[]) => {
+      if (method === "get_notes_extended") {
+        return JSON.stringify({ notes: existingNotes });
+      }
+
+      if (method === "add_new_notes") {
+        addedNotes.push(...(args[0] as { notes: T[] }).notes);
+      }
+
+      return "[]";
+    }),
+  };
+
+  return { mockClip, addedNotes };
+}
+
 describe("update-clip-transform-helpers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -99,25 +130,7 @@ describe("update-clip-transform-helpers", () => {
         rawNote(67, 2, 102),
       ];
 
-      const addedNotes: unknown[] = [];
-      const mockClip = {
-        getProperty: vi.fn((prop: string) => {
-          if (prop === "length") return 4;
-
-          return 0;
-        }),
-        call: vi.fn((method: string, ...args: unknown[]) => {
-          if (method === "get_notes_extended") {
-            return JSON.stringify({ notes: existingNotes });
-          }
-
-          if (method === "add_new_notes") {
-            addedNotes.push(...(args[0] as { notes: unknown[] }).notes);
-          }
-
-          return "[]";
-        }),
-      };
+      const { mockClip, addedNotes } = makeNotesMockClip(existingNotes);
 
       const result = applyTransformsToExistingNotes(
         mockClip as unknown as LiveAPI,
@@ -165,23 +178,9 @@ describe("update-clip-transform-helpers", () => {
         rawNote(60, 0, 101),
         rawNote(60, 1, 102),
       ];
-      const addedNotes: { start_time: number }[] = [];
-      const mockClip = {
-        getProperty: vi.fn((prop: string) => (prop === "length" ? 4 : 0)),
-        call: vi.fn((method: string, ...args: unknown[]) => {
-          if (method === "get_notes_extended") {
-            return JSON.stringify({ notes: existingNotes });
-          }
-
-          if (method === "add_new_notes") {
-            addedNotes.push(
-              ...(args[0] as { notes: { start_time: number }[] }).notes,
-            );
-          }
-
-          return "[]";
-        }),
-      };
+      const { mockClip, addedNotes } = makeNotesMockClip<{
+        start_time: number;
+      }>(existingNotes);
 
       applyTransformsToExistingNotes(
         mockClip as unknown as LiveAPI,
@@ -196,27 +195,10 @@ describe("update-clip-transform-helpers", () => {
 
     it("writes the expanded note list when a ratchet op runs", () => {
       const existingNotes = [rawNote(60, 0, 100), rawNote(64, 2, 101)];
-      const addedNotes: { start_time: number; duration: number }[] = [];
-      const mockClip = {
-        getProperty: vi.fn((prop: string) => (prop === "length" ? 4 : 0)),
-        call: vi.fn((method: string, ...args: unknown[]) => {
-          if (method === "get_notes_extended") {
-            return JSON.stringify({ notes: existingNotes });
-          }
-
-          if (method === "add_new_notes") {
-            addedNotes.push(
-              ...(
-                args[0] as {
-                  notes: { start_time: number; duration: number }[];
-                }
-              ).notes,
-            );
-          }
-
-          return "[]";
-        }),
-      };
+      const { mockClip, addedNotes } = makeNotesMockClip<{
+        start_time: number;
+        duration: number;
+      }>(existingNotes);
 
       applyTransformsToExistingNotes(
         mockClip as unknown as LiveAPI,
@@ -235,27 +217,10 @@ describe("update-clip-transform-helpers", () => {
 
     it("writes the collapsed note list when a merge op runs", () => {
       const existingNotes = [rawNote(60, 0, 100), rawNote(60, 1, 101)];
-      const addedNotes: { start_time: number; duration: number }[] = [];
-      const mockClip = {
-        getProperty: vi.fn((prop: string) => (prop === "length" ? 4 : 0)),
-        call: vi.fn((method: string, ...args: unknown[]) => {
-          if (method === "get_notes_extended") {
-            return JSON.stringify({ notes: existingNotes });
-          }
-
-          if (method === "add_new_notes") {
-            addedNotes.push(
-              ...(
-                args[0] as {
-                  notes: { start_time: number; duration: number }[];
-                }
-              ).notes,
-            );
-          }
-
-          return "[]";
-        }),
-      };
+      const { mockClip, addedNotes } = makeNotesMockClip<{
+        start_time: number;
+        duration: number;
+      }>(existingNotes);
 
       applyTransformsToExistingNotes(
         mockClip as unknown as LiveAPI,

--- a/src/tools/session/tests/select/select-advanced.test.ts
+++ b/src/tools/session/tests/select/select-advanced.test.ts
@@ -28,6 +28,18 @@ vi.mock(import("#src/tools/shared/utils.ts"), async (importOriginal) => {
   return selectSharedUtilsMockBody(await importOriginal());
 });
 
+// Clears the registry and mocks a view with nothing selected anywhere.
+function setupEmptySelection(view: "session" | "arrangement"): void {
+  clearMockRegistry();
+  setupViewStateMock({
+    view,
+    selectedTrack: { exists: false },
+    selectedScene: { exists: false },
+    selectedClip: { exists: false },
+    highlightedClipSlot: { exists: false },
+  });
+}
+
 describe("view", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -601,15 +613,7 @@ describe("view", () => {
     });
 
     it("reads arrangement view with nothing selected", () => {
-      clearMockRegistry();
-
-      setupViewStateMock({
-        view: "arrangement",
-        selectedTrack: { exists: false },
-        selectedScene: { exists: false },
-        selectedClip: { exists: false },
-        highlightedClipSlot: { exists: false },
-      });
+      setupEmptySelection("arrangement");
 
       const result = select({});
 
@@ -700,15 +704,7 @@ describe("view", () => {
     });
 
     it("omits null fields when nothing is selected", () => {
-      clearMockRegistry();
-
-      setupViewStateMock({
-        view: "arrangement",
-        selectedTrack: { exists: false },
-        selectedScene: { exists: false },
-        selectedClip: { exists: false },
-        highlightedClipSlot: { exists: false },
-      });
+      setupEmptySelection("arrangement");
 
       const result = select();
 

--- a/src/tools/track/read/tests/read-track-basic.test.ts
+++ b/src/tools/track/read/tests/read-track-basic.test.ts
@@ -44,6 +44,20 @@ function mockThisDeviceOnTrack1(): void {
   });
 }
 
+function registerEmptyReturnTrack(): void {
+  registerMockObject("return1", {
+    path: livePath.returnTrack(0),
+    type: "Track",
+    properties: {
+      has_midi_input: 0,
+      name: "Return Track",
+      clip_slots: [],
+      arrangement_clips: [],
+      devices: [],
+    },
+  });
+}
+
 function registerTrackWithSessionSlots(name: string): void {
   registerMockObject("track3", {
     path: livePath.track(2),
@@ -433,17 +447,7 @@ describe("readTrack", () => {
   });
 
   it("returns empty sessionClips for a return track when session-clips is included", () => {
-    registerMockObject("return1", {
-      path: livePath.returnTrack(0),
-      type: "Track",
-      properties: {
-        has_midi_input: 0,
-        name: "Return Track",
-        clip_slots: [],
-        arrangement_clips: [],
-        devices: [],
-      },
-    });
+    registerEmptyReturnTrack();
 
     const result = readTrack({
       trackIndex: 0,
@@ -455,17 +459,7 @@ describe("readTrack", () => {
   });
 
   it("returns empty arrangementClips for a return track when arrangement-clips is included", () => {
-    registerMockObject("return1", {
-      path: livePath.returnTrack(0),
-      type: "Track",
-      properties: {
-        has_midi_input: 0,
-        name: "Return Track",
-        clip_slots: [],
-        arrangement_clips: [],
-        devices: [],
-      },
-    });
+    registerEmptyReturnTrack();
 
     const result = readTrack({
       trackIndex: 0,

--- a/webui/src/hooks/context/tests/use-context-memory.test.ts
+++ b/webui/src/hooks/context/tests/use-context-memory.test.ts
@@ -46,6 +46,22 @@ describe("useContextMemory", () => {
     return ok;
   }
 
+  // Renders the hook with `{ memoryContent: "old" }` as the initial GET (plus any
+  // extra queued responses) and waits for that content to load.
+  async function renderWithLoadedContent(
+    ...extraResponses: Array<object | Response>
+  ): Promise<{ current: ReturnType<typeof useContextMemory> }> {
+    mockResponses({ memoryContent: "old" }, ...extraResponses);
+
+    const { result } = renderHook(() => useContextMemory());
+
+    await waitFor(() => {
+      expect(result.current.status).toMatchObject({ content: "old" });
+    });
+
+    return result;
+  }
+
   it("loads memory content on mount", async () => {
     mockResponses({ memoryContent: "# hi" });
 
@@ -93,13 +109,7 @@ describe("useContextMemory", () => {
   });
 
   it("save() posts content and updates status", async () => {
-    mockResponses({ memoryContent: "old" }, { memoryContent: "new" });
-
-    const { result } = renderHook(() => useContextMemory());
-
-    await waitFor(() => {
-      expect(result.current.status).toMatchObject({ content: "old" });
-    });
+    const result = await renderWithLoadedContent({ memoryContent: "new" });
 
     const saved = await callAndCapture(() => result.current.save("new"));
 
@@ -138,13 +148,7 @@ describe("useContextMemory", () => {
   });
 
   it("clear() saves empty content", async () => {
-    mockResponses({ memoryContent: "old" }, { memoryContent: "" });
-
-    const { result } = renderHook(() => useContextMemory());
-
-    await waitFor(() => {
-      expect(result.current.status).toMatchObject({ content: "old" });
-    });
+    const result = await renderWithLoadedContent({ memoryContent: "" });
 
     await act(async () => {
       await result.current.clear();
@@ -160,13 +164,7 @@ describe("useContextMemory", () => {
   });
 
   it("re-fetches on window focus so external writes surface", async () => {
-    mockResponses({ memoryContent: "old" }, { memoryContent: "new" });
-
-    const { result } = renderHook(() => useContextMemory());
-
-    await waitFor(() => {
-      expect(result.current.status).toMatchObject({ content: "old" });
-    });
+    const result = await renderWithLoadedContent({ memoryContent: "new" });
 
     await act(async () => {
       window.dispatchEvent(new Event("focus"));
@@ -226,13 +224,7 @@ describe("useContextMemory", () => {
   // clobbers status.content with pre-save content. These tests pin
   // each overlap ordering: the save's echo must always win.
   it("does not let an in-flight save's stale focus GET clobber the echo", async () => {
-    mockResponses({ memoryContent: "old" });
-
-    const { result } = renderHook(() => useContextMemory());
-
-    await waitFor(() => {
-      expect(result.current.status).toMatchObject({ content: "old" });
-    });
+    const result = await renderWithLoadedContent();
 
     const post = deferred<Response>();
     const staleGet = deferred<Response>();
@@ -261,13 +253,7 @@ describe("useContextMemory", () => {
   });
 
   it("defers to a save that starts mid-refresh", async () => {
-    mockResponses({ memoryContent: "old" });
-
-    const { result } = renderHook(() => useContextMemory());
-
-    await waitFor(() => {
-      expect(result.current.status).toMatchObject({ content: "old" });
-    });
+    const result = await renderWithLoadedContent();
 
     const staleGet = deferred<Response>();
     const post = deferred<Response>();
@@ -295,13 +281,7 @@ describe("useContextMemory", () => {
   });
 
   it("does not let a superseded refresh error override an in-flight save", async () => {
-    mockResponses({ memoryContent: "old" });
-
-    const { result } = renderHook(() => useContextMemory());
-
-    await waitFor(() => {
-      expect(result.current.status).toMatchObject({ content: "old" });
-    });
+    const result = await renderWithLoadedContent();
 
     const post = deferred<Response>();
     const failingGet = deferred<Response>();


### PR DESCRIPTION
## Summary

Reduces code duplication flagged by the `jscpd` duplication check, focused on test code. Branched off the latest `dev`.

All five duplication categories already passed their thresholds, but **Tests** was the largest offender (1.04% vs 1.25% threshold, 144 clones). Many flagged clones are unavoidable `vi.mock`/`vi.hoisted` boilerplate (vitest hoists these to file top, so they can't be extracted) or near-identical import headers. This PR targets the genuinely extractable logic — repeated mock-setup and assertion blocks — using focused helpers (the repo's preferred approach over loop-merging/trimming).

## Changes (11 test files, −154 net lines)

| File | Helper extracted |
|------|------------------|
| `delete-device` | `setupNestedDrumDeviceMocks` for nested drum-chain devices |
| `update-clip-transform-helpers` | `makeNotesMockClip` mock-clip builder (`get_notes_extended`/`add_new_notes`) |
| `duplicate-helpers` | `findRouting` wrapper around the stub source track |
| `read-track-basic` | `registerEmptyReturnTrack` |
| `create-clip-session` | `setupNumberedSessionClips` |
| `create-clip-take-lanes` | `registerEmptySessionSlot` |
| `create-clip-advanced` | `registerEmptyClipSlot` |
| `select-advanced` | `setupEmptySelection` |
| `transform-note-ops` | `expectMergeWarnsAndSkips` |
| `use-context-memory` (webui) | `renderWithLoadedContent` |

## Result

- Tests duplication: **1.04% → 0.87%** (144 → 126 clones, −221 duplicated lines)
- `npm run check` passes: **7679 tests pass, 100% function coverage**, lint/typecheck/format/duplication all green
- `npm run check:build` passes (production bundles + docs site compile)

No behavior changes — pure test refactoring.

https://claude.ai/code/session_012YDTBsJSmdPPv5dvayjE3y

---
_Generated by [Claude Code](https://claude.ai/code/session_012YDTBsJSmdPPv5dvayjE3y)_