### PR TITLE
docs: streamline install flow with clearer download CTAs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -140,33 +140,6 @@ export default defineConfig({
           { text: "Overview", link: "/installation" },
           { text: "Upgrading", link: "/installation/upgrading" },
           {
-            text: "Choose by Provider",
-            collapsed: false,
-            items: [
-              {
-                text: "Claude / Anthropic",
-                link: "/installation/choose-claude",
-              },
-              {
-                text: "ChatGPT / OpenAI",
-                link: "/installation/choose-openai",
-              },
-              {
-                text: "Gemini / Google",
-                link: "/installation/choose-gemini",
-              },
-              {
-                text: "Mistral / Mistral AI",
-                link: "/installation/choose-mistral",
-              },
-              { text: "Local / Offline", link: "/installation/choose-local" },
-              {
-                text: "Multiple Providers",
-                link: "/installation/choose-multi",
-              },
-            ],
-          },
-          {
             text: "Built-in Chat UI",
             collapsed: false,
             items: [
@@ -212,6 +185,33 @@ export default defineConfig({
               { text: "claude.ai", link: "/installation/claude-web" },
               { text: "ChatGPT", link: "/installation/chatgpt-web" },
               { text: "Le Chat", link: "/installation/mistral-le-chat" },
+            ],
+          },
+          {
+            text: "Choose by Provider",
+            collapsed: true,
+            items: [
+              {
+                text: "Claude / Anthropic",
+                link: "/installation/choose-claude",
+              },
+              {
+                text: "ChatGPT / OpenAI",
+                link: "/installation/choose-openai",
+              },
+              {
+                text: "Gemini / Google",
+                link: "/installation/choose-gemini",
+              },
+              {
+                text: "Mistral / Mistral AI",
+                link: "/installation/choose-mistral",
+              },
+              { text: "Local / Offline", link: "/installation/choose-local" },
+              {
+                text: "Multiple Providers",
+                link: "/installation/choose-multi",
+              },
             ],
           },
           {

--- a/docs/.vitepress/theme/get-started.css
+++ b/docs/.vitepress/theme/get-started.css
@@ -193,7 +193,164 @@
   }
 }
 
+/* Download band on homepage */
+.vp-doc {
+  .download-band {
+    max-width: 1152px;
+    margin: 0 auto;
+    padding: 40px 24px 8px;
+    text-align: center;
+  }
+
+  /* Compact variant for use inside content pages (e.g. /installation) */
+  .download-band-compact {
+    padding: 12px 6px 20px;
+    text-align: left;
+
+    .download-actions {
+      justify-content: flex-start;
+    }
+
+    .download-title {
+      font-size: 22px;
+    }
+
+    .download-subtitle {
+      font-size: 15px;
+      margin-bottom: 16px;
+    }
+  }
+
+  /* Two equally-required downloads (e.g. Claude Desktop): drop the double-border
+     ring so it's not overwhelming, keep a single solid border, widen the gap. */
+  .download-band-dual {
+    .download-actions {
+      gap: 24px;
+    }
+
+    .download-btn-primary,
+    .download-btn-primary:hover {
+      outline: none;
+    }
+  }
+
+  .download-title {
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--vp-c-text-1);
+    margin: 0 0 8px;
+    border: none;
+  }
+
+  .download-subtitle {
+    font-size: 17px;
+    color: var(--vp-c-text-2);
+    margin: 0 0 24px;
+  }
+
+  .download-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    justify-content: center;
+    align-items: stretch;
+  }
+
+  .download-btn {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 220px;
+    padding: 14px 22px;
+    border-radius: 10px;
+    text-decoration: none;
+    background-color: var(--vp-c-bg-soft);
+    border: 1px solid var(--vp-c-divider);
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease,
+      border-color 0.2s ease;
+
+    &:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 12px 24px -8px rgba(0, 0, 0, 0.15);
+      border-color: var(--vp-c-brand-2);
+    }
+  }
+
+  .download-btn-primary {
+    padding: 18px 28px;
+    background: linear-gradient(
+      135deg,
+      var(--vp-c-brand-soft) 0%,
+      var(--vp-c-bg-soft) 100%
+    );
+    /* Resting "double border" in the lighter brand shade — subtle. */
+    border: 2px solid var(--vp-c-brand-2);
+    outline: 2px solid var(--vp-c-brand-2);
+    outline-offset: 3px;
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease,
+      border-color 0.2s ease,
+      outline-color 0.2s ease,
+      outline-offset 0.2s ease;
+  }
+
+  /* Hover intensifies both rings to full brand + a bigger lift. */
+  .download-btn-primary:hover {
+    border-color: var(--vp-c-brand-1);
+    outline-color: var(--vp-c-brand-1);
+    outline-offset: 4px;
+    transform: translateY(-4px);
+    box-shadow: 0 16px 30px -8px rgba(0, 0, 0, 0.22);
+  }
+
+  .download-btn-primary .download-btn-label {
+    font-size: 18px;
+  }
+
+  .download-btn-primary .download-btn-sub {
+    font-size: 14px;
+  }
+
+  .download-btn-label {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--vp-c-brand-1);
+  }
+
+  .download-btn-sub {
+    font-size: 13px;
+    color: var(--vp-c-text-2);
+  }
+
+  .download-next {
+    font-size: 15px;
+    color: var(--vp-c-text-2);
+    margin: 24px 0 0;
+  }
+
+  @media (max-width: 600px) {
+    .download-band {
+      padding: 32px 16px 0;
+    }
+
+    .download-title {
+      font-size: 24px;
+    }
+
+    .download-btn {
+      width: 100%;
+    }
+  }
+}
+
 /* Dark mode overrides - must be outside .vp-doc nesting */
+.dark .vp-doc .download-btn:hover {
+  box-shadow: 0 12px 24px -8px rgba(0, 0, 0, 0.4);
+}
+
 .dark .vp-doc .arrow-path {
   stroke: var(--vp-c-text-3);
 }

--- a/docs/_partials/live-requirement.md
+++ b/docs/_partials/live-requirement.md
@@ -1,3 +1,12 @@
+<div class="download-band download-band-compact">
+  <div class="download-actions">
+    <a class="download-btn download-btn-primary" href="https://github.com/adamjmurray/producer-pal/releases/latest/download/Producer_Pal.amxd">
+      <span class="download-btn-label">Download Max for Live Device</span>
+      <span class="download-btn-sub">Producer_Pal.amxd — add it to a MIDI track in Ableton Live</span>
+    </a>
+  </div>
+</div>
+
 - [Ableton Live 12.3+](https://www.ableton.com/live/) with
   [Max for Live](https://www.ableton.com/live/max-for-live/). Live 12.4 or later
   is recommended — some features don't work on older versions of Live. Use the

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -21,10 +21,10 @@ Quick options:
   more
 - **[Claude Desktop](/installation/claude-desktop)** - Recommended for Anthropic
   users
-- **[Command Line Tools](/installation#command-line-interfaces)** - Gemini CLI,
-  Codex CLI, Claude Code, and other MCP-compatible coding agents
-- **[Local Models](/installation#local-offline-options)** - Run completely
-  offline with Ollama, LM Studio, and other MCP-compatible platforms
+- **[Command Line Tools](/installation#command-line)** - Gemini CLI, Codex CLI,
+  Claude Code, and other MCP-compatible coding agents
+- **[Local Models](/installation/lm-studio)** - Run completely offline with
+  Ollama, LM Studio, and other MCP-compatible platforms
 
 Already have an MCP-compatible client? Connect with `npx producer-pal`
 ([details](/installation/other-mcp))

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,10 @@ hero:
     alt: Producer Pal
   actions:
     - theme: brand
-      text: Install Now
+      text: Download for Ableton Live
+      link: https://github.com/adamjmurray/producer-pal/releases/latest/download/Producer_Pal.amxd
+    - theme: alt
+      text: Installation Guide
       link: /installation
     - theme: alt
       text: User Guide
@@ -48,6 +51,26 @@ features:
     link: https://github.com/adamjmurray/producer-pal
     linkText: View on GitHub
 ---
+
+<div class="download-band">
+  <h2 class="download-title">Get Producer Pal</h2>
+  <p class="download-subtitle">The Max for Live device is all you need to start — drop it onto a track in Ableton Live and it links you to the docs, the chat UI, and everything else.</p>
+  <div class="download-actions">
+    <a class="download-btn download-btn-primary" href="https://github.com/adamjmurray/producer-pal/releases/latest/download/Producer_Pal.amxd">
+      <span class="download-btn-label">Download Max for Live Device</span>
+      <span class="download-btn-sub">Producer_Pal.amxd · v{{ $frontmatter.version }}</span>
+    </a>
+    <a class="download-btn" href="https://github.com/adamjmurray/producer-pal/releases/latest/download/Producer_Pal.mcpb">
+      <span class="download-btn-label">Claude Desktop Extension</span>
+      <span class="download-btn-sub">Producer_Pal.mcpb</span>
+    </a>
+    <a class="download-btn" href="https://www.npmjs.com/package/producer-pal" target="_blank" rel="noreferrer">
+      <span class="download-btn-label">npx producer-pal</span>
+      <span class="download-btn-sub">npm — for any MCP client</span>
+    </a>
+  </div>
+  <p class="download-next">Then choose how you want to use it below, or follow the <a href="/installation">full Installation Guide</a>.</p>
+</div>
 
 <div class="get-started-wrapper">
   <section class="get-started-container">

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,14 +8,21 @@ description:
 # Installation Guide
 
 Producer Pal is a free, open-source Ableton MCP server that brings AI to Ableton
-Live. Choose your preferred AI platform to get started. Note that some AI
-services charge for usage.
+Live. It works with many AI providers — use whichever you prefer. Note that some
+AI services charge for usage.
 
-::: tip Prerequisites
+<div class="download-band download-band-compact">
+  <h2 class="download-title">Step 1: Get the Max for Live Device</h2>
+  <p class="download-subtitle">Required for every setup — add it to a MIDI track in Ableton Live.</p>
+  <div class="download-actions">
+    <a class="download-btn download-btn-primary" href="https://github.com/adamjmurray/producer-pal/releases/latest/download/Producer_Pal.amxd">
+      <span class="download-btn-label">Download Max for Live Device</span>
+      <span class="download-btn-sub">Producer_Pal.amxd · v{{ $frontmatter.version }}</span>
+    </a>
+  </div>
+</div>
 
-**Download** v{{ $frontmatter.version }}**:**&nbsp;
-[Producer_Pal.amxd](https://github.com/adamjmurray/producer-pal/releases/latest/download/Producer_Pal.amxd)
-(the Producer Pal Max for Live device)
+::: tip Requirements
 
 **Requires:** [Ableton Live 12.3+](https://www.ableton.com/live/) with
 [Max for Live](https://www.ableton.com/live/max-for-live/). Live 12.4 or later
@@ -28,74 +35,68 @@ Upgrading from a previous version? See the
 
 :::
 
-## Which AI Do You Use?
+## Choose How You Want to Use It
 
-Pick your preferred AI provider:
+Producer Pal works the same with any provider — the main choice is _how_ you
+want to interact with it. Every group below supports multiple AI providers, so
+pick the experience you like best.
 
-- **[Anthropic / Claude](./installation/choose-claude)** — Claude Desktop,
-  claude.ai, or Claude Code
-- **[OpenAI / ChatGPT](./installation/choose-openai)** — Codex app, ChatGPT web
-  app, or Codex CLI
-- **[Google / Gemini](./installation/choose-gemini)** — Built-in Chat UI or
-  Gemini CLI
-- **[Mistral / Mistral AI](./installation/choose-mistral)** — Le Chat or Mistral
-  Vibe
-- **[Local / Offline](./installation/choose-local)** — Ollama or LM Studio
-- **[Multiple Providers](./installation/choose-multi)** — OpenRouter,
-  flexibility across providers
+### Desktop Apps
 
-## Recommended Options
-
-These are the easiest and most reliable ways to use Producer Pal:
+Dedicated AI apps — the easiest setup for most people:
 
 - **[Claude Desktop](./installation/claude-desktop)** — Anthropic's desktop app
-  (easiest setup, subscription required)
-- **[Codex App](./installation/codex-app)** — OpenAI's desktop app (easy setup,
-  macOS only, subscription required)
-- **[Built-in Chat UI](./installation/chat-ui)** — Integrated chat interface
-  supporting cloud providers and local models
+  (subscription required)
+- **[Codex App](./installation/codex-app)** — OpenAI's desktop app (macOS only,
+  subscription required)
+- **[LM Studio](./installation/lm-studio)** — runs models fully offline, no
+  account needed
 
-Looking for offline/local options? See
-[Desktop Apps](./installation/desktop-apps) for LM Studio or
-[Ollama](./installation/ollama) via the built-in chat UI.
+### Built-in Chat UI
 
-Already have an MCP-compatible client? Connect with
-[`npx producer-pal`](https://www.npmjs.com/package/producer-pal) (see
-[Other MCP LLMs](./installation/other-mcp) and
-[CLI options](#command-line-interfaces))
+Producer Pal's own browser-based chat — bring an API key for any supported
+provider:
 
-## Command Line Interfaces
+- **[Chat UI overview](./installation/chat-ui)** — supported providers and setup
+- **[Gemini](./installation/gemini)**, **[OpenAI](./installation/openai)**,
+  **[Ollama](./installation/ollama)** (offline), or
+  **[OpenRouter, Mistral & more](./installation/chat-ui-other-providers)**
+
+### Command Line
 
 For users comfortable with the terminal:
 
-- **[Gemini CLI](./installation/gemini-cli)** - Google's command line agent
-  (free tier has strict rate limits)
-- **[Codex CLI](./installation/codex-cli)** - OpenAI's command line agent
-  (subscription required)
-- **[Claude Code](./installation/claude-code)** - Anthropic's command line agent
-  (subscription required)
-- **[Mistral Vibe](./installation/mistral-vibe)** - Mistral's command line agent
-  (API key required)
+- **[Claude Code](./installation/claude-code)** — Anthropic (subscription
+  required)
+- **[Codex CLI](./installation/codex-cli)** — OpenAI (subscription required)
+- **[Gemini CLI](./installation/gemini-cli)** — Google (free tier has strict
+  rate limits)
+- **[Mistral Vibe](./installation/mistral-vibe)** — Mistral (API key required)
 
-## Web Applications
+### Web Apps
 
-Use Producer Pal in your browser:
+Use a provider's website in your browser — each requires a
+[web tunnel](./installation/web-tunnels):
 
-- **[claude.ai Web App](./installation/claude-web)** - Anthropic's web app
-  (requires [web tunnel](./installation/web-tunnels))
-- **[ChatGPT Web App](./installation/chatgpt-web)** - OpenAI's web app (requires
-  [web tunnel](./installation/web-tunnels))
-- **[Le Chat](./installation/mistral-le-chat)** - Mistral's web app (requires
-  [web tunnel](./installation/web-tunnels))
+- **[claude.ai](./installation/claude-web)** — Anthropic
+- **[ChatGPT](./installation/chatgpt-web)** — OpenAI
+- **[Le Chat](./installation/mistral-le-chat)** — Mistral
 
-## Local & Offline Options
+### Any MCP Client
 
-Run models completely offline:
+Already have an MCP-compatible app? Connect directly with
+[`npx producer-pal`](https://www.npmjs.com/package/producer-pal) — see
+[Other MCP LLMs](./installation/other-mcp).
 
-- **[Ollama](./installation/ollama)** - Using the built-in chat interface
-- **[LM Studio](./installation/lm-studio)** - Alternative local model server
-- **[Other MCP-compatible LLMs](./installation/other-mcp)** - Any LLM supporting
-  MCP
+## Prefer to Pick by AI Provider?
+
+If you already know which AI you use, jump straight to its provider guide:
+[Claude / Anthropic](./installation/choose-claude) ·
+[OpenAI / ChatGPT](./installation/choose-openai) ·
+[Google / Gemini](./installation/choose-gemini) ·
+[Mistral](./installation/choose-mistral) ·
+[Local / Offline](./installation/choose-local) ·
+[Multiple Providers](./installation/choose-multi)
 
 ## Additional Resources
 

--- a/docs/installation/chat-ui-other-providers.md
+++ b/docs/installation/chat-ui-other-providers.md
@@ -3,6 +3,15 @@
 The built-in chat UI supports OpenAI API, Mistral, OpenRouter, and custom
 OpenAI-compatible providers.
 
+<div class="download-band download-band-compact">
+  <div class="download-actions">
+    <a class="download-btn download-btn-primary" href="https://github.com/adamjmurray/producer-pal/releases/latest/download/Producer_Pal.amxd">
+      <span class="download-btn-label">Download Max for Live Device</span>
+      <span class="download-btn-sub">Producer_Pal.amxd — add it to a MIDI track in Ableton Live</span>
+    </a>
+  </div>
+</div>
+
 ::: warning Pay-as-you-go Pricing
 
 Most of these options (besides LM Studio) use pay-as-you-go pricing which can

--- a/docs/installation/chat-ui.md
+++ b/docs/installation/chat-ui.md
@@ -3,6 +3,15 @@
 Producer Pal includes a [built-in chat interface](/guide/chat-ui) that runs in
 your browser. Click "Open Chat UI" in the Max for Live device to launch it.
 
+<div class="download-band download-band-compact">
+  <div class="download-actions">
+    <a class="download-btn download-btn-primary" href="https://github.com/adamjmurray/producer-pal/releases/latest/download/Producer_Pal.amxd">
+      <span class="download-btn-label">Download Max for Live Device</span>
+      <span class="download-btn-sub">Producer_Pal.amxd — add it to a MIDI track in Ableton Live</span>
+    </a>
+  </div>
+</div>
+
 The chat UI supports multiple AI providers. Choose based on your needs:
 
 ## Cloud Providers

--- a/docs/installation/claude-desktop.md
+++ b/docs/installation/claude-desktop.md
@@ -5,8 +5,25 @@ use Producer Pal.
 
 ## Requirements
 
-<!--@include: ../_partials/live-requirement.md-->
+<div class="download-band download-band-compact download-band-dual">
+  <p class="download-subtitle">Grab both downloads, then follow the steps below:</p>
+  <div class="download-actions">
+    <a class="download-btn download-btn-primary" href="https://github.com/adamjmurray/producer-pal/releases/latest/download/Producer_Pal.amxd">
+      <span class="download-btn-label">1. Max for Live Device</span>
+      <span class="download-btn-sub">Producer_Pal.amxd — for Ableton Live</span>
+    </a>
+    <a class="download-btn download-btn-primary" href="https://github.com/adamjmurray/producer-pal/releases/latest/download/Producer_Pal.mcpb">
+      <span class="download-btn-label">2. Claude Desktop Extension</span>
+      <span class="download-btn-sub">Producer_Pal.mcpb — for Claude Desktop</span>
+    </a>
+  </div>
+</div>
 
+- [Ableton Live 12.3+](https://www.ableton.com/live/) with
+  [Max for Live](https://www.ableton.com/live/max-for-live/). Live 12.4 or later
+  is recommended — some features don't work on older versions of Live. Use the
+  version of Max bundled with Live, or make sure your standalone Max is up to
+  date.
 - [Claude Desktop](https://claude.ai/download) (requires Anthropic account)
 
 ## Installation Steps


### PR DESCRIPTION
Inter-release docs-only hotfix (branched off `main`) to cut clicks and clarify CTAs in the installation flow.

## Changes
- **Homepage hero** leads with a **Download for Ableton Live** (`.amxd`) button — the single most important action — plus a "Get Producer Pal" download band (device, Claude Desktop extension, `npx producer-pal`).
- **`/installation` overview** is now **interface-first** (Desktop Apps / Built-in Chat UI / Command Line / Web Apps / Any MCP Client), each option listed once with direct links to leaf pages; the per-provider list is demoted to a secondary index. Sidebar reordered to match.
- **Every specific install page** gets a prominent Max for Live device download card (via the shared `live-requirement` partial + the two chat-ui pages). **Claude Desktop** shows both required downloads (`.amxd` + `.mcpb`) as a clear two-button band.
- **Download button styling** with a subtle-at-rest / intensify-on-hover double border for single-primary CTAs; single solid border for the paired (two-download) case.

## Validation
- `npm run check` green (lint, typecheck, format, duplication, 7847 tests, coverage above thresholds)
- `npm run docs:build` compiles

## Follow-up
After merge to `main`, forward to `dev` (merge or cherry-pick) so the next `dev` to `main` release does not revert these docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)