### PR TITLE
feat(chat): re-emit signed thinking blocks for cross-turn caching

### DIFF
--- a/webui/src/chat/sdk/build-model-messages.ts
+++ b/webui/src/chat/sdk/build-model-messages.ts
@@ -1,0 +1,234 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type ReasoningPart } from "@ai-sdk/provider-utils";
+import {
+  type ModelMessage,
+  type TextPart,
+  type ToolCallPart,
+  type ToolResultPart,
+} from "ai";
+import { type ChatMessage } from "./types";
+
+/**
+ * Placeholder result for a tool call the user stopped before it returned.
+ * Used both to keep the model conversation valid (every tool-call needs a
+ * matching tool-result or providers 400) and to render a sensible UI state.
+ */
+const CANCELED_TOOL_RESULT_TEXT =
+  "Canceled by the user before this tool finished.";
+
+/**
+ * Convert chat history to AI SDK ModelMessage format.
+ * Assistant messages with tool calls produce two ModelMessages:
+ * 1. assistant message with text + tool-call parts
+ * 2. tool message with tool-result parts
+ *
+ * Compaction keeps the prior turns in `history` for display but inserts a
+ * synthetic summary marker (`isCompactionSummary`). The model only needs the
+ * most recent summary plus everything after it, so we start the payload at the
+ * last summary marker — earlier turns are dropped from the model view only,
+ * while the UI still renders them above the divider.
+ *
+ * Consecutive user turns are merged into one. A compaction summary is a
+ * synthetic user message, so the next real user message would otherwise sit
+ * directly after it — Gemini and Mistral reject two user turns in a row (only
+ * Anthropic/OpenAI tolerate it). Folding them into a single user turn keeps the
+ * wire format valid for every provider while the UI still renders them
+ * separately (the divider plus the user bubble).
+ * @param history - Chat history to convert
+ * @param includeReasoning - When true, re-emit captured signed reasoning blocks
+ *   on assistant messages (only valid when the request enables thinking — see
+ *   isAnthropicThinkingEnabled). Keeps the Anthropic cache prefix byte-stable
+ *   across turns. Defaults to false so non-thinking requests are unchanged.
+ * @returns Array of ModelMessage for streamText
+ */
+export function buildModelMessages(
+  history: ChatMessage[],
+  includeReasoning = false,
+): ModelMessage[] {
+  const messages: ModelMessage[] = [];
+
+  // Start from the most recent compaction summary; everything before it is
+  // display-only history that the model should not see.
+  let lastSummaryIndex = -1;
+
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i]?.isCompactionSummary) {
+      lastSummaryIndex = i;
+      break;
+    }
+  }
+
+  const modelHistory =
+    lastSummaryIndex > 0 ? history.slice(lastSummaryIndex) : history;
+
+  for (const msg of modelHistory) {
+    if (msg.role === "user") {
+      const last = messages.at(-1);
+
+      if (last?.role === "user" && typeof last.content === "string") {
+        last.content = `${last.content}\n\n${msg.content}`;
+      } else {
+        messages.push({ role: "user", content: msg.content });
+      }
+
+      continue;
+    }
+
+    // Persisted UI error messages are not part of the model conversation
+    if (msg.isError) continue;
+
+    const emitReasoning =
+      includeReasoning &&
+      (msg.reasoningParts ?? []).some(
+        (p) => p.signature != null || p.redactedData != null,
+      );
+
+    if (!msg.toolCalls || msg.toolCalls.length === 0) {
+      // Plain string unless we need to carry reasoning blocks (which require the
+      // structured content form).
+      messages.push({
+        role: "assistant",
+        content: emitReasoning ? buildAssistantContent(msg, true) : msg.content,
+      });
+      continue;
+    }
+
+    // Assistant message with tool calls
+    messages.push({
+      role: "assistant",
+      content: buildAssistantContent(msg, emitReasoning),
+    });
+
+    // Tool message pairing EVERY tool-call with a result (required by providers
+    // for multi-turn). buildToolResultContent backfills a canceled result for
+    // any call the user stopped before it returned, so a persisted "stopped
+    // mid-tool" history can still be sent without a provider 400. (This runs
+    // before the stream's reconcile, so it must not assume a complete history.)
+    messages.push({
+      role: "tool",
+      content: buildToolResultContent(msg),
+    });
+  }
+
+  return messages;
+}
+
+/**
+ * Backfill a "canceled" tool-result for any tool-call in the streamed assistant
+ * messages that never received one — i.e. the user pressed Stop while a tool was
+ * still running. Without this, the dangling tool-call (a) makes the next request
+ * fail with a provider 400 (unmatched tool_use) and (b) leaves the tool rendered
+ * as perpetually running in the UI. A no-op when every call already has a result.
+ * @param history - The full chat history (mutated in place)
+ * @param fromIndex - Index of the first message added by the current stream
+ */
+export function reconcileDanglingToolCalls(
+  history: ChatMessage[],
+  fromIndex: number,
+): void {
+  for (let i = fromIndex; i < history.length; i++) {
+    const msg = history[i] as ChatMessage;
+
+    if (msg.role !== "assistant" || !msg.toolCalls?.length) continue;
+
+    const resultIds = new Set((msg.toolResults ?? []).map((tr) => tr.id));
+
+    for (const tc of msg.toolCalls) {
+      if (resultIds.has(tc.id)) continue;
+
+      msg.toolResults ??= [];
+      msg.toolResults.push({
+        id: tc.id,
+        name: tc.name,
+        args: tc.args,
+        result: CANCELED_TOOL_RESULT_TEXT,
+        isError: false,
+      });
+    }
+  }
+}
+
+/**
+ * Build tool result content for the tool role message, one part per tool-call
+ * (not per recorded result). A call with a recorded result emits it; a call the
+ * user stopped before it returned emits a synthetic "canceled" result. This
+ * guarantees no assistant tool-call is left without a matching tool-result,
+ * which Anthropic/OpenAI reject with a 400.
+ * @param msg - Assistant message with tool calls
+ * @returns Array of ToolResultPart, one per tool-call, in tool-call order
+ */
+function buildToolResultContent(msg: ChatMessage): ToolResultPart[] {
+  const resultsById = new Map(
+    (msg.toolResults ?? []).map((tr) => [tr.id, tr] as const),
+  );
+
+  return (msg.toolCalls ?? []).map((tc) => {
+    const tr = resultsById.get(tc.id);
+    const value =
+      tr == null
+        ? CANCELED_TOOL_RESULT_TEXT
+        : typeof tr.result === "string"
+          ? tr.result
+          : JSON.stringify(tr.result);
+
+    return {
+      type: "tool-result" as const,
+      toolCallId: tc.id,
+      toolName: tc.name,
+      output: { type: "text" as const, value },
+    };
+  });
+}
+
+/**
+ * Build typed AI SDK content parts for an assistant message. Reasoning blocks
+ * (when requested) come first — Anthropic renders the thinking block ahead of
+ * text/tool_use, and re-sending the signed block verbatim is what keeps the
+ * request prefix byte-stable across turns for prompt caching.
+ * @param msg - Assistant message
+ * @param includeReasoning - Whether to prepend captured signed reasoning blocks
+ * @returns Structured content array
+ */
+function buildAssistantContent(
+  msg: ChatMessage,
+  includeReasoning: boolean,
+): Array<ReasoningPart | TextPart | ToolCallPart> {
+  const parts: Array<ReasoningPart | TextPart | ToolCallPart> = [];
+
+  if (includeReasoning) {
+    for (const rp of msg.reasoningParts ?? []) {
+      if (rp.signature != null) {
+        parts.push({
+          type: "reasoning",
+          text: rp.text,
+          providerOptions: { anthropic: { signature: rp.signature } },
+        });
+      } else if (rp.redactedData != null) {
+        parts.push({
+          type: "reasoning",
+          text: "",
+          providerOptions: { anthropic: { redactedData: rp.redactedData } },
+        });
+      }
+    }
+  }
+
+  if (msg.content) {
+    parts.push({ type: "text", text: msg.content });
+  }
+
+  for (const tc of msg.toolCalls ?? []) {
+    parts.push({
+      type: "tool-call",
+      toolCallId: tc.id,
+      toolName: tc.name,
+      input: tc.args,
+    });
+  }
+
+  return parts;
+}

--- a/webui/src/chat/sdk/client.ts
+++ b/webui/src/chat/sdk/client.ts
@@ -4,32 +4,19 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { type Client } from "@modelcontextprotocol/sdk/client/index.js";
-import {
-  type FinishReason,
-  type ModelMessage,
-  type TextPart,
-  type ToolCallPart,
-  type ToolResultPart,
-  type ToolSet,
-  stepCountIs,
-  streamText,
-} from "ai";
+import { type FinishReason, type ToolSet, stepCountIs, streamText } from "ai";
 import { type MessageOverrides } from "#webui/hooks/chat/use-chat-types";
 import { getMcpUrl } from "#webui/utils/mcp-url";
+import {
+  buildModelMessages,
+  reconcileDanglingToolCalls,
+} from "./build-model-messages";
 import { summarizeHistory } from "./compaction";
 import { createMcpTools } from "./mcp-tools";
 import { createStreamErrorSignal } from "./stream-with-error-signal";
 import { type ChatClientConfig, type ChatMessage, toTokenUsage } from "./types";
 
 const MAX_TOOL_STEPS = 10;
-
-/**
- * Placeholder result for a tool call the user stopped before it returned.
- * Used both to keep the model conversation valid (every tool-call needs a
- * matching tool-result or providers 400) and to render a sensible UI state.
- */
-const CANCELED_TOOL_RESULT_TEXT =
-  "Canceled by the user before this tool finished.";
 
 /**
  * AI SDK client that wraps streamText for chat with MCP tool support.
@@ -157,7 +144,10 @@ export class ChatSdkClient {
       model: this.config.model,
       maxRetries: 0, // Disable SDK-level retry so app-level retry (executeWithRetry) handles 429s with UI feedback
       system: this.config.systemInstruction,
-      messages: buildModelMessages(this.chatHistory),
+      messages: buildModelMessages(
+        this.chatHistory,
+        isAnthropicThinkingEnabled(providerOptions),
+      ),
       tools: Object.keys(this.tools).length > 0 ? this.tools : undefined,
       stopWhen: stepCountIs(MAX_TOOL_STEPS),
       temperature: this.config.temperature,
@@ -250,6 +240,23 @@ export function detectToolLimitReached(
 }
 
 /**
+ * Whether the request's provider options enable Anthropic thinking. Only then is
+ * it valid to re-send signed reasoning blocks (the API rejects reasoning content
+ * when thinking is disabled), and only then does re-sending help caching.
+ * @param providerOptions - Provider options passed to streamText
+ * @returns True when Anthropic thinking is enabled for this request
+ */
+function isAnthropicThinkingEnabled(
+  providerOptions: Parameters<typeof streamText>[0]["providerOptions"],
+): boolean {
+  const anthropic = providerOptions?.anthropic as
+    | { thinking?: unknown }
+    | undefined;
+
+  return anthropic?.thinking != null;
+}
+
+/**
  * Stamp per-message setting overrides onto a user message.
  * Only sets fields that are present in the overrides.
  * @param msg - User message to stamp
@@ -279,10 +286,38 @@ function handleStreamPart(
     return true;
   }
 
+  // Reasoning arrives as start → delta(s) → end. We keep the flattened text in
+  // `reasoning` for display AND capture each block (text + signature) in
+  // `reasoningParts` so the signed thinking block can be re-sent on later turns
+  // (see buildAssistantContent — keeps the Anthropic cache prefix stable).
+  if (type === "reasoning-start") {
+    msg.reasoningParts ??= [];
+    msg.reasoningParts.push({ text: "" });
+    captureReasoningSignature(part, msg);
+
+    return false;
+  }
+
   if (type === "reasoning-delta") {
-    msg.reasoning = (msg.reasoning ?? "") + (part.text as string);
+    const text = part.text as string;
+
+    msg.reasoning = (msg.reasoning ?? "") + text;
+    msg.reasoningParts ??= [];
+
+    if (msg.reasoningParts.length === 0) msg.reasoningParts.push({ text: "" });
+
+    const last = msg.reasoningParts.at(-1) as { text: string };
+
+    last.text += text;
+    captureReasoningSignature(part, msg);
 
     return true;
+  }
+
+  if (type === "reasoning-end") {
+    captureReasoningSignature(part, msg);
+
+    return false;
   }
 
   if (type === "tool-call") {
@@ -347,175 +382,28 @@ function handleStreamPart(
 }
 
 /**
- * Convert chat history to AI SDK ModelMessage format.
- * Assistant messages with tool calls produce two ModelMessages:
- * 1. assistant message with text + tool-call parts
- * 2. tool message with tool-result parts
- *
- * Compaction keeps the prior turns in `history` for display but inserts a
- * synthetic summary marker (`isCompactionSummary`). The model only needs the
- * most recent summary plus everything after it, so we start the payload at the
- * last summary marker — earlier turns are dropped from the model view only,
- * while the UI still renders them above the divider.
- *
- * Consecutive user turns are merged into one. A compaction summary is a
- * synthetic user message, so the next real user message would otherwise sit
- * directly after it — Gemini and Mistral reject two user turns in a row (only
- * Anthropic/OpenAI tolerate it). Folding them into a single user turn keeps the
- * wire format valid for every provider while the UI still renders them
- * separately (the divider plus the user bubble).
- * @param history - Chat history to convert
- * @returns Array of ModelMessage for streamText
+ * Capture an Anthropic reasoning block's signature (or redacted data) from a
+ * stream part's provider metadata onto the message's current reasoning block.
+ * @param part - Stream part (reasoning-start/delta/end)
+ * @param msg - Message whose last reasoning block receives the signature
  */
-export function buildModelMessages(history: ChatMessage[]): ModelMessage[] {
-  const messages: ModelMessage[] = [];
-
-  // Start from the most recent compaction summary; everything before it is
-  // display-only history that the model should not see.
-  let lastSummaryIndex = -1;
-
-  for (let i = history.length - 1; i >= 0; i--) {
-    if (history[i]?.isCompactionSummary) {
-      lastSummaryIndex = i;
-      break;
-    }
-  }
-
-  const modelHistory =
-    lastSummaryIndex > 0 ? history.slice(lastSummaryIndex) : history;
-
-  for (const msg of modelHistory) {
-    if (msg.role === "user") {
-      const last = messages.at(-1);
-
-      if (last?.role === "user" && typeof last.content === "string") {
-        last.content = `${last.content}\n\n${msg.content}`;
-      } else {
-        messages.push({ role: "user", content: msg.content });
-      }
-
-      continue;
-    }
-
-    // Persisted UI error messages are not part of the model conversation
-    if (msg.isError) continue;
-
-    if (!msg.toolCalls || msg.toolCalls.length === 0) {
-      messages.push({ role: "assistant", content: msg.content });
-      continue;
-    }
-
-    // Assistant message with tool calls
-    messages.push({
-      role: "assistant",
-      content: buildAssistantContent(msg),
-    });
-
-    // Tool message pairing EVERY tool-call with a result (required by providers
-    // for multi-turn). buildToolResultContent backfills a canceled result for
-    // any call the user stopped before it returned, so a persisted "stopped
-    // mid-tool" history can still be sent without a provider 400. (This runs
-    // before the stream's reconcile, so it must not assume a complete history.)
-    messages.push({
-      role: "tool",
-      content: buildToolResultContent(msg),
-    });
-  }
-
-  return messages;
-}
-
-/**
- * Build tool result content for the tool role message, one part per tool-call
- * (not per recorded result). A call with a recorded result emits it; a call the
- * user stopped before it returned emits a synthetic "canceled" result. This
- * guarantees no assistant tool-call is left without a matching tool-result,
- * which Anthropic/OpenAI reject with a 400.
- * @param msg - Assistant message with tool calls
- * @returns Array of ToolResultPart, one per tool-call, in tool-call order
- */
-function buildToolResultContent(msg: ChatMessage): ToolResultPart[] {
-  const resultsById = new Map(
-    (msg.toolResults ?? []).map((tr) => [tr.id, tr] as const),
-  );
-
-  return (msg.toolCalls ?? []).map((tc) => {
-    const tr = resultsById.get(tc.id);
-    const value =
-      tr == null
-        ? CANCELED_TOOL_RESULT_TEXT
-        : typeof tr.result === "string"
-          ? tr.result
-          : JSON.stringify(tr.result);
-
-    return {
-      type: "tool-result" as const,
-      toolCallId: tc.id,
-      toolName: tc.name,
-      output: { type: "text" as const, value },
-    };
-  });
-}
-
-/**
- * Backfill a "canceled" tool-result for any tool-call in the streamed assistant
- * messages that never received one — i.e. the user pressed Stop while a tool was
- * still running. Without this, the dangling tool-call (a) makes the next request
- * fail with a provider 400 (unmatched tool_use) and (b) leaves the tool rendered
- * as perpetually running in the UI. A no-op when every call already has a result.
- * @param history - The full chat history (mutated in place)
- * @param fromIndex - Index of the first message added by the current stream
- */
-function reconcileDanglingToolCalls(
-  history: ChatMessage[],
-  fromIndex: number,
-): void {
-  for (let i = fromIndex; i < history.length; i++) {
-    const msg = history[i] as ChatMessage;
-
-    if (msg.role !== "assistant" || !msg.toolCalls?.length) continue;
-
-    const resultIds = new Set((msg.toolResults ?? []).map((tr) => tr.id));
-
-    for (const tc of msg.toolCalls) {
-      if (resultIds.has(tc.id)) continue;
-
-      msg.toolResults ??= [];
-      msg.toolResults.push({
-        id: tc.id,
-        name: tc.name,
-        args: tc.args,
-        result: CANCELED_TOOL_RESULT_TEXT,
-        isError: false,
-      });
-    }
-  }
-}
-
-/**
- * Build typed AI SDK content parts for an assistant message with tool calls.
- * @param msg - Assistant message with tool calls
- * @returns Structured content array
- */
-function buildAssistantContent(
+function captureReasoningSignature(
+  part: Record<string, unknown>,
   msg: ChatMessage,
-): Array<TextPart | ToolCallPart> {
-  const parts: Array<TextPart | ToolCallPart> = [];
+): void {
+  const providerMetadata = part.providerMetadata as
+    | { anthropic?: { signature?: unknown; redactedData?: unknown } }
+    | undefined;
+  const meta = providerMetadata?.anthropic;
+  const last = msg.reasoningParts?.at(-1);
 
-  if (msg.content) {
-    parts.push({ type: "text", text: msg.content });
+  if (!meta || !last) return;
+
+  if (typeof meta.signature === "string") last.signature = meta.signature;
+
+  if (typeof meta.redactedData === "string") {
+    last.redactedData = meta.redactedData;
   }
-
-  for (const tc of msg.toolCalls ?? []) {
-    parts.push({
-      type: "tool-call",
-      toolCallId: tc.id,
-      toolName: tc.name,
-      input: tc.args,
-    });
-  }
-
-  return parts;
 }
 
 /**

--- a/webui/src/chat/sdk/tests/build-model-messages.test.ts
+++ b/webui/src/chat/sdk/tests/build-model-messages.test.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
-import { buildModelMessages } from "#webui/chat/sdk/client";
+import { buildModelMessages } from "#webui/chat/sdk/build-model-messages";
 
 describe("buildModelMessages", () => {
   it("merges consecutive user turns into a single user message", () => {
@@ -106,5 +106,100 @@ describe("buildModelMessages", () => {
       { role: "user", content: "u1" },
       { role: "assistant", content: "a1" },
     ]);
+  });
+
+  describe("reasoning re-emission", () => {
+    const withReasoning = {
+      role: "assistant" as const,
+      content: "answer",
+      reasoningParts: [{ text: "thinking", signature: "sig-1" }],
+    };
+
+    it("re-emits a signed reasoning block before the text when enabled", () => {
+      const result = buildModelMessages([withReasoning], true);
+
+      expect(result[0]!.content).toStrictEqual([
+        {
+          type: "reasoning",
+          text: "thinking",
+          providerOptions: { anthropic: { signature: "sig-1" } },
+        },
+        { type: "text", text: "answer" },
+      ]);
+    });
+
+    it("re-emits reasoning before tool calls", () => {
+      const result = buildModelMessages(
+        [
+          {
+            role: "assistant",
+            content: "",
+            toolCalls: [{ id: "t1", name: "read-song", args: {} }],
+            toolResults: [
+              { id: "t1", name: "read-song", args: {}, result: "ok" },
+            ],
+            reasoningParts: [{ text: "plan", signature: "sig-2" }],
+          },
+        ],
+        true,
+      );
+
+      expect(result[0]!.content).toStrictEqual([
+        {
+          type: "reasoning",
+          text: "plan",
+          providerOptions: { anthropic: { signature: "sig-2" } },
+        },
+        {
+          type: "tool-call",
+          toolCallId: "t1",
+          toolName: "read-song",
+          input: {},
+        },
+      ]);
+    });
+
+    it("re-emits redacted reasoning as an empty block", () => {
+      const result = buildModelMessages(
+        [
+          {
+            role: "assistant",
+            content: "answer",
+            reasoningParts: [{ text: "", redactedData: "redacted-blob" }],
+          },
+        ],
+        true,
+      );
+
+      expect(result[0]!.content).toStrictEqual([
+        {
+          type: "reasoning",
+          text: "",
+          providerOptions: { anthropic: { redactedData: "redacted-blob" } },
+        },
+        { type: "text", text: "answer" },
+      ]);
+    });
+
+    it("keeps plain string content when reasoning is not requested", () => {
+      const result = buildModelMessages([withReasoning], false);
+
+      expect(result[0]!.content).toBe("answer");
+    });
+
+    it("keeps plain string content when a block has no signature", () => {
+      const result = buildModelMessages(
+        [
+          {
+            role: "assistant",
+            content: "answer",
+            reasoningParts: [{ text: "t" }],
+          },
+        ],
+        true,
+      );
+
+      expect(result[0]!.content).toBe("answer");
+    });
   });
 });

--- a/webui/src/chat/sdk/tests/client-reasoning.test.ts
+++ b/webui/src/chat/sdk/tests/client-reasoning.test.ts
@@ -1,0 +1,201 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Focused coverage for adaptive-thinking reasoning handling: capturing the
+ * Anthropic signature off the stream into `reasoningParts`, and re-emitting the
+ * signed block on later turns ONLY when the request enables thinking. Re-sending
+ * the signed thinking block keeps the request prefix byte-stable so the
+ * conversation (incl. the ppal-connect skills result) stays prompt-cached.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { type ChatClientConfig, type ChatMessage } from "#webui/chat/sdk/types";
+
+// Mock streamText from ai
+vi.mock(import("ai"), async (importOriginal) => {
+  const actual = await importOriginal();
+
+  return {
+    ...actual,
+    streamText: vi.fn(),
+    generateText: vi.fn(),
+  };
+});
+
+// Mock MCP tools
+vi.mock(import("#webui/chat/sdk/mcp-tools"), () => ({
+  createMcpTools: vi.fn().mockResolvedValue({ tools: {}, mcpClient: {} }),
+}));
+
+// Mock getMcpUrl
+vi.mock(import("#webui/utils/mcp-url"), () => ({
+  getMcpUrl: vi.fn(() => "http://localhost:3000/mcp"),
+}));
+
+import { streamText } from "ai";
+import { ChatSdkClient } from "#webui/chat/sdk/client";
+
+/**
+ * Create a mock config.
+ * @param overrides - Config overrides
+ * @returns Mock ChatClientConfig
+ */
+function createConfig(overrides?: Partial<ChatClientConfig>): ChatClientConfig {
+  return {
+    model: {
+      modelId: "test",
+      provider: "anthropic",
+      specificationVersion: "v3",
+    } as never,
+    showThoughts: false,
+    ...overrides,
+  };
+}
+
+/**
+ * Send a message through a new client with mocked stream parts.
+ * @param parts - Stream parts to emit
+ * @returns Final chat history
+ */
+async function sendWithParts(
+  parts: Record<string, unknown>[],
+): Promise<ChatMessage[]> {
+  async function* iterate(): AsyncIterable<Record<string, unknown>> {
+    for (const p of parts) yield p;
+  }
+
+  (streamText as ReturnType<typeof vi.fn>).mockReturnValue({
+    fullStream: iterate(),
+  });
+
+  const client = new ChatSdkClient("key", createConfig());
+  let last: ChatMessage[] = [];
+
+  for await (const history of client.sendMessage("Hello")) {
+    last = history;
+  }
+
+  return last;
+}
+
+/**
+ * Send a message with pre-seeded chat history and an empty stream, returning the
+ * arguments streamText was called with (so the built model messages can be asserted).
+ * @param chatHistory - Pre-seeded chat history
+ * @param providerOptions - Provider options forwarded to the client config
+ * @returns The first call arguments passed to streamText
+ */
+async function sendWithHistory(
+  chatHistory: ChatMessage[],
+  providerOptions?: ChatClientConfig["providerOptions"],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test helper accessing mock internals
+): Promise<Record<string, any>> {
+  async function* empty(): AsyncIterable<Record<string, unknown>> {}
+
+  (streamText as ReturnType<typeof vi.fn>).mockReturnValue({
+    fullStream: empty(),
+  });
+
+  const client = new ChatSdkClient(
+    "key",
+    createConfig({ chatHistory, providerOptions }),
+  );
+
+  for await (const _ of client.sendMessage("Next")) {
+    /* consume */
+  }
+
+  return (streamText as ReturnType<typeof vi.fn>).mock.calls[0]![0];
+}
+
+const SIGNED_ASSISTANT: ChatMessage = {
+  role: "assistant",
+  content: "Done",
+  reasoning: "pondering",
+  reasoningParts: [{ text: "pondering", signature: "sig-1" }],
+};
+
+describe("ChatSdkClient reasoning (adaptive thinking)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("signature capture from the stream", () => {
+    it("captures a signature from reasoning-end onto the reasoning block", async () => {
+      const last = await sendWithParts([
+        { type: "reasoning-start" },
+        { type: "reasoning-delta", text: "Think" },
+        {
+          type: "reasoning-end",
+          providerMetadata: { anthropic: { signature: "sig-1" } },
+        },
+        { type: "text-delta", text: "Answer" },
+      ]);
+
+      expect(last[1]!.reasoning).toBe("Think");
+      expect(last[1]!.reasoningParts).toStrictEqual([
+        { text: "Think", signature: "sig-1" },
+      ]);
+    });
+
+    it("captures redactedData from a reasoning-start part", async () => {
+      const last = await sendWithParts([
+        {
+          type: "reasoning-start",
+          providerMetadata: { anthropic: { redactedData: "blob" } },
+        },
+        { type: "text-delta", text: "Answer" },
+      ]);
+
+      expect(last[1]!.reasoningParts).toStrictEqual([
+        { text: "", redactedData: "blob" },
+      ]);
+    });
+
+    it("ignores reasoning metadata when there is no reasoning block yet", async () => {
+      // reasoning-end with no preceding start/delta: nothing to attach to, no throw.
+      const last = await sendWithParts([
+        {
+          type: "reasoning-end",
+          providerMetadata: { anthropic: { signature: "sig-x" } },
+        },
+        { type: "text-delta", text: "Answer" },
+      ]);
+
+      expect(last[1]!.reasoningParts).toBeUndefined();
+      expect(last[1]!.content).toBe("Answer");
+    });
+  });
+
+  describe("re-emission gating", () => {
+    it("re-emits signed reasoning blocks when the request enables thinking", async () => {
+      const callArgs = await sendWithHistory(
+        [{ role: "user", content: "Think hard" }, SIGNED_ASSISTANT],
+        { anthropic: { thinking: { type: "adaptive" } } },
+      );
+
+      // assistant content becomes structured parts with the signed reasoning first
+      expect(callArgs.messages[1].content).toStrictEqual([
+        {
+          type: "reasoning",
+          text: "pondering",
+          providerOptions: { anthropic: { signature: "sig-1" } },
+        },
+        { type: "text", text: "Done" },
+      ]);
+    });
+
+    it("keeps assistant content a plain string when thinking is disabled", async () => {
+      // No providerOptions → thinking disabled → reasoning must NOT be re-sent
+      // (the API rejects reasoning content when thinking is off).
+      const callArgs = await sendWithHistory([
+        { role: "user", content: "Think hard" },
+        SIGNED_ASSISTANT,
+      ]);
+
+      expect(callArgs.messages[1].content).toBe("Done");
+    });
+  });
+});

--- a/webui/src/chat/sdk/types.ts
+++ b/webui/src/chat/sdk/types.ts
@@ -31,6 +31,19 @@ export interface ChatMessage {
     isError?: boolean;
   }>;
   reasoning?: string;
+  /**
+   * Structured reasoning blocks with provider signatures, captured from the
+   * stream so they can be re-emitted verbatim on later turns. Re-sending the
+   * signed thinking blocks keeps the Anthropic request prefix byte-stable across
+   * turns, so the conversation history (incl. the ppal-connect skills result)
+   * stays prompt-cached when adaptive thinking is on. `reasoning` holds the same
+   * text flattened for display.
+   */
+  reasoningParts?: Array<{
+    text: string;
+    signature?: string;
+    redactedData?: string;
+  }>;
   /** Model ID from the API response (assistant messages only) */
   responseModel?: string;
   /** Token usage from the API response (assistant messages only) */


### PR DESCRIPTION
## Problem

Prompt caching for the chat shipped, but with **adaptive thinking ON** (the common case) cross-turn cache reads stopped at the static head (tools+system, ~12k). The assistant tool-call turn carries a thinking block Anthropic requires in-turn, but the AI SDK dropped it across turns — so the request prefix diverged right after that turn and the ~9k ppal-connect **skills result** (downstream of it) was re-written every turn instead of read from cache.

## Fix

Capture the Anthropic reasoning **signature** (`providerMetadata.anthropic.signature` / `redactedData`) off the stream into `reasoningParts`, and re-emit the signed thinking block on later turns so the request prefix stays byte-stable and the whole conversation — including the skills result — stays cached.

Re-emission is **gated on thinking being enabled** (`isAnthropicThinkingEnabled`): the API 400s on reasoning content when thinking is off, and there's nothing to recover there anyway.

`build-model-messages.ts` is extracted out of `client.ts` (it was over the 325-line limit); the reasoning tests live in the new `client-reasoning.test.ts`.

## Verification

Verified live against Anthropic (Sonnet 4.6, adaptive thinking ON) with a local 3-turn conversation:

```
cache_read_input_tokens seen=[0,0, 11977,11977, 25076,25076, 25204,25204]  max=25204  apiErrors=[]
```

- **No 4xx** — the signed re-send is accepted (the signature re-send was the risk).
- Cache read climbs from the ~12k head (the old broken ceiling) to **~25k**, i.e. **through the ~9k skills blob**.

`npm run check` green (functions 100%, branches 96.08%, 7926 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)