### PR TITLE
feat(voice): auto-retry rate-limited responses + parse sub-second waits

### DIFF
--- a/webui/src/components/voice/RateLimitRetry.tsx
+++ b/webui/src/components/voice/RateLimitRetry.tsx
@@ -11,8 +11,10 @@ interface RateLimitRetryProps {
 }
 
 /**
- * Countdown until an OpenAI rate-limit window expires, with a retry button
- * that becomes enabled when the countdown reaches zero.
+ * Countdown until an OpenAI rate-limit window expires. The session auto-retries
+ * once it elapses (see useVoiceSession), so this is primarily a status display;
+ * the button is a manual fallback that becomes enabled when the countdown
+ * reaches zero (e.g. if an auto-retry itself gets re-limited).
  *
  * @param props - component props
  * @param props.until - Epoch ms when the rate limit clears
@@ -42,7 +44,7 @@ export function RateLimitRetry({ until, onRetry }: RateLimitRetryProps) {
   return (
     <div className="flex items-center gap-3">
       <span className="text-xs text-zinc-600 dark:text-zinc-400">
-        {ready ? "Ready to retry." : `Retry available in ${seconds}s…`}
+        {ready ? "Retrying…" : `Auto-retrying in ${seconds}s…`}
       </span>
       <button
         type="button"
@@ -50,7 +52,7 @@ export function RateLimitRetry({ until, onRetry }: RateLimitRetryProps) {
         disabled={!ready}
         className="text-sm px-3 py-1 rounded border border-red-400 dark:border-red-600 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-red-100 dark:hover:bg-red-900/40"
       >
-        Retry
+        Retry now
       </button>
     </div>
   );

--- a/webui/src/components/voice/VoiceApp.test.tsx
+++ b/webui/src/components/voice/VoiceApp.test.tsx
@@ -249,7 +249,7 @@ describe("VoiceApp", () => {
     renderVoiceApp();
 
     expect(screen.getByText(/rate limit exceeded/i)).toBeDefined();
-    const retryBtn = screen.getByRole("button", { name: "Retry" });
+    const retryBtn = screen.getByRole("button", { name: "Retry now" });
 
     expect((retryBtn as HTMLButtonElement).disabled).toBe(false);
   });
@@ -266,10 +266,10 @@ describe("VoiceApp", () => {
     renderVoiceApp();
 
     expect(
-      (screen.getByRole("button", { name: "Retry" }) as HTMLButtonElement)
+      (screen.getByRole("button", { name: "Retry now" }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
-    expect(screen.getByText(/retry available in/i)).toBeDefined();
+    expect(screen.getByText(/auto-retrying in/i)).toBeDefined();
   });
 
   it("clicking Retry while ready calls retryResponse()", () => {
@@ -283,7 +283,7 @@ describe("VoiceApp", () => {
 
     renderVoiceApp();
 
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    fireEvent.click(screen.getByRole("button", { name: "Retry now" }));
     expect(session.retryResponse).toHaveBeenCalledOnce();
   });
 
@@ -302,7 +302,7 @@ describe("VoiceApp", () => {
     try {
       renderVoiceApp();
       const retryBtn = screen.getByRole("button", {
-        name: "Retry",
+        name: "Retry now",
       }) as HTMLButtonElement;
 
       expect(retryBtn.disabled).toBe(true);

--- a/webui/src/hooks/voice/tests/use-voice-session-controls.test.ts
+++ b/webui/src/hooks/voice/tests/use-voice-session-controls.test.ts
@@ -228,6 +228,65 @@ describe("useVoiceSession mute / interrupt / retry", () => {
     expect(result.current.error).toBeNull();
   });
 
+  it("sets a fallback retry window when the rate-limit wait is unparseable", async () => {
+    const { result, session } = await connectAndGetSession();
+
+    // No "try again in …" in the message — without a fallback this would leave a
+    // dead error banner with no retry path.
+    await act(() => {
+      session.emit("transport_event", {
+        type: "response.done",
+        response: {
+          status: "failed",
+          status_details: {
+            error: {
+              code: "rate_limit_exceeded",
+              message: "Rate limit reached. Please slow down.",
+            },
+          },
+        },
+      });
+    });
+    expect(result.current.rateLimitedUntil).not.toBeNull();
+  });
+
+  it("auto-retries once the rate-limit window elapses", async () => {
+    const { result, session } = await connectAndGetSession();
+
+    vi.useFakeTimers();
+
+    try {
+      await act(() => {
+        session.emit("transport_event", {
+          type: "response.done",
+          response: {
+            status: "failed",
+            status_details: {
+              error: {
+                code: "rate_limit_exceeded",
+                message: "Please try again in 166ms",
+              },
+            },
+          },
+        });
+      });
+      expect(result.current.rateLimitedUntil).not.toBeNull();
+      expect(session.transport.sendEvent).not.toHaveBeenCalled();
+
+      // Past the floor + safety buffer the session nudges itself to continue,
+      // no manual Retry click or user speech needed.
+      await act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(session.transport.sendEvent).toHaveBeenCalledWith({
+        type: "response.create",
+      });
+      expect(result.current.rateLimitedUntil).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("retryResponse surfaces SDK errors", async () => {
     const { result, session } = await connectAndGetSession();
 

--- a/webui/src/hooks/voice/tests/use-voice-session-helpers.test.ts
+++ b/webui/src/hooks/voice/tests/use-voice-session-helpers.test.ts
@@ -12,6 +12,7 @@ import {
   createPlaybackAudioElement,
   endHalfDuplexMute,
   extractResponseFailure,
+  parseRetrySeconds,
   setAudioVolume,
   teardownAudioElement,
 } from "#webui/hooks/voice/use-voice-session-helpers";
@@ -86,6 +87,36 @@ describe("extractResponseFailure", () => {
     expect(
       extractResponseFailure(doneEvent({ status: "incomplete" })),
     ).toBeNull();
+  });
+});
+
+describe("parseRetrySeconds", () => {
+  it("parses a fractional seconds wait", () => {
+    expect(
+      parseRetrySeconds("Rate limit reached. Please try again in 3.057s."),
+    ).toBeCloseTo(3.057);
+  });
+
+  it("parses a millisecond wait and normalizes to seconds", () => {
+    expect(
+      parseRetrySeconds("Rate limit reached. Please try again in 166ms."),
+    ).toBeCloseTo(0.166);
+  });
+
+  it("parses a minutes wait and normalizes to seconds", () => {
+    expect(parseRetrySeconds("Please try again in 2m.")).toBe(120);
+  });
+
+  it("tolerates whitespace between the value and unit", () => {
+    expect(parseRetrySeconds("Please try again in 5 s")).toBe(5);
+  });
+
+  it("does not match a bare unit inside a word like 'seconds'", () => {
+    expect(parseRetrySeconds("Please try again in 5 seconds")).toBeNull();
+  });
+
+  it("returns null when there is no parseable wait", () => {
+    expect(parseRetrySeconds("Rate limit reached. Try later.")).toBeNull();
   });
 });
 

--- a/webui/src/hooks/voice/tests/use-voice-session.test.ts
+++ b/webui/src/hooks/voice/tests/use-voice-session.test.ts
@@ -507,8 +507,9 @@ describe("useVoiceSession transport event handling", () => {
     expect(result.current.rateLimitedUntil).toBeNull();
   });
 
-  it("rate_limit_exceeded without a 'try again in Xs' pattern keeps rateLimitedUntil=null", async () => {
+  it("rate_limit_exceeded without a 'try again in Xs' pattern still sets a fallback countdown", async () => {
     const { result, session } = await connectAndGetSession();
+    const before = Date.now();
 
     await emitResponseFailure(
       session,
@@ -516,8 +517,11 @@ describe("useVoiceSession transport event handling", () => {
       "Rate limit exceeded (no retry hint).",
     );
 
+    // A rate limit with no parseable wait must still arm the retry path rather
+    // than leaving a dead error banner with no way forward.
     expect(result.current.error).toMatch(/rate limit/i);
-    expect(result.current.rateLimitedUntil).toBeNull();
+    expect(result.current.rateLimitedUntil).not.toBeNull();
+    expect(result.current.rateLimitedUntil!).toBeGreaterThan(before);
   });
 
   it("a successful response.done clears a prior rate-limit indicator", async () => {

--- a/webui/src/hooks/voice/use-voice-session-helpers.ts
+++ b/webui/src/hooks/voice/use-voice-session-helpers.ts
@@ -134,19 +134,36 @@ export function extractResponseFailure(event: unknown): ResponseFailure | null {
   return null;
 }
 
+// How many seconds each rate-limit unit normalizes to. OpenAI reports the wait
+// as "166ms", "3.057s", or (rarely) "2m"; all three flow through the same
+// countdown/auto-retry path once normalized to seconds.
+const RETRY_UNIT_SECONDS: Record<string, number> = { ms: 0.001, s: 1, m: 60 };
+
+// Fallback wait when a rate_limit_exceeded message carries no parseable time, so
+// the retry UI still renders and auto-retry still arms instead of leaving a dead
+// error banner with no path forward.
+export const DEFAULT_RATE_LIMIT_BACKOFF_SECONDS = 2;
+
 /**
- * Parse "...Please try again in 15.796s..." from an OpenAI rate-limit message.
+ * Parse the wait from an OpenAI rate-limit message — "...Please try again in
+ * 15.796s...", "...in 166ms...", or "...in 2m..." — and normalize to seconds.
+ * The unit alternation is ordered ms|m|s so the two-char "ms" wins over a bare
+ * "s"/"m", and the trailing \b stops "s"/"m" from matching inside a word like
+ * "seconds".
  *
  * @param message - The rate-limit error message
  * @returns Seconds to wait, or null if not parseable
  */
 export function parseRetrySeconds(message: string): number | null {
-  const match = /try again in ([\d.]+)s/i.exec(message);
+  const match = /try again in ([\d.]+)\s*(ms|m|s)\b/i.exec(message);
 
   if (!match?.[1]) return null;
-  const seconds = Number.parseFloat(match[1]);
+  const value = Number.parseFloat(match[1]);
 
-  return Number.isFinite(seconds) ? seconds : null;
+  if (!Number.isFinite(value)) return null;
+  const multiplier = RETRY_UNIT_SECONDS[match[2]?.toLowerCase() ?? "s"] ?? 1;
+
+  return value * multiplier;
 }
 
 /** Minimal session surface the transport helpers need (mic mute control). */
@@ -281,11 +298,13 @@ function applyResponseFailure(
   deps.setError(failure.message);
 
   if (failure.code === "rate_limit_exceeded") {
-    const seconds = parseRetrySeconds(failure.message);
+    // Always set the window — fall back to a default when the wait can't be
+    // parsed — so the retry UI renders and auto-retry arms even for a
+    // sub-second/unparseable wait (no dead banner).
+    const seconds =
+      parseRetrySeconds(failure.message) ?? DEFAULT_RATE_LIMIT_BACKOFF_SECONDS;
 
-    if (seconds != null) {
-      deps.setRateLimitedUntil(Date.now() + seconds * 1000);
-    }
+    deps.setRateLimitedUntil(Date.now() + seconds * 1000);
   }
 }
 

--- a/webui/src/hooks/voice/use-voice-session.ts
+++ b/webui/src/hooks/voice/use-voice-session.ts
@@ -36,6 +36,13 @@ import {
   getVoiceLanguage,
 } from "#webui/lib/constants/voice-language";
 
+// Auto-retry timing. Fire a touch past the server-indicated wait (buffer), but
+// never spin faster than the floor even when the server reports a sub-second
+// wait (or none), so a rate-limit storm can't become a tight retry loop. The
+// server's wait — which grows on repeated limits — is the primary throttle.
+const AUTO_RETRY_SAFETY_BUFFER_MS = 300;
+const AUTO_RETRY_MIN_DELAY_MS = 1000;
+
 export type VoiceStatus =
   | "idle"
   | "connecting"
@@ -449,6 +456,10 @@ export function useVoiceSession(
     }
   }, []);
 
+  // Auto-nudge the model to continue once a rate-limit window elapses, so
+  // hands-free voice recovers without a manual click or the user speaking again.
+  useRateLimitAutoRetry(rateLimitedUntil, retryResponse);
+
   // Push live volume changes mid-session (no Stop → Talk needed, unlike speed):
   // drive the GainNode (active path, can boost above unity) and keep element
   // .volume in sync for the no-Web-Audio fallback (capped at 1.0).
@@ -476,6 +487,34 @@ export function useVoiceSession(
     resetHistory: () => setHistory([]),
     activeVoice,
   };
+}
+
+/**
+ * Auto-retry a rate-limited response once its window elapses. Fires a touch past
+ * the server-indicated wait, but never faster than a floor, so a sub-second (or
+ * unparseable, fallback) wait can't spin into a tight retry loop — the server's
+ * wait, which grows on repeated limits, is the primary throttle. retryResponse()
+ * no-ops once the session is torn down, so a timer that outlives the session is
+ * harmless (and the effect clears it on unmount / re-arm anyway).
+ *
+ * @param rateLimitedUntil - Epoch ms the limit clears, or null when not limited
+ * @param retryResponse - Nudges the server to generate the next response
+ */
+function useRateLimitAutoRetry(
+  rateLimitedUntil: number | null,
+  retryResponse: () => void,
+): void {
+  useEffect(() => {
+    if (rateLimitedUntil == null) return;
+
+    const delay = Math.max(
+      AUTO_RETRY_MIN_DELAY_MS,
+      rateLimitedUntil - Date.now() + AUTO_RETRY_SAFETY_BUFFER_MS,
+    );
+    const id = setTimeout(() => retryResponse(), delay);
+
+    return () => clearTimeout(id);
+  }, [rateLimitedUntil, retryResponse]);
 }
 
 /**


### PR DESCRIPTION
## Summary

Two tightly-coupled fixes for hands-free realtime voice (OpenAI) rate limiting:

- **Auto-retry rate-limited responses** instead of requiring a manual Retry click. Once the rate-limit window elapses the session nudges the model to continue on its own — correct for a voice-first, hands-free flow.
- **Parse sub-second waits.** `parseRetrySeconds` only matched seconds, so "try again in 166ms" returned null, no retry UI rendered, and the banner only self-healed if the user happened to speak again.

## Changes

- `parseRetrySeconds` parses `ms`/`s`/`m` and normalizes to seconds. Alternation ordered `ms|m|s` (so `166ms` beats a bare `s`) with a trailing `\b` (so "seconds" doesn't false-match).
- A rate limit with no parseable wait now arms a 2s fallback window rather than leaving a dead error banner with no path forward.
- New `useRateLimitAutoRetry` hook fires `retryResponse()` past the server-indicated wait, with a 300ms safety buffer and a 1s floor so a sub-second/unparseable wait can't spin into a tight loop. The server's (growing) wait is the primary throttle. `retryResponse()` no-ops after teardown, respecting the stale-session guards.
- `RateLimitRetry` is now a status display ("Auto-retrying in Ns…") with a manual "Retry now" fallback for the re-limited case.
- Gemini Live untouched (it has its own resume/backoff path).

## Testing

- `npm run check` ✓ (100% function coverage), `npm run check:build` ✓, `npm run ui:test` ✓
- Added: `parseRetrySeconds` unit cases (ms/s/m/whitespace/word-boundary/null), fallback-window test, fake-timer auto-retry test; updated the prior dead-banner test and `VoiceApp` copy assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)