### PR TITLE
test(mutation): triage track domain, ratchet break to 85

### DIFF
--- a/config/mutation-scopes.mjs
+++ b/config/mutation-scopes.mjs
@@ -16,9 +16,17 @@
 //            ~1 point below its triaged score, matching notation's ratchet.
 
 // Glob set for one tool domain under src/tools/. Excludes tests, test dirs,
-// test helpers, and type-only modules — none carry mutable behavior worth
-// asserting on. (src/tools/ currently has no types.ts, but the exclusion is
-// kept for parity with the notation scope and future-proofing.)
+// test/mock helpers, `.def.ts` tool definitions, and type-only modules — none
+// carry mutable behavior worth asserting on. `.def.ts` files are purely
+// declarative (a `defineTool()` call: Zod schema + LLM-facing description
+// strings, no logic): mutating a `.describe("…")` string just blanks prose that
+// is eval-tested, not unit-tested, so asserting exact wording would over-fit and
+// fight the description-iteration workflow. Schema constraints (`.min`/`.max`)
+// are enforced by the MCP SDK, not our runtime code. `*-mock-helpers.ts` is
+// test-only mock infrastructure (like `*-test-helpers.ts`); it stays
+// source-classified for coverage but must not be mutated. (src/tools/ currently
+// has no types.ts, but that exclusion is kept for parity with the notation
+// scope and future-proofing.)
 function toolDomain(name) {
   const dir = `src/tools/${name}`;
 
@@ -27,6 +35,8 @@ function toolDomain(name) {
     `!${dir}/**/*.test.ts`,
     `!${dir}/**/tests/**`,
     `!${dir}/**/*-test-helpers.ts`,
+    `!${dir}/**/*-mock-helpers.ts`,
+    `!${dir}/**/*.def.ts`,
     `!${dir}/**/types.ts`,
   ];
 }
@@ -43,9 +53,8 @@ const NOTATION_GLOBS = [
   "!src/notation/**/peggy-parser-types.ts",
 ];
 
-// Tool domains: one subdirectory each under src/tools/. break stays null until
-// each domain's survivors are triaged in its own PR (src/tools/constants.ts is
-// a plain root-level constants module, intentionally left unscoped).
+// Tool domains: one subdirectory each under src/tools/ (src/tools/constants.ts
+// is a plain root-level constants module, intentionally left unscoped).
 const TOOL_DOMAINS = [
   "actions",
   "advanced",
@@ -59,12 +68,21 @@ const TOOL_DOMAINS = [
   "track",
 ];
 
+// Per-domain break gate (mutation-score floor). A domain stays in baseline mode
+// (absent here → null, measure-only) until its survivors are triaged in its own
+// PR; it then earns a floor ~1 point below its triaged score, matching
+// notation's ratchet. Raise a floor as the score climbs; never lower one
+// without triaging why.
+const TOOL_DOMAIN_BREAKS = {
+  track: 85, // triaged 2026-07-14 at 86.15% (see dev/Mutation-Testing.md)
+};
+
 export const SCOPES = {
   notation: { mutate: NOTATION_GLOBS, break: 86 },
   ...Object.fromEntries(
     TOOL_DOMAINS.map((name) => [
       name,
-      { mutate: toolDomain(name), break: null },
+      { mutate: toolDomain(name), break: TOOL_DOMAIN_BREAKS[name] ?? null },
     ]),
   ),
 };

--- a/dev/Mutation-Testing.md
+++ b/dev/Mutation-Testing.md
@@ -30,9 +30,11 @@ Scopes are defined in `config/mutation-scopes.mjs`:
 
 - **`notation`** — `src/notation/` (the default). Ratcheted: `break: 86`.
 - **One scope per `src/tools/` domain** — `actions`, `advanced`, `clip`, `core`,
-  `device`, `live-set`, `scene`, `session`, `shared`, `track`. Each starts in
-  **baseline mode** (`break: null`, measure-only) until its survivors are
-  triaged in its own PR and it earns a floor.
+  `device`, `live-set`, `scene`, `session`, `shared`, `track`. Each excludes
+  tests, test helpers, `.def.ts` tool-definition files, and type-only modules
+  (see `toolDomain()`). A domain starts in **baseline mode** (`break: null`,
+  measure-only) until its survivors are triaged in its own PR and it earns a
+  floor in `TOOL_DOMAIN_BREAKS`; `track` is the first, ratcheted at `break: 85`.
 - **Groups** — `tools` (all ten tool domains) and `all` (notation + tools),
   expanded by the runner into their member scopes.
 
@@ -125,6 +127,82 @@ sorted input, so the sort was untested.
 guard (in `transform-split-note-op.test.ts` and
 `barbeat-interpreter-helpers.test.ts`).
 
+## Baseline (2026-07-14, `src/tools/track/`)
+
+First `src/tools/` domain triaged (highest-priority write-op tier). Full pass —
+Stryker 9.6.1, Node 24, `coverageAnalysis: "perTest"`:
+
+| Metric                     | Value      |
+| -------------------------- | ---------- |
+| **Mutation score**         | **86.15%** |
+| Mutants killed             | 764        |
+| Survived                   | 116        |
+| Timeout (counts as killed) | 1          |
+| No coverage                | 7          |
+| Total mutants              | 888        |
+| Wall-clock                 | 54s        |
+
+Gate: `break: 85` (`TOOL_DOMAIN_BREAKS.track` in `config/mutation-scopes.mjs`),
+~1 point below the score for timeout-classification variance.
+
+Two scope refinements landed with this triage (both in `toolDomain()`), applying
+to **every** tool domain going forward:
+
+- **`.def.ts` excluded.** Tool-definition files are purely declarative — a
+  `defineTool()` call (Zod schema + LLM-facing description strings), no logic.
+  Mutating a `.describe("…")` string just blanks prose that is eval-tested, not
+  unit-tested; asserting exact wording would over-fit and fight the
+  description-iteration workflow. This lifted the raw `track` score from 73.14%
+  (dominated by 111 description-string survivors across 3 def files) to a
+  behavioral 82.21%.
+- **`*-mock-helpers.ts` excluded.** `read-track-drum-rack-mock-helpers.ts` is
+  test-only mock infrastructure (it imports the mock Live API; its sole importer
+  is another test helper), so mutating it is meaningless. The exclusion glob
+  already caught `*-test-helpers.ts`; extended to `*-mock-helpers.ts` too. Left
+  source-classified for coverage — only the mutation scope excludes it.
+
+Per-file scores after triage:
+
+| File                           | Score  | Survived |
+| ------------------------------ | ------ | -------- |
+| `track-routing-helpers.ts`     | 96.88% | 2        |
+| `read-track.ts`                | 88.76% | 18       |
+| `update-track.ts`              | 87.69% | 31       |
+| `read-track-helpers.ts`        | 86.18% | 30       |
+| `create-track.ts`              | 85.34% | 17       |
+| `read-track-device-helpers.ts` | 58.49% | 18       |
+
+`read-track-device-helpers.ts` is the low outlier by design, not weak testing:
+most of its survivors are **equivalent mutants**. `categorizeDevices` splits
+devices into midi-effect / instrument / audio-effect buckets, but its sole
+consumer (`read-track.ts`'s drum-map path) immediately re-flattens them — so
+mutating which bucket a device lands in cannot change any observable output.
+
+### Gaps closed (track)
+
+Mutation surfaced that several "warn and skip" tests asserted only the returned
+`{id}` object (returned regardless), never the warning or the skipped write — so
+real misbehavior slipped through (an unmatched `sendReturn` would silently write
+the _wrong_ send):
+
+| Gap (now killed)                                                     | Test strengthened / added    |
+| -------------------------------------------------------------------- | ---------------------------- |
+| Unmatched `sendReturn` silently wrote the wrong send (sentinel flip) | `update-track-send.test.ts`  |
+| Send letter-prefix over-matched (`"A"` matched `"Analog"`)           | `update-track-send.test.ts`  |
+| Send-pair / no-mixer / no-sends / index-exceeds warnings unasserted  | `update-track-send.test.ts`  |
+| Invalid `monitoringState` wrote an undefined value                   | `update-track.test.ts`       |
+| `createTrack` count/reach boundary (`count === MAX` allowed)         | `create-track.test.ts`       |
+| Return-track index from the wrong collection (mock symmetry masked)  | `create-track.test.ts`       |
+| Multi-track append shifted the insert index                          | `create-track.test.ts`       |
+| `firedSlotIndex === 0` boundary dropped                              | `read-track-basic.test.ts`   |
+| Multi-instrument warning unasserted                                  | `read-track-devices.test.ts` |
+
+Remaining survivors are bucket 2 (equivalent — the categorization split,
+`instruments[0] ?? null`, return/master/group clip guards that compute `0`
+either way since those track types have no clips) and bucket 3 (warn/error
+message string contents, internal option-passing flags, `.exists()` guards on
+always-present mocks).
+
 ## Interpreting survivors
 
 Each survivor falls into one of three buckets — triage before acting:
@@ -143,21 +221,24 @@ wins, and a cross-check against the line-coverage gate.
 
 ## Status & next steps
 
-The `notation` scope is **ratcheted** (`thresholds.break = 86`). The per-domain
-scope mechanism (`config/mutation-scopes.mjs` + the runner) is in place, so each
-`src/tools/` domain can be mutated on its own — all currently in **baseline
-mode** (`break: null`, measure-only). Mutation testing stays off the per-PR hot
-path (a full pass is minutes). Remaining work (later releases):
+The `notation` scope is **ratcheted** (`thresholds.break = 86`), as is `track`
+(`break: 85`, the first triaged tool domain). The per-domain scope mechanism
+(`config/mutation-scopes.mjs` + the runner) is in place, so each `src/tools/`
+domain can be mutated on its own; the untriaged ones remain in **baseline mode**
+(`break: null`, measure-only). Mutation testing stays off the per-PR hot path (a
+full pass is minutes). Remaining work (later releases):
 
 - Keep triaging the ~588 notation survivors, but expect diminishing returns: the
   dense clusters left are epsilon-boundary / warning-string / equivalent mutants
   (bucket 2/3), so genuine bucket-1 gaps are now sparse.
 - Raise each scope's `break` as its score climbs.
-- Triage the `src/tools/` domains one PR at a time (write operations first —
-  `clip`, `device`, `track`). Per domain: run `npm run mutation -- <domain>`,
-  close real gaps, flip that domain's `break` from `null` to ~1 point below its
-  triaged score. The big clean wins tend to be untested lookup/enum tables, as
-  in notation's chord table.
+- Triage the remaining `src/tools/` domains one PR at a time (write operations
+  first — `clip`, `device`, `session`, `actions`; `track` done). Per domain: run
+  `npm run mutation -- <domain>`, close real gaps, flip that domain's `break`
+  from `null` to ~1 point below its triaged score (add it to
+  `TOOL_DOMAIN_BREAKS`). The big clean wins tend to be untested lookup/enum
+  tables (as in notation's chord table) and warn-and-skip guards whose tests
+  assert only the result, never the warning or the skipped write.
 - Optionally wire a scheduled (nightly/weekly) non-blocking CI job once several
   domains have floors — full-tree runtime is hours, not minutes.
 

--- a/src/tools/track/create/create-track.test.ts
+++ b/src/tools/track/create/create-track.test.ts
@@ -229,6 +229,45 @@ describe("createTrack", () => {
     ).toThrow(/exceeds the maximum allowed/);
   });
 
+  it("should allow creating exactly the maximum number of tracks", () => {
+    // Boundary: count === MAX is allowed (the cap is strictly greater-than).
+    registerMockObject("midi_track_-1", {});
+
+    const result = createTrack({ count: MAX_AUTO_CREATED_TRACKS });
+
+    expect(result).toHaveLength(MAX_AUTO_CREATED_TRACKS);
+  });
+
+  it("should allow an insert whose reach lands exactly on the maximum", () => {
+    // Boundary: effectiveTrackIndex + count === MAX is allowed, not rejected.
+    registerMockObject("midi_track_97", {});
+    registerMockObject("midi_track_98", {});
+    registerMockObject("midi_track_99", {});
+
+    const result = createTrack({
+      trackIndex: MAX_AUTO_CREATED_TRACKS - 3,
+      count: 3,
+    });
+
+    expect(result).toHaveLength(3);
+  });
+
+  it("should keep appending at -1 for a multi-track append", () => {
+    registerMockObject("midi_track_-1", {});
+
+    const result = createTrack({ count: 2 });
+
+    // Append keeps calling with -1; currentIndex is NOT incremented (only
+    // explicit-index inserts shift right as earlier tracks are added).
+    expect(liveSet.call).toHaveBeenNthCalledWith(1, "create_midi_track", -1);
+    expect(liveSet.call).toHaveBeenNthCalledWith(2, "create_midi_track", -1);
+    // Result indices reflect final positions after the 2 existing tracks.
+    expect(result).toStrictEqual([
+      { id: "midi_track_-1", trackIndex: 2 },
+      { id: "midi_track_-1", trackIndex: 3 },
+    ]);
+  });
+
   it("should handle single track name without incrementing", () => {
     const track = registerMockObject("midi_track_0", {});
 
@@ -333,13 +372,49 @@ describe("createTrack", () => {
     it("should warn when trackIndex provided for return track", () => {
       registerMockObject("return_track_0", {});
 
-      createTrack({ type: "return", trackIndex: 5, name: "Ignored Index" });
+      const result = createTrack({
+        type: "return",
+        trackIndex: 5,
+        name: "Ignored Index",
+      });
 
       expect(console.warn).toHaveBeenCalledWith(
         "createTrack: trackIndex is ignored for return tracks (always added at end)",
       );
       // Should still create the track
       expect(liveSet.call).toHaveBeenCalledWith("create_return_track");
+      // The ignored trackIndex must NOT leak into the result index: a return
+      // track is always appended, so returnTrackIndex is the existing return
+      // count (2), never the passed-in 5.
+      expect(result).toStrictEqual({
+        id: "return_track_0",
+        returnTrackIndex: 2,
+      });
+    });
+
+    it("should index a return track by the return-track count, not the total track count", () => {
+      // Regression guard: the default mock happens to have equal regular and
+      // return track counts, which masks whether returnTrackIndex is derived
+      // from return_tracks (correct) or tracks (wrong). Use asymmetric counts.
+      registerMockObject("liveSet", {
+        path: livePath.liveSet,
+        properties: {
+          tracks: children("r1", "r2", "r3"), // 3 regular tracks
+          return_tracks: children("returnA", "returnB"), // 2 return tracks
+        },
+        methods: {
+          create_return_track: () => ["id", "return_track_0"],
+        },
+      });
+      registerMockObject("return_track_0", {});
+
+      const result = createTrack({ type: "return", name: "New Return" });
+
+      // 2 existing return tracks → index 2 (NOT 3, the regular-track count).
+      expect(result).toStrictEqual({
+        id: "return_track_0",
+        returnTrackIndex: 2,
+      });
     });
   });
 

--- a/src/tools/track/read/tests/read-track-basic.test.ts
+++ b/src/tools/track/read/tests/read-track-basic.test.ts
@@ -157,6 +157,32 @@ describe("readTrack", () => {
     });
   });
 
+  it("reports slot indices at the boundary value 0", () => {
+    // Boundary: playing/fired slot index 0 (first scene) must be reported, not
+    // dropped as if it were the -1 "none" sentinel (guard is `>= 0`, not `> 0`).
+    setupTrackPathMappedMocks({
+      trackPath: String(livePath.track(1)),
+      trackId: "track2",
+      objects: {
+        Track: {
+          has_midi_input: 1,
+          name: "Boundary Track",
+          playing_slot_index: 0,
+          fired_slot_index: 0,
+          clip_slots: [],
+          devices: [],
+        },
+      },
+    });
+
+    const result = readTrack({ trackIndex: 1 });
+
+    expect(result).toMatchObject({
+      playingSlotIndex: 0,
+      firedSlotIndex: 0,
+    });
+  });
+
   it("returns track group information", () => {
     setupTrackPathMappedMocks({
       trackId: "track1",

--- a/src/tools/track/read/tests/read-track-devices.test.ts
+++ b/src/tools/track/read/tests/read-track-devices.test.ts
@@ -62,6 +62,45 @@ describe("readTrack", () => {
       expect(result.devices).toBeUndefined();
     });
 
+    it("warns when a track has more than one instrument", () => {
+      // Defensive warning: a track is expected to have 0 or 1 instrument. Two
+      // instruments (unusual) must surface a warning. Reached via the drum-map
+      // path, which categorizes devices.
+      setupTrackMock({
+        trackId: "track1",
+        properties: {
+          devices: children("device1", "device2"),
+        },
+      });
+      registerMockObject("device1", {
+        path: livePath.track(0).device(0),
+        type: "Device",
+        properties: createDeviceMockProperties({
+          name: "Analog",
+          className: "InstrumentVector",
+          classDisplayName: "Analog",
+          type: LIVE_API_DEVICE_TYPE_INSTRUMENT,
+        }),
+      });
+      registerMockObject("device2", {
+        path: livePath.track(0).device(1),
+        type: "Device",
+        properties: createDeviceMockProperties({
+          name: "Operator",
+          className: "Operator",
+          classDisplayName: "Operator",
+          type: LIVE_API_DEVICE_TYPE_INSTRUMENT,
+        }),
+      });
+
+      readTrack({ trackIndex: 0, include: ["drum-map"] });
+
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("instruments, which is unusual"),
+      );
+    });
+
     it("categorizes devices correctly", () => {
       setupTrackMock({
         trackId: "track1",

--- a/src/tools/track/update/tests/update-track-send.test.ts
+++ b/src/tools/track/update/tests/update-track-send.test.ts
@@ -108,6 +108,11 @@ describe("updateTrack - send properties", () => {
       sendGainDb: -12,
     });
 
+    expect(send1.set).not.toHaveBeenCalled();
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("must both be specified"),
+    );
     expect(result).toStrictEqual({ id: "123" });
   });
 
@@ -118,17 +123,53 @@ describe("updateTrack - send properties", () => {
       sendReturn: "A",
     });
 
+    expect(send1.set).not.toHaveBeenCalled();
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("must both be specified"),
+    );
     expect(result).toStrictEqual({ id: "123" });
   });
 
   it("should warn and skip when return track not found", () => {
-    // Should not throw, just warn and skip the send update
+    // Should not throw, just warn and skip the send update. Crucially, no send
+    // is touched — a mis-initialized "not found" sentinel would silently write
+    // the wrong send instead of skipping.
     const result = updateTrack({
       ids: "123",
       sendGainDb: -12,
       sendReturn: "C",
     });
 
+    expect(send1.set).not.toHaveBeenCalled();
+    expect(send2.set).not.toHaveBeenCalled();
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining('no return track found matching "C"'),
+    );
+    expect(result).toStrictEqual({ id: "123" });
+  });
+
+  it("should not over-match a return whose name merely starts with the letter", () => {
+    // "A" matches "A-Reverb" (letter-dash prefix) or an exact name — it must NOT
+    // match any name that happens to start with "A" (e.g. "Analog"). Guards the
+    // `+ "-"` in the prefix check.
+    registerMockObject("return_A", {
+      path: livePath.returnTrack(0),
+      properties: { name: "Analog" },
+    });
+
+    const result = updateTrack({
+      ids: "123",
+      sendGainDb: -9,
+      sendReturn: "A",
+    });
+
+    expect(send1.set).not.toHaveBeenCalled();
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining('no return track found matching "A"'),
+    );
     expect(result).toStrictEqual({ id: "123" });
   });
 
@@ -146,6 +187,10 @@ describe("updateTrack - send properties", () => {
       sendReturn: "A",
     });
 
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("has no sends"),
+    );
     expect(result).toStrictEqual({ id: "123" });
   });
 
@@ -196,6 +241,10 @@ describe("updateTrack - send properties", () => {
       sendReturn: "A",
     });
 
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("has no mixer device"),
+    );
     expect(result).toStrictEqual({ id: "123" });
   });
 
@@ -219,6 +268,12 @@ describe("updateTrack - send properties", () => {
       sendReturn: "C", // Matches return track at index 2
     });
 
+    expect(send1.set).not.toHaveBeenCalled();
+    expect(send2.set).not.toHaveBeenCalled();
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("doesn't exist on track"),
+    );
     expect(result).toStrictEqual({ id: "123" });
   });
 });

--- a/src/tools/track/update/tests/update-track.test.ts
+++ b/src/tools/track/update/tests/update-track.test.ts
@@ -220,12 +220,21 @@ describe("updateTrack", () => {
     });
 
     it("should warn and skip for invalid monitoring state", () => {
-      // Should not throw, just warn and skip the monitoring state update
+      // Should not throw, just warn and skip the monitoring state update — and
+      // crucially NOT write an undefined monitoring value onto the track.
       const result = updateTrack({
         ids: "123",
         monitoringState: "invalid",
       });
 
+      expect(track123.set).not.toHaveBeenCalledWith(
+        "current_monitoring_state",
+        expect.anything(),
+      );
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("invalid monitoring state"),
+      );
       expect(result).toStrictEqual({ id: "123" });
     });
 


### PR DESCRIPTION
First `src/tools/` domain triaged under the per-domain mutation mechanism (highest-priority write-op tier). **Test/config/docs only — no product code changes.**

## Mechanism refinements (apply to all tool domains)

Both in `toolDomain()` (`config/mutation-scopes.mjs`):

- **Exclude `.def.ts`** — tool-definition files are purely declarative (a `defineTool()` call: Zod schema + LLM-facing description strings, no logic). Mutating a `.describe("…")` string just blanks prose that is eval-tested, not unit-tested; asserting exact wording would over-fit and fight the description-iteration workflow. This lifted the meaningful `track` score from a prose-dominated **73.14%** (111 description-string survivors across 3 def files) to a behavioral **82.21%**.
- **Exclude `*-mock-helpers.ts`** — `read-track-drum-rack-mock-helpers.ts` is test-only mock infra (imports the mock Live API; sole importer is another test helper). The glob already caught `*-test-helpers.ts`; extended to `*-mock-helpers.ts` too. Stays source-classified for coverage.

## Triage result: 82.21% → 86.15%, `break: 85`

| Metric | Value |
|---|---|
| Mutation score | **86.15%** |
| Killed / Survived / No-cov | 764 / 116 / 7 |

The `update-track` "warn and skip" tests asserted only the returned `{id}` (returned regardless), never the warning or the skipped write. Mutation exposed that:
- an unmatched `sendReturn` would **silently write the wrong send** (sentinel `-1` flip), and
- a send letter-prefix would **over-match** (`"A"` matching `"Analog"`).

These are latent — today's code is correct; the tests just didn't guard the regressions. Gaps closed:

| Gap (now killed) | Test |
|---|---|
| Unmatched `sendReturn` writes the wrong send; prefix over-match; unasserted send warnings | `update-track-send.test.ts` |
| Invalid `monitoringState` writes an undefined value | `update-track.test.ts` |
| `createTrack` MAX boundary; return-track index (symmetric mock masked it); multi-track append | `create-track.test.ts` |
| `firedSlotIndex === 0` boundary | `read-track-basic.test.ts` |
| Multi-instrument warning | `read-track-devices.test.ts` |

Remaining survivors are bucket 2 (equivalent — notably `categorizeDevices`' midi/audio split, which its sole consumer re-flattens) and bucket 3 (message strings, internal flags). See `dev/Mutation-Testing.md` for the full baseline + triage record.

Gate verified green: `npm run mutation -- track` exits 0 (86.15% ≥ 85). `npm run check` and `check:build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)