### PR TITLE
Keep prior conversation visible after compaction

### DIFF
--- a/webui/src/chat/sdk/client.ts
+++ b/webui/src/chat/sdk/client.ts
@@ -352,6 +352,12 @@ function handleStreamPart(
  * 1. assistant message with text + tool-call parts
  * 2. tool message with tool-result parts
  *
+ * Compaction keeps the prior turns in `history` for display but inserts a
+ * synthetic summary marker (`isCompactionSummary`). The model only needs the
+ * most recent summary plus everything after it, so we start the payload at the
+ * last summary marker — earlier turns are dropped from the model view only,
+ * while the UI still renders them above the divider.
+ *
  * Consecutive user turns are merged into one. A compaction summary is a
  * synthetic user message, so the next real user message would otherwise sit
  * directly after it — Gemini and Mistral reject two user turns in a row (only
@@ -364,7 +370,21 @@ function handleStreamPart(
 export function buildModelMessages(history: ChatMessage[]): ModelMessage[] {
   const messages: ModelMessage[] = [];
 
-  for (const msg of history) {
+  // Start from the most recent compaction summary; everything before it is
+  // display-only history that the model should not see.
+  let lastSummaryIndex = -1;
+
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i]?.isCompactionSummary) {
+      lastSummaryIndex = i;
+      break;
+    }
+  }
+
+  const modelHistory =
+    lastSummaryIndex > 0 ? history.slice(lastSummaryIndex) : history;
+
+  for (const msg of modelHistory) {
     if (msg.role === "user") {
       const last = messages.at(-1);
 

--- a/webui/src/chat/sdk/tests/build-model-messages.test.ts
+++ b/webui/src/chat/sdk/tests/build-model-messages.test.ts
@@ -63,4 +63,48 @@ describe("buildModelMessages", () => {
     ]);
     expect(result.at(-1)).toStrictEqual({ role: "user", content: "u2" });
   });
+
+  it("starts the model payload at the compaction summary, dropping prior turns", () => {
+    // Compaction keeps the prior turns in history for display, but the model
+    // should only see the summary and everything after it.
+    const result = buildModelMessages([
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1" },
+      { role: "user", content: "u2" },
+      { role: "assistant", content: "a2" },
+      { role: "user", content: "summary", isCompactionSummary: true },
+      { role: "user", content: "continue from here" },
+    ]);
+
+    expect(result).toStrictEqual([
+      { role: "user", content: "summary\n\ncontinue from here" },
+    ]);
+  });
+
+  it("uses the most recent summary when the history is compacted twice", () => {
+    const result = buildModelMessages([
+      { role: "user", content: "u1" },
+      { role: "user", content: "first summary", isCompactionSummary: true },
+      { role: "assistant", content: "a1" },
+      { role: "user", content: "second summary", isCompactionSummary: true },
+      { role: "assistant", content: "a2" },
+    ]);
+
+    expect(result).toStrictEqual([
+      { role: "user", content: "second summary" },
+      { role: "assistant", content: "a2" },
+    ]);
+  });
+
+  it("returns the full history when there is no compaction summary", () => {
+    const result = buildModelMessages([
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1" },
+    ]);
+
+    expect(result).toStrictEqual([
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1" },
+    ]);
+  });
 });

--- a/webui/src/components/chat/assistant/MessageRow.tsx
+++ b/webui/src/components/chat/assistant/MessageRow.tsx
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { type VNode } from "preact";
@@ -126,6 +127,13 @@ function AssistantRow({
   const previousUserMessageIdx = canRetry
     ? findPreviousUserMessageIndex(messages, originalIdx)
     : -1;
+  // Compaction is gated to the last assistant message: "compact up to here" only
+  // ever means "compact everything." Compacting from an earlier message (the
+  // small-model recovery flow that also discards the tail) is deferred, because
+  // keeping prior turns visible (the current behavior) conflicts with discarding
+  // the tail.
+  const isLastAssistantMessage =
+    messages.findLastIndex((m) => m.role === "model") === originalIdx;
   const timestamp = renderTimestamp(message.timestamp, showTimestamps);
   const prevModelUsage = getPrevModelUsage(messages, originalIdx);
 
@@ -149,7 +157,9 @@ function AssistantRow({
         timestamp={timestamp}
         showRetry={canRetry && previousUserMessageIdx >= 0}
         onRetry={() => void handleRetry(previousUserMessageIdx)}
-        showCompact={canRetry && handleCompact != null}
+        showCompact={
+          canRetry && handleCompact != null && isLastAssistantMessage
+        }
         onCompact={() => {
           if (handleCompact) void handleCompact(originalIdx);
         }}

--- a/webui/src/components/chat/tests/MessageList.test.tsx
+++ b/webui/src/components/chat/tests/MessageList.test.tsx
@@ -658,6 +658,34 @@ describe("MessageList", () => {
       expect(handleCompact).toHaveBeenCalledWith(1);
     });
 
+    it("only shows the compact button on the last assistant message", () => {
+      render(
+        <MessageList
+          messages={[
+            createUserMessage("hi", 0),
+            createModelMessage("first", 1),
+            createUserMessage("more", 2),
+            createModelMessage("last", 3),
+          ]}
+          queuedMessages={[]}
+          onRemoveQueued={vi.fn()}
+          isAssistantResponding={false}
+          handleRetry={vi.fn()}
+          handleEdit={vi.fn()}
+          handleCompact={vi.fn()}
+          showTimestamps={false}
+          showTokenUsage={false}
+        />,
+      );
+
+      // Two assistant messages, but compaction is gated to the last one.
+      expect(
+        screen.getAllByRole("button", {
+          name: /compact the conversation up to here/i,
+        }),
+      ).toHaveLength(1);
+    });
+
     it("renders a divider for a compaction summary message", () => {
       const summaryMsg: UIMessage = {
         role: "user",

--- a/webui/src/hooks/chat/tests/use-chat.test.ts
+++ b/webui/src/hooks/chat/tests/use-chat.test.ts
@@ -609,7 +609,9 @@ describe("useChat", () => {
 
       expect(adapter.createClient).toHaveBeenCalledTimes(1);
       expect(created?.summarize).toHaveBeenCalledWith(RESTORED_HISTORY);
+      // Non-destructive: restored turns are kept, summary marker appended.
       expect(created?.chatHistory).toStrictEqual([
+        ...RESTORED_HISTORY,
         { role: "user", content: "Summary of 2 messages" },
       ]);
       expect(result.current.canUndoCompaction).toBe(true);

--- a/webui/src/hooks/chat/tests/use-compaction.test.ts
+++ b/webui/src/hooks/chat/tests/use-compaction.test.ts
@@ -72,7 +72,10 @@ describe("useCompaction", () => {
       { role: "user", content: "u1" },
       { role: "assistant", content: "a1" },
     ]);
+    // Non-destructive: prior turns are kept and the summary marker is appended.
     expect(client.chatHistory).toStrictEqual([
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1" },
       { role: "user", content: "Summary of 2 messages" },
     ]);
     expect(setMessages).toHaveBeenCalled();
@@ -80,7 +83,9 @@ describe("useCompaction", () => {
     expect(result.current.canUndoCompaction).toBe(true);
   });
 
-  it("drops the tail when an earlier message is targeted", async () => {
+  it("compacts the full history regardless of the targeted index", async () => {
+    // The compact button is gated to the last assistant message, so there is no
+    // tail to drop — compaction always summarizes the entire visible history.
     const { result, client } = setup({
       chatHistory: [
         { role: "user", content: "u1" },
@@ -98,8 +103,16 @@ describe("useCompaction", () => {
     expect(client.summarize).toHaveBeenCalledWith([
       { role: "user", content: "u1" },
       { role: "assistant", content: "a1" },
+      { role: "user", content: "u2" },
+      { role: "assistant", content: "a2" },
     ]);
-    expect(client.chatHistory).toHaveLength(1);
+    expect(client.chatHistory).toStrictEqual([
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1" },
+      { role: "user", content: "u2" },
+      { role: "assistant", content: "a2" },
+      { role: "user", content: "Summary of 4 messages" },
+    ]);
   });
 
   it("does nothing while the assistant is responding", async () => {

--- a/webui/src/hooks/chat/use-compaction.ts
+++ b/webui/src/hooks/chat/use-compaction.ts
@@ -45,10 +45,11 @@ interface UseCompactionReturn {
 }
 
 /**
- * Manual conversation compaction: summarize the history up to (and including) a
- * chosen UI message into a single synthetic message and continue from it,
- * dropping everything after the cut. Requires an active client (a conversation
- * that has been sent at least once this session).
+ * Manual conversation compaction: summarize the visible history into a single
+ * synthetic summary marker appended to the end of the history. The prior turns
+ * are KEPT for display — buildModelMessages starts the model payload from the
+ * marker, so they are dropped from the model view only. Requires an active
+ * client (a conversation that has been sent at least once this session).
  * @param params - Compaction inputs from useChat
  * @param params.clientRef - Ref to the active chat client
  * @param params.bootstrapClientRef - Ref to a callback that creates a client from pending history
@@ -84,10 +85,11 @@ export function useCompaction<
     setCanUndoCompaction(false);
   }, []);
 
-  // Summarize the conversation up to (and including) the given UI message into a
-  // single synthetic message and continue from it. Everything after the cut is
-  // dropped — clicking an earlier message both compacts and discards the broken
-  // tail (the small-model recovery flow).
+  // Summarize the entire visible history into a single synthetic summary marker
+  // appended to the end. Prior turns are kept for display; the model boundary
+  // (buildModelMessages) starts at the marker, so the model only sees the
+  // summary going forward. The compact button is gated to the last assistant
+  // message, so there is never a tail after the cut to discard.
   const compact = useCallback(
     async (mergedMessageIndex: number) => {
       if (isCompacting || isAssistantResponding) return;
@@ -116,23 +118,25 @@ export function useCompaction<
         if (!client?.summarize) return;
 
         const history = client.chatHistory;
-        const nextMessage = messages[mergedMessageIndex + 1];
-        const cutEnd = nextMessage
-          ? nextMessage.rawHistoryIndex - 1
-          : history.length - 1;
-        const toCompact = history.slice(0, cutEnd + 1);
 
-        if (toCompact.length === 0) return;
+        if (history.length === 0) return;
 
-        const summary = await client.summarize(toCompact);
+        const summary = await client.summarize(history);
 
         // Switched/torn down while summarizing: the captured client is no longer
         // active. Applying its summary now would overwrite the conversation the
         // user moved to and arm an undo pointing at the wrong history.
         if (clientRef.current !== client) return;
 
+        // Non-destructive: keep the prior turns for display and append the
+        // summary marker. The model boundary in buildModelMessages drops the
+        // earlier turns from the model payload only. Undo restores the snapshot
+        // (the history without the marker).
         undoRef.current = history.slice();
-        client.chatHistory = [adapter.createCompactionSummary(summary)];
+        client.chatHistory = [
+          ...history,
+          adapter.createCompactionSummary(summary),
+        ];
         setMessages(adapter.formatMessages(client.chatHistory));
         setCanUndoCompaction(true);
         autoSaveRef?.current?.();


### PR DESCRIPTION
## Problem

Manual compaction replaced the visible conversation with a single summary message — prior turns disappeared from the UI and from IndexedDB, with only an ephemeral in-memory undo. There was no separation between "what's displayed" and "what's sent to the model": one array (`chatHistory`) drove both, and compaction physically truncated it.

## Approach

Introduce a **model boundary** instead of truncating.

- **`buildModelMessages()`** now starts the model payload at the most recent `isCompactionSummary` marker. Earlier turns are dropped from the *model* view only; the UI keeps rendering them above the `CompactionDivider`.
- **`compact()`** appends the summary marker non-destructively (`[...history, summary]`) instead of replacing the history, so prior turns stay visible and persist. Undo (snapshot restore) simply removes the marker.
- The compact button is **gated to the last assistant message**, so compaction always targets the full history — there is never a tail after the cut to discard, which keeps the model-boundary rule simple.

## Scope notes

- No token/context-counting changes needed: there is no cumulative context-window meter; per-response `usage` is unaffected.
- "Compact from an earlier message" (small-model recovery, which also discarded the tail) is **deferred** as a follow-up — blocking it removes the only case where a tail exists.
- IndexedDB history growth is now unbounded by design (accepted).

## Testing

- `npm run check` green (lint, typecheck, format, duplication, coverage — functions 100%).
- Added/updated tests: `build-model-messages` (boundary cases incl. chained summaries), `use-compaction`, `use-chat`, `MessageList` (button gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)