### PR TITLE
test(e2e): add stubbed Playwright coverage for the /context webui app

### DIFF
--- a/e2e/ui/README.md
+++ b/e2e/ui/README.md
@@ -39,13 +39,47 @@ current source.
 
 ## Test Files
 
+Chat UI (`ui-test-helpers.ts`, IndexedDB-backed):
+
 - `conversation-crud.spec.ts` — conversation history: list/order, load messages,
   rename, star/unstar, delete (all backed by assertions against IndexedDB).
+- `conversation-branching.spec.ts`, `assistant-markdown.spec.ts` — edit/retry
+  forks and assistant markdown rendering.
+
+Context editor (`context-test-helpers.ts`, REST-backed) — the `/context` app
+(Project | Global | Instructions | Skills | Memory tabs):
+
+- `context-global-context.spec.ts` — global context: edit → save → reload
+  persists; clear to empty persists.
+- `context-memory.spec.ts` — memory: create → appears in the index → edit →
+  delete.
+- `context-instructions.spec.ts` — custom system prompt: customize → save →
+  reload persists → reset restores the built-in.
+- `context-skills.spec.ts` — skills fragment override: customize → edit → save →
+  reload persists.
+
+### Context editor harness
+
+`context-test-helpers.ts` fulfils the five REST endpoints the `/context` app
+uses (`/config`, `/global-context`, `/system-prompt`, `/skill-overrides`,
+`/memory`) with a small **stateful** in-memory backend, so a GET reflects the
+latest write and "edit → save → reload persists" is a real assertion (unlike the
+chat UI, whose state lives client-side in IndexedDB).
+
+- **`setupContextTest(page, overrides?)`** — install the stubs, load `/context`,
+  and return the mutable `ContextBackend`. Read it back (e.g.
+  `expect.poll(() => state.globalContext)`) to assert the REST round-trip
+  landed.
+- **`openContextTab(page, label)`** — switch tabs (`Project` … `Memory`).
+- **`primaryEditor` / `typeInPrimaryEditor` / `customizeOverride`** — drive the
+  CodeMirror editors (which need real keystrokes, not `fill()`) and the
+  Instructions / Skills "Customize" override flow.
 
 ## Adding tests
 
-Use `setupUiTest` for the standard "configured app + seeded history" starting
-point, then drive the UI with role/test-id locators. Conversation rows expose
+Use `setupUiTest` for the chat "configured app + seeded history" starting point,
+or `setupContextTest` for the `/context` editor, then drive the UI with
+role/test-id locators. Conversation rows expose
 `data-testid="conversation-item"`; row actions use their accessible labels
 (`Rename conversation`, `Delete conversation`, `Bookmark conversation` /
 `Remove bookmark`, `Export conversation`).

--- a/e2e/ui/context-global-context.spec.ts
+++ b/e2e/ui/context-global-context.spec.ts
@@ -1,0 +1,47 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { expect, test } from "@playwright/test";
+import {
+  expectNoConsoleOutput,
+  openContextTab,
+  primaryEditor,
+  setupConsoleCapture,
+  setupContextTest,
+  typeInPrimaryEditor,
+} from "./context-test-helpers";
+
+const captured = setupConsoleCapture();
+
+test.describe("Context editor — global context (stubbed backend)", () => {
+  test("edits and saves, persists across reload, then clears to empty", async ({
+    page,
+  }) => {
+    const state = await setupContextTest(page);
+
+    await openContextTab(page, "Global");
+    await expect(primaryEditor(page)).toBeVisible();
+
+    // Edit → the debounced autosave PUTs to /global-context.
+    await typeInPrimaryEditor(page, "Global notes v1");
+    await expect.poll(() => state.globalContext).toBe("Global notes v1");
+
+    // Reload re-reads the persisted value from the (stateful) backend.
+    await page.reload();
+    await openContextTab(page, "Global");
+    await expect(primaryEditor(page)).toContainText("Global notes v1");
+
+    // Clear → confirm → the empty state persists too.
+    page.on("dialog", (dialog) => void dialog.accept());
+    await page.getByRole("button", { name: "Clear", exact: true }).click();
+    await expect.poll(() => state.globalContext).toBe("");
+
+    await page.reload();
+    await openContextTab(page, "Global");
+    await expect(primaryEditor(page)).not.toContainText("Global notes v1");
+
+    expectNoConsoleOutput(captured);
+  });
+});

--- a/e2e/ui/context-instructions.spec.ts
+++ b/e2e/ui/context-instructions.spec.ts
@@ -1,0 +1,47 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { expect, test } from "@playwright/test";
+import {
+  customizeOverride,
+  expectNoConsoleOutput,
+  openContextTab,
+  primaryEditor,
+  setupConsoleCapture,
+  setupContextTest,
+  typeInPrimaryEditor,
+} from "./context-test-helpers";
+
+const captured = setupConsoleCapture();
+
+test.describe("Context editor — custom instructions (stubbed backend)", () => {
+  test("customizes the system prompt, persists it, then restores the default", async ({
+    page,
+  }) => {
+    const state = await setupContextTest(page);
+
+    await openContextTab(page, "Instructions");
+    // With no override the built-in is shown read-only behind a "Customize".
+    await expect(page.getByRole("button", { name: "Customize" })).toBeVisible();
+
+    // Fork the built-in, replace it, and confirm it saved to /system-prompt.
+    await customizeOverride(page);
+    await typeInPrimaryEditor(page, "MY CUSTOM INSTRUCTIONS", true);
+    await expect.poll(() => state.systemPrompt).toBe("MY CUSTOM INSTRUCTIONS");
+
+    // The override persists across a reload.
+    await page.reload();
+    await openContextTab(page, "Instructions");
+    await expect(primaryEditor(page)).toContainText("MY CUSTOM INSTRUCTIONS");
+
+    // Reset → confirm → the override is deleted and the built-in returns.
+    page.on("dialog", (dialog) => void dialog.accept());
+    await page.getByRole("button", { name: "Reset to default" }).click();
+    await expect.poll(() => state.systemPrompt).toBe("");
+    await expect(page.getByRole("button", { name: "Customize" })).toBeVisible();
+
+    expectNoConsoleOutput(captured);
+  });
+});

--- a/e2e/ui/context-memory.spec.ts
+++ b/e2e/ui/context-memory.spec.ts
@@ -1,0 +1,69 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { expect, test } from "@playwright/test";
+import {
+  expectNoConsoleOutput,
+  openContextTab,
+  setupConsoleCapture,
+  setupContextTest,
+} from "./context-test-helpers";
+
+const captured = setupConsoleCapture();
+
+test.describe("Context editor — memory (stubbed backend)", () => {
+  test("creates a memory, edits it, and deletes it", async ({ page }) => {
+    const state = await setupContextTest(page);
+
+    await openContextTab(page, "Memory");
+    await expect(page.getByText("No memories yet.")).toBeVisible();
+
+    // --- Create ---
+
+    await page.getByPlaceholder("prefers-c-minor").fill("prefers-c-minor");
+    await page
+      .getByRole("textbox", { name: "Description" })
+      .fill("Likes the key of C minor");
+    const body = page.getByRole("textbox", { name: "Memory" });
+
+    await body.click();
+    await body.pressSequentially("Uses C minor a lot.");
+    await page.getByRole("button", { name: "Create memory" }).click();
+
+    // Appears in the index and lands in the backend.
+    await expect(
+      page.getByRole("button", { name: "Edit prefers-c-minor" }),
+    ).toBeVisible();
+    await expect
+      .poll(() => state.memories.map((m) => m.name))
+      .toContain("prefers-c-minor");
+
+    // --- Edit (autosaves) ---
+
+    await page
+      .getByRole("textbox", { name: "Description" })
+      .fill("Prefers C minor for basslines");
+    await expect
+      .poll(
+        () =>
+          state.memories.find((m) => m.name === "prefers-c-minor")?.description,
+      )
+      .toBe("Prefers C minor for basslines");
+
+    // The edit persists across a reload.
+    await page.reload();
+    await openContextTab(page, "Memory");
+    await expect(page.getByText("Prefers C minor for basslines")).toBeVisible();
+
+    // --- Delete ---
+
+    page.on("dialog", (dialog) => void dialog.accept());
+    await page.getByRole("button", { name: "Delete prefers-c-minor" }).click();
+    await expect(page.getByText("No memories yet.")).toBeVisible();
+    await expect.poll(() => state.memories.length).toBe(0);
+
+    expectNoConsoleOutput(captured);
+  });
+});

--- a/e2e/ui/context-skills.spec.ts
+++ b/e2e/ui/context-skills.spec.ts
@@ -1,0 +1,43 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { expect, test } from "@playwright/test";
+import {
+  customizeOverride,
+  expectNoConsoleOutput,
+  openContextTab,
+  primaryEditor,
+  setupConsoleCapture,
+  setupContextTest,
+  typeInPrimaryEditor,
+} from "./context-test-helpers";
+
+const captured = setupConsoleCapture();
+
+test.describe("Context editor — skills fragments (stubbed backend)", () => {
+  test("overrides a skill fragment, saves it, and persists across reload", async ({
+    page,
+  }) => {
+    const state = await setupContextTest(page);
+
+    await openContextTab(page, "Skills");
+    // The first slot has no override, so its built-in is shown with "Customize".
+    await expect(page.getByRole("button", { name: "Customize" })).toBeVisible();
+
+    // Fork the built-in fragment, replace it, and confirm the override saved.
+    await customizeOverride(page);
+    await typeInPrimaryEditor(page, "CUSTOM SKILL FRAGMENT", true);
+    await expect
+      .poll(() => state.slots.find((s) => s.name === "slot-one")?.override)
+      .toBe("CUSTOM SKILL FRAGMENT");
+
+    // The override persists across a reload.
+    await page.reload();
+    await openContextTab(page, "Skills");
+    await expect(primaryEditor(page)).toContainText("CUSTOM SKILL FRAGMENT");
+
+    expectNoConsoleOutput(captured);
+  });
+});

--- a/e2e/ui/context-test-helpers.ts
+++ b/e2e/ui/context-test-helpers.ts
@@ -1,0 +1,437 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type Locator, type Page, type Route, expect } from "@playwright/test";
+import { BUILT_UI_PATH } from "./ui-test-helpers";
+
+// Stubbed, CI-runnable harness for the `/context` webui app (the Project |
+// Global | Instructions | Skills | Memory editor). Unlike the chat UI (whose
+// state lives client-side in IndexedDB), every context tab round-trips through a
+// REST endpoint, so this fulfils those endpoints with a small STATEFUL in-memory
+// backend: a GET reflects the latest write, so "edit → save → reload persists"
+// is a real assertion. One fresh `ContextBackend` per test closes over the route
+// handlers; tests read it back to assert the server-side round-trip landed.
+
+// Reuse the console-capture helpers from the live suite (same reason as
+// ui-test-helpers — keep the two suites in lockstep and avoid a duplicate copy).
+export {
+  expectNoConsoleOutput,
+  setupConsoleCapture,
+} from "../webui/webui-test-helpers";
+
+/** One stored memory, matching the `/memory` collection's entry shape. */
+export interface FakeMemory {
+  name: string;
+  description: string;
+  body: string;
+}
+
+/** One overridable skills fragment, matching the `/skill-overrides` shape. */
+export interface FakeSkillSlot {
+  name: string;
+  title: string;
+  description: string;
+  builtIn: string;
+  override: string;
+  drifted: boolean;
+  provenance: { producerPalVersion: string } | null;
+}
+
+/** The in-memory backend state behind the five `/context` REST endpoints. */
+export interface ContextBackend {
+  /** Project context memory blob (via `/config` `memoryContent`). */
+  memoryContent: string;
+  /** Machine-global context (`/global-context`). */
+  globalContext: string;
+  /** Custom system prompt (`/system-prompt`); "" means use the built-in. */
+  systemPrompt: string;
+  /** Overridable skills fragments (`/skill-overrides`). */
+  slots: FakeSkillSlot[];
+  /** LLM-managed memory collection (`/memory`). */
+  memories: FakeMemory[];
+}
+
+/**
+ * Build a fresh backend with sensible defaults (everything empty, two skills
+ * slots so the Skills dropdown has options). Override any field via `overrides`.
+ * @param overrides - Fields to override on the default backend
+ * @returns A fresh, mutable backend
+ */
+export function makeContextBackend(
+  overrides: Partial<ContextBackend> = {},
+): ContextBackend {
+  return {
+    memoryContent: "",
+    globalContext: "",
+    systemPrompt: "",
+    slots: [
+      makeSlot("slot-one", "Built-in fragment one."),
+      makeSlot("slot-two", "Built-in fragment two."),
+    ],
+    memories: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Full setup for a stubbed `/context` test: build a fresh backend, install its
+ * route stubs, load the `/context` bundle, and wait for the tab strip to render.
+ * @param page - Playwright page
+ * @param overrides - Initial backend field overrides
+ * @returns The mutable backend, for reading back after writes
+ */
+export async function setupContextTest(
+  page: Page,
+  overrides: Partial<ContextBackend> = {},
+): Promise<ContextBackend> {
+  const state = makeContextBackend(overrides);
+
+  await installContextStubs(page, state);
+  await page.goto("/context");
+  // The Project tab is active by default; the strip's presence means the
+  // ContextTabs shell (and all five hooks) mounted and loaded.
+  await expect(
+    page.getByRole("button", { name: "Global", exact: true }),
+  ).toBeVisible();
+
+  return state;
+}
+
+/**
+ * Install all `/context` route stubs against the given backend. Must run before
+ * the first navigation. The document (`/context`) is served from the built
+ * bundle; the five data endpoints are stateful (see the module comment).
+ * @param page - Playwright page
+ * @param state - The mutable backend the handlers read/write
+ */
+export async function installContextStubs(
+  page: Page,
+  state: ContextBackend,
+): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/context",
+    (route) =>
+      route.fulfill({
+        path: BUILT_UI_PATH,
+        contentType: "text/html; charset=utf-8",
+      }),
+  );
+  await page.route(
+    (url) => url.pathname === "/config",
+    (route) => handleConfig(route, state),
+  );
+  await page.route(
+    (url) => url.pathname === "/global-context",
+    (route) => handleContentDoc(route, state, "globalContext"),
+  );
+  await page.route(
+    (url) => url.pathname === "/system-prompt",
+    (route) => handleContentDoc(route, state, "systemPrompt"),
+  );
+  await page.route(
+    (url) => url.pathname === "/skill-overrides",
+    (route) => fulfillJson(route, { slots: state.slots }),
+  );
+  await page.route(
+    (url) => url.pathname.startsWith("/skill-overrides/"),
+    (route) => handleSkillSlot(route, state),
+  );
+  await page.route(
+    (url) => url.pathname === "/memory",
+    (route) => fulfillJson(route, { entries: state.memories }),
+  );
+  await page.route(
+    (url) => url.pathname.startsWith("/memory/"),
+    (route) => handleMemoryEntry(route, state),
+  );
+}
+
+/**
+ * Click a context editor tab by its label.
+ * @param page - Playwright page
+ * @param label - The tab to open
+ */
+export async function openContextTab(
+  page: Page,
+  label: "Project" | "Global" | "Instructions" | "Skills" | "Memory",
+): Promise<void> {
+  await page.getByRole("button", { name: label, exact: true }).click();
+}
+
+/**
+ * The primary editable CodeMirror region on screen. For the plain doc tabs it is
+ * the only editor; in override mode (Instructions/Skills) it is the editable
+ * override pane, rendered before any revealed built-in reference.
+ * @param page - Playwright page
+ * @returns Locator for the primary editor's content region
+ */
+export function primaryEditor(page: Page): Locator {
+  return page.locator(".cm-content").first();
+}
+
+/**
+ * Type into the primary editor. CodeMirror only observes real keystrokes (not
+ * `fill()`), so this focuses and presses each character; `replace` select-alls
+ * first so the typed text fully replaces the seeded content.
+ * @param page - Playwright page
+ * @param text - Text to type
+ * @param replace - Select all before typing (replace rather than append)
+ */
+export async function typeInPrimaryEditor(
+  page: Page,
+  text: string,
+  replace = false,
+): Promise<void> {
+  const editor = primaryEditor(page);
+
+  await editor.click();
+  if (replace) await page.keyboard.press("ControlOrMeta+a");
+  await editor.pressSequentially(text);
+}
+
+/**
+ * Fork the current built-in into an editable override (the "Customize" button on
+ * the Instructions / Skills tabs) and wait for the editable pane to appear (the
+ * "Reset to default" affordance only shows once there is an override).
+ * @param page - Playwright page
+ */
+export async function customizeOverride(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Customize" }).click();
+  await expect(
+    page.getByRole("button", { name: "Reset to default" }),
+  ).toBeVisible();
+}
+
+// --- Endpoint handlers below main exports ---
+
+/** Standard config fields the webui reads (only `memoryContent` is exercised). */
+const BASE_CONFIG = {
+  smallModelMode: false,
+  liveApiEnabled: false,
+  liveApiForcedOn: false,
+};
+
+/**
+ * `/config`: GET echoes the config (incl. project `memoryContent`); a partial
+ * POST merges `memoryContent` and echoes the full config.
+ * @param route - The intercepted route
+ * @param state - The mutable backend
+ */
+async function handleConfig(
+  route: Route,
+  state: ContextBackend,
+): Promise<void> {
+  if (route.request().method() === "POST") {
+    const body = readJsonBody(route);
+
+    if (typeof body.memoryContent === "string") {
+      state.memoryContent = body.memoryContent;
+    }
+  }
+
+  await fulfillJson(route, {
+    ...BASE_CONFIG,
+    memoryContent: state.memoryContent,
+  });
+}
+
+/**
+ * A single-content markdown doc endpoint (`/global-context`, `/system-prompt`):
+ * GET echoes `{content}`; PUT stores the body's content and echoes it back.
+ * @param route - The intercepted route
+ * @param state - The mutable backend
+ * @param key - Which backend field this endpoint stores
+ */
+async function handleContentDoc(
+  route: Route,
+  state: ContextBackend,
+  key: "globalContext" | "systemPrompt",
+): Promise<void> {
+  if (route.request().method() === "PUT") {
+    state[key] = readJsonBody(route).content ?? "";
+  }
+
+  await fulfillJson(route, { content: state[key] });
+}
+
+/**
+ * `/skill-overrides/:slot`: PUT stores that slot's override; DELETE resets it to
+ * the built-in. Both echo the updated slot.
+ * @param route - The intercepted route
+ * @param state - The mutable backend
+ */
+async function handleSkillSlot(
+  route: Route,
+  state: ContextBackend,
+): Promise<void> {
+  const name = decodeURIComponent(pathTail(route, "/skill-overrides/"));
+  const slot = state.slots.find((s) => s.name === name);
+
+  if (slot == null) {
+    await fulfillJson(route, { error: `Unknown slot "${name}"` }, 404);
+
+    return;
+  }
+
+  const method = route.request().method();
+
+  if (method === "PUT") slot.override = readJsonBody(route).content ?? "";
+  else if (method === "DELETE") slot.override = "";
+
+  await fulfillJson(route, { slot });
+}
+
+/**
+ * `/memory/:name` (and `/memory/:name/rename`): PUT create/overwrite (409 on a
+ * create-only name collision), PUT rename moves an entry to a new slug, DELETE
+ * removes one. Writes echo `{entry}`; the slug is derived like the real server.
+ * @param route - The intercepted route
+ * @param state - The mutable backend
+ */
+async function handleMemoryEntry(
+  route: Route,
+  state: ContextBackend,
+): Promise<void> {
+  const tail = pathTail(route, "/memory/");
+  const isRename = tail.endsWith("/rename");
+  const name = decodeURIComponent(
+    isRename ? tail.slice(0, -"/rename".length) : tail,
+  );
+  const method = route.request().method();
+
+  if (method === "DELETE") {
+    state.memories = state.memories.filter((m) => m.name !== name);
+    await fulfillJson(route, {});
+
+    return;
+  }
+
+  if (method === "PUT") {
+    await putMemory(route, state, name, isRename);
+
+    return;
+  }
+
+  await fulfillJson(route, { error: "Method not allowed" }, 405);
+}
+
+/**
+ * Handle a memory PUT (create/overwrite or rename), rejecting a name collision.
+ * @param route - The intercepted route
+ * @param state - The mutable backend
+ * @param name - The (decoded) current entry name from the URL
+ * @param isRename - Whether this is the `/rename` variant
+ */
+async function putMemory(
+  route: Route,
+  state: ContextBackend,
+  name: string,
+  isRename: boolean,
+): Promise<void> {
+  const body = readJsonBody(route);
+  const slug = slugify(isRename ? (body.newName ?? "") : name);
+  const collidesWith = isRename ? slug !== name : Boolean(body.createOnly);
+
+  if (collidesWith && state.memories.some((m) => m.name === slug)) {
+    await fulfillJson(
+      route,
+      { error: `A memory named "${slug}" already exists.` },
+      409,
+    );
+
+    return;
+  }
+
+  const entry: FakeMemory = {
+    name: slug,
+    description: body.description ?? "",
+    body: body.content ?? "",
+  };
+  const priorName = isRename ? name : slug;
+  const idx = state.memories.findIndex((m) => m.name === priorName);
+
+  if (idx >= 0) state.memories[idx] = entry;
+  else state.memories.push(entry);
+
+  await fulfillJson(route, { entry });
+}
+
+/**
+ * Build a default skills slot with an empty override.
+ * @param name - The slot's stable name
+ * @param builtIn - The built-in fragment body
+ * @returns A fresh slot
+ */
+function makeSlot(name: string, builtIn: string): FakeSkillSlot {
+  return {
+    name,
+    title: name,
+    description: `Fragment ${name}.`,
+    builtIn,
+    override: "",
+    drifted: false,
+    provenance: null,
+  };
+}
+
+/** The parsed shape of the JSON bodies these endpoints receive. */
+interface RequestBody {
+  content?: string;
+  memoryContent?: string;
+  description?: string;
+  newName?: string;
+  createOnly?: boolean;
+}
+
+/**
+ * Parse a route's request body as JSON (the writes here always send one).
+ * @param route - The intercepted route
+ * @returns The parsed body
+ */
+function readJsonBody(route: Route): RequestBody {
+  return (route.request().postDataJSON() ?? {}) as RequestBody;
+}
+
+/**
+ * The pathname segment after a known prefix (e.g. the slot/memory name).
+ * @param route - The intercepted route
+ * @param prefix - The path prefix to strip
+ * @returns The remaining path tail
+ */
+function pathTail(route: Route, prefix: string): string {
+  return new URL(route.request().url()).pathname.slice(prefix.length);
+}
+
+/**
+ * Slugify a memory name the way the real store does (lowercase, non-alphanumeric
+ * runs to single hyphens, trimmed).
+ * @param name - The raw name
+ * @returns The slug
+ */
+function slugify(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Fulfil a route with a JSON body.
+ * @param route - The intercepted route
+ * @param body - The response body (JSON-serialized)
+ * @param status - HTTP status (default 200)
+ */
+async function fulfillJson(
+  route: Route,
+  body: unknown,
+  status = 200,
+): Promise<void> {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}

--- a/e2e/ui/ui-test-helpers.ts
+++ b/e2e/ui/ui-test-helpers.ts
@@ -13,7 +13,13 @@ export {
   setupConsoleCapture,
 } from "../webui/webui-test-helpers";
 
-const BUILT_UI_PATH = fileURLToPath(
+/**
+ * Filesystem path to the built single-file UI bundle. The same bundle serves
+ * both `/chat` and `/context` (main.tsx branches on the pathname), so the
+ * context suite fulfills its document route from this too (see
+ * ./context-test-helpers.ts).
+ */
+export const BUILT_UI_PATH = fileURLToPath(
   new URL("../../max-for-live-device/chat-ui.html", import.meta.url),
 );
 


### PR DESCRIPTION
## Summary

The `/context` webui editor (Project | Global | Instructions | Skills | Memory tabs) had **no Playwright e2e coverage** — both suites only ever loaded `/chat`. This adds a CI-runnable stubbed spec family under `e2e/ui/` that drives the `/context` screens end-to-end.

The key idea: the `/context` tabs round-trip through REST endpoints (unlike the chat UI, whose state lives client-side in IndexedDB), so `context-test-helpers.ts` fulfils those endpoints with a small **stateful** in-memory fake backend. A GET reflects the latest write, which makes *"edit → save → reload persists"* a real assertion rather than a client-side illusion.

## What's covered

- **Global context** — edit → save → reload persists; clear to empty persists.
- **Memory** — create → appears in the index → edit → delete.
- **Custom instructions** — customize → save → reload persists → reset restores the built-in.
- **Skills fragments** — override edit → save → reload persists.

## Files

- `context-test-helpers.ts` — stateful backend for the five endpoints (`/config`, `/global-context`, `/system-prompt`, `/skill-overrides`, `/memory`) + setup/drive helpers (CodeMirror typing, the Customize override flow). Serves `/context` from the shared bundle (`main.tsx` branches on `location.pathname`), reusing `BUILT_UI_PATH` now exported from `ui-test-helpers.ts`.
- `context-{global-context,memory,instructions,skills}.spec.ts` — one spec per flow above.
- `e2e/ui/README.md` — documents the new context harness.

## Decisions

- **Stubbed-only, by design.** It's the CI win (deterministic, no Ableton/keys). The `ppal-context` tool's global + memory REST round-trip already has MCP-side e2e coverage, and a live suite can't run in CI.
- Skills tab covers the shipped **fragment overrides**; the hidden custom-skills collection is out of scope for the milestone.

## Verification

- New context specs: 4/4 pass; full stubbed `e2e/ui` suite: 14/14 pass.
- `npm run check`: green (lint, typecheck, format, 9293 tests, coverage functions 100%, E2E duplication 0.51% < 1.4% cap).
- `npm run check:build`: production bundle + docs site compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)