### PR TITLE
test: ratchet the src/notation mutation-score gate + close chord/stark test gaps

### DIFF
--- a/config/stryker.config.mjs
+++ b/config/stryker.config.mjs
@@ -53,12 +53,15 @@ export default {
   incremental: true,
   incrementalFile: "reports/mutation/stryker-incremental.json",
 
-  // Baseline mode: report the score but do not fail the run. Once a defensible
-  // baseline is triaged, set `break` to ratchet the score like the coverage and
-  // lint-suppression gates.
+  // Ratcheted gate: the run FAILS (exit 1) if the score drops below `break`,
+  // like the coverage and lint-suppression limits. The floor sits ~1 point below
+  // the current src/notation score (86.90% as of 2026-07-14) — enough headroom
+  // for run-to-run timeout-classification variance (a timeout counts as killed,
+  // so it nudges the score), tight enough to catch a real test-quality
+  // regression. Raise it as the score improves; never lower without triaging why.
   thresholds: {
-    high: 80,
+    high: 85,
     low: 60,
-    break: null,
+    break: 86,
   },
 };

--- a/dev/Mutation-Testing.md
+++ b/dev/Mutation-Testing.md
@@ -33,48 +33,67 @@ the test environment, and env flags all apply unchanged.
 cover it, not the whole ~8k-test suite — this is the main reason a run is
 minutes, not hours.
 
-## Baseline (2026-06-28, `src/notation/`)
+## Baseline (2026-07-14, `src/notation/`)
 
-First full pass — Stryker 9.6.1, Node 24, `coverageAnalysis: "perTest"`:
+Current full pass — Stryker 9.6.1, Node 24, `coverageAnalysis: "perTest"`:
 
 | Metric                     | Value      |
 | -------------------------- | ---------- |
-| **Mutation score**         | **85.45%** |
-| Mutants killed             | 2921       |
-| Survived                   | 489        |
-| Timeout (counts as killed) | 28         |
-| No coverage                | 13         |
+| **Mutation score**         | **86.90%** |
+| Mutants killed             | 3846       |
+| Survived                   | 577        |
+| Timeout (counts as killed) | 53         |
+| No coverage                | 11         |
 | Errors (non-compiling)     | 0          |
-| Total mutants              | 3451       |
-| Wall-clock                 | 5m 45s     |
-| Avg tests run per mutant   | 21.6       |
+| Total mutants              | 4487       |
+| Wall-clock                 | 7m 31s     |
+| Avg tests run per mutant   | 25.6       |
 
-Lowest-scoring files (richest triage targets):
+The gate is **ratcheted**: `thresholds.break = 86` in the config, so a run fails
+(exit 1) if the score drops below 86% — ~1 point of headroom below the current
+score for run-to-run timeout-classification variance (a timeout counts as
+killed, so it nudges the score). Raise the floor as the score climbs; never
+lower it without triaging the regression.
+
+Lowest-scoring files (remaining triage targets):
 
 | File                                                                | Score | Survived |
 | ------------------------------------------------------------------- | ----- | -------- |
-| `transform/helpers/transform-predicate-helpers.ts`                  | 73.3% | 12       |
-| `barbeat/interpreter/helpers/barbeat-interpreter-buffer-helpers.ts` | 73.9% | 17       |
-| `transform/helpers/note-cut-helpers.ts`                             | 79.3% | 17       |
+| `barbeat/interpreter/helpers/barbeat-interpreter-buffer-helpers.ts` | 78.5% | 14       |
 | `transform/transform-audio-evaluator.ts`                            | 78.7% | 64       |
+| `barbeat/serializer/helpers/barbeat-serializer-drum.ts`             | 81.2% | 26       |
+| `stark/stark-serializer.ts`                                         | 82.7% | 33       |
 
-Clean (100%): `barbeat-apply-v0-deletions.ts`, `barbeat-config.ts`.
+These are **not** cheap wins: the survivors cluster on `± *_EPSILON` boundary
+flips (killing them over-fits to a ~1e-9 / 0.001 slack), warning/error message
+strings, and equivalent mutants (e.g. a `.sort()` that is provably a no-op
+because its input is already ascending). Triage before acting.
 
-### Follow-up: 3 real gaps closed (2026-06-28)
+Clean (100%): `barbeat-apply-v0-deletions.ts`.
 
-A first triage pass found three bucket-1 (real test gap) survivors and added
-assertions for them; the rest of the survivors are dominated by `± GRID_EPSILON`
-/ `± SELECTOR_EPSILON` boundary flips (bucket 2/3 — killing them would over-fit
-to a 1e-9 slack). Score after: **85.83%** (476 survived, 2934 killed).
+### Gaps closed
 
-| Gap (now killed)                                            | Test added in                         |
-| ----------------------------------------------------------- | ------------------------------------- |
-| `resolveSplitPoints` de-dupe + ascending sort of cut points | `transform-split-note-op.test.ts`     |
-| `MAX_NOTE_PIECES` clamp boundary (`>`/`+1` off-by-one)      | `transform-split-note-op.test.ts`     |
-| `validateBufferedState` `buffered > 0` guard (vs `>= 0`)    | `barbeat-interpreter-helpers.test.ts` |
+**2026-07-14** — `chords/chord-symbols.ts` jumped **73.3% → 96.7%**. A
+golden-spec table test now asserts every one of the ~44 chord qualities resolves
+to the correct intervals — 24 qualities (`min6`, `m7b5`'s cousins, all the
+9/11/13 extensions, …) were reachable but unasserted, so blanking their interval
+rows survived. Targeted tests also cover the slash-bass-equals-root octave drop
+and invalid-root rejection. `stark/stark-serializer.ts` gained an unsorted-input
+test: `walkLine` sorts notes by start time, but every prior test already fed
+sorted input, so the sort was untested.
 
-The split-point gaps needed `splitNotes`-direct tests: through `applyTransforms`
-the final zero-duration sweep hides a missed de-dupe before it can be observed.
+| Gap (now killed)                                           | Test added in              |
+| ---------------------------------------------------------- | -------------------------- |
+| 24 unasserted chord qualities → interval spec              | `chord-symbols.test.ts`    |
+| Slash bass equal to the root drops an octave (`>=` vs `>`) | `chord-symbols.test.ts`    |
+| Invalid root letter with an accidental is rejected         | `chord-symbols.test.ts`    |
+| Serializer sorts unsorted input by start time              | `stark-serializer.test.ts` |
+
+**2026-06-28** — first triage closed three bucket-1 survivors:
+`resolveSplitPoints` de-dupe + ascending sort of cut points, the
+`MAX_NOTE_PIECES` clamp boundary, and the `validateBufferedState` `buffered > 0`
+guard (in `transform-split-note-op.test.ts` and
+`barbeat-interpreter-helpers.test.ts`).
 
 ## Interpreting survivors
 
@@ -94,12 +113,14 @@ wins, and a cross-check against the line-coverage gate.
 
 ## Status & next steps
 
-This is **baseline mode**: the score is reported but `thresholds.break` is
-`null`, so the run never fails. The next steps (later release) are:
+The gate is **ratcheted** (`thresholds.break = 86`) but still **scoped to
+`src/notation/`** and off the per-PR hot path (a full pass is minutes).
+Remaining work (later releases):
 
-- Triage the 489 survivors into the three buckets above.
-- Once a defensible floor is known, set `thresholds.break` to **ratchet** the
-  score like the coverage and lint-suppression gates.
+- Keep triaging the ~588 survivors, but expect diminishing returns: the dense
+  clusters left are epsilon-boundary / warning-string / equivalent mutants
+  (bucket 2/3), so genuine bucket-1 gaps are now sparse.
+- Raise `thresholds.break` as the score climbs.
 - Widen `mutate` to `src/tools/` (write operations first), likely as a scheduled
   (nightly/weekly) non-blocking CI job — full-tree runtime is hours, not
   minutes.

--- a/src/notation/chords/tests/chord-symbols.test.ts
+++ b/src/notation/chords/tests/chord-symbols.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  CHORD_QUALITY_INTERVALS,
   chordSymbolPitches,
   realizeChordSymbol,
   resolveChordSymbol,
@@ -137,6 +138,16 @@ describe("chordSymbolPitches — root spelling", () => {
   it("null on a malformed accidental in the root", () => {
     expect(chordSymbolPitches("Cx", "", null, C2, 0)).toBeNull();
   });
+
+  it("null on an invalid root letter that carries an accidental (Hb)", () => {
+    // The bad-letter guard must fire before the accidental is applied — else
+    // "Hb" would resolve to a NaN pitch class instead of rejecting the symbol.
+    expect(chordSymbolPitches("Hb", "", null, C2, 0)).toBeNull();
+  });
+
+  it("null on an empty root name", () => {
+    expect(resolveChordSymbol("", "", null)).toBeNull();
+  });
 });
 
 describe("chordSymbolPitches — slash bass", () => {
@@ -157,6 +168,14 @@ describe("chordSymbolPitches — slash bass", () => {
   it("accepts an accidental on the slash bass", () => {
     expect(chordSymbolPitches("C", "m7", "Bb", C2, 0)).toStrictEqual([
       46, 48, 51, 55, 58,
+    ]);
+  });
+
+  it("a slash bass equal to the root drops a full octave below it (not onto it)", () => {
+    // C/C: root C2=48; the bass C must land at 36 — the highest C *strictly*
+    // below the root — rather than collapsing onto the root at 48.
+    expect(chordSymbolPitches("C", "", "C", C2, 0)).toStrictEqual([
+      36, 48, 52, 55,
     ]);
   });
 });
@@ -229,4 +248,80 @@ describe("resolveChordSymbol", () => {
       bassPc: null,
     });
   });
+});
+
+// An independent golden spec of the semitone intervals every chord quality must
+// produce. Deliberately hand-written here rather than imported from source — it
+// is the contract CHORD_QUALITY_INTERVALS must satisfy, so blanking a row or
+// mistyping an interval in the source table is caught by these assertions
+// instead of passing silently on a quality no other test happens to exercise.
+const EXPECTED_INTERVALS: Record<string, readonly number[]> = {
+  // Triads
+  "": [0, 4, 7],
+  maj: [0, 4, 7],
+  M: [0, 4, 7],
+  m: [0, 3, 7],
+  min: [0, 3, 7],
+  dim: [0, 3, 6],
+  aug: [0, 4, 8],
+  "+": [0, 4, 8],
+  sus2: [0, 2, 7],
+  sus4: [0, 5, 7],
+  sus: [0, 5, 7],
+  "5": [0, 7],
+  // Sixths
+  "6": [0, 4, 7, 9],
+  m6: [0, 3, 7, 9],
+  min6: [0, 3, 7, 9],
+  "69": [0, 4, 7, 9, 14],
+  m69: [0, 3, 7, 9, 14],
+  // Sevenths
+  "7": [0, 4, 7, 10],
+  maj7: [0, 4, 7, 11],
+  M7: [0, 4, 7, 11],
+  m7: [0, 3, 7, 10],
+  min7: [0, 3, 7, 10],
+  m7b5: [0, 3, 6, 10],
+  dim7: [0, 3, 6, 9],
+  aug7: [0, 4, 8, 10],
+  "7b5": [0, 4, 6, 10],
+  "7#5": [0, 4, 8, 10],
+  "7b9": [0, 4, 7, 10, 13],
+  "7#9": [0, 4, 7, 10, 15],
+  "7#11": [0, 4, 7, 10, 18],
+  mMaj7: [0, 3, 7, 11],
+  // Ninths
+  "9": [0, 4, 7, 10, 14],
+  maj9: [0, 4, 7, 11, 14],
+  M9: [0, 4, 7, 11, 14],
+  m9: [0, 3, 7, 10, 14],
+  min9: [0, 3, 7, 10, 14],
+  add9: [0, 4, 7, 14],
+  madd9: [0, 3, 7, 14],
+  // Elevenths
+  "11": [0, 4, 7, 10, 14, 17],
+  m11: [0, 3, 7, 10, 14, 17],
+  maj11: [0, 4, 7, 11, 14, 17],
+  add11: [0, 4, 7, 17],
+  // Thirteenths
+  "13": [0, 4, 7, 10, 14, 21],
+  m13: [0, 3, 7, 10, 14, 21],
+  maj13: [0, 4, 7, 11, 14, 21],
+  add13: [0, 4, 7, 21],
+};
+
+describe("CHORD_QUALITY_INTERVALS — every quality matches the golden spec", () => {
+  it("covers exactly the golden set of qualities (no untested rows drift in)", () => {
+    expect(Object.keys(CHORD_QUALITY_INTERVALS).sort()).toStrictEqual(
+      Object.keys(EXPECTED_INTERVALS).sort(),
+    );
+  });
+
+  for (const [quality, intervals] of Object.entries(EXPECTED_INTERVALS)) {
+    it(`resolves "${quality || "(bare root)"}" to [${intervals.join(", ")}]`, () => {
+      expect(resolveChordSymbol("C", quality, null)?.intervals).toStrictEqual(
+        intervals,
+      );
+    });
+  }
 });

--- a/src/notation/stark/tests/stark-serializer.test.ts
+++ b/src/notation/stark/tests/stark-serializer.test.ts
@@ -597,3 +597,19 @@ describe("round-trip (interpret → serialize → interpret)", () => {
     expect(formatNotation(first, { drumMode: true })).toBe("hihat /16: X*16");
   });
 });
+
+describe("stark serializer — input note ordering", () => {
+  it("sorts notes by start time, so a shuffled input serializes identically", () => {
+    // Live API note lists are not guaranteed to arrive in start-time order, so
+    // the serializer sorts them itself. The same four on-grid hits fed out of
+    // order must still collapse to X*4 — not a mis-walk of leading rests.
+    const shuffled = [
+      note(36, 2, 1),
+      note(36, 0, 1),
+      note(36, 3, 1),
+      note(36, 1, 1),
+    ];
+
+    expect(formatNotation(shuffled, DRUM)).toBe("kick: X*4");
+  });
+});


### PR DESCRIPTION
## What

Completes the mutation-testing work: flips the Stryker gate from baseline mode to a **ratcheted threshold**, and closes the real test gaps that mutation testing surfaced along the way.

The Stryker infrastructure (config, `npm run mutation`, exact-pinned deps, `src/notation/` baseline, `dev/Mutation-Testing.md`) already shipped earlier. The only unmet acceptance criterion was the ratchet; this PR wires it and does a fresh triage pass.

## Changes

**Close real bucket-1 gaps** (found via mutation survivors, not visible to line/branch coverage):

- `chords/chord-symbols.ts` **73.3% → 96.7%** — 24 chord qualities (`min6`, all the 9/11/13 extensions, `mMaj7`, altered dominants, …) were reachable but unasserted, so blanking their interval rows survived. A golden-spec table test now verifies every quality resolves to the correct intervals, plus targeted tests for the slash-bass-equals-root octave drop (`>=` vs `>`) and invalid-root rejection.
- `stark/stark-serializer.ts` — `walkLine` sorts notes by `start_time`, but every prior test fed already-sorted input, leaving the sort untested (Live API note lists aren't guaranteed ordered). Added an unsorted-input test.

**Ratchet the gate** — `config/stryker.config.mjs`: `thresholds.break: null → 86` (report green tier `high: 80 → 85`). The gate now fails a run (exit 1) below 86%, ~1 point below the current score to absorb run-to-run timeout-classification variance. Verified the gate actually fires by temporarily raising `break` above the measured score and confirming the non-zero exit.

**Docs** — `dev/Mutation-Testing.md` updated with the new baseline, the wired ratchet, the closed gaps, and the triage rationale.

## Result

Full `src/notation/` pass: **86.90%** (was 86.20% pre-change; old documented baseline 85.83%). 3846 killed / 53 timeout / 577 survived / 11 no-coverage / 0 errors across 4487 mutants, ~7m30s.

The remaining survivors were triaged and deliberately left: they cluster on `± *_EPSILON` boundary flips (killing over-fits to a ~1e-9 / 0.001 slack), warning/error message strings, and equivalent mutants (e.g. a `.sort()` that's provably a no-op because its input is always ascending).

Mutation testing stays scoped to `src/notation/` and off the per-PR hot path (`npm run check` doesn't run it). `npm run check` + `npm run check:build` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)