### PR TITLE
docs: add YouTube social link to nav

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -228,6 +228,7 @@ export default defineConfig({
 
     socialLinks: [
       { icon: "discord", link: "https://discord.gg/rmU3DSzgwH" },
+      { icon: "youtube", link: "https://www.youtube.com/@adammurray-link" },
       { icon: "github", link: "https://github.com/adamjmurray/producer-pal" },
     ],
 


### PR DESCRIPTION
Adds a YouTube social icon to the top nav, between the existing Discord and GitHub icons, linking to the channel home (https://www.youtube.com/@adammurray-link).

Uses VitePress's built-in `youtube` social icon — one-line config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)