### PR TITLE
test(mutation): per-domain scope mechanism for src/tools/

### DIFF
--- a/config/mutation-scopes.mjs
+++ b/config/mutation-scopes.mjs
@@ -1,0 +1,76 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Mutation-testing scopes: named subsets of the source tree Stryker mutates
+// independently. A whole-tree run is too slow (hours), so we run per-domain.
+// `MUTATION_SCOPE` picks one scope (read by config/stryker.config.mjs); the
+// runner (config/run-mutation.mjs) drives one or many.
+//
+// Each scope has:
+//   mutate — Stryker `mutate` globs (project-root-relative)
+//   break  — the thresholds.break gate. A NUMBER fails the run (exit 1) when
+//            the score drops below it; NULL is baseline mode (measure, never
+//            fail) until the domain has been triaged and earns a floor
+//            ~1 point below its triaged score, matching notation's ratchet.
+
+// Glob set for one tool domain under src/tools/. Excludes tests, test dirs,
+// test helpers, and type-only modules — none carry mutable behavior worth
+// asserting on. (src/tools/ currently has no types.ts, but the exclusion is
+// kept for parity with the notation scope and future-proofing.)
+function toolDomain(name) {
+  const dir = `src/tools/${name}`;
+
+  return [
+    `${dir}/**/*.ts`,
+    `!${dir}/**/*.test.ts`,
+    `!${dir}/**/tests/**`,
+    `!${dir}/**/*-test-helpers.ts`,
+    `!${dir}/**/types.ts`,
+  ];
+}
+
+// The notation scope's globs, preserved verbatim from the original single-scope
+// config so its baseline (and the break: 86 ratchet) is unchanged.
+const NOTATION_GLOBS = [
+  "src/notation/**/*.ts",
+  "!src/notation/**/*.test.ts",
+  "!src/notation/**/tests/**",
+  "!src/notation/**/*-test-helpers.ts",
+  "!src/notation/types.ts",
+  "!src/notation/peggy-parser-types.ts",
+  "!src/notation/**/peggy-parser-types.ts",
+];
+
+// Tool domains: one subdirectory each under src/tools/. break stays null until
+// each domain's survivors are triaged in its own PR (src/tools/constants.ts is
+// a plain root-level constants module, intentionally left unscoped).
+const TOOL_DOMAINS = [
+  "actions",
+  "advanced",
+  "clip",
+  "core",
+  "device",
+  "live-set",
+  "scene",
+  "session",
+  "shared",
+  "track",
+];
+
+export const SCOPES = {
+  notation: { mutate: NOTATION_GLOBS, break: 86 },
+  ...Object.fromEntries(
+    TOOL_DOMAINS.map((name) => [
+      name,
+      { mutate: toolDomain(name), break: null },
+    ]),
+  ),
+};
+
+// Named groups the runner expands into multiple scopes.
+export const SCOPE_GROUPS = {
+  tools: [...TOOL_DOMAINS],
+  all: ["notation", ...TOOL_DOMAINS],
+};

--- a/config/run-mutation.mjs
+++ b/config/run-mutation.mjs
@@ -1,0 +1,84 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Runner for scoped mutation testing. Expands the requested scope/group names,
+// then runs Stryker once per scope with MUTATION_SCOPE set, aggregating exit
+// codes (non-zero if any scope's break gate fires). Driven by `npm run mutation`.
+//
+// Usage:
+//   npm run mutation                 # default: notation
+//   npm run mutation -- clip         # one tool domain
+//   npm run mutation -- tools        # all tool domains (group)
+//   npm run mutation -- notation clip
+//   npm run mutation -- all          # notation + every tool domain
+//
+// Plain ESM (not scripts/*.ts) so it needs no build step and can import the
+// .mjs scope table directly.
+
+import { spawnSync } from "node:child_process";
+import { SCOPES, SCOPE_GROUPS } from "./mutation-scopes.mjs";
+
+// Expand group names into their member scopes, validate each, de-dupe while
+// preserving order. Throws on an unknown name (listing what is known).
+function resolveScopes(args) {
+  const requested = args.length > 0 ? args : ["notation"];
+  const expanded = [];
+
+  for (const name of requested) {
+    if (SCOPE_GROUPS[name] != null) {
+      expanded.push(...SCOPE_GROUPS[name]);
+    } else if (SCOPES[name] != null) {
+      expanded.push(name);
+    } else {
+      const known = [...Object.keys(SCOPES), ...Object.keys(SCOPE_GROUPS)].join(
+        ", ",
+      );
+
+      throw new Error(`Unknown mutation scope "${name}". Known: ${known}`);
+    }
+  }
+
+  return [...new Set(expanded)];
+}
+
+// Regenerate the peggy parsers first (tests import them transitively). Fail
+// fast if that step errors.
+function buildParsers() {
+  const result = spawnSync("npm", ["run", "parser:build"], {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+const scopes = resolveScopes(process.argv.slice(2));
+
+buildParsers();
+
+let failed = false;
+
+for (const scope of scopes) {
+  console.log(`\n=== Mutation testing scope: ${scope} ===\n`);
+  const result = spawnSync(
+    "npx",
+    ["stryker", "run", "config/stryker.config.mjs"],
+    {
+      stdio: "inherit",
+      env: { ...process.env, MUTATION_SCOPE: scope },
+    },
+  );
+
+  if (result.status !== 0) {
+    failed = true;
+    console.error(
+      `\n✗ Mutation scope "${scope}" failed (exit ${result.status}).`,
+    );
+  }
+}
+
+process.exit(failed ? 1 : 0);

--- a/config/stryker.config.mjs
+++ b/config/stryker.config.mjs
@@ -9,12 +9,24 @@
 // checks whether the test suite fails. A surviving mutant = a behavior no test
 // asserts on — a test-quality gap that line/branch coverage cannot detect.
 //
-// SCOPED on purpose: full-tree runs are expensive (hours). We start with
-// src/notation/ — dense, branch-heavy parsers/DSLs where high coverage most
-// easily hides weak assertions. Widen the `mutate` globs to add more areas.
+// SCOPED on purpose: full-tree runs are expensive (hours). The area to mutate
+// is selected by the `MUTATION_SCOPE` env var (default: notation), resolved
+// against the scope table in mutation-scopes.mjs. Each scope carries its own
+// `mutate` globs and `break` gate. Add domains there, not here.
 //
-// Run with: npm run mutation
+// Run with: npm run mutation [-- <scope>...]  (see config/run-mutation.mjs)
 // This is NOT part of `npm run check` — too slow for the per-PR hot path.
+
+import { SCOPES } from "./mutation-scopes.mjs";
+
+const scopeName = process.env.MUTATION_SCOPE ?? "notation";
+const scope = SCOPES[scopeName];
+
+if (scope == null) {
+  throw new Error(
+    `Unknown MUTATION_SCOPE "${scopeName}". Known scopes: ${Object.keys(SCOPES).join(", ")}`,
+  );
+}
 
 /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
 export default {
@@ -31,37 +43,31 @@ export default {
   // instead of the whole 8k-test suite per mutant — the main runtime win.
   coverageAnalysis: "perTest",
 
-  // Scope: notation source only. Exclude tests, test helpers, and type-only
-  // modules. Generated peggy parsers are .js and are never matched by *.ts.
-  mutate: [
-    "src/notation/**/*.ts",
-    "!src/notation/**/*.test.ts",
-    "!src/notation/**/tests/**",
-    "!src/notation/**/*-test-helpers.ts",
-    "!src/notation/types.ts",
-    "!src/notation/peggy-parser-types.ts",
-    "!src/notation/**/peggy-parser-types.ts",
-  ],
+  // Source to mutate, selected by MUTATION_SCOPE (see mutation-scopes.mjs).
+  // Excludes tests, test helpers, and type-only modules; generated peggy
+  // parsers are .js and are never matched by *.ts.
+  mutate: scope.mutate,
 
   reporters: ["html", "clear-text", "progress"],
-  htmlReporter: {
-    fileName: "reports/mutation/notation.html",
-  },
 
-  // Subsequent runs only re-test mutants in changed files. The incremental
-  // file is gitignored (large, machine-specific); the first run is a full pass.
+  // Per-scope report + incremental cache so runs of different scopes don't
+  // clobber each other (a scoped run used to overwrite the shared incremental
+  // file). Both live under reports/mutation/ (gitignored).
+  htmlReporter: {
+    fileName: `reports/mutation/${scopeName}.html`,
+  },
   incremental: true,
-  incrementalFile: "reports/mutation/stryker-incremental.json",
+  incrementalFile: `reports/mutation/${scopeName}-incremental.json`,
 
   // Ratcheted gate: the run FAILS (exit 1) if the score drops below `break`,
-  // like the coverage and lint-suppression limits. The floor sits ~1 point below
-  // the current src/notation score (86.90% as of 2026-07-14) — enough headroom
-  // for run-to-run timeout-classification variance (a timeout counts as killed,
-  // so it nudges the score), tight enough to catch a real test-quality
-  // regression. Raise it as the score improves; never lower without triaging why.
+  // like the coverage and lint-suppression limits. Per-scope: notation sits at
+  // 86 (~1 point below its 86.90% score for run-to-run timeout-classification
+  // variance); tool domains are null (baseline mode, measure-only) until each
+  // is triaged and earns a floor in its own PR. Raise a floor as the score
+  // improves; never lower one without triaging why.
   thresholds: {
     high: 85,
     low: 60,
-    break: 86,
+    break: scope.break,
   },
 };

--- a/dev/Mutation-Testing.md
+++ b/dev/Mutation-Testing.md
@@ -15,23 +15,53 @@ steps" below.
 ## Running
 
 ```bash
-npm run mutation
+npm run mutation                 # default scope: notation
+npm run mutation -- clip         # one src/tools/ domain
+npm run mutation -- tools        # every tool domain (group)
+npm run mutation -- notation clip
+npm run mutation -- all          # notation + every tool domain
 ```
 
-This is **scoped to `src/notation/`** and is deliberately **not** part of
-`npm run check` — a full pass takes minutes, too slow for the per-PR hot path.
+Mutation testing is **scoped** and deliberately **not** part of `npm run check`
+— a full pass takes minutes, too slow for the per-PR hot path. Whole-tree runs
+are hours, so we mutate one area ("scope") at a time.
 
-- Config: `config/stryker.config.mjs`
-- HTML report (gitignored): `reports/mutation/notation.html` — open it to browse
-  survivors per file with the exact source diff of each mutant.
-- Reruns are incremental (`reports/mutation/stryker-incremental.json`, also
-  gitignored): after the first full pass, only mutants in changed files re-run.
+Scopes are defined in `config/mutation-scopes.mjs`:
+
+- **`notation`** — `src/notation/` (the default). Ratcheted: `break: 86`.
+- **One scope per `src/tools/` domain** — `actions`, `advanced`, `clip`, `core`,
+  `device`, `live-set`, `scene`, `session`, `shared`, `track`. Each starts in
+  **baseline mode** (`break: null`, measure-only) until its survivors are
+  triaged in its own PR and it earns a floor.
+- **Groups** — `tools` (all ten tool domains) and `all` (notation + tools),
+  expanded by the runner into their member scopes.
+
+Mechanics:
+
+- Runner: `config/run-mutation.mjs` — resolves the requested scopes/groups,
+  rebuilds the peggy parsers, then runs Stryker once per scope with
+  `MUTATION_SCOPE` set, aggregating exit codes (non-zero if any gate fires).
+- Config: `config/stryker.config.mjs` — reads `MUTATION_SCOPE` (default
+  `notation`) and pulls that scope's `mutate` globs and `break` gate from the
+  scope table.
+- HTML report + incremental cache are **per scope** and gitignored:
+  `reports/mutation/<scope>.html` and
+  `reports/mutation/<scope>-incremental.json`. Per-scope incremental files mean
+  running one scope no longer clobbers another's cache. Open the HTML report to
+  browse survivors per file with the exact source diff of each mutant.
 
 The config reuses the project `vitest.config.ts`, so path aliases (`#src` etc.),
 the test environment, and env flags all apply unchanged.
 `coverageAnalysis: "perTest"` means each mutant only re-runs the tests that
 cover it, not the whole ~8k-test suite — this is the main reason a run is
 minutes, not hours.
+
+### Adding a new scope
+
+Add an entry to `SCOPES` in `config/mutation-scopes.mjs` (`mutate` globs +
+`break: null` for baseline mode); tool domains can use the `toolDomain()`
+helper. Optionally add it to a group. That's it — the config and runner pick it
+up by name.
 
 ## Baseline (2026-07-14, `src/notation/`)
 
@@ -113,17 +143,23 @@ wins, and a cross-check against the line-coverage gate.
 
 ## Status & next steps
 
-The gate is **ratcheted** (`thresholds.break = 86`) but still **scoped to
-`src/notation/`** and off the per-PR hot path (a full pass is minutes).
-Remaining work (later releases):
+The `notation` scope is **ratcheted** (`thresholds.break = 86`). The per-domain
+scope mechanism (`config/mutation-scopes.mjs` + the runner) is in place, so each
+`src/tools/` domain can be mutated on its own — all currently in **baseline
+mode** (`break: null`, measure-only). Mutation testing stays off the per-PR hot
+path (a full pass is minutes). Remaining work (later releases):
 
-- Keep triaging the ~588 survivors, but expect diminishing returns: the dense
-  clusters left are epsilon-boundary / warning-string / equivalent mutants
+- Keep triaging the ~588 notation survivors, but expect diminishing returns: the
+  dense clusters left are epsilon-boundary / warning-string / equivalent mutants
   (bucket 2/3), so genuine bucket-1 gaps are now sparse.
-- Raise `thresholds.break` as the score climbs.
-- Widen `mutate` to `src/tools/` (write operations first), likely as a scheduled
-  (nightly/weekly) non-blocking CI job — full-tree runtime is hours, not
-  minutes.
+- Raise each scope's `break` as its score climbs.
+- Triage the `src/tools/` domains one PR at a time (write operations first —
+  `clip`, `device`, `track`). Per domain: run `npm run mutation -- <domain>`,
+  close real gaps, flip that domain's `break` from `null` to ~1 point below its
+  triaged score. The big clean wins tend to be untested lookup/enum tables, as
+  in notation's chord table.
+- Optionally wire a scheduled (nightly/weekly) non-blocking CI job once several
+  domains have floors — full-tree runtime is hours, not minutes.
 
 ### CI-rollout sketch
 
@@ -141,17 +177,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mutate:
-          - "src/notation/**/*.ts"
-          - "src/tools/clip/**/*.ts"
-          - "src/tools/track/**/*.ts"
-          - "src/tools/device/**/*.ts"
-          - "src/tools/actions/**/*.ts"
-          - "src/tools/{scene,control,live-set,workflow}/**/*.ts"
+        scope: [notation, clip, device, track, actions, session, shared]
     steps:
-      - run: npx stryker run --mutate '${{ matrix.mutate }}'
-      # Upload HTML report as artifact
+      - run: npm run mutation -- ${{ matrix.scope }}
+      # Upload reports/mutation/<scope>.html as an artifact
 ```
+
+Each matrix job runs one scope from `config/mutation-scopes.mjs`, so the matrix
+is just a list of scope names — no duplicated glob strings to keep in sync.
 
 After the first full run, `--incremental` mode only re-tests mutants in changed
 files, bringing per-PR runs down to minutes — viable as a non-blocking check.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:coverage:verbose": "npm run test:setup && vitest run --coverage --reporter=default --silent=true",
     "test:setup": "npm run parser:build",
     "coverage": "npm run test:coverage",
-    "mutation": "npm run parser:build && stryker run config/stryker.config.mjs",
+    "mutation": "node config/run-mutation.mjs",
     "check": "npm run lint --silent && npm run typecheck --silent && npm run format:check --silent && npm run validate:typescript-only --silent && npm run duplication --silent && npm run test:coverage --silent",
     "check:build": "npm run build && npm run docs:build",
     "fix": "npm run lint:fix && npm run format",


### PR DESCRIPTION
## What

Adds a **per-domain scope mechanism** so Stryker can mutate one area of the tree at a time, extending mutation testing beyond the single `src/notation/` scope without ever needing a whole-tree run (hours). This is the mechanism ("PR1") for widening mutation coverage into `src/tools/`; the per-domain triage happens in later, independent PRs.

## How

- **`config/mutation-scopes.mjs`** (new) — the scope table:
  - `SCOPES`: `notation` (keeps its `break: 86` ratchet) plus one scope per `src/tools/` domain (`actions`, `advanced`, `clip`, `core`, `device`, `live-set`, `scene`, `session`, `shared`, `track`), each in **baseline mode** (`break: null`, measure-only) until triaged in its own PR.
  - `SCOPE_GROUPS`: `tools` (all ten domains) and `all` (notation + tools).
- **`config/stryker.config.mjs`** — reads `MUTATION_SCOPE` (default `notation`) and pulls that scope's `mutate` globs and `break` gate from the table. HTML report and incremental cache are now **per scope** (`reports/mutation/<scope>.{html,-incremental.json}`), so running one scope no longer clobbers another's cache.
- **`config/run-mutation.mjs`** (new) — runner: expands scopes/groups, validates (unknown name fails fast), rebuilds the peggy parsers, runs Stryker once per scope, aggregates exit codes.
- **`package.json`** — `mutation` script points at the runner. Usage:
  ```
  npm run mutation                 # default: notation
  npm run mutation -- clip         # one domain
  npm run mutation -- tools        # all tool domains
  npm run mutation -- all          # notation + tools
  ```
- **`dev/Mutation-Testing.md`** — documents scopes, groups, and how to add a new one.

## Validation

- Scope resolution for all 11 scopes + both groups + unknown-throws (config resolves the right globs / report paths / `break` per scope).
- End-to-end run on the `advanced` domain: only that domain was mutated, per-scope report written; baseline (`break: null`) exits 0; a temporary floor above the score exits 1, **propagated through the runner**.
- `npm run check` and `npm run check:build` green.

## Sequencing

Based on `ajm-560-mutation-testing` (the notation ratchet PR), not `dev` — both edit `config/stryker.config.mjs` (this PR migrates that PR's `break: 86` into the scope table). After the base PR merges to `dev`, this branch rebases onto `dev` and retargets, becoming an independent PR. The per-domain triage PRs are then independent off `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)