### PR TITLE
docs: refresh homepage demo videos

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,13 +158,40 @@ features:
     </div>
   </div>
   <div>
-    <p class="demo-video-label">Producer Pal Walk-through with Claude Desktop</p>
+    <p class="demo-video-label">Claude Desktop vs Ableton Live in 2026</p>
     <div class="demo-video">
       <iframe
-        src="https://www.youtube.com/embed/IB19LqTZQDU?list=PLFqWfbwGKmqenUb1DUFZ5ECYU6klUWNtX&t=202s"
-        title="Producer Pal walk-through with Claude Desktop"
+        src="https://www.youtube.com/embed/_p6Qll5Mqcs"
+        title="Claude Desktop vs Ableton Live in 2026"
         frameborder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerpolicy="strict-origin-when-cross-origin"
+        allowfullscreen>
+      </iframe>
+    </div>
+  </div>
+  <div>
+    <p class="demo-video-label">Transforming MIDI with AI in Ableton via Producer Pal</p>
+    <div class="demo-video">
+      <iframe
+        src="https://www.youtube.com/embed/2T_w5Roe6jY"
+        title="Transforming MIDI with AI in Ableton via Producer Pal"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerpolicy="strict-origin-when-cross-origin"
+        allowfullscreen>
+      </iframe>
+    </div>
+  </div>
+  <div>
+    <p class="demo-video-label">Talking to Ableton Live with AI (via OpenAI Realtime 2)</p>
+    <div class="demo-video">
+      <iframe
+        src="https://www.youtube.com/embed/iz2dyftiSFU"
+        title="Talking to Ableton Live with AI (via OpenAI Realtime 2)"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerpolicy="strict-origin-when-cross-origin"
         allowfullscreen>
       </iframe>
     </div>


### PR DESCRIPTION
## Summary

Updates the YouTube demo videos on the docs site homepage (`docs/index.md`).

- **Keep** "Ableton Live Project Management with Producer Pal" (`_pB3qESiIhw`) unchanged.
- **Replace** the "Producer Pal Walk-through with Claude Desktop" (`IB19LqTZQDU`) video with **"Claude Desktop vs Ableton Live in 2026"** (`_p6Qll5Mqcs`).
- **Add** "Transforming MIDI with AI in Ableton via Producer Pal" (`2T_w5Roe6jY`).
- **Add** "Talking to Ableton Live with AI (via OpenAI Realtime 2)" (`iz2dyftiSFU`).

The provided links were mobile (`m.youtube.com/watch?v=…`) URLs; I inferred the corresponding embed URLs (`www.youtube.com/embed/<id>`). The demo grid is `1fr 1fr`, so the four videos render as a clean 2×2 on desktop and stack on mobile.

## Testing

- `npm run docs:build` — builds successfully.

https://claude.ai/code/session_012Ev85eSKSzxG3su8gMCcpP

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ev85eSKSzxG3su8gMCcpP)_