### PR TITLE
fix(branching): clear stranded fork-scroll ref on no-op branch switch

### DIFF
--- a/webui/src/components/chat/MessageList.tsx
+++ b/webui/src/components/chat/MessageList.tsx
@@ -83,14 +83,13 @@ export function MessageList({
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [editText, setEditText] = useState("");
 
-  const branchByIndex = new Map(
-    (branchNav?.points ?? []).map((point) => [point.anchorIndex, point]),
-  );
+  const branchByIndex = buildBranchIndex(branchNav);
 
-  const switchToSibling = (siblingId: string, anchorIndex: number) => {
-    pendingBranchScrollRef.current = anchorIndex;
-    void branchNav?.onSwitch(siblingId);
-  };
+  const switchToSibling = useBranchSwitch(
+    messages,
+    pendingBranchScrollRef,
+    branchNav?.onSwitch,
+  );
 
   // Show "Still thinking..." after delay. Clear any open editor on every
   // transcript change (branch switch, conversation select, new chat) so a stale
@@ -200,6 +199,62 @@ export function MessageList({
       <div ref={messagesEndRef} className="col-span-3" />
     </div>
   );
+}
+
+/**
+ * Indexes branch points by the message index their arrows anchor on, so each
+ * rendered row can look up its branch point in O(1).
+ * @param branchNav - Sibling-branch navigation state, if any
+ * @returns Map from anchor message index to its branch point
+ */
+function buildBranchIndex(
+  branchNav: BranchNavState | undefined,
+): Map<number, BranchPoint> {
+  return new Map(
+    (branchNav?.points ?? []).map((point) => [point.anchorIndex, point]),
+  );
+}
+
+/**
+ * Builds the sibling-switch handler: remembers the fork-point scroll target,
+ * loads the sibling, then clears the target if the switch turned out to be a
+ * no-op. A switch that doesn't replace the transcript (the sibling was
+ * concurrently deleted, or it's a voice record that leaves the text transcript
+ * untouched) never changes `messages`, so useScrollToForkPoint never fires to
+ * consume the pending ref — clearing it here stops the stranded value from
+ * suppressing the next new-user-message auto-scroll.
+ * @param messages - Current messages array (tracked to detect a transcript swap)
+ * @param pendingBranchScrollRef - Ref holding the pending fork-point index
+ * @param pendingBranchScrollRef.current - The pending index, or null
+ * @param onSwitch - Loads a sibling conversation by id
+ * @returns A handler that switches to the given sibling
+ */
+function useBranchSwitch(
+  messages: UIMessage[],
+  pendingBranchScrollRef: { current: number | null },
+  onSwitch: BranchNavState["onSwitch"] | undefined,
+): (siblingId: string, anchorIndex: number) => void {
+  // Tracks the latest committed transcript so the handler can tell whether an
+  // awaited branch switch actually swapped it.
+  const messagesRef = useRef(messages);
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+
+  return (siblingId, anchorIndex) => {
+    const before = messagesRef.current;
+
+    pendingBranchScrollRef.current = anchorIndex;
+
+    void (async () => {
+      await onSwitch?.(siblingId);
+
+      if (messagesRef.current === before) {
+        pendingBranchScrollRef.current = null;
+      }
+    })();
+  };
 }
 
 /**

--- a/webui/src/components/chat/tests/MessageList-branch-nav.test.tsx
+++ b/webui/src/components/chat/tests/MessageList-branch-nav.test.tsx
@@ -171,4 +171,48 @@ describe("MessageList branch navigation", () => {
       block: "center",
     });
   });
+
+  it("clears the pending scroll after a no-op switch so the next user message still auto-scrolls", async () => {
+    // A switch that doesn't replace the transcript (deleted sibling / voice
+    // record) resolves without changing `messages`. The pending fork-scroll ref
+    // must be cleared so it can't suppress the next new-user-message scroll.
+    let resolveSwitch: () => void = () => {};
+    const onSwitch = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSwitch = resolve;
+        }),
+    );
+    const messages = [user("first", 0), model("a1", 1)];
+    const { rerender } = renderList(messages, {
+      points: [FORK_AT_0],
+      onSwitch,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /next version/i }));
+
+    // The switch is a no-op: the transcript array identity is unchanged.
+    resolveSwitch();
+    await Promise.resolve();
+
+    const scrollSpy = vi.fn();
+
+    Element.prototype.scrollIntoView = scrollSpy;
+    rerender(
+      <MessageList
+        messages={[...messages, user("second", 2)]}
+        queuedMessages={[]}
+        onRemoveQueued={vi.fn()}
+        isAssistantResponding={false}
+        handleRetry={vi.fn()}
+        handleEdit={vi.fn()}
+        showTimestamps={false}
+        showTokenUsage={false}
+        branchNav={{ points: [FORK_AT_0], onSwitch }}
+      />,
+    );
+
+    // The new user message scrolls to the bottom (endRef), not the fork point.
+    expect(scrollSpy).toHaveBeenCalledWith({ behavior: "smooth" });
+  });
 });


### PR DESCRIPTION
## Problem

`switchToSibling` in `MessageList.tsx` sets `pendingBranchScrollRef.current = anchorIndex` before awaiting the switch. `useScrollToForkPoint` only nulls that ref inside an effect keyed on `messages` — i.e. only when the transcript array identity actually changes.

If the switch does **not** replace the text transcript — `switchConversation` early-returns because the record was concurrently deleted (`!record`) or the target sibling is a **voice** record (text `messages` untouched) — then `messages` never changes, the ref stays non-null, and `useScrollOnUserMessage` then suppresses the next legitimate new-user-message auto-scroll. Scroll-to-bottom silently stops working until another branch switch clears the ref.

## Fix

`switchToSibling` now awaits the switch and clears `pendingBranchScrollRef` when the transcript is unchanged (identity comparison via a tracked ref). The working path is unaffected: a real transcript swap leaves `messagesRef.current !== before`, so the ref is left for `useScrollToForkPoint` to consume.

Extracted `useBranchSwitch` and `buildBranchIndex` helpers to keep `MessageList` under the per-function line limit.

## Tests

Added a regression test asserting that after a no-op switch, the next new user message scrolls to the bottom (`{ behavior: "smooth" }`) rather than the fork point. Verified the test fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)