### PR TITLE
test(mutation): triage session domain, ratchet break to 89

### DIFF
--- a/config/mutation-scopes.mjs
+++ b/config/mutation-scopes.mjs
@@ -75,6 +75,7 @@ const TOOL_DOMAINS = [
 // without triaging why.
 const TOOL_DOMAIN_BREAKS = {
   track: 85, // triaged 2026-07-14 at 86.15% (see dev/Mutation-Testing.md)
+  session: 89, // triaged 2026-07-14 at 90.46% (see dev/Mutation-Testing.md)
 };
 
 export const SCOPES = {

--- a/dev/Mutation-Testing.md
+++ b/dev/Mutation-Testing.md
@@ -34,7 +34,8 @@ Scopes are defined in `config/mutation-scopes.mjs`:
   tests, test helpers, `.def.ts` tool-definition files, and type-only modules
   (see `toolDomain()`). A domain starts in **baseline mode** (`break: null`,
   measure-only) until its survivors are triaged in its own PR and it earns a
-  floor in `TOOL_DOMAIN_BREAKS`; `track` is the first, ratcheted at `break: 85`.
+  floor in `TOOL_DOMAIN_BREAKS`; triaged so far: `track` (`break: 85`),
+  `session` (`break: 89`).
 - **Groups** — `tools` (all ten tool domains) and `all` (notation + tools),
   expanded by the runner into their member scopes.
 
@@ -203,6 +204,83 @@ either way since those track types have no clips) and bucket 3 (warn/error
 message string contents, internal option-passing flags, `.exists()` guards on
 always-present mocks).
 
+## Baseline (2026-07-14, `src/tools/session/`)
+
+Second write-op domain triaged (`library` / `playback` / `select` /
+`read-samples` tools). Full pass — Stryker 9.6.1, Node 24,
+`coverageAnalysis: "perTest"`:
+
+| Metric                     | Value      |
+| -------------------------- | ---------- |
+| **Mutation score**         | **90.46%** |
+| Mutants killed             | 1125       |
+| Survived                   | 117        |
+| Timeout (counts as killed) | 4          |
+| No coverage                | 2          |
+| Total mutants              | 1248       |
+| Wall-clock                 | 1m 12s     |
+
+Gate: `break: 89` (`TOOL_DOMAIN_BREAKS.session`), ~1.5 points below the score
+for timeout-classification variance. Triage lifted the score from a **87.10%**
+baseline (159 survivors), killing 42 mutants with test-only changes — no product
+code touched.
+
+Per-file scores after triage:
+
+| File                              | Score  | Survived | Notes                          |
+| --------------------------------- | ------ | -------- | ------------------------------ |
+| `library.ts`                      | 97.59% | 6        | sort/filter/reason gaps closed |
+| `playback.ts`                     | 95.71% | 6        |                                |
+| `library-search-batch-helpers.ts` | 94.55% | 3        |                                |
+| `read-samples.ts`                 | 94.44% | 4        |                                |
+| `playback-helpers.ts`             | 94.00% | 6        |                                |
+| `select.ts`                       | 89.78% | 19       |                                |
+| `select-helpers.ts`               | 86.56% | 34       |                                |
+| `select-id-helpers.ts`            | 86.27% | 7        |                                |
+| `select-response-helpers.ts`      | 82.64% | 19       |                                |
+| `library-query-schema.ts`         | 38.10% | 13       | prose/equivalent — see below   |
+
+`library-query-schema.ts` is the low outlier by design, not weak testing: it is
+mostly a Zod schema whose 11 surviving `.describe("…")` mutations are the same
+untestable LLM-facing prose that `.def.ts` files carry (asserting exact wording
+over-fits). Its two logic survivors are the `preprocess` guard — a
+`typeof value === "string"` check whose mutant is provably equivalent (the
+`catch` returns the original value on any parse failure, so a non-string
+round-trips identically).
+
+The `select*` files carry most of the remaining survivors, and they are
+dominated by bucket-2/3 mutants: response-shape field guards
+(`if (info) result.x = info` where the builder never returns null on tested
+paths), `.exists()` guards on always-present mocks, and
+`validateIdType(id, type, "select")` error-context strings. Genuine bucket-1
+gaps there are sparse; left for a future pass rather than over-fitting the
+current one.
+
+### Gaps closed (session)
+
+The clean wins mirror the cross-domain pattern: an untested sort/lookup path
+plus warn-and-skip / boundary guards whose tests asserted only the happy-path
+result.
+
+| Gap (now killed)                                                     | Test strengthened / added      |
+| -------------------------------------------------------------------- | ------------------------------ |
+| `sortPartition` name / mod_date / use_count ordering all untested\*  | `library.test.ts`              |
+| Merged/folder-only `reason` key leaked as `undefined` when absent    | `library.test.ts`              |
+| Folder-scan item shape (`kind: "audio"`, empty `tags`) unasserted    | `library.test.ts`              |
+| `callRoute` success-with-no-result must throw, not resolve undefined | `library.test.ts`              |
+| `deviceKind: "audiofx"` passthrough + valid/absent no-warn controls  | `library-list-plugins.test.ts` |
+| searchBatch cap boundary (exactly 20 no-warn) + dropped-count math   | `library-search-batch.test.ts` |
+| searchBatch keeps the _first_ stalenessRisk, not the last            | `library-search-batch.test.ts` |
+| searchBatch omits the `reason` key on entries with no reason         | `library-search-batch.test.ts` |
+| Zero-length loop (`loopEnd` exactly at `loopStart`, `<= 0` boundary) | `playback-basic.test.ts`       |
+| `select` conflict-view warn fired on matching / no-view selections   | `select-basic.test.ts`         |
+| Wildcard search regex-escaping (`(` matched literally) + limit guard | `read-samples.test.ts`         |
+
+\* The prior sort tests used coincidentally-aligned data (all `useCount: 0`, or
+a use_count order matching the alphabetical order), so a wrong sort branch
+produced the same output. The new tests use a DB partition where name-order,
+useCount- order, and upstream-order all differ, uniquely pinning each mode.
+
 ## Interpreting survivors
 
 Each survivor falls into one of three buckets — triage before acting:
@@ -221,21 +299,22 @@ wins, and a cross-check against the line-coverage gate.
 
 ## Status & next steps
 
-The `notation` scope is **ratcheted** (`thresholds.break = 86`), as is `track`
-(`break: 85`, the first triaged tool domain). The per-domain scope mechanism
-(`config/mutation-scopes.mjs` + the runner) is in place, so each `src/tools/`
-domain can be mutated on its own; the untriaged ones remain in **baseline mode**
-(`break: null`, measure-only). Mutation testing stays off the per-PR hot path (a
-full pass is minutes). Remaining work (later releases):
+The `notation` scope is **ratcheted** (`thresholds.break = 86`), as are `track`
+(`break: 85`) and `session` (`break: 89`), the first two triaged tool domains.
+The per-domain scope mechanism (`config/mutation-scopes.mjs` + the runner) is in
+place, so each `src/tools/` domain can be mutated on its own; the untriaged ones
+remain in **baseline mode** (`break: null`, measure-only). Mutation testing
+stays off the per-PR hot path (a full pass is minutes). Remaining work (later
+releases):
 
 - Keep triaging the ~588 notation survivors, but expect diminishing returns: the
   dense clusters left are epsilon-boundary / warning-string / equivalent mutants
   (bucket 2/3), so genuine bucket-1 gaps are now sparse.
 - Raise each scope's `break` as its score climbs.
 - Triage the remaining `src/tools/` domains one PR at a time (write operations
-  first — `clip`, `device`, `session`, `actions`; `track` done). Per domain: run
-  `npm run mutation -- <domain>`, close real gaps, flip that domain's `break`
-  from `null` to ~1 point below its triaged score (add it to
+  first — `clip`, `device`, `actions`; `track` and `session` done). Per domain:
+  run `npm run mutation -- <domain>`, close real gaps, flip that domain's
+  `break` from `null` to ~1 point below its triaged score (add it to
   `TOOL_DOMAIN_BREAKS`). The big clean wins tend to be untested lookup/enum
   tables (as in notation's chord table) and warn-and-skip guards whose tests
   assert only the result, never the warning or the skipped write.

--- a/src/tools/session/tests/library-list-plugins.test.ts
+++ b/src/tools/session/tests/library-list-plugins.test.ts
@@ -88,6 +88,45 @@ describe("library tool — listPlugins action", () => {
     warnSpy.mockRestore();
   });
 
+  it("maps deviceKind=audiofx to the category filter without warning", async () => {
+    // Pins the second PLUGIN_CATEGORIES member: audiofx is a valid plugin
+    // category, so it passes through as category and must not warn.
+    const consoleModule = await import("#src/shared/v8-max-console.ts");
+    const warnSpy = vi
+      .spyOn(consoleModule, "warn")
+      .mockImplementation(() => {});
+
+    mockPluginsRoute();
+
+    await library({ action: "listPlugins", deviceKind: "audiofx" });
+
+    expect(protocolMock.requestNode).toHaveBeenCalledWith(
+      "library.listPlugins",
+      expect.objectContaining({ category: "audiofx" }),
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it("does not warn for a valid deviceKind or when deviceKind is absent", async () => {
+    // Negative control for the warn guard: only an invalid plugin category
+    // (e.g. midifx) should warn — a valid one and an absent one must stay silent.
+    const consoleModule = await import("#src/shared/v8-max-console.ts");
+    const warnSpy = vi
+      .spyOn(consoleModule, "warn")
+      .mockImplementation(() => {});
+
+    mockPluginsRoute();
+
+    await library({ action: "listPlugins", deviceKind: "instrument" });
+    await library({ action: "listPlugins" });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
   it("returns the plugins payload from the route", async () => {
     mockPluginsRoute([
       {

--- a/src/tools/session/tests/library-search-batch.test.ts
+++ b/src/tools/session/tests/library-search-batch.test.ts
@@ -233,6 +233,31 @@ describe("library tool — searchBatch action", () => {
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("exceeds cap of 20"),
     );
+    // The dropped count must be queries - cap (25 - 20 = 5), not a sum.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ignoring the extra 5"),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("does not warn when the batch is exactly at the cap of 20", async () => {
+    // Boundary of the > cap guard: 20 queries is allowed in full, so no warn.
+    const consoleModule = await import("#src/shared/v8-max-console.ts");
+    const warnSpy = vi
+      .spyOn(consoleModule, "warn")
+      .mockImplementation(() => {});
+
+    mockSearchByFilter({});
+
+    const queries = Array.from({ length: 20 }, (_, i) => ({
+      query: String(i),
+    }));
+    const result = await library({ action: "searchBatch", queries });
+
+    if (!("results" in result)) throw new Error("expected results");
+    expect(result.results).toHaveLength(20);
+    expect(warnSpy).not.toHaveBeenCalled();
 
     warnSpy.mockRestore();
   });
@@ -356,6 +381,60 @@ describe("library tool — searchBatch action", () => {
 
     if (!("results" in result)) throw new Error("expected results");
     expect("stalenessRisk" in result).toBe(false);
+  });
+
+  it("keeps the first stalenessRisk reading when two queries report different ones", async () => {
+    // Staleness is a single global DB property; the batch captures the first
+    // non-null reading and must not overwrite it with a later query's copy.
+    const first = {
+      kind: "wal-pending" as const,
+      dbMtime: 1_000_000,
+      walMtime: 4_600_000,
+      walSizeMb: 12,
+      ageSeconds: 3_600,
+    };
+    const second = {
+      kind: "wal-pending" as const,
+      dbMtime: 9_000_000,
+      walMtime: 9_600_000,
+      walSizeMb: 99,
+      ageSeconds: 9_999,
+    };
+
+    vi.mocked(protocolMock.requestNode)
+      .mockResolvedValueOnce({
+        success: true,
+        result: { dbAvailable: true, stalenessRisk: first, items: [] },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        result: { dbAvailable: true, stalenessRisk: second, items: [] },
+      });
+
+    const result = await library({
+      action: "searchBatch",
+      queries: [{ tags: "Kick" }, { tags: "Snare" }],
+    });
+
+    if (!("results" in result)) throw new Error("expected results");
+    expect(result.stalenessRisk).toStrictEqual(first);
+  });
+
+  it("omits the reason key on an entry whose query returned no reason", async () => {
+    // A matched query with no diagnostic must yield { label, items } exactly —
+    // no reason: undefined leaking into the entry.
+    mockSearchByFilter({ Kick: [dbItem("kick.wav")] });
+
+    const result = await library({
+      action: "searchBatch",
+      queries: [{ label: "Kicks", tags: "Kick" }],
+    });
+
+    if (!("results" in result)) throw new Error("expected results");
+    const entry = result.results[0];
+
+    expect(entry).toBeDefined();
+    expect(entry && "reason" in entry).toBe(false);
   });
 
   it("preserves entries from other queries when a single query throws (per-query graceful degrade)", async () => {

--- a/src/tools/session/tests/library.test.ts
+++ b/src/tools/session/tests/library.test.ts
@@ -38,6 +38,39 @@ function mockSearchRoute(items: unknown[]): void {
 }
 
 /**
+ * Build a minimal DB library item with the given name and useCount.
+ *
+ * @param name - Item name (also its leaf path)
+ * @param useCount - Usage count driving the default (use_count desc) sort
+ * @returns A LibraryItem-shaped object sourced from the DB ("user")
+ */
+function dbItem(name: string, useCount: number): Record<string, unknown> {
+  return {
+    name,
+    path: `/L/${name}`,
+    kind: "audio",
+    tags: [],
+    useCount,
+    source: "user",
+  };
+}
+
+/**
+ * Stub the search route with three DB items whose name order, useCount order,
+ * and upstream (array) order all differ, so each sort mode yields a distinct
+ * sequence. This is what pins sortPartition: with coincidentally-aligned data
+ * a wrong sort branch produces the same output and survives mutation.
+ *
+ *   upstream: b(1), a(3), c(2)
+ *   name:     a, b, c
+ *   use_count desc (default): a(3), c(2), b(1)
+ *   mod_date (DB upstream order preserved): b, a, c
+ */
+function mockDiscriminatingSortRoute(): void {
+  mockSearchRoute([dbItem("b.wav", 1), dbItem("a.wav", 3), dbItem("c.wav", 2)]);
+}
+
+/**
  * Stub the "/samples/" folder with the given top-level .wav file names.
  *
  * @param names - File names to place directly under "/samples/"
@@ -178,6 +211,16 @@ describe("library tool — action dispatch", () => {
       "Unknown action: bogus",
     );
   });
+
+  it("throws when a route reports success but omits the result payload", async () => {
+    // callRoute guards on `!success || !result`: a truthy success with a
+    // missing result must still throw, not resolve to an undefined payload.
+    vi.mocked(protocolMock.requestNode).mockResolvedValue({ success: true });
+
+    await expect(library({ action: "listTags" })).rejects.toThrow(
+      "library.listTags failed",
+    );
+  });
 });
 
 describe("library tool — folder scan integration", () => {
@@ -208,10 +251,13 @@ describe("library tool — folder scan integration", () => {
     expect(names).toContain("kick.wav");
     expect(names).toContain("snare.wav");
     expect(names).toContain("clap.wav");
-    // Folder items get source: "sampleFolder"
-    expect(result.items.find((i) => i.name === "kick.wav")?.source).toBe(
-      "sampleFolder",
-    );
+    // Folder items get source: "sampleFolder", kind: "audio", and empty tags
+    // (the folder scan only surfaces audio and carries no tag metadata).
+    const kick = result.items.find((i) => i.name === "kick.wav");
+
+    expect(kick?.source).toBe("sampleFolder");
+    expect(kick?.kind).toBe("audio");
+    expect(kick?.tags).toStrictEqual([]);
   });
 
   it("marks sampleFolder items pathExists: true when verifyPaths is set", async () => {
@@ -284,6 +330,9 @@ describe("library tool — folder scan integration", () => {
     // Folder-only requests bypass the DB; dbAvailable should be absent
     // rather than fabricated.
     expect("dbAvailable" in result).toBe(false);
+    // No diagnostic cause here, so the reason key must be omitted entirely
+    // (not present-but-undefined).
+    expect("reason" in result).toBe(false);
   });
 
   it("merged requests propagate dbAvailable from the DB call", async () => {
@@ -294,6 +343,9 @@ describe("library tool — folder scan integration", () => {
 
     if (!("items" in result)) throw new Error("expected items");
     expect(result.dbAvailable).toBe(true);
+    // Neither the folder scan nor the DB supplied a reason, so the merged
+    // result must omit the key rather than carry reason: undefined.
+    expect("reason" in result).toBe(false);
   });
 
   it("skips folder scan when tags filter is set (folder has no tag info)", async () => {
@@ -593,5 +645,52 @@ describe("library tool — folder scan integration", () => {
     expect(result.items.find((i) => i.name === "kick.wav")?.folder).toBe(
       "samples",
     );
+  });
+});
+
+describe("library tool — sort ordering (DB partition)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("default sort orders the DB partition by use_count desc (name tiebreak)", async () => {
+    mockDiscriminatingSortRoute();
+
+    const result = await library({}, {});
+
+    if (!("items" in result)) throw new Error("expected items");
+    expect(result.items.map((i) => i.name)).toStrictEqual([
+      "a.wav", // useCount 3
+      "c.wav", // useCount 2
+      "b.wav", // useCount 1
+    ]);
+  });
+
+  it("sort=name orders the DB partition alphabetically, ignoring use_count", async () => {
+    mockDiscriminatingSortRoute();
+
+    const result = await library({ sort: "name" }, {});
+
+    if (!("items" in result)) throw new Error("expected items");
+    expect(result.items.map((i) => i.name)).toStrictEqual([
+      "a.wav",
+      "b.wav",
+      "c.wav",
+    ]);
+  });
+
+  it("sort=mod_date preserves the DB's upstream order for mixed-source items", async () => {
+    mockDiscriminatingSortRoute();
+
+    const result = await library({ sort: "mod_date" }, {});
+
+    if (!("items" in result)) throw new Error("expected items");
+    // The DB partition is not all-sampleFolder, so mod_date keeps the upstream
+    // (SQL-provided) order rather than re-sorting by name or use_count.
+    expect(result.items.map((i) => i.name)).toStrictEqual([
+      "b.wav",
+      "a.wav",
+      "c.wav",
+    ]);
   });
 });

--- a/src/tools/session/tests/playback-basic.test.ts
+++ b/src/tools/session/tests/playback-basic.test.ts
@@ -108,6 +108,29 @@ describe("transport", () => {
     );
   });
 
+  it("skips a zero-length loop (loopEnd exactly at loopStart) and warns", () => {
+    // Boundary of the non-positive guard (<= 0, not < 0): loopEnd landing
+    // exactly on loopStart is a length of 0, which is just as invalid in Live
+    // as a negative length — it must warn and skip, not write loop_length: 0.
+    liveSet = setupPlaybackLiveSet({ is_playing: 0, current_song_time: 0 });
+
+    playback({
+      action: "update-arrangement",
+      loop: true,
+      loopStart: "3|1", // beat 8
+      loopEnd: "3|1", // beat 8 → length 8 - 8 = 0
+    });
+
+    expect(liveSet.set).not.toHaveBeenCalledWith(
+      "loop_length",
+      expect.anything(),
+    );
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("loopEnd must be after loopStart"),
+    );
+  });
+
   it("reports the actual loop bounds, not the rejected loopEnd, when loop length is non-positive", () => {
     // The Live Set's real loop is bars 1–2. A loopEnd at/before loopStart is
     // rejected (loop_length not written), so the response must echo the

--- a/src/tools/session/tests/read-samples.test.ts
+++ b/src/tools/session/tests/read-samples.test.ts
@@ -191,6 +191,20 @@ describe("readSamples", () => {
       );
     });
 
+    it("does not warn when the file count stays under the limit", () => {
+      // Negative control for the limit warn: a small folder never trips the
+      // MAX_SAMPLE_FILES cap, so the "Stopped scanning" warning must not fire.
+      context.sampleFolder = "/samples/";
+      mockKickSnareFolder();
+
+      readSamples({}, context);
+
+      expect(outlet).not.toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("Stopped scanning for samples"),
+      );
+    });
+
     it("should stop scanning nested folders when limit is reached", () => {
       context.sampleFolder = "/samples/";
 
@@ -319,6 +333,23 @@ describe("readSamples", () => {
       const result = readSamples({ search: "kick.wav" }, context);
 
       expect(result.samples).toStrictEqual(["kick.wav"]);
+    });
+
+    it("escapes regex specials in a wildcard pattern so parens match literally", () => {
+      context.sampleFolder = "/samples/";
+      mockFolderStructure({
+        "/samples/": [
+          { name: "kick(1).wav", type: "file", extension: ".wav" },
+          { name: "kick1.wav", type: "file", extension: ".wav" },
+        ],
+      });
+
+      // With "*" present the query becomes a regex; the "(" must be escaped to
+      // a literal, not treated as a group opener. Only "kick(..." should match;
+      // if escaping is dropped, "kick.*" would also match "kick1.wav".
+      const result = readSamples({ search: "kick(*" }, context);
+
+      expect(result.samples).toStrictEqual(["kick(1).wav"]);
     });
 
     it("should only count matching files toward MAX_SAMPLE_FILES limit", () => {

--- a/src/tools/session/tests/select/select-basic.test.ts
+++ b/src/tools/session/tests/select/select-basic.test.ts
@@ -273,6 +273,15 @@ describe("view", () => {
         "highlighted_clip_slot",
         `id ${clipSlot.id}`,
       );
+      // No view was requested, so the conflict warn (which is gated on a
+      // non-null requestedView) must not fire.
+      const outletMock = (globalThis as Record<string, unknown>)
+        .outlet as ReturnType<typeof vi.fn>;
+
+      expect(outletMock).not.toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("ignoring view="),
+      );
     });
   });
 
@@ -294,6 +303,24 @@ describe("view", () => {
       // Live switches to the clip's required (session) view, so the response
       // must report that — not the overridden requested "arrangement" view.
       expect(result.view).toBe("session");
+    });
+
+    it("does not warn when the requested view already matches the clip's required view", () => {
+      // Negative control for the conflict warn: a session clip requested with
+      // view="session" agrees with its required view, so no warning fires.
+      const { clip } = setupSessionClipMock("session_clip_match", 1, 2);
+
+      setupSongViewMock();
+
+      select({ id: `id ${clip.id}`, view: "session" });
+
+      const outletMock = (globalThis as Record<string, unknown>)
+        .outlet as ReturnType<typeof vi.fn>;
+
+      expect(outletMock).not.toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("ignoring view="),
+      );
     });
   });
 


### PR DESCRIPTION
Second write-op tool domain triaged for mutation testing (follows the `track` domain, PR #963). **Test/config/docs only — no product code changed.**

## Result

| | Baseline | After triage |
| --- | --- | --- |
| Mutation score | 87.10% | **90.46%** |
| Survived | 159 | 117 |
| Gate (`break`) | `null` | **89** |

`npm run mutation -- session` exits 0 (90.46% ≥ 89). Killed 42 mutants with test-only changes.

## What was closed

The clean wins mirror the cross-domain pattern: an untested sort/lookup path plus warn-and-skip / boundary guards whose tests asserted only the happy-path result.

- **`library.ts` sort ordering** — the prior `sortPartition` tests used coincidentally-aligned data (all `useCount: 0`, or a use_count order matching alphabetical), so a wrong sort branch produced identical output and survived. New tests use a DB partition where name-order, useCount-order, and upstream-order all differ, uniquely pinning each mode. Also: `reason`-key absence, folder-item shape (`kind`/`tags`), and `callRoute` success-with-no-result throwing.
- **`listPlugins` deviceKind** — `audiofx` passthrough + valid/absent no-warn controls.
- **`searchBatch`** — exactly-at-cap (20) no-warn, dropped-count math, first-`stalenessRisk`-wins, and no `reason` key on entries without one.
- **playback** — zero-length loop boundary (`loopEnd` exactly at `loopStart`, the `<= 0` guard; prior tests only covered negative lengths).
- **`select`** — conflict-view warning must not fire on matching / no-view selections.
- **`read-samples`** — wildcard regex-escaping (`(` matched literally) + under-limit no-warn.

## Remaining survivors (accepted)

All bucket 2 (equivalent) or bucket 3 (prose/defensive), documented in `dev/Mutation-Testing.md`:
- `library-query-schema.ts` (38%) is mostly a Zod schema — its survivors are `.describe()` LLM-facing prose (same untestable class as `.def.ts`) plus one provably-equivalent `preprocess` guard.
- The `select*` files' remaining survivors are response-shape field guards, `.exists()` guards on always-present mocks, and error-context strings.

## Verification

`npm run check` (9365 passed, Functions 100%), `npm run check:build`, and the mutation gate all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)