### PR TITLE
test(mutation): triage actions domain, ratchet break to 90

### DIFF
--- a/config/mutation-scopes.mjs
+++ b/config/mutation-scopes.mjs
@@ -76,6 +76,7 @@ const TOOL_DOMAINS = [
 const TOOL_DOMAIN_BREAKS = {
   track: 85, // triaged 2026-07-14 at 86.15% (see dev/Mutation-Testing.md)
   session: 89, // triaged 2026-07-14 at 90.46% (see dev/Mutation-Testing.md)
+  actions: 90, // triaged 2026-07-15 at 91.79% (see dev/Mutation-Testing.md)
 };
 
 export const SCOPES = {

--- a/dev/Mutation-Testing.md
+++ b/dev/Mutation-Testing.md
@@ -35,7 +35,7 @@ Scopes are defined in `config/mutation-scopes.mjs`:
   (see `toolDomain()`). A domain starts in **baseline mode** (`break: null`,
   measure-only) until its survivors are triaged in its own PR and it earns a
   floor in `TOOL_DOMAIN_BREAKS`; triaged so far: `track` (`break: 85`),
-  `session` (`break: 89`).
+  `session` (`break: 89`), `actions` (`break: 90`).
 - **Groups** — `tools` (all ten tool domains) and `all` (notation + tools),
   expanded by the runner into their member scopes.
 
@@ -281,6 +281,85 @@ a use_count order matching the alphabetical order), so a wrong sort branch
 produced the same output. The new tests use a DB partition where name-order,
 useCount- order, and upstream-order all differ, uniquely pinning each mode.
 
+## Baseline (2026-07-15, `src/tools/actions/`)
+
+Third write-op domain triaged (`delete` and `duplicate` tools — the latter
+spanning ten `duplicate-*-helpers.ts` files). Full pass — Stryker 9.6.1, Node
+24, `coverageAnalysis: "perTest"`:
+
+| Metric                     | Value      |
+| -------------------------- | ---------- |
+| **Mutation score**         | **91.79%** |
+| Mutants killed             | 1145       |
+| Survived                   | 93         |
+| Timeout (counts as killed) | 6          |
+| No coverage                | 10         |
+| Total mutants              | 1254       |
+| Wall-clock                 | 1m 9s      |
+
+Gate: `break: 90` (`TOOL_DOMAIN_BREAKS.actions`), ~1.8 points below the score
+for timeout-classification variance. Triage lifted the score from an **83.97%**
+baseline (191 survivors), killing 96 mutants with test-only changes — no product
+code touched.
+
+Per-file scores after triage:
+
+| File                                 | Score   | Survived | Notes                            |
+| ------------------------------------ | ------- | -------- | -------------------------------- |
+| `duplicate-focus-helpers.ts`         | 100.00% | 0        | determineTargetView fully pinned |
+| `duplicate-validation-helpers.ts`    | 99.38%  | 1        | direct unit tests (81% → 99%)    |
+| `duplicate-take-lane-helpers.ts`     | 96.30%  | 2        | setAll/message/color-fallback    |
+| `delete.ts`                          | 94.22%  | 15       | 2-digit indices + comparator     |
+| `duplicate-routing-helpers.ts`       | 94.12%  | 6        | mock fix exposed routing branch  |
+| `duplicate-track-scene-helpers.ts`   | 91.62%  | 11       |                                  |
+| `duplicate-clip-position-helpers.ts` | 90.70%  | 4        |                                  |
+| `duplicate.ts`                       | 87.60%  | 15       |                                  |
+| `duplicate-transform-helpers.ts`     | 86.67%  | 4        | edge/optional-chain (bucket 2)   |
+| `duplicate-device-helpers.ts`        | 85.54%  | 10       | 2-digit track regexes            |
+| `duplicate-helpers.ts`               | 81.65%  | 25       | heavy tiling paths — see below   |
+
+`duplicate-helpers.ts` is the low outlier, and its survivors are mostly
+bucket-2/3: the `createClipsForLength` / `lengthenClipAndCollectInfo` /
+`duplicateClipToArrangement` arrangement-tiling paths route through several
+mocked shared helpers, so `setAll({name, color})` object mutants and
+`is_midi_clip === 1` branch mutants there are hard to observe without a full
+Live-API integration harness. Two more provably-equivalent classes live here:
+the `omitFields: string[] = []` default (mutating to `["Stryker…"]` omits a
+field name nothing checks) and the `parseArrangementLength` catch-wrapper
+(`msg.includes("Invalid duration format")` — both branches throw a message the
+substring assertions already accept). Left for a future integration-test pass
+rather than over-fitting.
+
+### Gaps closed (actions)
+
+Two structural wins beyond the usual warn-and-skip hardening:
+
+- **Discriminating id-sort data** (mirrors the `session` `sortPartition` fix):
+  `findRoutingOptionForDuplicateNames` sorts duplicate-named tracks by numeric
+  id to pick the right routing option. The new unit test uses children order
+  (5,2,9) ≠ id-sorted order (2,5,9) plus a non-matching low-id track, so a
+  blanked/`+`-comparator/kept-filter mutant each picks a different position.
+- **A mock that hid a whole branch.** `setupRouteToSourceMock` stored
+  routing-type properties as plain objects, but `getProperty` JSON-parses them —
+  so every routeToSource test silently hit a parse-failure path and the real
+  input/output routing-change code (`configureSourceTrackInput` /
+  `applyOutputRouting`) was never executed. Storing them as JSON strings (as
+  Live returns) made the routing branch testable and killed its survivors.
+
+| Gap (now killed)                                                     | Test strengthened / added                               |
+| -------------------------------------------------------------------- | ------------------------------------------------------- |
+| Track / scene / return-track / clip / device index regexes (`\d+`)   | `delete.test.ts`, `delete-device.test.ts`               |
+| Device-deletion comparator tiebreaker (chains-before-return_chains)  | `delete-device.test.ts`                                 |
+| `validateAndConfigureRouteToSource` warns + forced `{true,true}`     | `duplicate-validation-helpers.test.ts`                  |
+| `inferDestination` / `validateArrangementParameters` whitespace trim | `duplicate-validation-helpers.test.ts`                  |
+| `findRoutingOptionForDuplicateNames` id-sort position                | `duplicate-routing-helpers.test.ts`                     |
+| Input/output routing-change branch (mock stored objects, not JSON)   | `duplicate-test-helpers.ts` + `duplicate-track.test.ts` |
+| transforms/code-ignored warn (clip no-warn control + code-only arm)  | `duplicate-transforms.test.ts`                          |
+| Take-lane setAll property copies + "created on lane N" + color-copy  | `duplicate-take-lane.test.ts`                           |
+| determineTargetView track/device/scene arms + empty-array `.at(-1)`  | `duplicate-focus-helpers.test.ts`                       |
+| name/color/omit-trackIndex/has_clip guards on duplicated tracks      | `duplicate-track-scene-helpers.test.ts`                 |
+| 2-digit source/destination track regexes in device duplication       | `duplicate-device.test.ts`                              |
+
 ## Interpreting survivors
 
 Each survivor falls into one of three buckets — triage before acting:
@@ -300,19 +379,19 @@ wins, and a cross-check against the line-coverage gate.
 ## Status & next steps
 
 The `notation` scope is **ratcheted** (`thresholds.break = 86`), as are `track`
-(`break: 85`) and `session` (`break: 89`), the first two triaged tool domains.
-The per-domain scope mechanism (`config/mutation-scopes.mjs` + the runner) is in
-place, so each `src/tools/` domain can be mutated on its own; the untriaged ones
-remain in **baseline mode** (`break: null`, measure-only). Mutation testing
-stays off the per-PR hot path (a full pass is minutes). Remaining work (later
-releases):
+(`break: 85`), `session` (`break: 89`), and `actions` (`break: 90`), the first
+three triaged tool domains. The per-domain scope mechanism
+(`config/mutation-scopes.mjs` + the runner) is in place, so each `src/tools/`
+domain can be mutated on its own; the untriaged ones remain in **baseline mode**
+(`break: null`, measure-only). Mutation testing stays off the per-PR hot path (a
+full pass is minutes). Remaining work (later releases):
 
 - Keep triaging the ~588 notation survivors, but expect diminishing returns: the
   dense clusters left are epsilon-boundary / warning-string / equivalent mutants
   (bucket 2/3), so genuine bucket-1 gaps are now sparse.
 - Raise each scope's `break` as its score climbs.
 - Triage the remaining `src/tools/` domains one PR at a time (write operations
-  first — `clip`, `device`, `actions`; `track` and `session` done). Per domain:
+  first — `clip`, `device`; `track`, `session`, and `actions` done). Per domain:
   run `npm run mutation -- <domain>`, close real gaps, flip that domain's
   `break` from `null` to ~1 point below its triaged score (add it to
   `TOOL_DOMAIN_BREAKS`). The big clean wins tend to be untested lookup/enum

--- a/src/tools/actions/delete/tests/delete-device.test.ts
+++ b/src/tools/actions/delete/tests/delete-device.test.ts
@@ -64,6 +64,17 @@ describe("deleteObject device deletion", () => {
     );
   });
 
+  it("should delete a device at a multi-digit index", () => {
+    // A `\d`-only device-index regex would read "12" as "1" and delete the
+    // wrong device.
+    expectDeviceDeleted(
+      "device_12",
+      String(livePath.track(0).device(12)),
+      String(livePath.track(0)),
+      12,
+    );
+  });
+
   it("should delete multiple devices", () => {
     const ids = "device_1,device_2";
 
@@ -112,6 +123,23 @@ describe("deleteObject device deletion", () => {
       { id: "device_0_1", type: "device", deleted: true },
       { id: "device_0_0", type: "device", deleted: true },
     ]);
+  });
+
+  it("should order multi-digit sibling device indices highest-first", () => {
+    // parsePathSegments must read the FULL index: a `\d`-only match reads
+    // "devices 13" as index 1, sorting it below index 2 and flipping the
+    // positional delete order (which would then shift the survivor down).
+    const { parents } = setupDeviceMocks(["d2", "d13"], {
+      d2: String(livePath.track(0).device(2)),
+      d13: String(livePath.track(0).device(13)),
+    });
+
+    deleteObject({ ids: "d2,d13", type: "device" });
+
+    const parent = parents.get(String(livePath.track(0)));
+
+    expect(parent?.call).toHaveBeenNthCalledWith(1, "delete_device", 13);
+    expect(parent?.call).toHaveBeenNthCalledWith(2, "delete_device", 2);
   });
 
   it("should delete a device referenced by a duplicate id only once", () => {
@@ -263,33 +291,47 @@ describe("deleteObject device deletion", () => {
       expect(result).toHaveLength(3);
     });
 
-    it("orders cross-collection siblings (chains vs return_chains) by a stable name comparison", () => {
+    it("orders cross-collection siblings (chains before return_chains) deterministically", () => {
       // When two device paths diverge at a sub-collection name (chains vs
       // return_chains under the same device) the deletes are independent, so the
-      // order is correctness-irrelevant — the comparator falls back to a stable
-      // name comparison. Run both input orders so both arms of that comparison
-      // are exercised; either way both devices delete successfully.
+      // order is correctness-irrelevant — but the comparator still returns a
+      // DETERMINISTIC order (a stable name compare: "chains" < "return_chains" →
+      // chains first) to keep the sort transitive. Pin that order's sign in BOTH
+      // input orders: forward exercises the natural compare, reversed proves the
+      // tiebreaker (not input order) decides — which a blanked/flipped comparator
+      // would get wrong.
       const rack = String(livePath.track(0).device(0));
 
-      const firstResult = (() => {
-        setupDeviceMocks(["ch", "rc"], {
-          ch: `${rack} chains 0 devices 0`,
-          rc: `${rack} return_chains 0 devices 0`,
+      function deleteAndMeasure(
+        ids: string,
+        chId: string,
+        rcId: string,
+      ): { result: unknown; chainOrder: number; returnChainOrder: number } {
+        const { parents } = setupDeviceMocks([chId, rcId], {
+          [chId]: `${rack} chains 0 devices 0`,
+          [rcId]: `${rack} return_chains 0 devices 0`,
         });
 
-        return deleteObject({ ids: "ch, rc", type: "device" });
-      })();
+        const result = deleteObject({ ids, type: "device" });
+        const chainOrder =
+          parents.get(`${rack} chains 0`)?.call.mock.invocationCallOrder[0] ??
+          0;
+        const returnChainOrder =
+          parents.get(`${rack} return_chains 0`)?.call.mock
+            .invocationCallOrder[0] ?? 0;
 
-      const secondResult = (() => {
-        setupDeviceMocks(["ch2", "rc2"], {
-          ch2: `${rack} chains 0 devices 0`,
-          rc2: `${rack} return_chains 0 devices 0`,
-        });
+        return { result, chainOrder, returnChainOrder };
+      }
 
-        return deleteObject({ ids: "rc2, ch2", type: "device" });
-      })();
+      const forward = deleteAndMeasure("ch, rc", "ch", "rc");
+      const reversed = deleteAndMeasure("rc2, ch2", "ch2", "rc2");
 
-      for (const result of [firstResult, secondResult]) {
+      for (const { result, chainOrder, returnChainOrder } of [
+        forward,
+        reversed,
+      ]) {
+        // chains deletes before return_chains regardless of input order.
+        expect(chainOrder).toBeLessThan(returnChainOrder);
         expect(result).toHaveLength(2);
         expect(result).toStrictEqual(
           expect.arrayContaining([

--- a/src/tools/actions/delete/tests/delete.test.ts
+++ b/src/tools/actions/delete/tests/delete.test.ts
@@ -415,5 +415,69 @@ describe("deleteObject", () => {
     ]);
   });
 
+  it("should delete multi-digit track indices in descending order", () => {
+    // Two-digit indices guard both the sort regex and the delete regex: a
+    // `\d`-only match reads "13" as "1", which would collapse the descending
+    // order AND pass a truncated index to delete_track.
+    setupTrackMocks({
+      track_2: String(livePath.track(2)),
+      track_13: String(livePath.track(13)),
+    });
+
+    deleteObject({ ids: "track_2,track_13", type: "track" });
+
+    expect(liveSet.call).toHaveBeenNthCalledWith(1, "delete_track", 13);
+    expect(liveSet.call).toHaveBeenNthCalledWith(2, "delete_track", 2);
+  });
+
+  it("should delete a return track at a multi-digit index", () => {
+    registerMockObject("return_12", {
+      path: livePath.returnTrack(12),
+      type: "Track",
+    });
+
+    const result = deleteObject({ ids: "return_12", type: "track" });
+
+    expect(result).toStrictEqual({
+      id: "return_12",
+      type: "track",
+      deleted: true,
+    });
+    expect(liveSet.call).toHaveBeenCalledWith("delete_return_track", 12);
+  });
+
+  it("should delete multi-digit scene indices in descending order", () => {
+    setupSceneMocks({
+      scene_3: livePath.scene(3),
+      scene_12: livePath.scene(12),
+    });
+
+    deleteObject({ ids: "scene_3,scene_12", type: "scene" });
+
+    expect(liveSet.call).toHaveBeenNthCalledWith(1, "delete_scene", 12);
+    expect(liveSet.call).toHaveBeenNthCalledWith(2, "delete_scene", 3);
+  });
+
+  it("should delete a clip on a multi-digit track index", () => {
+    registerMockObject("clip_10_0", {
+      path: livePath.track(10).clipSlot(0).clip(),
+      type: "Clip",
+    });
+    const track10 = registerMockObject("live_set/tracks/10", {
+      path: livePath.track(10),
+    });
+
+    const result = deleteObject({ ids: "clip_10_0", type: "clip" });
+
+    expect(result).toStrictEqual({
+      id: "clip_10_0",
+      type: "clip",
+      deleted: true,
+    });
+    // A truncated "\d" would resolve track index 1, calling delete_clip on the
+    // wrong track — assert the two-digit track's own parent was called.
+    expect(track10.call).toHaveBeenCalledWith("delete_clip", "id clip_10_0");
+  });
+
   // Device deletion tests are in delete-device.test.js
 });

--- a/src/tools/actions/duplicate/helpers/duplicate-test-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/duplicate-test-helpers.ts
@@ -52,12 +52,23 @@ export function registerClipSlot(
 interface SourceTrackMock {
   name: string;
   current_monitoring_state: number;
-  input_routing_type: { display_name: string };
-  available_input_routing_types: Array<{
-    display_name: string;
-    identifier: string;
-  }>;
+  // Live returns routing-type properties as JSON strings that getProperty()
+  // parses (an object/array here would trip its JSON.parse and yield null,
+  // silently skipping the real routing-change branches under test).
+  input_routing_type: string;
+  available_input_routing_types: string;
   arm?: number;
+}
+
+/**
+ * Wrap a routing-type value the way Live's API delivers it: a JSON string keyed
+ * by the property name, which getProperty() parses back out.
+ * @param property - Routing property name (e.g. "input_routing_type")
+ * @param value - The object or array value to wrap
+ * @returns JSON string as the raw Live API value
+ */
+function routingValue(property: string, value: unknown): string {
+  return JSON.stringify({ [property]: value });
 }
 
 /**
@@ -112,11 +123,16 @@ export function setupRouteToSourceMock(
   const sourceTrackMock: SourceTrackMock = {
     name: trackName,
     current_monitoring_state: monitoringState,
-    input_routing_type: { display_name: inputRoutingName },
-    available_input_routing_types: [
-      { display_name: "No Input", identifier: "no_input_id" },
-      { display_name: "Audio In", identifier: "audio_in_id" },
-    ],
+    input_routing_type: routingValue("input_routing_type", {
+      display_name: inputRoutingName,
+    }),
+    available_input_routing_types: routingValue(
+      "available_input_routing_types",
+      [
+        { display_name: "No Input", identifier: "no_input_id" },
+        { display_name: "Audio In", identifier: "audio_in_id" },
+      ],
+    ),
   };
 
   if (arm !== undefined) {
@@ -129,10 +145,13 @@ export function setupRouteToSourceMock(
       unknown
     >,
     [livePath.track(1).toString()]: {
-      available_output_routing_types: [
-        { display_name: "Master", identifier: "master_id" },
-        { display_name: trackName, identifier: "source_track_id" },
-      ],
+      available_output_routing_types: routingValue(
+        "available_output_routing_types",
+        [
+          { display_name: "Master", identifier: "master_id" },
+          { display_name: trackName, identifier: "source_track_id" },
+        ],
+      ),
     },
   };
 }

--- a/src/tools/actions/duplicate/helpers/tests/duplicate-focus-helpers.test.ts
+++ b/src/tools/actions/duplicate/helpers/tests/duplicate-focus-helpers.test.ts
@@ -70,6 +70,35 @@ describe("duplicate-focus-helpers", () => {
       expect(selectMock.get()).not.toHaveBeenCalled();
     });
 
+    it("does nothing for a track even when the destination would map to a view", () => {
+      // determineTargetView short-circuits to null for track/device BEFORE the
+      // destination is consulted, so a "session" destination must not select.
+      focusIfRequested(true, "session", "track", [{ id: "track1" }]);
+
+      expect(selectMock.get()).not.toHaveBeenCalled();
+    });
+
+    it("does nothing for a device even when the destination would map to a view", () => {
+      focusIfRequested(true, "session", "device", [{ id: "device1" }]);
+
+      expect(selectMock.get()).not.toHaveBeenCalled();
+    });
+
+    it("switches to session view for a scene without id and no destination", () => {
+      // Reaches determineTargetView's `type === "scene"` arm (a scene WITH id
+      // returns earlier), independent of the destination === "session" arm.
+      focusIfRequested(true, undefined, "scene", [{}]);
+
+      expect(selectMock.get()).toHaveBeenCalledWith({ view: "session" });
+    });
+
+    it("handles an empty createdObjects array without throwing", () => {
+      // `.at(-1)` is undefined here; the optional chain must not dereference it.
+      focusIfRequested(true, "session", "clip", []);
+
+      expect(selectMock.get()).toHaveBeenCalledWith({ view: "session" });
+    });
+
     it("falls back to view switch for clips without id", () => {
       focusIfRequested(true, "session", "clip", [{}]);
 

--- a/src/tools/actions/duplicate/helpers/tests/duplicate-routing-helpers.test.ts
+++ b/src/tools/actions/duplicate/helpers/tests/duplicate-routing-helpers.test.ts
@@ -1,0 +1,104 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it, vi } from "vitest";
+import "#src/live-api-adapter/live-api-extensions.ts";
+import * as console from "#src/shared/v8-max-console.ts";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import { children } from "#src/test/mocks/mock-live-api.ts";
+import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
+import {
+  findRoutingOptionForDuplicateNames,
+  type RoutingType,
+} from "../duplicate-routing-helpers.ts";
+
+/**
+ * Build a routing option named "Bass" with a position-tagged identifier so a
+ * test can tell which of several same-named options was returned.
+ * @param i - Position tag
+ * @returns Routing option
+ */
+function bassOption(i: number): RoutingType {
+  return { display_name: "Bass", identifier: `b${i}` };
+}
+
+/**
+ * Register a live_set whose `tracks` children resolve to the given
+ * (id, name) pairs, in the given order.
+ * @param spec - Track id/name pairs, in children (creation-input) order
+ */
+function setupTracks(spec: Array<{ id: string; name: string }>): void {
+  registerMockObject("live_set", {
+    path: livePath.liveSet,
+    properties: { tracks: children(...spec.map((t) => t.id)) },
+  });
+
+  for (const t of spec) {
+    registerMockObject(t.id, {
+      path: livePath.track(0),
+      type: "Track",
+      properties: { name: t.name },
+    });
+  }
+}
+
+describe("findRoutingOptionForDuplicateNames", () => {
+  it("returns the single matching option directly when names are not duplicated", () => {
+    const sourceTrack = registerMockObject("5", {
+      path: livePath.track(0),
+      type: "Track",
+    });
+
+    const result = findRoutingOptionForDuplicateNames(
+      sourceTrack as unknown as LiveAPI,
+      "Bass",
+      [bassOption(0), { display_name: "Lead", identifier: "l0" }],
+    );
+
+    expect(result).toStrictEqual(bassOption(0));
+  });
+
+  it("maps the source track to the option at its id-sorted (creation-order) position", () => {
+    // Discriminating data: children order (5,2,9) differs from the id-sorted
+    // order (2,5,9), and a non-matching LOW-id track ("1"=Other) is present so
+    // the name filter genuinely narrows the list. Source id 5 lands at sorted
+    // position 1 → options[1]. A blanked/reversed sort, a `+` comparator, or a
+    // filter that keeps "Other" would all pick a different position.
+    setupTracks([
+      { id: "5", name: "Bass" },
+      { id: "2", name: "Bass" },
+      { id: "9", name: "Bass" },
+      { id: "1", name: "Other" },
+    ]);
+
+    const result = findRoutingOptionForDuplicateNames(
+      LiveAPI.from("id 5"),
+      "Bass",
+      [bassOption(0), bassOption(1), bassOption(2)],
+    );
+
+    expect(result).toStrictEqual(bassOption(1));
+  });
+
+  it("warns and returns undefined when the source track is not among the duplicates", () => {
+    const warnSpy = vi.spyOn(console, "warn");
+
+    setupTracks([
+      { id: "5", name: "Bass" },
+      { id: "2", name: "Bass" },
+    ]);
+
+    const result = findRoutingOptionForDuplicateNames(
+      LiveAPI.from("id 99"),
+      "Bass",
+      [bassOption(0), bassOption(1)],
+    );
+
+    expect(result).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Could not find source track in duplicate name list for "Bass"',
+    );
+  });
+});

--- a/src/tools/actions/duplicate/helpers/tests/duplicate-track-scene-helpers.test.ts
+++ b/src/tools/actions/duplicate/helpers/tests/duplicate-track-scene-helpers.test.ts
@@ -118,7 +118,7 @@ describe("duplicate-track-scene-helpers", () => {
         properties: { tracks: ["id", "10", "id", "11", "id", "12"] },
       });
 
-      registerMockObject("live_set/tracks/1", {
+      const newTrack = registerMockObject("live_set/tracks/1", {
         path: livePath.track(1),
         properties: { devices: [], clip_slots: [], arrangement_clips: [] },
       });
@@ -131,6 +131,12 @@ describe("duplicate-track-scene-helpers", () => {
       });
 
       expect(liveSet.call).toHaveBeenCalledWith("duplicate_track", 0);
+      // No name/color/routeToSource → none of those side effects fire.
+      expect(newTrack.set).not.toHaveBeenCalledWith("name", expect.anything());
+      expect(outlet).not.toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("routing options"),
+      );
     });
 
     it("should set name when provided", () => {
@@ -365,7 +371,7 @@ describe("duplicate-track-scene-helpers", () => {
         path: livePath.track(1),
         properties: {
           devices: [],
-          clip_slots: children("slot0"),
+          clip_slots: children("slot0", "emptySlot"),
           arrangement_clips: [],
         },
       });
@@ -373,10 +379,16 @@ describe("duplicate-track-scene-helpers", () => {
         path: livePath.track(1).clipSlot(0),
         properties: { has_clip: 1 },
       });
+      const emptySlot = registerMockObject("emptySlot", {
+        path: livePath.track(1).clipSlot(1),
+        properties: { has_clip: 0 },
+      });
 
       duplicateTrack(0, undefined, undefined, true);
 
       expect(slot0.call).toHaveBeenCalledWith("delete_clip");
+      // An empty slot (has_clip 0) is skipped, not deleted.
+      expect(emptySlot.call).not.toHaveBeenCalledWith("delete_clip");
     });
 
     it("should not set color when color is not provided", () => {
@@ -448,6 +460,10 @@ describe("duplicate-track-scene-helpers", () => {
       // Should collect arrangement clips
       expect(result.clips.length).toBeGreaterThan(0);
       expect(result.clips[0]!.id).toBe(arrClipId);
+      // Arrangement clips on a duplicated track omit trackIndex (they all share
+      // the new track) but keep arrangementStart.
+      expect(result.clips[0]).not.toHaveProperty("trackIndex");
+      expect(result.clips[0]).toHaveProperty("arrangementStart");
     });
   });
 
@@ -474,7 +490,7 @@ describe("duplicate-track-scene-helpers", () => {
 
   describe("duplicateScene", () => {
     it("should duplicate a scene and return basic info", () => {
-      const { liveSet } = setupDuplicateSceneMocks();
+      const { liveSet, scene } = setupDuplicateSceneMocks();
 
       const result = duplicateScene(0);
 
@@ -484,6 +500,8 @@ describe("duplicate-track-scene-helpers", () => {
       });
 
       expect(liveSet.call).toHaveBeenCalledWith("duplicate_scene", 0);
+      // No name provided → the name setter is skipped.
+      expect(scene.set).not.toHaveBeenCalledWith("name", expect.anything());
     });
 
     it("should set name when provided", () => {

--- a/src/tools/actions/duplicate/helpers/tests/duplicate-validation-helpers.test.ts
+++ b/src/tools/actions/duplicate/helpers/tests/duplicate-validation-helpers.test.ts
@@ -1,0 +1,182 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it, vi } from "vitest";
+import * as console from "#src/shared/v8-max-console.ts";
+import {
+  inferDestination,
+  validateAndConfigureRouteToSource,
+  validateArrangementParameters,
+  validateClipParameters,
+} from "../duplicate-validation-helpers.ts";
+
+describe("validateAndConfigureRouteToSource", () => {
+  it("returns the user values unchanged when routeToSource is falsy", () => {
+    expect(
+      validateAndConfigureRouteToSource("track", false, false, true),
+    ).toStrictEqual({ withoutClips: false, withoutDevices: true });
+    expect(
+      validateAndConfigureRouteToSource(
+        "track",
+        undefined,
+        undefined,
+        undefined,
+      ),
+    ).toStrictEqual({ withoutClips: undefined, withoutDevices: undefined });
+  });
+
+  it("throws when routeToSource is used with a non-track type", () => {
+    expect(() =>
+      validateAndConfigureRouteToSource("scene", true, undefined, undefined),
+    ).toThrow("routeToSource is only supported for type 'track'");
+  });
+
+  it("forces withoutClips/withoutDevices to true and warns when the user passed false", () => {
+    const warnSpy = vi.spyOn(console, "warn");
+
+    const result = validateAndConfigureRouteToSource(
+      "track",
+      true,
+      false,
+      false,
+    );
+
+    // Returned config is forced to true for both, regardless of the user's false.
+    expect(result).toStrictEqual({ withoutClips: true, withoutDevices: true });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "routeToSource requires withoutClips=true, ignoring user-provided withoutClips=false",
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      "routeToSource requires withoutDevices=true, ignoring user-provided withoutDevices=false",
+    );
+  });
+
+  it("does not warn when withoutClips/withoutDevices are not explicitly false", () => {
+    const warnSpy = vi.spyOn(console, "warn");
+
+    const result = validateAndConfigureRouteToSource(
+      "track",
+      true,
+      true,
+      undefined,
+    );
+
+    expect(result).toStrictEqual({ withoutClips: true, withoutDevices: true });
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("ignoring user-provided withoutClips"),
+    );
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("ignoring user-provided withoutDevices"),
+    );
+  });
+});
+
+describe("inferDestination", () => {
+  it("returns 'arrangement' when arrangementStart is a real position", () => {
+    expect(inferDestination("clip", "1|1", undefined, undefined)).toBe(
+      "arrangement",
+    );
+  });
+
+  it("treats a whitespace-only arrangementStart as no arrangement params", () => {
+    // The `.trim() !== ""` guard: "   " must NOT be read as an arrangement start.
+    expect(inferDestination("clip", "   ", undefined, "0/0")).toBe("session");
+    expect(inferDestination("track", "   ", undefined, undefined)).toBe(
+      "session",
+    );
+  });
+
+  it("returns 'arrangement' when a locator is given", () => {
+    expect(inferDestination("clip", undefined, "Verse", undefined)).toBe(
+      "arrangement",
+    );
+  });
+
+  it("returns 'session' for a clip only when toSlot is present, else undefined", () => {
+    expect(inferDestination("clip", undefined, undefined, "0/0")).toBe(
+      "session",
+    );
+    expect(
+      inferDestination("clip", undefined, undefined, undefined),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for a device", () => {
+    expect(
+      inferDestination("device", undefined, undefined, undefined),
+    ).toBeUndefined();
+  });
+
+  it("defaults tracks and scenes to session", () => {
+    expect(inferDestination("track", undefined, undefined, undefined)).toBe(
+      "session",
+    );
+    expect(inferDestination("scene", undefined, undefined, undefined)).toBe(
+      "session",
+    );
+  });
+});
+
+describe("validateClipParameters", () => {
+  it("does nothing for non-clip types", () => {
+    expect(() =>
+      validateClipParameters("track", undefined, undefined),
+    ).not.toThrow();
+  });
+
+  it("throws when a clip has no resolved destination", () => {
+    expect(() => validateClipParameters("clip", undefined, undefined)).toThrow(
+      "clip requires toSlot",
+    );
+  });
+
+  it("throws when a session clip is missing toSlot (whitespace only)", () => {
+    expect(() => validateClipParameters("clip", "session", "  ")).toThrow(
+      "toSlot is required for session clips",
+    );
+  });
+
+  it("accepts a session clip with a real toSlot", () => {
+    expect(() =>
+      validateClipParameters("clip", "session", "0/0"),
+    ).not.toThrow();
+  });
+
+  it("accepts an arrangement clip with no toSlot", () => {
+    expect(() =>
+      validateClipParameters("clip", "arrangement", undefined),
+    ).not.toThrow();
+  });
+});
+
+describe("validateArrangementParameters", () => {
+  it("does nothing when destination is not arrangement", () => {
+    // Even with both start and locator present, a non-arrangement destination
+    // must return early without throwing.
+    expect(() =>
+      validateArrangementParameters("session", "1|1", "Verse"),
+    ).not.toThrow();
+  });
+
+  it("throws when both arrangementStart and locator are given", () => {
+    expect(() =>
+      validateArrangementParameters("arrangement", "1|1", "Verse"),
+    ).toThrow("arrangementStart and locator are mutually exclusive");
+  });
+
+  it("treats a whitespace-only arrangementStart as absent (no conflict with locator)", () => {
+    // The `.trim() !== ""` guard: "   " is not a real start, so pairing it with
+    // a locator must NOT trip the mutual-exclusivity throw.
+    expect(() =>
+      validateArrangementParameters("arrangement", "   ", "Verse"),
+    ).not.toThrow();
+  });
+
+  it("accepts arrangementStart alone", () => {
+    expect(() =>
+      validateArrangementParameters("arrangement", "1|1", undefined),
+    ).not.toThrow();
+  });
+});

--- a/src/tools/actions/duplicate/tests/duplicate-device.test.ts
+++ b/src/tools/actions/duplicate/tests/duplicate-device.test.ts
@@ -46,7 +46,7 @@ describe("duplicate - device duplication", () => {
       path: livePath.liveSet,
     });
 
-    registerMockObject("live_set/tracks/1/devices/2", {
+    const tempDevice = registerMockObject("live_set/tracks/1/devices/2", {
       path: livePath.track(1).device(2),
     });
 
@@ -55,6 +55,12 @@ describe("duplicate - device duplication", () => {
     expect(result).toStrictEqual({
       id: "live_set/tracks/1/devices/2",
     });
+
+    // Default count (1) and no name → neither the count warn nor the name set fire.
+    expect(consoleMock.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("count parameter ignored"),
+    );
+    expect(tempDevice.set).not.toHaveBeenCalledWith("name", expect.anything());
 
     // Should duplicate track 0
     expect(liveSet.call).toHaveBeenCalledWith("duplicate_track", 0);
@@ -253,6 +259,50 @@ describe("duplicate - device duplication", () => {
     // Should call duplicateDevice twice (once per path)
     expect(Array.isArray(result)).toBe(true);
     expect(result).toHaveLength(2);
+  });
+
+  it("should duplicate a device from a multi-digit source track index", async () => {
+    // extractRegularTrackIndex / extractDevicePathWithinTrack read the track
+    // index with \d+; a \d-only match would read "12" as "1" and look for the
+    // temp device on the wrong track, throwing "device not found".
+    registerMockObject("device1", {
+      path: livePath.track(12).device(0),
+      type: "PluginDevice",
+    });
+    registerMockObject("live_set", { path: livePath.liveSet });
+    registerMockObject("live_set/tracks/13/devices/0", {
+      path: livePath.track(13).device(0),
+    });
+
+    const result = await duplicate({ type: "device", id: "device1" });
+
+    expect(result).toStrictEqual({ id: "live_set/tracks/13/devices/0" });
+    // Default destination places the copy after the original on the source track.
+    expect(moveDeviceToPathMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "t12/d1",
+    );
+  });
+
+  it("should adjust a multi-digit destination track index after the source", async () => {
+    // adjustTrackIndicesForTempTrack matches and rewrites the destination track
+    // with \d+; a \d-only match would mangle "t12" into "t2"/"t132".
+    registerMockObject("device1", {
+      path: livePath.track(0).device(0),
+      type: "PluginDevice",
+    });
+    registerMockObject("live_set", { path: livePath.liveSet });
+    registerMockObject("live_set/tracks/1/devices/0", {
+      path: livePath.track(1).device(0),
+    });
+
+    await duplicate({ type: "device", id: "device1", toPath: "t12/d0" });
+
+    // Temp track inserted at index 1 shifts t12 → t13.
+    expect(moveDeviceToPathMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "t13/d0",
+    );
   });
 
   it("should handle device path ending with chain segment (not device)", async () => {

--- a/src/tools/actions/duplicate/tests/duplicate-take-lane.test.ts
+++ b/src/tools/actions/duplicate/tests/duplicate-take-lane.test.ts
@@ -132,13 +132,63 @@ describe("duplicate take lane", () => {
     expect(newClip?.call).toHaveBeenCalledWith("add_new_notes", {
       notes: [SOURCE_NOTE],
     });
+    // Every loop/marker/signature property is copied from the source (each read
+    // is a distinct getProperty; blanking any one would set undefined instead).
+    expect(newClip?.set).toHaveBeenCalledWith("start_marker", 0);
+    expect(newClip?.set).toHaveBeenCalledWith("loop_start", 0);
     expect(newClip?.set).toHaveBeenCalledWith("loop_end", 4);
+    expect(newClip?.set).toHaveBeenCalledWith("end_marker", 4);
     expect(newClip?.set).toHaveBeenCalledWith("looping", 1);
+    expect(newClip?.set).toHaveBeenCalledWith("signature_numerator", 4);
+    expect(newClip?.set).toHaveBeenCalledWith("signature_denominator", 4);
+    // The lane number (1-based) is reported so the user can find the new clip.
+    expect(consoleMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining("created on take lane 1"),
+    );
     expect(result).toMatchObject({
       trackIndex: 0,
       arrangementStart: "5|1",
       takeLane: 1,
     });
+  });
+
+  it("copies the source clip's color when no color override is given", async () => {
+    registerLiveSet();
+    registerMockObject("src_clip", {
+      path: livePath.track(0).arrangementClip(0),
+      type: "Clip",
+      properties: {
+        is_midi_clip: 1,
+        is_arrangement_clip: 1,
+        length: 4,
+        loop_start: 0,
+        loop_end: 4,
+        start_marker: 0,
+        end_marker: 4,
+        looping: 1,
+        signature_numerator: 4,
+        signature_denominator: 4,
+        color: 0x123456,
+      },
+      methods: { get_notes_extended: () => JSON.stringify({ notes: [] }) },
+    });
+    registerTakeLaneTrack({ initialLanes: 0 });
+
+    await duplicate({
+      type: "clip",
+      id: "src_clip",
+      arrangementStart: "1|1",
+      takeLane: "new",
+    });
+
+    const newClip = lookupMockObject(
+      undefined,
+      livePath.track(0).takeLane(0).arrangementClip(0),
+    );
+
+    // No override → the raw source color int is copied straight through (the
+    // else branch, bypassing setColor's #RRGGBB path).
+    expect(newClip?.set).toHaveBeenCalledWith("color", 0x123456);
   });
 
   it("captures a pickup note (negative start_time) when copying to a take lane", async () => {
@@ -339,8 +389,12 @@ describe("duplicate take lane", () => {
     );
 
     expect(created).toStrictEqual([]);
+    // The wrapped warning carries the inner "failed to create Arrangement clip"
+    // throw (from the not-exists guard), not some other downstream error.
     expect(consoleMock.warn).toHaveBeenCalledWith(
-      expect.stringContaining("failed to create take-lane clip at beat 0"),
+      expect.stringContaining(
+        "failed to create take-lane clip at beat 0: failed to create Arrangement clip",
+      ),
     );
   });
 

--- a/src/tools/actions/duplicate/tests/duplicate-track.test.ts
+++ b/src/tools/actions/duplicate/tests/duplicate-track.test.ts
@@ -222,6 +222,11 @@ describe("duplicate - track duplication", () => {
       "delete_device",
       1, // Index 1 where the Producer Pal device is
     );
+    // ...and the removal is reported to the user.
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "Removed Producer Pal device from duplicated track - the device cannot be duplicated",
+    );
   });
 
   it("should not remove Producer Pal device when withoutDevices is true", async () => {
@@ -254,7 +259,7 @@ describe("duplicate - track duplication", () => {
     });
 
     it("should configure routing when routeToSource is true", async () => {
-      setupRoutingMocks({
+      const { sourceTrack, newTrack } = setupRoutingMocks({
         monitoringState: 1,
         inputRoutingName: "Audio In",
       });
@@ -266,6 +271,68 @@ describe("duplicate - track duplication", () => {
       });
 
       expect(result).toStrictEqual(createTrackResult(1));
+
+      // Source input was "Audio In" (not "No Input"), so it is switched to the
+      // "No Input" routing type and the change is reported.
+      expect(sourceTrack.set).toHaveBeenCalledWith(
+        "input_routing_type",
+        JSON.stringify({ input_routing_type: { identifier: "no_input_id" } }),
+      );
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        'Changed track "Source Track" input routing from "Audio In" to "No Input"',
+      );
+
+      // New track output is routed to the (single-name-match) source track.
+      expect(newTrack.set).toHaveBeenCalledWith(
+        "output_routing_type",
+        JSON.stringify({
+          output_routing_type: { identifier: "source_track_id" },
+        }),
+      );
+    });
+
+    it("warns when the source track name is absent from the output routing options", async () => {
+      // newTrack advertises only "Master" as an output — the source name has no
+      // match, so no output routing is applied and the miss is reported.
+      registerMockObject("track1", { path: livePath.track(0) });
+      registerMockObject("live_set", { path: livePath.liveSet });
+      registerMockObject("live_set/tracks/0", {
+        path: livePath.track(0),
+        properties: {
+          name: "Source Track",
+          // Already "No Input" so the input-routing branch is skipped; JSON
+          // string form matches what getProperty() parses.
+          input_routing_type: JSON.stringify({
+            input_routing_type: { display_name: "No Input" },
+          }),
+          arm: 1,
+        },
+      });
+      const newTrack = registerMockObject("live_set/tracks/1", {
+        path: livePath.track(1),
+        properties: {
+          available_output_routing_types: JSON.stringify({
+            available_output_routing_types: [
+              { display_name: "Master", identifier: "master_id" },
+            ],
+          }),
+          devices: [],
+          clip_slots: [],
+          arrangement_clips: [],
+        },
+      });
+
+      await duplicate({ type: "track", id: "track1", routeToSource: true });
+
+      expect(newTrack.set).not.toHaveBeenCalledWith(
+        "output_routing_type",
+        expect.anything(),
+      );
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        'Could not find track "Source Track" in routing options',
+      );
     });
 
     it("should not change source track monitoring if already set to In", async () => {
@@ -337,6 +404,7 @@ describe("duplicate - track duplication", () => {
     it("should arm the source track when routeToSource is true", async () => {
       const { sourceTrack } = setupRoutingMocks({
         inputRoutingName: "Audio In",
+        arm: 0,
       });
 
       await duplicate({
@@ -347,6 +415,12 @@ describe("duplicate - track duplication", () => {
 
       // Verify the source track was armed
       expect(sourceTrack.set).toHaveBeenCalledWith("arm", 1);
+
+      // It wasn't already armed, so the arm action is reported.
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        "routeToSource: Armed the source track",
+      );
     });
 
     it("should not emit arm warning when source track is already armed", async () => {

--- a/src/tools/actions/duplicate/tests/duplicate-transforms.test.ts
+++ b/src/tools/actions/duplicate/tests/duplicate-transforms.test.ts
@@ -68,6 +68,11 @@ describe("duplicate - transforms/code", () => {
         { ids: destId, transforms: "velocity *= 0.5", code: undefined },
         expect.anything(),
       );
+      // A clip legitimately supports transforms — the "ignored" warn (gated on
+      // type !== "clip") must NOT fire here.
+      expect(consoleMock.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("transforms/code ignored"),
+      );
       expect(result).toStrictEqual({
         id: destId,
         slot: "0/1",
@@ -154,6 +159,28 @@ describe("duplicate - transforms/code", () => {
         type: "track",
         id: "track1",
         transforms: "velocity *= 0.5",
+      });
+
+      expect(updateClipMock).not.toHaveBeenCalled();
+      expect(consoleMock.warn).toHaveBeenCalledWith(
+        expect.stringContaining("transforms/code ignored"),
+      );
+    });
+
+    it("warns and skips code (no transforms) for non-clip types", async () => {
+      // Exercises the `code != null` arm of the ignore condition independently
+      // of transforms, so a mutated `code == null` no longer suppresses the warn.
+      registerMockObject("track1", { path: livePath.track(0) });
+      registerMockObject("live_set", { path: livePath.liveSet });
+      registerMockObject("live_set/tracks/1", {
+        path: livePath.track(1),
+        properties: { devices: [], clip_slots: [], arrangement_clips: [] },
+      });
+
+      await duplicate({
+        type: "track",
+        id: "track1",
+        code: "return notes;",
       });
 
       expect(updateClipMock).not.toHaveBeenCalled();


### PR DESCRIPTION
Third write-op domain in the `src/tools/` mutation-testing triage (follow-on to the AJM-560 notation ratchet + mechanism). Companion to the merged `track` (#963) and `session` (#964) domain PRs.

## Result
- **Mutation score: 83.97% → 91.79%** (killed 96 mutants, 191 → 93 survivors)
- **Test/config/docs only — no product code touched.**
- `TOOL_DOMAIN_BREAKS.actions = 90` (~1.8 below the score for timeout-classification variance).
- Gate verified: `npm run mutation -- actions` → EXIT 0 ("91.79 ≥ break threshold 90").
- `npm run check` (9402 passed, Functions 100%) and `npm run check:build` green.

## Two structural wins beyond warn-and-skip hardening
1. **Discriminating id-sort data** for `findRoutingOptionForDuplicateNames` (mirrors the `session` `sortPartition` fix): children order (5,2,9) ≠ id-sorted order (2,5,9), plus a non-matching low-id track, so a blanked / `+`-comparator / kept-filter mutant each picks a different routing position.
2. **A mock that hid a whole branch.** `setupRouteToSourceMock` stored routing-type properties as plain objects, but `getProperty` JSON-parses them — so every `routeToSource` test silently hit a parse-failure path and the real input/output routing-change code (`configureSourceTrackInput` / `applyOutputRouting`) never ran. Storing them as JSON strings (as Live returns) made the branch testable and killed its survivors.

## Per-file (after triage)
| File | Score | Survived |
| --- | --- | --- |
| `duplicate-focus-helpers.ts` | 100.00% | 0 |
| `duplicate-validation-helpers.ts` | 99.38% | 1 |
| `duplicate-take-lane-helpers.ts` | 96.30% | 2 |
| `delete.ts` | 94.22% | 15 |
| `duplicate-routing-helpers.ts` | 94.12% | 6 |
| `duplicate-track-scene-helpers.ts` | 91.62% | 11 |
| `duplicate-clip-position-helpers.ts` | 90.70% | 4 |
| `duplicate.ts` | 87.60% | 15 |
| `duplicate-transform-helpers.ts` | 86.67% | 4 |
| `duplicate-device-helpers.ts` | 85.54% | 10 |
| `duplicate-helpers.ts` | 81.65% | 25 |

`duplicate-helpers.ts` is the low outlier by design: its survivors sit in the `createClipsForLength` / arrangement-tiling paths (mocked shared helpers make `setAll`/`is_midi_clip` mutants unobservable without a Live-API integration harness) plus two provably-equivalent classes (the `omitFields = []` default; the `parseArrangementLength` catch-wrapper). Deferred rather than over-fitted.

Full triage record: `dev/Mutation-Testing.md` → "Baseline (2026-07-15, `src/tools/actions/`)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)