### PR TITLE
test(chat): harden message-queuing coverage

### DIFF
--- a/webui/src/chat/sdk/tests/client-interrupt.test.ts
+++ b/webui/src/chat/sdk/tests/client-interrupt.test.ts
@@ -1,0 +1,188 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Focused coverage for the message-queuing interrupt path in processStream:
+ * shouldInterrupt is checked ONLY at start-step boundaries (between tool steps),
+ * so a queued follow-up cuts a multi-step tool loop short without discarding
+ * already-streamed content or leaving a dangling tool-call.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { type ChatClientConfig, type ChatMessage } from "#webui/chat/sdk/types";
+
+// Mock streamText from ai
+vi.mock(import("ai"), async (importOriginal) => {
+  const actual = await importOriginal();
+
+  return {
+    ...actual,
+    streamText: vi.fn(),
+    generateText: vi.fn(),
+  };
+});
+
+// Mock MCP tools
+vi.mock(import("#webui/chat/sdk/mcp-tools"), () => ({
+  createMcpTools: vi.fn().mockResolvedValue({ tools: {}, mcpClient: {} }),
+}));
+
+// Mock getMcpUrl
+vi.mock(import("#webui/utils/mcp-url"), () => ({
+  getMcpUrl: vi.fn(() => "http://localhost:3000/mcp"),
+}));
+
+import { streamText } from "ai";
+import { ChatSdkClient } from "#webui/chat/sdk/client";
+
+/**
+ * Create a mock config.
+ * @param overrides - Config overrides
+ * @returns Mock ChatClientConfig
+ */
+function createConfig(overrides?: Partial<ChatClientConfig>): ChatClientConfig {
+  return {
+    model: {
+      modelId: "test",
+      provider: "openai",
+      specificationVersion: "v3",
+    } as never,
+    showThoughts: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Stream the given parts through a fresh client, passing a shouldInterrupt
+ * callback, and return the final chat-history snapshot.
+ * @param parts - Stream parts to emit
+ * @param shouldInterrupt - Interrupt callback forwarded to sendMessage
+ * @returns Final chat history
+ */
+async function sendWithInterrupt(
+  parts: Record<string, unknown>[],
+  shouldInterrupt: () => boolean,
+): Promise<ChatMessage[]> {
+  async function* iterate(): AsyncIterable<Record<string, unknown>> {
+    for (const p of parts) yield p;
+  }
+
+  (streamText as ReturnType<typeof vi.fn>).mockReturnValue({
+    fullStream: iterate(),
+  });
+
+  const client = new ChatSdkClient("key", createConfig());
+  let last: ChatMessage[] = [];
+
+  for await (const history of client.sendMessage(
+    "Hello",
+    undefined,
+    undefined,
+    shouldInterrupt,
+  )) {
+    last = history;
+  }
+
+  return last;
+}
+
+describe("ChatSdkClient interrupt (message queuing)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps history valid when interrupting after a completed tool step", async () => {
+    // A full tool step (call + result) finishes, then the model starts a new
+    // step. A queued message interrupts at that boundary. The completed
+    // tool-call already has its result, so reconcile must NOT fabricate a
+    // "Canceled" result — the history is already valid.
+    const last = await sendWithInterrupt(
+      [
+        {
+          type: "tool-call",
+          toolCallId: "tc1",
+          toolName: "ppal-read-song",
+          input: {},
+        },
+        {
+          type: "tool-result",
+          toolCallId: "tc1",
+          toolName: "ppal-read-song",
+          input: {},
+          output: "OK",
+        },
+        { type: "finish-step" },
+        { type: "start-step", messageId: "m2" },
+        { type: "text-delta", text: "Should not appear" },
+      ],
+      () => true,
+    );
+
+    // Only user + the first assistant turn (interrupted before step 2).
+    expect(last).toHaveLength(2);
+
+    const assistant = last[1]!;
+
+    expect(assistant.toolCalls).toHaveLength(1);
+    expect(assistant.toolResults).toHaveLength(1);
+    expect(assistant.toolResults![0]!.id).toBe("tc1");
+    expect(assistant.toolResults![0]!.result).toBe("OK");
+    expect(assistant.toolResults![0]!.isError).toBe(false);
+    // The post-interrupt text never made it into history.
+    expect(assistant.content).toBe("");
+  });
+
+  it("continues through every step when shouldInterrupt stays false", async () => {
+    // Guards against an inverted interrupt condition: a false callback must let
+    // a multi-step response run to completion.
+    const last = await sendWithInterrupt(
+      [
+        { type: "text-delta", text: "First" },
+        { type: "start-step", messageId: "m2" },
+        { type: "text-delta", text: "Second" },
+      ],
+      () => false,
+    );
+
+    expect(last).toHaveLength(3);
+    expect(last[1]!.content).toBe("First");
+    expect(last[2]!.content).toBe("Second");
+  });
+
+  it("interrupts only at the step boundary, not mid-text", async () => {
+    // shouldInterrupt is true throughout, but the first step's text deltas must
+    // all land before the start-step check cuts the stream off.
+    const last = await sendWithInterrupt(
+      [
+        { type: "text-delta", text: "First" },
+        { type: "text-delta", text: " and more" },
+        { type: "start-step", messageId: "m2" },
+        { type: "text-delta", text: "Second" },
+      ],
+      () => true,
+    );
+
+    expect(last).toHaveLength(2);
+    expect(last[1]!.content).toBe("First and more");
+  });
+
+  it("never checks shouldInterrupt for a single-turn response", async () => {
+    // No start-step means no step boundary, so a non-empty queue must NOT
+    // interrupt a plain single-turn reply — it streams to completion and the
+    // queue drains afterward (handled one level up in useChat).
+    const shouldInterrupt = vi.fn(() => true);
+
+    const last = await sendWithInterrupt(
+      [
+        { type: "text-delta", text: "Complete answer" },
+        { type: "finish", finishReason: "stop" },
+      ],
+      shouldInterrupt,
+    );
+
+    expect(shouldInterrupt).not.toHaveBeenCalled();
+    expect(last).toHaveLength(2);
+    expect(last[1]!.content).toBe("Complete answer");
+  });
+});

--- a/webui/src/hooks/chat/tests/use-chat-message-queue.test.ts
+++ b/webui/src/hooks/chat/tests/use-chat-message-queue.test.ts
@@ -1,0 +1,189 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @vitest-environment happy-dom
+ */
+import { renderHook, act } from "@testing-library/preact";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useChat } from "#webui/hooks/chat/use-chat";
+import {
+  type TestMessage,
+  createDefaultProps,
+  createMockAdapter,
+  createScriptedAdapter,
+} from "./use-chat-test-helpers";
+
+// Mock streaming helpers (mirrors use-chat.test.ts so handleSend can stream).
+vi.mock(import("#webui/hooks/chat/helpers/streaming-helpers"), async () => {
+  const { streamingHelpersMockBody } = await import("./use-chat-test-helpers");
+
+  return streamingHelpersMockBody();
+});
+
+const mockAdapter = createMockAdapter();
+const defaultProps = createDefaultProps(mockAdapter);
+
+/** Context passed to a recording adapter's mid-send hook. */
+interface MidSend {
+  message: string;
+  overrides?: unknown;
+  shouldInterrupt?: () => boolean;
+}
+
+/**
+ * Build an adapter whose client records every sent message and runs a hook
+ * between the user-echo and assistant-reply yields (so tests can mutate the
+ * queue, inspect overrides, or steer control flow mid-send). The hook may
+ * return "interrupt" to abandon the turn early (mirroring an SDK interrupt),
+ * or throw to simulate a failed send.
+ * @param sent - Array that each sent message is pushed onto
+ * @param onMidSend - Called after the user-echo yield with the send context
+ * @returns Scripted adapter
+ */
+function createRecordingAdapter(
+  sent: string[],
+  onMidSend?: (ctx: MidSend) => "interrupt" | void,
+) {
+  return createScriptedAdapter(
+    mockAdapter,
+    (client) =>
+      async function* send(
+        message: string,
+        _signal: AbortSignal,
+        overrides?: unknown,
+        shouldInterrupt?: () => boolean,
+      ): AsyncIterable<TestMessage[]> {
+        sent.push(message);
+        client.chatHistory.push({ role: "user", content: message });
+        yield [...client.chatHistory];
+
+        if (
+          onMidSend?.({ message, overrides, shouldInterrupt }) === "interrupt"
+        )
+          return;
+
+        client.chatHistory.push({
+          role: "assistant",
+          content: `Response to: ${message}`,
+        });
+        yield [...client.chatHistory];
+      },
+  );
+}
+
+describe("useChat message queuing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps draining when a message is queued during a drained send", async () => {
+    const sent: string[] = [];
+    let enqueue: ((text: string) => void) | null = null;
+    const adapter = createRecordingAdapter(sent, ({ message }) => {
+      // While the first drained follow-up ("A") streams, queue one more to
+      // force a SECOND drain iteration — proving the loop keeps going.
+      if (message === "A" && enqueue) {
+        enqueue("B");
+        enqueue = null;
+      }
+    });
+
+    const { result } = renderHook(() => useChat({ ...defaultProps, adapter }));
+
+    enqueue = result.current.enqueueMessage;
+
+    await act(() => result.current.enqueueMessage("A"));
+    await act(async () => {
+      await result.current.handleSend("Hello");
+    });
+
+    expect(sent).toStrictEqual(["Hello", "A", "B"]);
+    expect(result.current.queuedMessages).toStrictEqual([]);
+  });
+
+  it("reports the pending queue to the SDK via shouldInterrupt", async () => {
+    const sent: string[] = [];
+    const interruptByMessage: Record<string, boolean | undefined> = {};
+    const adapter = createRecordingAdapter(
+      sent,
+      ({ message, shouldInterrupt }) => {
+        interruptByMessage[message] = shouldInterrupt?.();
+      },
+    );
+
+    const { result } = renderHook(() => useChat({ ...defaultProps, adapter }));
+
+    await act(() => result.current.enqueueMessage("Q"));
+    await act(async () => {
+      await result.current.handleSend("Hello");
+    });
+
+    // During "Hello" the queue still held "Q", so an interrupt was requested.
+    expect(interruptByMessage.Hello).toBe(true);
+    // The drained "Q" send saw an empty queue, so no interrupt was requested.
+    expect(interruptByMessage.Q).toBe(false);
+  });
+
+  it("auto-sends a queued message after the SDK interrupts a tool loop", async () => {
+    const sent: string[] = [];
+    // Mirror the real client: abandon a multi-step tool loop the moment a
+    // follow-up is queued, emitting no further assistant content.
+    const adapter = createRecordingAdapter(sent, ({ shouldInterrupt }) =>
+      shouldInterrupt?.() ? "interrupt" : undefined,
+    );
+
+    const { result } = renderHook(() => useChat({ ...defaultProps, adapter }));
+
+    await act(() => result.current.enqueueMessage("follow up"));
+    await act(async () => {
+      await result.current.handleSend("Hello");
+    });
+
+    // "Hello" bailed out early (queue held "follow up"); the drain loop then
+    // sent "follow up", which ran to completion against an empty queue.
+    expect(sent).toStrictEqual(["Hello", "follow up"]);
+    expect(result.current.queuedMessages).toStrictEqual([]);
+  });
+
+  it("carries the first queued message's overrides into the drained send", async () => {
+    const sent: string[] = [];
+    const overridesByMessage: Record<string, unknown> = {};
+    const adapter = createRecordingAdapter(sent, ({ message, overrides }) => {
+      overridesByMessage[message] = overrides;
+    });
+
+    const { result } = renderHook(() => useChat({ ...defaultProps, adapter }));
+
+    await act(() => result.current.enqueueMessage("Q", { thinking: "high" }));
+    await act(async () => {
+      await result.current.handleSend("Hello");
+    });
+
+    expect(sent).toStrictEqual(["Hello", "Q"]);
+    expect(overridesByMessage.Q).toStrictEqual({ thinking: "high" });
+  });
+
+  it("stops the drain loop and surfaces an error when a drained send fails", async () => {
+    const sent: string[] = [];
+    const adapter = createRecordingAdapter(sent, ({ message }) => {
+      if (message === "Q") throw new Error("drained send failed");
+    });
+
+    const { result } = renderHook(() => useChat({ ...defaultProps, adapter }));
+
+    await act(() => result.current.enqueueMessage("Q"));
+    await act(async () => {
+      await result.current.handleSend("Hello");
+    });
+
+    // The failed drained send terminates the loop (no infinite retry): the
+    // error is surfaced, the queue is already drained, and we're idle again.
+    expect(sent).toStrictEqual(["Hello", "Q"]);
+    expect(result.current.messages.at(-1)?.parts[0]?.type).toBe("error");
+    expect(result.current.queuedMessages).toStrictEqual([]);
+    expect(result.current.isAssistantResponding).toBe(false);
+  });
+});

--- a/webui/src/hooks/chat/tests/use-chat-retry.test.ts
+++ b/webui/src/hooks/chat/tests/use-chat-retry.test.ts
@@ -21,20 +21,7 @@ import {
 vi.mock(import("#webui/hooks/chat/helpers/streaming-helpers"), async () => {
   const { streamingHelpersMockBody } = await import("./use-chat-test-helpers");
 
-  return {
-    ...streamingHelpersMockBody(),
-    showMissingApiKeyError: vi.fn(
-      (adapter, msg, setMessages, pendingHistoryRef) => {
-        const entry = adapter.createUserMessage(msg);
-        const error = new Error(
-          "No API key configured. Please add your API key in Settings.",
-        );
-
-        pendingHistoryRef.current = [entry];
-        setMessages(adapter.createErrorMessage(error, [entry]));
-      },
-    ),
-  };
+  return streamingHelpersMockBody();
 });
 
 // Shrink retry backoff so tests don't sit through real seconds-long delays.

--- a/webui/src/hooks/chat/tests/use-chat-test-helpers.ts
+++ b/webui/src/hooks/chat/tests/use-chat-test-helpers.ts
@@ -189,6 +189,17 @@ export function streamingHelpersMockBody(): Partial<typeof StreamingHelpers> {
     }),
     validateMcpConnection: vi.fn(),
     filterOverrides: vi.fn((overrides) => overrides),
+    showMissingApiKeyError: vi.fn(
+      (adapter, msg, setMessages, pendingHistoryRef) => {
+        const entry = adapter.createUserMessage(msg);
+        const error = new Error(
+          "No API key configured. Please add your API key in Settings.",
+        );
+
+        pendingHistoryRef.current = [entry];
+        setMessages(adapter.createErrorMessage(error, [entry]));
+      },
+    ) as typeof StreamingHelpers.showMissingApiKeyError,
   };
 }
 

--- a/webui/src/hooks/chat/tests/use-chat.test.ts
+++ b/webui/src/hooks/chat/tests/use-chat.test.ts
@@ -21,20 +21,7 @@ import {
 vi.mock(import("#webui/hooks/chat/helpers/streaming-helpers"), async () => {
   const { streamingHelpersMockBody } = await import("./use-chat-test-helpers");
 
-  return {
-    ...streamingHelpersMockBody(),
-    showMissingApiKeyError: vi.fn(
-      (adapter, msg, setMessages, pendingHistoryRef) => {
-        const entry = adapter.createUserMessage(msg);
-        const error = new Error(
-          "No API key configured. Please add your API key in Settings.",
-        );
-
-        pendingHistoryRef.current = [entry];
-        setMessages(adapter.createErrorMessage(error, [entry]));
-      },
-    ),
-  };
+  return streamingHelpersMockBody();
 });
 
 const mockAdapter = createMockAdapter();


### PR DESCRIPTION
Follow-up to #760 (message queuing during AI responses): adds focused automated tests for the queue feature's interrupt and drain-loop behavior, including the interactions introduced when #760 was merged over the compaction/`reconcileDanglingToolCalls` work on dev.

## New tests

**`webui/src/chat/sdk/tests/client-interrupt.test.ts`** — `shouldInterrupt` in `processStream` is checked *only* at start-step boundaries:
- interrupting after a completed tool step keeps history valid (no spurious "Canceled" reconcile)
- a `false` callback runs every step to completion (guards against an inverted condition)
- interrupt never fires mid-text — first-step deltas all land
- a single-turn reply (no start-step) is never interrupted even with a non-empty queue

**`webui/src/hooks/chat/tests/use-chat-message-queue.test.ts`** — the `handleSend` drain loop:
- multi-iteration drain when a message is queued *during* a drained send
- `shouldInterrupt` wiring reflects the pending queue (true while queued, false once drained)
- SDK-interrupt → auto-send of the queued follow-up (end-to-end)
- the drained send carries the first queued message's overrides
- a failed drained send terminates the loop (no infinite retry) and surfaces the error

## Refactor

Hoisted the shared `showMissingApiKeyError` mock into `streamingHelpersMockBody` so `use-chat`/`-retry`/`-edit`/`-message-queue` tests stop duplicating it (keeps the tests-duplication metric in check).

## Checks

`npm run check`, `npm run ui:test`, and `npm run check:build` all pass. 7879 unit tests (+9), Functions coverage 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)