### PR TITLE
test(mutation): triage device domain, ratchet break to 90

### DIFF
--- a/config/mutation-scopes.mjs
+++ b/config/mutation-scopes.mjs
@@ -77,6 +77,7 @@ const TOOL_DOMAIN_BREAKS = {
   track: 85, // triaged 2026-07-14 at 86.15% (see dev/Mutation-Testing.md)
   session: 89, // triaged 2026-07-14 at 90.46% (see dev/Mutation-Testing.md)
   actions: 90, // triaged 2026-07-15 at 91.79% (see dev/Mutation-Testing.md)
+  device: 90, // triaged 2026-07-15 at 91.18% (see dev/Mutation-Testing.md)
 };
 
 export const SCOPES = {

--- a/dev/Mutation-Testing.md
+++ b/dev/Mutation-Testing.md
@@ -360,6 +360,84 @@ Two structural wins beyond the usual warn-and-skip hardening:
 | name/color/omit-trackIndex/has_clip guards on duplicated tracks      | `duplicate-track-scene-helpers.test.ts`                 |
 | 2-digit source/destination track regexes in device duplication       | `duplicate-device.test.ts`                              |
 
+## Baseline (2026-07-15, `src/tools/device/`)
+
+Fourth write-op domain triaged (`create` / `read` / `update` device tools, the
+last spanning `update-device-*` parsers, setters, and helpers). Full pass —
+Stryker 9.6.1, Node 24, `coverageAnalysis: "perTest"`:
+
+| Metric                     | Value      |
+| -------------------------- | ---------- |
+| **Mutation score**         | **91.68%** |
+| Mutants killed             | 1093       |
+| Survived                   | 93         |
+| Timeout (counts as killed) | 9          |
+| No coverage                | 7          |
+| Total mutants              | 1202       |
+| Wall-clock                 | 1m 6s      |
+
+Gate: `break: 90` (`TOOL_DOMAIN_BREAKS.device`), ~1.7 points below the score for
+timeout-classification variance. Triage lifted the score from an **82.20%**
+baseline (214 survivors), killing 114 mutants with test-only changes — no
+product code touched. The dominant lever was `update-device-wrap-helpers.ts` at
+**57.32%** (69 survivors): its wrap tests asserted the return value but not the
+emitted warnings, the Live-API method/property-name arguments, or the
+chain-creation arithmetic.
+
+Per-file scores after triage:
+
+| File                                | Score   | Survived | Notes                             |
+| ----------------------------------- | ------- | -------- | --------------------------------- |
+| `update-device-type-helpers.ts`     | 100.00% | 0        | warnIfSet null-guard pinned       |
+| `update-device-property-helpers.ts` | 96.63%  | 3        | cross-type not-applicable warns   |
+| `update-device-helpers.ts`          | 95.31%  | 10       | macro variation/count, drum chain |
+| `update-device.ts`                  | 93.52%  | 7        | focus `.at(-1)`, move/type warns  |
+| `read-device.ts`                    | 92.31%  | 12       | return-chains + nested bounds     |
+| `update-device-param-parser.ts`     | 92.31%  | 2        | pan/unit equivalents (bucket 2)   |
+| `create-device.ts`                  | 91.75%  | 8        | name-set guard                    |
+| `device-params-schema.ts`           | 88.24%  | 2        | JSON preprocess (bucket 2/3)      |
+| `update-device-param-setters.ts`    | 87.76%  | 28       | binary-search tolerance — below   |
+| `update-device-wrap-helpers.ts`     | 86.59%  | 21       | instrument reverse-loop internals |
+
+`update-device-param-setters.ts` is the low outlier, and its survivors are
+mostly bucket 2: `findRawValueForDisplay`'s linear-vs-binary-search detection.
+For a nearly-linear param the linear shortcut and the binary search converge on
+the same written value, so the `< tolerance` / `true &&` boundary mutants are
+only observable with contrived non-physical `str_for_value` mappings —
+over-fitting. The genuinely testable branches (division-label OR,
+min-label-unparseable fallback, pan max from display labels not the `50`
+fallback) were closed. `update-device-wrap-helpers.ts`'s remaining survivors are
+the instrument-rack reverse-loop's internal `LiveAPI.from(...)`/`move_device`
+string args and the best-effort `restoreStrandedInstruments` cleanup loop —
+low-value defensive paths left for a future integration pass.
+
+### Gaps closed (device)
+
+One durable test-authoring gotcha surfaced (worth reusing across domains):
+
+- **`expect.anything()` does not match `undefined`.** A warn-and-skip guard like
+  `if (name != null) device.set("name", name)` mutated to `if (true)` writes
+  `set("name", undefined)`. Asserting
+  `not.toHaveBeenCalledWith("name", expect.anything())` **passes anyway** —
+  `expect.anything()` excludes `null`/`undefined` — so the mutant survives. Use
+  a `mock.calls.filter((c) => c[0] === "name")` length check instead. This hid
+  the `create-device`/`wrap` name-set guard mutants until the assertion was
+  rewritten.
+
+| Gap (now killed)                                                    | Test strengthened / added                   |
+| ------------------------------------------------------------------- | ------------------------------------------- |
+| Chain-creation loop bounds/arithmetic (rack with N existing chains) | `update-device-wrap-in-rack-chains.test.ts` |
+| wrapInRack warn messages + name-set + insert_chain failure detect   | `update-device-wrap-in-rack.test.ts`        |
+| `setVariationIndex` load/delete index-set paired with the action    | `update-device-macro-variation.test.ts`     |
+| Variation index-count boundary (`>=`) + skip-executes-action guard  | `update-device-macro-variation.test.ts`     |
+| Drum-chain move: single-chain vs whole-pad, sharp note, `p*`        | `update-device-drum-chain-move.test.ts`     |
+| Nested drum-pad chain/device index boundary + non-numeric segments  | `read-device-drum-pad-path.test.ts`         |
+| Device `focus` selects `.at(-1)` (3 devices, not a 2-element tie)   | `update-device-focus.test.ts`               |
+| Cross-type "not applicable" warns (rack-only on non-rack, etc.)     | `update-device-chains.test.ts`              |
+| Division-label OR, min-unparseable fallback, pan display-max        | `update-device-param-conversion.test.ts`    |
+| return-chains include on/off; malformed-path safe-resolve warn      | `read-device.test.ts`, `update-device-path` |
+| Malformed-JSON `params` string rejected (not swallowed)             | `device-params-schema.test.ts`              |
+
 ## Interpreting survivors
 
 Each survivor falls into one of three buckets — triage before acting:
@@ -379,21 +457,21 @@ wins, and a cross-check against the line-coverage gate.
 ## Status & next steps
 
 The `notation` scope is **ratcheted** (`thresholds.break = 86`), as are `track`
-(`break: 85`), `session` (`break: 89`), and `actions` (`break: 90`), the first
-three triaged tool domains. The per-domain scope mechanism
-(`config/mutation-scopes.mjs` + the runner) is in place, so each `src/tools/`
-domain can be mutated on its own; the untriaged ones remain in **baseline mode**
-(`break: null`, measure-only). Mutation testing stays off the per-PR hot path (a
-full pass is minutes). Remaining work (later releases):
+(`break: 85`), `session` (`break: 89`), `actions` (`break: 90`), and `device`
+(`break: 90`), the first four triaged tool domains. The per-domain scope
+mechanism (`config/mutation-scopes.mjs` + the runner) is in place, so each
+`src/tools/` domain can be mutated on its own; the untriaged ones remain in
+**baseline mode** (`break: null`, measure-only). Mutation testing stays off the
+per-PR hot path (a full pass is minutes). Remaining work (later releases):
 
 - Keep triaging the ~588 notation survivors, but expect diminishing returns: the
   dense clusters left are epsilon-boundary / warning-string / equivalent mutants
   (bucket 2/3), so genuine bucket-1 gaps are now sparse.
 - Raise each scope's `break` as its score climbs.
 - Triage the remaining `src/tools/` domains one PR at a time (write operations
-  first — `clip`, `device`; `track`, `session`, and `actions` done). Per domain:
-  run `npm run mutation -- <domain>`, close real gaps, flip that domain's
-  `break` from `null` to ~1 point below its triaged score (add it to
+  first — `clip` next; `track`, `session`, `actions`, and `device` done). Per
+  domain: run `npm run mutation -- <domain>`, close real gaps, flip that
+  domain's `break` from `null` to ~1 point below its triaged score (add it to
   `TOOL_DOMAIN_BREAKS`). The big clean wins tend to be untested lookup/enum
   tables (as in notation's chord table) and warn-and-skip guards whose tests
   assert only the result, never the warning or the skipped write.

--- a/src/tools/device/create/create-device.test.ts
+++ b/src/tools/device/create/create-device.test.ts
@@ -70,6 +70,7 @@ function registerSimplerCreationFixture(): {
 describe("createDevice", () => {
   let track0: RegisteredMockObject;
   let chain0: RegisteredMockObject;
+  let createdDevice: RegisteredMockObject;
 
   beforeEach(() => {
     track0 = registerMockObject("track-0", {
@@ -77,7 +78,7 @@ describe("createDevice", () => {
       methods: { insert_device: () => ["id", "device123"] },
     });
 
-    registerMockObject("device123", {
+    createdDevice = registerMockObject("device123", {
       path: livePath.track(0).device(2),
     });
 
@@ -208,6 +209,14 @@ describe("createDevice", () => {
         });
 
         expect(track0.call).toHaveBeenCalledWith("insert_device", "Compressor");
+        // With no name given, the created device's name is left untouched.
+        // (Checked via call args, not expect.anything(), which ignores an
+        // undefined value the guard would otherwise write.)
+        const nameSets = createdDevice.set.mock.calls.filter(
+          (c: unknown[]) => c[0] === "name",
+        );
+
+        expect(nameSets).toHaveLength(0);
         expect(result).toStrictEqual({
           id: "device123",
           deviceIndex: 2,

--- a/src/tools/device/read/tests/read-device-drum-pad-path.test.ts
+++ b/src/tools/device/read/tests/read-device-drum-pad-path.test.ts
@@ -211,6 +211,25 @@ describe("readDevice with drum pad path", () => {
     );
   });
 
+  it("should throw for a chain index equal to the chain count (boundary)", () => {
+    // One chain (index 0); "c1" is one past the end. Pins the `>=` bound: a `>`
+    // mutant would fall through to an assertDefined error instead.
+    setupKickPadMocks({ padExtra: { chainIds: ["chain-1"] } });
+
+    expect(() => readDevice({ path: "t1/d0/pC1/c1" })).toThrow(
+      "Invalid chain index in path: t1/d0/pC1/c1",
+    );
+  });
+
+  it("should throw for a non-numeric chain segment", () => {
+    // "cX" parses to NaN; the NaN guard must reject it with the index error.
+    setupKickPadMocks({ padExtra: { chainIds: ["chain-1"] } });
+
+    expect(() => readDevice({ path: "t1/d0/pC1/cX" })).toThrow(
+      "Invalid chain index in path: t1/d0/pC1/cX",
+    );
+  });
+
   it("should read device inside drum pad chain", () => {
     setupKickPadMocks({
       padExtra: { chainIds: ["chain-1"] },
@@ -251,6 +270,36 @@ describe("readDevice with drum pad path", () => {
 
     expect(() => readDevice({ path: "t1/d0/pC1/c0/d5" })).toThrow(
       "Invalid device index in path: t1/d0/pC1/c0/d5",
+    );
+  });
+
+  it("should throw for a device index equal to the device count (boundary)", () => {
+    // One device (index 0); "d1" is one past the end (pins the `>=` bound).
+    setupKickPadMocks({
+      padExtra: { chainIds: ["chain-1"] },
+      chainProperties: {
+        "chain-1": { name: "Layer 1", deviceIds: ["device-1"] },
+      },
+      deviceProperties: { "device-1": simplerDevice },
+    });
+
+    expect(() => readDevice({ path: "t1/d0/pC1/c0/d1" })).toThrow(
+      "Invalid device index in path: t1/d0/pC1/c0/d1",
+    );
+  });
+
+  it("should throw for a non-numeric device segment", () => {
+    // "dX" parses to NaN; the NaN guard must reject it with the index error.
+    setupKickPadMocks({
+      padExtra: { chainIds: ["chain-1"] },
+      chainProperties: {
+        "chain-1": { name: "Layer 1", deviceIds: ["device-1"] },
+      },
+      deviceProperties: { "device-1": simplerDevice },
+    });
+
+    expect(() => readDevice({ path: "t1/d0/pC1/c0/dX" })).toThrow(
+      "Invalid device index in path: t1/d0/pC1/c0/dX",
     );
   });
 });

--- a/src/tools/device/read/tests/read-device.test.ts
+++ b/src/tools/device/read/tests/read-device.test.ts
@@ -245,6 +245,55 @@ describe("readDevice", () => {
     });
   });
 
+  describe("return chains", () => {
+    function setupRackWithReturnChain(): void {
+      registerMockObject("rack-rc", {
+        type: "Device",
+        properties: {
+          class_display_name: "Audio Effect Rack",
+          name: "Audio Effect Rack",
+          type: 2,
+          can_have_chains: 1,
+          can_have_drum_pads: 0,
+          is_active: 1,
+          parameters: [],
+          chains: [],
+          return_chains: ["id", "rchain-a"],
+        },
+      });
+
+      registerMockObject("rchain-a", {
+        type: "Chain",
+        properties: {
+          name: "Return A",
+          mute: 0,
+          solo: 0,
+          devices: [],
+        },
+      });
+    }
+
+    it("includes returnChains when return-chains is requested", () => {
+      setupRackWithReturnChain();
+
+      const result = readDevice({
+        deviceId: "rack-rc",
+        include: ["return-chains"],
+      });
+
+      expect(result.returnChains).toBeDefined();
+    });
+
+    it("omits returnChains when only chains are requested", () => {
+      setupRackWithReturnChain();
+
+      const result = readDevice({ deviceId: "rack-rc", include: ["chains"] });
+
+      // The rack HAS return chains, but they must not appear unless requested.
+      expect(result).not.toHaveProperty("returnChains");
+    });
+  });
+
   describe("drum rack includes", () => {
     // Shared setup for drum rack with chain-based mocking (in_note)
     function setupDrumRackWithChain(): void {

--- a/src/tools/device/update/tests/params/device-params-schema.test.ts
+++ b/src/tools/device/update/tests/params/device-params-schema.test.ts
@@ -1,0 +1,35 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { paramsInputSchema } from "../../device-params-schema.ts";
+
+describe("paramsInputSchema", () => {
+  it("parses a JSON-stringified array of entries", () => {
+    const result = paramsInputSchema.parse(
+      JSON.stringify([{ name: "Volume", value: "0.5" }]),
+    );
+
+    expect(result).toStrictEqual([{ name: "Volume", value: "0.5" }]);
+  });
+
+  it("accepts an already-structured array unchanged", () => {
+    const result = paramsInputSchema.parse([{ name: "Pan", value: "0" }]);
+
+    expect(result).toStrictEqual([{ name: "Pan", value: "0" }]);
+  });
+
+  it("rejects a malformed JSON string rather than swallowing it as undefined", () => {
+    // The catch must return the original (unparseable) string so array
+    // validation fails; returning undefined would masquerade as "no params".
+    expect(() => paramsInputSchema.parse("not json [")).toThrow();
+  });
+
+  it("coerces numeric name/value fields to strings", () => {
+    const result = paramsInputSchema.parse([{ name: 3, value: 1 }]);
+
+    expect(result).toStrictEqual([{ name: "3", value: "1" }]);
+  });
+});

--- a/src/tools/device/update/tests/params/update-device-division-params.test.ts
+++ b/src/tools/device/update/tests/params/update-device-division-params.test.ts
@@ -9,7 +9,7 @@ import {
   type RegisteredMockObject,
   registerMockObject,
 } from "#src/test/mocks/mock-registry.ts";
-import { updateDevice } from "../update-device.ts";
+import { updateDevice } from "../../update-device.ts";
 import "#src/live-api-adapter/live-api-extensions.ts";
 
 describe("updateDevice - division params", () => {

--- a/src/tools/device/update/tests/params/update-device-param-conversion.test.ts
+++ b/src/tools/device/update/tests/params/update-device-param-conversion.test.ts
@@ -1,0 +1,144 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  type RegisteredMockObject,
+  children,
+  expectValueSet,
+  livePath,
+  registerMockObject,
+  updateDevice,
+} from "../update-device-test-helpers.ts";
+
+// Discriminating cases for the param value-conversion pipeline. Each uses
+// str_for_value mappings crafted so that a single mutated branch produces an
+// observably different written value (or a warning instead of a write).
+describe("updateDevice - param conversion discriminators", () => {
+  describe("division detection uses current OR min label", () => {
+    let param: RegisteredMockObject;
+
+    beforeEach(() => {
+      registerMockObject("dev1", {
+        path: livePath.track(0).device(0),
+        type: "Device",
+        properties: { parameters: children("div-param") },
+      });
+      // Current value (-3) reads as a division label, but the MIN value (-6)
+      // reads as a plain number. Only an OR keeps this classified as a division
+      // param; an AND would fall through to the numeric branch.
+      param = registerMockObject("div-param", {
+        properties: {
+          name: "Rate",
+          original_name: "Rate",
+          is_quantized: 0,
+          value: -3,
+          min: -6,
+          max: 0,
+        },
+        methods: {
+          str_for_value: (v: unknown) => {
+            if (v === -3) return "1/8";
+            if (v === -4) return "1/16";
+            if (v === -6) return "0.5";
+
+            return String(v);
+          },
+        },
+      });
+    });
+
+    it("resolves a division value when only the current label is a fraction", () => {
+      updateDevice({ ids: "dev1", params: [{ name: "Rate", value: "1/16" }] });
+
+      // "1/16" resolves to raw -4 via the division path; a numeric-branch
+      // fallthrough would fail to interpret the fraction and warn instead.
+      expect(param.set).toHaveBeenCalledWith("value", -4);
+      expect(outlet).not.toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("could not interpret"),
+      );
+    });
+  });
+
+  describe("min-label-unparseable numeric fallback", () => {
+    let param: RegisteredMockObject;
+
+    beforeEach(() => {
+      registerMockObject("dev1", {
+        path: livePath.track(0).device(0),
+        type: "Device",
+        properties: { parameters: children("mirror-param") },
+      });
+      // Mirror of the existing max-unparseable case: here the MIN label can't be
+      // parsed while the max label can. The min-side null guard must short out to
+      // the raw input, not proceed into a (bogus) linear/binary conversion.
+      param = registerMockObject("mirror-param", {
+        properties: {
+          name: "Mirror",
+          original_name: "Mirror",
+          is_quantized: 0,
+          value: 0.5,
+          min: 0,
+          max: 1,
+        },
+        methods: {
+          str_for_value: (v: unknown) =>
+            Number(v) <= 0 ? "custom" : `${1000 * Number(v)} Hz`,
+        },
+      });
+    });
+
+    it("falls back to the raw value when the min label is unparseable", () => {
+      updateDevice({ ids: "dev1", params: [{ name: "Mirror", value: "0.7" }] });
+
+      // Unparseable min label => no linear range => write the raw input as-is.
+      // Skipping the guard would binary-search a garbage value near the min.
+      expect(param.set).toHaveBeenCalledWith("value", 0.7);
+    });
+  });
+
+  describe("pan max value comes from the display labels, not the 50 fallback", () => {
+    let param: RegisteredMockObject;
+
+    beforeEach(() => {
+      registerMockObject("dev1", {
+        path: livePath.track(0).device(0),
+        type: "Device",
+        properties: { parameters: children("pan-param") },
+      });
+      // Display max is "100R" (not 50), so the pan scale is 0..100. The current
+      // value reads as "C" (a pan label) so the pan branch is taken; any other
+      // read (e.g. an empty property name) would read as a non-pan label.
+      param = registerMockObject("pan-param", {
+        properties: {
+          name: "Pan",
+          original_name: "Pan",
+          is_quantized: 0,
+          value: 0,
+          min: -1,
+          max: 1,
+        },
+        methods: {
+          str_for_value: (v: unknown) => {
+            if (v === 1) return "100R";
+            if (v === -1) return "30L";
+            if (v === 0) return "C";
+
+            return "5000 Hz";
+          },
+        },
+      });
+    });
+
+    it("scales a directional label by the param's own display max", () => {
+      updateDevice({ ids: "dev1", params: [{ name: "Pan", value: "50R" }] });
+
+      // 50R on a 0..100 scale is +0.5; internal = ((0.5+1)/2)*(1-(-1)) + (-1)
+      // = 0.5. The 50 fallback would read it as full-right (+1 -> internal 1).
+      expect(expectValueSet(param)).toBeCloseTo(0.5, 5);
+    });
+  });
+});

--- a/src/tools/device/update/tests/params/update-device-param-setters.test.ts
+++ b/src/tools/device/update/tests/params/update-device-param-setters.test.ts
@@ -12,7 +12,7 @@ import {
   registerMockObject,
   registerSimplerDevice,
   updateDevice,
-} from "./update-device-test-helpers.ts";
+} from "../update-device-test-helpers.ts";
 
 describe("updateDevice - param value conversion", () => {
   describe("non-linear params (binary search)", () => {

--- a/src/tools/device/update/tests/params/update-device-parse-params.test.ts
+++ b/src/tools/device/update/tests/params/update-device-parse-params.test.ts
@@ -4,8 +4,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
-import { paramsInputSchema } from "../device-params-schema.ts";
-import { normalizeParamValue } from "../update-device-param-parser.ts";
+import { paramsInputSchema } from "../../device-params-schema.ts";
+import { normalizeParamValue } from "../../update-device-param-parser.ts";
 
 describe("normalizeParamValue", () => {
   it("coerces numeric values", () => {

--- a/src/tools/device/update/tests/update-device-chains.test.ts
+++ b/src/tools/device/update/tests/update-device-chains.test.ts
@@ -255,6 +255,102 @@ describe("updateDevice - Chain and DrumPad support", () => {
     });
   });
 
+  describe("cross-type not-applicable warnings", () => {
+    beforeEach(() => {
+      // A non-rack device (rack-only props don't apply) and a rack device.
+      registerMockObject("800", { type: "PluginDevice" });
+      registerMockObject("801", {
+        type: "RackDevice",
+        properties: { can_have_chains: 1, visible_macro_count: 4 },
+      });
+    });
+
+    it.each([
+      ["macroVariation", { macroVariation: "create" }, "PluginDevice", "800"],
+      [
+        "macroVariationIndex",
+        { macroVariationIndex: 1 },
+        "PluginDevice",
+        "800",
+      ],
+      ["solo", { solo: true }, "RackDevice", "123"],
+      ["mappedPitch", { mappedPitch: "C3" }, "RackDevice", "123"],
+    ] as const)(
+      "warns that %s is not applicable to a device",
+      (label, args, type, id) => {
+        updateDevice({ ids: id, ...args });
+
+        expect(outlet).toHaveBeenCalledWith(
+          1,
+          `updateDevice: '${label}' not applicable to ${type}`,
+        );
+      },
+    );
+
+    it.each([
+      ["macroVariation", { macroVariation: "create" }],
+      ["macroVariationIndex", { macroVariationIndex: 1 }],
+      ["macroCount", { macroCount: 4 }],
+      ["abCompare", { abCompare: "a" }],
+    ] as const)("warns that %s is not applicable to a Chain", (label, args) => {
+      updateDevice({ ids: "456", ...args });
+
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        `updateDevice: '${label}' not applicable to Chain`,
+      );
+    });
+
+    it("does not spuriously warn about A/B Compare when abCompare is unset", () => {
+      updateDevice({ ids: "123", mute: true });
+
+      expect(outlet).not.toHaveBeenCalledWith(
+        1,
+        "updateDevice: A/B Compare not available on this device",
+      );
+    });
+
+    it("does not spuriously adjust macro count on a rack when macroCount is unset", () => {
+      updateDevice({ ids: "801", abCompare: "a" });
+
+      expect(outlet).not.toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("macro count rounded"),
+      );
+    });
+  });
+
+  describe("unset property guards", () => {
+    it("does not touch mute/solo on a Chain when only color is set", () => {
+      updateDevice({ ids: "456", color: "#FF0000" });
+
+      expect(chain.set).not.toHaveBeenCalledWith("mute", expect.anything());
+      expect(chain.set).not.toHaveBeenCalledWith("solo", expect.anything());
+      // Unset (null) params must be treated as absent, not warned about.
+      expect(outlet).not.toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("not applicable"),
+      );
+    });
+
+    it("does not touch chokeGroup/mappedPitch on a DrumChain when only mute is set", () => {
+      updateDevice({ ids: "789", mute: true });
+
+      expect(drumChain.set).not.toHaveBeenCalledWith(
+        "choke_group",
+        expect.anything(),
+      );
+      expect(drumChain.set).not.toHaveBeenCalledWith(
+        "out_note",
+        expect.anything(),
+      );
+      expect(outlet).not.toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("invalid note name"),
+      );
+    });
+  });
+
   describe("invalid types", () => {
     it("should warn and skip for Track type", () => {
       // Should not throw, just warn and return empty array (no valid targets)

--- a/src/tools/device/update/tests/update-device-drum-chain-move.test.ts
+++ b/src/tools/device/update/tests/update-device-drum-chain-move.test.ts
@@ -58,7 +58,24 @@ describe("updateDevice - drum chain moving", () => {
 
     // Should set in_note to 38 (D1)
     expect(chain0.set).toHaveBeenCalledWith("in_note", 38);
+    // An explicit chain path (pC1/c0) moves ONLY that chain, not the whole pad,
+    // so the sibling chain on the same in_note is untouched.
+    expect(chain1.set).not.toHaveBeenCalled();
     expect(result).toStrictEqual({ id: "chain-0" });
+  });
+
+  it("should resolve a sharp-accidental target pad note", () => {
+    // "pF#1" exercises the [#b]? branch of the drum-pad-note regex; F#1 = 42.
+    updateDevice({ path: "t0/d0/pC1/c0", toPath: "t0/d0/pF#1" });
+
+    expect(chain0.set).toHaveBeenCalledWith("in_note", 42);
+  });
+
+  it("should move a chain to the wildcard pad (in_note -1)", () => {
+    // "p*" targets the all-notes wildcard, which maps to in_note -1.
+    updateDevice({ path: "t0/d0/pC1/c0", toPath: "t0/d0/p*" });
+
+    expect(chain0.set).toHaveBeenCalledWith("in_note", -1);
   });
 
   it("should move all chains in a drum pad when using pad path", () => {
@@ -82,11 +99,16 @@ describe("updateDevice - drum chain moving", () => {
       toPath: "t1",
     });
 
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      'toPath "t1" is not a drum pad path',
+    );
+    expect(chain0.set).not.toHaveBeenCalledWith("in_note", expect.anything());
     expect(result).toStrictEqual({ id: "chain-0" });
   });
 
   it("should warn and skip when trying to move a regular Chain to a drum pad", () => {
-    registerMockObject("123", { type: "Chain" });
+    const chain = registerMockObject("123", { type: "Chain" });
 
     // Should not throw, just warn and skip the move
     const result = updateDevice({
@@ -94,6 +116,9 @@ describe("updateDevice - drum chain moving", () => {
       toPath: "t0/d0/pD1",
     });
 
+    // A non-drum Chain is not moveable to a pad: warn, and never touch in_note.
+    expect(outlet).toHaveBeenCalledWith(1, "cannot move Chain");
+    expect(chain.set).not.toHaveBeenCalledWith("in_note", expect.anything());
     expect(result).toStrictEqual({ id: "123" });
   });
 });

--- a/src/tools/device/update/tests/update-device-focus.test.ts
+++ b/src/tools/device/update/tests/update-device-focus.test.ts
@@ -32,6 +32,11 @@ describe("updateDevice - focus functionality", () => {
       path: livePath.track(0).device(1),
       type: "Device",
     });
+
+    registerMockObject("789", {
+      path: livePath.track(0).device(2),
+      type: "Device",
+    });
   });
 
   it("should select device and show device detail when focus=true", () => {
@@ -44,10 +49,12 @@ describe("updateDevice - focus functionality", () => {
   });
 
   it("should select last device when focus=true with multiple devices", () => {
-    updateDevice({ ids: "123,456", name: "Test", focus: true });
+    // Three devices so "last" (789) is distinct from index +1 (456): pins
+    // result.at(-1), not a coincidental two-element match.
+    updateDevice({ ids: "123,456,789", name: "Test", focus: true });
 
     expect(selectMock.get()).toHaveBeenCalledWith({
-      deviceId: "456",
+      deviceId: "789",
       detailView: "device",
     });
     expect(selectMock.get()).toHaveBeenCalledTimes(1);

--- a/src/tools/device/update/tests/update-device-macro-variation.test.ts
+++ b/src/tools/device/update/tests/update-device-macro-variation.test.ts
@@ -65,6 +65,29 @@ describe("updateDevice - macroVariation", () => {
       "selected_variation_index",
       expect.anything(),
     );
+    // Out of range must also abort the action, not just skip the index-set.
+    expect(rackDevice.call).not.toHaveBeenCalled();
+    expect(result).toStrictEqual({ id: "123" });
+  });
+
+  it("should reject an index equal to variation_count (boundary)", () => {
+    // variation_count is 3, so valid indices are 0-2; index 3 is out of range.
+    // This pins the `>=` bound: a `>` mutant would accept index 3.
+    const result = updateDevice({
+      ids: "123",
+      macroVariation: "load",
+      macroVariationIndex: 3,
+    });
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "updateDevice: variation index 3 out of range (3 available)",
+    );
+    expect(rackDevice.set).not.toHaveBeenCalledWith(
+      "selected_variation_index",
+      expect.anything(),
+    );
+    expect(rackDevice.call).not.toHaveBeenCalled();
     expect(result).toStrictEqual({ id: "123" });
   });
 
@@ -75,6 +98,16 @@ describe("updateDevice - macroVariation", () => {
     });
 
     expect(rackDevice.call).toHaveBeenCalledWith("store_variation");
+    // 'create' never selects an index, and with no index there is nothing to
+    // warn about being ignored.
+    expect(rackDevice.set).not.toHaveBeenCalledWith(
+      "selected_variation_index",
+      expect.anything(),
+    );
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("ignored"),
+    );
     expect(result).toStrictEqual({ id: "123" });
   });
 
@@ -85,7 +118,14 @@ describe("updateDevice - macroVariation", () => {
       macroVariationIndex: 1,
     });
 
+    // 'load' selects the index first, then recalls it; a valid index is used,
+    // not ignored.
+    expect(rackDevice.set).toHaveBeenCalledWith("selected_variation_index", 1);
     expect(rackDevice.call).toHaveBeenCalledWith("recall_selected_variation");
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("ignored"),
+    );
     expect(result).toStrictEqual({ id: "123" });
   });
 
@@ -106,6 +146,8 @@ describe("updateDevice - macroVariation", () => {
       macroVariationIndex: 1,
     });
 
+    // 'delete' also selects the index before deleting it.
+    expect(rackDevice.set).toHaveBeenCalledWith("selected_variation_index", 1);
     expect(rackDevice.call).toHaveBeenCalledWith("delete_selected_variation");
     expect(result).toStrictEqual({ id: "123" });
   });
@@ -196,6 +238,11 @@ describe("updateDevice - macroVariation", () => {
     expect(outlet).toHaveBeenCalledWith(
       1,
       "updateDevice: macroVariationIndex ignored for 'create' (variations always appended)",
+    );
+    // The index is ignored for 'create': it must NOT be written as a selection.
+    expect(rackDevice.set).not.toHaveBeenCalledWith(
+      "selected_variation_index",
+      expect.anything(),
     );
     expect(rackDevice.call).toHaveBeenCalledWith("store_variation");
     expect(result).toStrictEqual({ id: "123" });

--- a/src/tools/device/update/tests/update-device-path.test.ts
+++ b/src/tools/device/update/tests/update-device-path.test.ts
@@ -345,6 +345,18 @@ describe("updateDevice with path parameter", () => {
 
       expect(result).toStrictEqual([]);
     });
+
+    it("should warn and skip a malformed path that fails to resolve", () => {
+      // "zzz" is not a valid path segment, so resolvePathToLiveApi throws; the
+      // safe resolver catches it, warns, and drops the item instead of aborting.
+      const result = updateDevice({ path: "zzz", name: "Test" });
+
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("updateDevice:"),
+      );
+      expect(result).toStrictEqual([]);
+    });
   });
 
   describe("multiple comma-separated paths", () => {

--- a/src/tools/device/update/tests/update-device-wrap-in-rack-chains.test.ts
+++ b/src/tools/device/update/tests/update-device-wrap-in-rack-chains.test.ts
@@ -1,0 +1,113 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  type RegisteredMockObject,
+  livePath,
+  registerMockObject,
+  updateDevice,
+} from "./update-device-test-helpers.ts";
+
+// Chain-creation is only exercised when the rack starts with FEWER chains than
+// devices being wrapped. The default wrap tests pre-populate the rack with
+// enough chains, so the insert-chain loop never runs. These tests use a rack
+// that grows its chain count as insert_chain is called, so the loop's bounds
+// and arithmetic become observable.
+describe("updateDevice - wrapInRack chain creation", () => {
+  let newRack: RegisteredMockObject;
+  let liveSet: RegisteredMockObject;
+
+  beforeEach(() => {
+    // Two audio effects to wrap.
+    registerMockObject("device-0", {
+      path: livePath.track(0).device(0),
+      type: "RackDevice",
+      properties: { type: 2 },
+    });
+    registerMockObject("device-1", {
+      path: livePath.track(0).device(1),
+      type: "RackDevice",
+      properties: { type: 2 },
+    });
+
+    registerMockObject("track-0", {
+      path: livePath.track(0),
+      methods: { insert_device: () => ["id", "new-rack"] },
+    });
+
+    // Rack starts with ONE chain and grows by one per insert_chain.
+    let chainCount = 1;
+
+    newRack = registerMockObject("new-rack", {
+      path: "new-rack",
+      type: "RackDevice",
+      properties: { chains: [] },
+    });
+    newRack.get.mockImplementation((prop: string) => {
+      if (prop === "chains") {
+        const chains: string[] = [];
+
+        for (let i = 0; i < chainCount; i++) chains.push("id", `chain-${i}`);
+
+        return chains;
+      }
+
+      return [0];
+    });
+    newRack.call.mockImplementation((method: string) => {
+      if (method === "insert_chain") {
+        chainCount++;
+
+        return ["id", `chain-${chainCount - 1}`];
+      }
+
+      return null;
+    });
+
+    // Chains resolvable by "${rack.path} chains ${i}".
+    registerMockObject("chain-0", { type: "Chain", path: "new-rack chains 0" });
+    registerMockObject("chain-1", { type: "Chain", path: "new-rack chains 1" });
+
+    liveSet = registerMockObject("live-set", { path: "live_set" });
+  });
+
+  it("inserts exactly one chain per device beyond the rack's existing chains", () => {
+    // Rack has 1 chain; wrapping 2 devices needs exactly 1 more (not 0, not 2).
+    const result = updateDevice({ path: "t0/d0,t0/d1", wrapInRack: true });
+
+    const insertChainCalls = newRack.call.mock.calls.filter(
+      (c: unknown[]) => c[0] === "insert_chain",
+    );
+
+    expect(insertChainCalls).toHaveLength(1);
+
+    // Device 0 reuses the pre-existing chain 0; device 1 lands in the new chain 1.
+    expect(liveSet.call).toHaveBeenCalledWith(
+      "move_device",
+      "id device-0",
+      "id chain-0",
+      0,
+    );
+    expect(liveSet.call).toHaveBeenCalledWith(
+      "move_device",
+      "id device-1",
+      "id chain-1",
+      0,
+    );
+
+    // A successful insert must not report a chain-creation failure.
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("failed to create chain"),
+    );
+
+    expect(result).toStrictEqual({
+      id: "new-rack",
+      type: "audio-effect-rack",
+      deviceCount: 2,
+    });
+  });
+});

--- a/src/tools/device/update/tests/update-device-wrap-in-rack.test.ts
+++ b/src/tools/device/update/tests/update-device-wrap-in-rack.test.ts
@@ -95,6 +95,12 @@ describe("updateDevice - wrapInRack", () => {
       0,
     );
 
+    // With no name option, the rack name is left untouched. (Checked via call
+    // args, not expect.anything(), which ignores an undefined value.)
+    expect(
+      newRack.set.mock.calls.filter((c: unknown[]) => c[0] === "name"),
+    ).toHaveLength(0);
+
     expect(result).toStrictEqual({
       id: "new-rack",
       type: "audio-effect-rack",
@@ -284,6 +290,14 @@ describe("updateDevice - wrapInRack", () => {
         3,
       );
 
+      // One chain is inserted per instrument (the reverse loop runs exactly
+      // deviceCount times) — a bound-off mutant makes too few or too many.
+      const insertChainCalls = newRack.call.mock.calls.filter(
+        (c: unknown[]) => c[0] === "insert_chain",
+      );
+
+      expect(insertChainCalls).toHaveLength(2);
+
       expect(result).toStrictEqual({
         id: "new-rack",
         type: "instrument-rack",
@@ -297,6 +311,8 @@ describe("updateDevice - wrapInRack", () => {
         wrapInRack: true,
         name: "My Instrument Rack",
       });
+
+      expect(newRack.set).toHaveBeenCalledWith("name", "My Instrument Rack");
 
       const r = result as Record<string, unknown>;
 
@@ -500,6 +516,10 @@ describe("updateDevice - wrapInRack", () => {
       wrapInRack: true,
     });
 
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "wrapInRack: cannot mix MIDI and Audio effects in one rack",
+    );
     expect(result).toBeNull();
   });
 
@@ -532,6 +552,9 @@ describe("updateDevice - wrapInRack", () => {
       name: "My Effect Rack",
     });
 
+    // The provided name is written to the newly created rack.
+    expect(newRack.set).toHaveBeenCalledWith("name", "My Effect Rack");
+
     const r = result as Record<string, unknown>;
 
     expect(r.id).toBe("new-rack");
@@ -559,6 +582,12 @@ describe("updateDevice - wrapInRack", () => {
       wrapInRack: true,
     });
 
+    // The unresolved id is reported, then the empty set aborts the wrap.
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      'wrapInRack: device not found at "nonexistent"',
+    );
+    expect(outlet).toHaveBeenCalledWith(1, "wrapInRack: no devices found");
     expect(result).toBeNull();
   });
 
@@ -571,6 +600,10 @@ describe("updateDevice - wrapInRack", () => {
       toPath: "t99",
     });
 
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "wrapInRack: target container does not exist",
+    );
     expect(result).toBeNull();
   });
 
@@ -586,6 +619,10 @@ describe("updateDevice - wrapInRack", () => {
       wrapInRack: true,
     });
 
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "wrapInRack: no valid effect devices found",
+    );
     expect(result).toBeNull();
   });
 
@@ -602,6 +639,10 @@ describe("updateDevice - wrapInRack", () => {
       wrapInRack: true,
     });
 
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      'wrapInRack: "not-a-device" is not a device (type: Chain)',
+    );
     expect(result).toBeNull();
   });
 
@@ -623,6 +664,12 @@ describe("updateDevice - wrapInRack", () => {
       wrapInRack: true,
     });
 
+    // The failed chain insertion is reported (1/1), but the wrap continues.
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "wrapInRack: failed to create chain 1/1",
+    );
+
     // Result contains rack info even if chain creation failed
     expect(result).toMatchObject({
       id: "new-rack",
@@ -640,6 +687,12 @@ describe("updateDevice - wrapInRack", () => {
     );
 
     const result = updateDevice({ path: "t0/d0", wrapInRack: true });
+
+    // A returned array whose head isn't "id" is treated as a failure and warned.
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "wrapInRack: failed to create chain 1/1",
+    );
 
     expect(result).toMatchObject({
       id: "new-rack",

--- a/src/tools/device/update/tests/update-device.test.ts
+++ b/src/tools/device/update/tests/update-device.test.ts
@@ -680,6 +680,14 @@ describe("updateDevice", () => {
         toPath: "t1",
       });
 
+      // A plain Chain is neither a device nor a DrumChain: it cannot be moved.
+      expect(outlet).toHaveBeenCalledWith(1, "cannot move Chain");
+      expect(liveSet.call).not.toHaveBeenCalledWith(
+        "move_device",
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
       expect(result).toStrictEqual({ id: "123" });
     });
 
@@ -692,6 +700,7 @@ describe("updateDevice", () => {
         toPath: "t1",
       });
 
+      expect(outlet).toHaveBeenCalledWith(1, "cannot move DrumPad");
       expect(result).toStrictEqual({ id: "123" });
     });
 
@@ -704,6 +713,17 @@ describe("updateDevice", () => {
         toPath: "t99",
       });
 
+      // The missing container is reported and no move is attempted.
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        'move target at path "t99" does not exist',
+      );
+      expect(liveSet.call).not.toHaveBeenCalledWith(
+        "move_device",
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
       expect(result).toStrictEqual({ id: "123" });
     });
 
@@ -726,6 +746,21 @@ describe("updateDevice", () => {
       expect(device123.set).toHaveBeenCalledWith("name", "Moved Device");
 
       expect(result).toStrictEqual({ id: "123" });
+    });
+  });
+
+  describe("type validation", () => {
+    it("should warn and skip an object that is not a device, chain, or pad", () => {
+      registerMockObject("999", {
+        path: livePath.track(3),
+        type: "Track",
+      });
+
+      const result = updateDevice({ ids: "999", name: "Nope" });
+
+      expect(outlet).toHaveBeenCalledWith(1, "cannot update Track objects");
+      // Nothing is written to an unsupported object, and it drops from results.
+      expect(result).toStrictEqual([]);
     });
   });
 


### PR DESCRIPTION
Fourth AJM-668 write-op domain triaged (after `track`, `session`, `actions`).

## Result

`src/tools/device/` mutation score **82.20% → 91.68%** — killed 114 additional mutants (214 → 93 survivors) with **test-only** changes; **no product code touched**. Gate set to `break: 90` in `TOOL_DOMAIN_BREAKS.device` (~1.7 below the score for timeout-classification variance). Baseline recorded in `dev/Mutation-Testing.md`.

Verified: `npm run mutation -- device` → exit 0, "Final mutation score of 91.68 is greater than or equal to break threshold 90". `npm run check` (9434 passed, Functions 100%) and `npm run check:build` both green.

## Per-file (after triage)

| File | Score | Was |
| --- | --- | --- |
| `update-device-type-helpers.ts` | 100.00% | 97.14% |
| `update-device-property-helpers.ts` | 96.63% | 82.02% |
| `update-device-helpers.ts` | 95.31% | 84.04% |
| `update-device.ts` | 93.52% | 87.04% |
| `read-device.ts` | 92.31% | 87.50% |
| `create-device.ts` | 91.75% | 88.66% |
| `update-device-param-setters.ts` | 87.76% | 84.49% |
| `update-device-wrap-helpers.ts` | 86.59% | **57.32%** |

## Notable gaps closed

- **wrap-helpers (biggest lever, 57%→87%):** tests asserted the return value but not the emitted warnings, the Live-API method/property-name args, or the chain-creation arithmetic. Added a discriminating chain-creation test (rack with N pre-existing chains, wrap 2 devices → assert exact `insert_chain` count).
- **macro-variation:** `setVariationIndex` load/delete now assert the index-set paired with the action; index-count boundary (`>=`) and the skip-executes-action guard.
- **read-device:** nested drum-pad chain/device index **boundary** (`>=`) + **non-numeric** (`cX`/`dX`) segments; return-chains include on/off.
- **param conversion:** division-label OR, min-label-unparseable fallback, pan scaling from the display max (not the `50` fallback).

## Durable gotcha (also in the docs)

`expect.anything()` does **not** match `undefined`, so `not.toHaveBeenCalledWith("name", expect.anything())` passes even when a mutated guard writes `set("name", undefined)`. Assert via a `mock.calls.filter((c) => c[0] === "name")` length check instead. This hid the `create-device`/`wrap` name-set guard mutants until the assertion was rewritten.

## Housekeeping

Moved the param-focused test files into `tests/params/` to keep `src/tools/device/update/tests/` within the 12-item folder cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)