### PR TITLE
test(mutation): triage clip domain, ratchet break to 96

### DIFF
--- a/config/mutation-scopes.mjs
+++ b/config/mutation-scopes.mjs
@@ -16,17 +16,21 @@
 //            ~1 point below its triaged score, matching notation's ratchet.
 
 // Glob set for one tool domain under src/tools/. Excludes tests, test dirs,
-// test/mock helpers, `.def.ts` tool definitions, and type-only modules — none
-// carry mutable behavior worth asserting on. `.def.ts` files are purely
-// declarative (a `defineTool()` call: Zod schema + LLM-facing description
-// strings, no logic): mutating a `.describe("…")` string just blanks prose that
-// is eval-tested, not unit-tested, so asserting exact wording would over-fit and
-// fight the description-iteration workflow. Schema constraints (`.min`/`.max`)
-// are enforced by the MCP SDK, not our runtime code. `*-mock-helpers.ts` is
-// test-only mock infrastructure (like `*-test-helpers.ts`); it stays
-// source-classified for coverage but must not be mutated. (src/tools/ currently
-// has no types.ts, but that exclusion is kept for parity with the notation
-// scope and future-proofing.)
+// test/mock helpers, `.def.ts` tool definitions, `*-disabled.ts` build-time
+// stubs, and type-only modules — none carry mutable behavior worth asserting on.
+// `.def.ts` files are purely declarative (a `defineTool()` call: Zod schema +
+// LLM-facing description strings, no logic): mutating a `.describe("…")` string
+// just blanks prose that is eval-tested, not unit-tested, so asserting exact
+// wording would over-fit and fight the description-iteration workflow. Schema
+// constraints (`.min`/`.max`) are enforced by the MCP SDK, not our runtime code.
+// `*-mock-helpers.ts` is test-only mock infrastructure (like
+// `*-test-helpers.ts`); it stays source-classified for coverage but must not be
+// mutated. `*-disabled.ts` are build-time substitution stubs swapped in by
+// rollup when a feature flag is off (e.g. ENABLE_CODE_EXEC); tests run with the
+// feature enabled so the stubs are never imported (all-NoCoverage by
+// construction) — they are already coverage-excluded in vitest.config.ts, so
+// exclude them here too. (src/tools/ currently has no types.ts, but that
+// exclusion is kept for parity with the notation scope and future-proofing.)
 function toolDomain(name) {
   const dir = `src/tools/${name}`;
 
@@ -37,6 +41,7 @@ function toolDomain(name) {
     `!${dir}/**/*-test-helpers.ts`,
     `!${dir}/**/*-mock-helpers.ts`,
     `!${dir}/**/*.def.ts`,
+    `!${dir}/**/*-disabled.ts`,
     `!${dir}/**/types.ts`,
   ];
 }
@@ -78,6 +83,7 @@ const TOOL_DOMAIN_BREAKS = {
   session: 89, // triaged 2026-07-14 at 90.46% (see dev/Mutation-Testing.md)
   actions: 90, // triaged 2026-07-15 at 91.79% (see dev/Mutation-Testing.md)
   device: 90, // triaged 2026-07-15 at 91.18% (see dev/Mutation-Testing.md)
+  clip: 96, // triaged 2026-07-15 at 97.48% (see dev/Mutation-Testing.md)
 };
 
 export const SCOPES = {

--- a/dev/Mutation-Testing.md
+++ b/dev/Mutation-Testing.md
@@ -31,11 +31,13 @@ Scopes are defined in `config/mutation-scopes.mjs`:
 - **`notation`** — `src/notation/` (the default). Ratcheted: `break: 86`.
 - **One scope per `src/tools/` domain** — `actions`, `advanced`, `clip`, `core`,
   `device`, `live-set`, `scene`, `session`, `shared`, `track`. Each excludes
-  tests, test helpers, `.def.ts` tool-definition files, and type-only modules
-  (see `toolDomain()`). A domain starts in **baseline mode** (`break: null`,
-  measure-only) until its survivors are triaged in its own PR and it earns a
-  floor in `TOOL_DOMAIN_BREAKS`; triaged so far: `track` (`break: 85`),
-  `session` (`break: 89`), `actions` (`break: 90`).
+  tests, test helpers, `.def.ts` tool-definition files, `*-disabled.ts`
+  build-time substitution stubs, and type-only modules (see `toolDomain()`). A
+  domain starts in **baseline mode** (`break: null`, measure-only) until its
+  survivors are triaged in its own PR and it earns a floor in
+  `TOOL_DOMAIN_BREAKS`; triaged so far: `track` (`break: 85`), `session`
+  (`break: 89`), `actions` (`break: 90`), `device` (`break: 90`), `clip`
+  (`break: 96`).
 - **Groups** — `tools` (all ten tool domains) and `all` (notation + tools),
   expanded by the runner into their member scopes.
 
@@ -438,6 +440,95 @@ One durable test-authoring gotcha surfaced (worth reusing across domains):
 | return-chains include on/off; malformed-path safe-resolve warn      | `read-device.test.ts`, `update-device-path` |
 | Malformed-JSON `params` string rejected (not swallowed)             | `device-params-schema.test.ts`              |
 
+## Baseline (2026-07-15, `src/tools/clip/`)
+
+Fifth and largest write-op domain triaged (`create` / `read` / `update` clip
+tools plus arrangement operations, in-clip code execution, and the shared clip
+helpers) — this completes the write-op tier. Full pass — Stryker 9.6.1, Node 24,
+`coverageAnalysis: "perTest"`:
+
+| Metric                     | Value      |
+| -------------------------- | ---------- |
+| **Mutation score**         | **97.48%** |
+| Mutants killed             | 1741       |
+| Survived                   | 45         |
+| Timeout (counts as killed) | 1          |
+| No coverage                | 0          |
+| Total mutants              | 1787       |
+| Wall-clock                 | 2m 0s      |
+
+Gate: `break: 96` (`TOOL_DOMAIN_BREAKS.clip`), ~1.5 points below the score for
+timeout-classification variance. Triage lifted the score from an **80.23%**
+baseline (338 survivors), killing ~297 mutants with test-only changes — no
+product code touched. This was by far the biggest domain (28 mutated files, 1787
+mutants — more than `track` + `session` + `actions` combined) yet finished with
+the **highest** final score of the five write-op domains, because the clip
+helpers are mostly pure functions with tight, directly-unit-testable contracts.
+
+One scope-config change accompanied the tests: `toolDomain()` in
+`config/mutation-scopes.mjs` now excludes `*-disabled.ts`, the build-time
+substitution stubs rollup swaps in when a feature flag is off (e.g.
+`ENABLE_CODE_EXEC`). Tests run with the feature enabled, so the stubs are never
+imported — 14 all-`NoCoverage` mutants that can never be killed.
+`vitest.config.ts` already coverage-excludes them; this mirrors that exclusion.
+
+Per-file scores after triage (files with remaining survivors; 12 more files hit
+100%):
+
+| File                                 | Score  | Survived | Notes                                   |
+| ------------------------------------ | ------ | -------- | --------------------------------------- |
+| `update-clip-arrangement-optimizer`  | 90.32% | 6        | merge-group length boundary (bkt 2)     |
+| `update-clip-notes-helpers`          | 91.82% | 9        | redundant fast-path guards (bkt 2)      |
+| `create-clip-loop-helpers`           | 93.02% | 6        | loop-region default equivalents         |
+| `update-clip.ts`                     | 93.75% | 6        | toSlot dual-return + split integ.       |
+| `create-clip-audio-helpers`          | 95.45% | 1        | arrangementStart null-guard (bkt 2)     |
+| `update-clip-properties-helpers`     | 96.47% | 3        | setEndFirst redundant operands          |
+| `read-clip-helpers`                  | 97.30% | 2        | dead `=== ""` clause (bkt 2)            |
+| `code-exec-helpers`                  | 97.75% | 2        | view-branch guards (weak, need LiveAPI) |
+| `read-clip.ts`                       | 98.31% | 3        | `?? "barbeat"` fallthrough (bkt 2)      |
+| 7 more (`create-clip.ts`, timing, …) | 98–99% | 1 each   | isolated equivalents (bkt 2)            |
+
+The remaining 45 survivors are overwhelmingly **bucket 2 (equivalent)**. The
+recurring shapes:
+
+- **Redundant fast-path guards** (`update-clip-notes-helpers` L201/L309/L353):
+  an early `existingNotes.length === 0` / `preTransformString == null` short-
+  circuit duplicating a guard `applyTransforms` already performs internally, so
+  forcing it changes nothing observable.
+- **Merge-group length boundaries** (`update-clip-arrangement-optimizer`):
+  `>= 1` / `< 1` on group lengths the merge loop can only ever enter with ≥1
+  element.
+- **Dual null-returns** (`update-clip.ts` `parseToSlotParam`): the
+  `toSlot == null` early return and the `slots.length === 0` return converge on
+  the same `null`.
+- **Never-nullish fallbacks / never-equal bounds** across create/read helpers:
+  `?? "barbeat"` (both branches fall through `resolveNotation`), the
+  `"arrangement" → ""` view string never surfaced in a result, `color` /
+  `arrangementStart` null-guards behind a `setAll` that already skips null.
+
+The only weak-not-equivalent leftovers are the arrangement-splitting branch in
+`update-clip.ts` (L353) and the `buildCodeLocationContext` view guards
+(`code-exec-helpers` L221/L225) — reachable but low-value defensive paths left
+for a future integration pass.
+
+### Gaps closed (clip)
+
+Same `undefined`-valued-property gotcha as the device pass (see above): a
+`buildClipProperties` `if (clipName)` guard forced to `true` writes
+`name: undefined`, which a `.name` → `toBeUndefined()` assertion cannot
+distinguish from an absent property. Fixed with `not.toHaveProperty("name")`.
+
+| Gap (now killed)                                                    | Test strengthened / added                          |
+| ------------------------------------------------------------------- | -------------------------------------------------- |
+| Loop/unlooped arrangement clip property math (43 mutants, 0 → 100%) | `arrangement-unlooped-helpers.test.ts`             |
+| `buildClipPropertiesToSet` boundary/loop-flag matrix                | `update-clip-properties.test.ts`                   |
+| Loop-region defaults + transform normalization (create)             | `create-clip-loop-helpers.test.ts`, `-transform`   |
+| Note transform / timing / audio helper conditionals + warns         | `update-clip-notes-helpers.test.ts`, `-timing`     |
+| read-clip warp-marker + notation-resolution branches                | `read-clip-coverage.test.ts`, `read-clip-helpers`  |
+| In-clip code-exec helper guards + deadline / scale-mask             | `code-exec-helpers-coverage.test.ts`, `scale-mask` |
+| create-clip name/color distribution + take-lane resolution          | `create-clip-*.test.ts` (basic/advanced/…)         |
+| Empty `clipName` must not write a `name` property                   | `create-clip-advanced.test.ts`                     |
+
 ## Interpreting survivors
 
 Each survivor falls into one of three buckets — triage before acting:
@@ -457,24 +548,27 @@ wins, and a cross-check against the line-coverage gate.
 ## Status & next steps
 
 The `notation` scope is **ratcheted** (`thresholds.break = 86`), as are `track`
-(`break: 85`), `session` (`break: 89`), `actions` (`break: 90`), and `device`
-(`break: 90`), the first four triaged tool domains. The per-domain scope
-mechanism (`config/mutation-scopes.mjs` + the runner) is in place, so each
-`src/tools/` domain can be mutated on its own; the untriaged ones remain in
-**baseline mode** (`break: null`, measure-only). Mutation testing stays off the
-per-PR hot path (a full pass is minutes). Remaining work (later releases):
+(`break: 85`), `session` (`break: 89`), `actions` (`break: 90`), `device`
+(`break: 90`), and `clip` (`break: 96`) — the five triaged write-op tool
+domains. The per-domain scope mechanism (`config/mutation-scopes.mjs` + the
+runner) is in place, so each `src/tools/` domain can be mutated on its own; the
+untriaged ones remain in **baseline mode** (`break: null`, measure-only).
+Mutation testing stays off the per-PR hot path (a full pass is minutes).
+Remaining work (later releases):
 
 - Keep triaging the ~588 notation survivors, but expect diminishing returns: the
   dense clusters left are epsilon-boundary / warning-string / equivalent mutants
   (bucket 2/3), so genuine bucket-1 gaps are now sparse.
 - Raise each scope's `break` as its score climbs.
-- Triage the remaining `src/tools/` domains one PR at a time (write operations
-  first — `clip` next; `track`, `session`, `actions`, and `device` done). Per
-  domain: run `npm run mutation -- <domain>`, close real gaps, flip that
-  domain's `break` from `null` to ~1 point below its triaged score (add it to
-  `TOOL_DOMAIN_BREAKS`). The big clean wins tend to be untested lookup/enum
-  tables (as in notation's chord table) and warn-and-skip guards whose tests
-  assert only the result, never the warning or the skipped write.
+- Triage the remaining `src/tools/` domains one PR at a time. The write-op tier
+  is now complete (`track`, `session`, `actions`, `device`, `clip` done); the
+  read-op / shared domains (`advanced`, `core`, `live-set`, `scene`, `shared`)
+  remain in baseline mode. Per domain: run `npm run mutation -- <domain>`, close
+  real gaps, flip that domain's `break` from `null` to ~1 point below its
+  triaged score (add it to `TOOL_DOMAIN_BREAKS`). The big clean wins tend to be
+  untested lookup/enum tables (as in notation's chord table) and warn-and-skip
+  guards whose tests assert only the result, never the warning or the skipped
+  write.
 - Optionally wire a scheduled (nightly/weekly) non-blocking CI job once several
   domains have floors — full-tree runtime is hours, not minutes.
 

--- a/src/tools/clip/arrangement/helpers/arrangement-operations-helpers.test.ts
+++ b/src/tools/clip/arrangement/helpers/arrangement-operations-helpers.test.ts
@@ -204,6 +204,186 @@ describe("arrangement-operations-helpers", () => {
 
       mockTileClipToRange.mockRestore();
     });
+
+    it("computes clipLength as loop_end - loop_start for looped clips", () => {
+      // loop_start=2, loop_end=8 → clipLength = 6 (subtraction, not addition=10).
+      // arrangementLengthBeats=7 sits between 6 and 10, so with the correct
+      // subtraction 7 < 6 is false → tiling branch (adjustPreRoll:true). If the
+      // operator were `+`, clipLength=10 → 7 < 10 → expose branch
+      // (adjustPreRoll:false).
+      const { tile, clip } = runLengthening(
+        { loop_start: 2, loop_end: 8, start_marker: 2, end_marker: 8 },
+        {
+          arrangementLengthBeats: 7,
+          currentArrangementLength: 4,
+          currentStartTime: 0,
+          currentEndTime: 4,
+        },
+      );
+
+      expect(tile).toHaveBeenCalledWith(
+        clip,
+        expect.anything(),
+        4,
+        3,
+        40000,
+        expect.anything(),
+        expect.objectContaining({ adjustPreRoll: true }),
+      );
+
+      tile.mockRestore();
+    });
+
+    it("uses the tiling branch at the exact arrangementLengthBeats == clipLength boundary", () => {
+      // clipLength = loop_end(8) - loop_start(0) = 8. At arrangementLengthBeats=8
+      // the correct `<` yields 8 < 8 = false → tiling (adjustPreRoll:true).
+      // A `<=` mutant would take the expose branch (adjustPreRoll:false).
+      const { tile, clip } = runLengthening(
+        {},
+        {
+          arrangementLengthBeats: 8,
+          currentArrangementLength: 4,
+          currentStartTime: 0,
+          currentEndTime: 4,
+        },
+      );
+
+      expect(tile).toHaveBeenCalledWith(
+        clip,
+        expect.anything(),
+        4,
+        4,
+        40000,
+        expect.anything(),
+        expect.objectContaining({ adjustPreRoll: true }),
+      );
+
+      tile.mockRestore();
+    });
+
+    it("derives the expose-branch startOffset from start_marker - loop_start", () => {
+      // Expose branch (arrangementLengthBeats 12 < clipLength 14).
+      // currentOffset = start_marker(5) - loop_start(2) = 3, so
+      // startOffset = currentOffset(3) + currentArrangementLength(4) = 7.
+      // An addition mutant would make currentOffset 7 → startOffset 11.
+      const { tile, clip } = runLengthening(
+        { loop_start: 2, loop_end: 16, start_marker: 5, end_marker: 16 },
+        {
+          arrangementLengthBeats: 12,
+          currentArrangementLength: 4,
+          currentStartTime: 0,
+          currentEndTime: 4,
+        },
+      );
+
+      expect(tile).toHaveBeenCalledWith(
+        clip,
+        expect.anything(),
+        4,
+        8,
+        40000,
+        expect.anything(),
+        expect.objectContaining({
+          adjustPreRoll: false,
+          startOffset: 7,
+          tileLength: 4,
+        }),
+      );
+
+      tile.mockRestore();
+    });
+
+    it("tiles the properly-sized clip when currentArrangementLength == totalContentLength", () => {
+      // totalContentLength = loop_end(8) - start_marker(0) = 8, equal to
+      // currentArrangementLength(8) → the equal branch. firstTileLength =
+      // currentEndTime(10) - currentStartTime(2) = 8, remainingSpace = 20 - 8 =
+      // 12, position = currentEndTime(10). The exact options object (no
+      // startOffset) also pins the `<` boundary, adjustPreRoll, and the object
+      // literal.
+      const { tile, clip } = runLengthening(
+        {},
+        {
+          arrangementLengthBeats: 20,
+          currentArrangementLength: 8,
+          currentStartTime: 2,
+          currentEndTime: 10,
+        },
+      );
+
+      expect(tile).toHaveBeenCalledWith(
+        clip,
+        expect.anything(),
+        10,
+        12,
+        40000,
+        expect.anything(),
+        { adjustPreRoll: true, tileLength: 8 },
+      );
+
+      tile.mockRestore();
+    });
+
+    it("uses the equal branch (not shorten-then-tile) when currentArrangementLength == totalContentLength", () => {
+      // At the boundary currentArrangementLength(8) == totalContentLength(8) the
+      // correct `>` is false → equal branch: firstTileLength = currentEndTime(20)
+      // - currentStartTime(0) = 20, remainingSpace = 30 - 20 = 10, position =
+      // currentEndTime(20). A `>=` mutant (or forced-true) would shorten first,
+      // producing position=8 instead.
+      const { tile, clip } = runLengthening(
+        {},
+        {
+          arrangementLengthBeats: 30,
+          currentArrangementLength: 8,
+          currentStartTime: 0,
+          currentEndTime: 20,
+        },
+      );
+
+      expect(tile).toHaveBeenCalledWith(
+        clip,
+        expect.anything(),
+        20,
+        10,
+        40000,
+        expect.anything(),
+        { adjustPreRoll: true, tileLength: 20 },
+      );
+
+      tile.mockRestore();
+    });
+
+    it("pins the shorten-then-tile arithmetic when currentArrangementLength > totalContentLength", () => {
+      // totalContentLength = loop_end(8) - start_marker(2) = 6 <
+      // currentArrangementLength(10) → shorten-then-tile branch.
+      //   newEndTime = currentStartTime(1) + totalContentLength(6) = 7
+      //   tempClipLength = currentEndTime(11) - newEndTime(7) = 4  → temp clip
+      //   firstTileLength = newEndTime(7) - currentStartTime(1) = 6
+      //   remainingSpace = arrangementLengthBeats(20) - firstTileLength(6) = 14
+      const { tile, clip } = runLengthening(
+        { loop_start: 0, loop_end: 8, start_marker: 2, end_marker: 8 },
+        {
+          arrangementLengthBeats: 20,
+          currentArrangementLength: 10,
+          currentStartTime: 1,
+          currentEndTime: 11,
+        },
+      );
+
+      const track = requireMockObject(livePath.track(0));
+
+      expect(track.call).toHaveBeenCalledWith("create_midi_clip", 7, 4);
+      expect(tile).toHaveBeenCalledWith(
+        clip,
+        expect.anything(),
+        7,
+        14,
+        40000,
+        expect.anything(),
+        { adjustPreRoll: true, tileLength: 6 },
+      );
+
+      tile.mockRestore();
+    });
   });
 
   describe("handleArrangementShortening", () => {
@@ -268,6 +448,8 @@ describe("arrangement-operations-helpers", () => {
       expect(arrangementClip.set).toHaveBeenCalledWith("looping", 1);
       expect(arrangementClip.set).toHaveBeenCalledWith("loop_end", 4.0);
       expect(mockSlotCall).toHaveBeenCalledWith("delete_clip");
+      // The temp arrangement clip is removed via Track.delete_clip by id.
+      expect(track.call).toHaveBeenCalledWith("delete_clip", "id arr-456");
 
       mockCreateAudioClip.mockRestore();
     });
@@ -300,3 +482,47 @@ describe("arrangement-operations-helpers", () => {
     });
   });
 });
+
+interface RunLengtheningArgs {
+  arrangementLengthBeats: number;
+  currentArrangementLength: number;
+  currentStartTime: number;
+  currentEndTime: number;
+  isAudioClip?: boolean;
+}
+
+/**
+ * Set up mocks for a looped clip, run handleArrangementLengthening, and return
+ * the tileClipToRange spy plus the mock clip for call-argument assertions.
+ * @param clipProps - Clip property overrides (loop_start, loop_end, markers)
+ * @param args - Lengthening arguments
+ * @param args.arrangementLengthBeats - Target length in beats
+ * @param args.currentArrangementLength - Current length in beats
+ * @param args.currentStartTime - Current start time in beats
+ * @param args.currentEndTime - Current end time in beats
+ * @param args.isAudioClip - Whether the clip is audio (default false)
+ * @returns The tileClipToRange spy and the mock clip
+ */
+function runLengthening(
+  clipProps: Record<string, number>,
+  args: RunLengtheningArgs,
+): { tile: ReturnType<typeof vi.spyOn>; clip: LiveAPI } {
+  setupArrangementMocks({ clipProps });
+
+  const tile = vi
+    .spyOn(arrangementTiling, "tileClipToRange")
+    .mockReturnValue([{ id: "tile1" }]);
+  const clip = createMockClip({ props: clipProps }) as unknown as LiveAPI;
+
+  handleArrangementLengthening({
+    clip,
+    isAudioClip: args.isAudioClip ?? false,
+    arrangementLengthBeats: args.arrangementLengthBeats,
+    currentArrangementLength: args.currentArrangementLength,
+    currentStartTime: args.currentStartTime,
+    currentEndTime: args.currentEndTime,
+    context: { holdingAreaStartBeats: 40000, silenceWavPath: "/test.wav" },
+  });
+
+  return { tile, clip };
+}

--- a/src/tools/clip/arrangement/helpers/arrangement-unlooped-helpers.test.ts
+++ b/src/tools/clip/arrangement/helpers/arrangement-unlooped-helpers.test.ts
@@ -1,0 +1,405 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as tilingHelpers from "#src/tools/shared/arrangement/arrangement-tiling-helpers.ts";
+import { handleUnloopedLengthening } from "./arrangement-unlooped-helpers.ts";
+
+const EPSILON = 0.001;
+
+interface RunOpts {
+  props: Record<string, unknown>;
+  isAudioClip: boolean;
+  arrangementLengthBeats: number;
+  currentArrangementLength: number;
+  currentEndTime?: number;
+  clipStartMarker: number;
+  fileContentBoundary?: number;
+}
+
+/**
+ * Invoke handleUnloopedLengthening with a mock clip and a spied
+ * createAudioClipInSession (used by the warped-audio path).
+ * @param opts - Test inputs (clip props, dispatch flags, boundary values)
+ * @returns The result array, the clip.set spy, and the session-creation spy
+ */
+function run(opts: RunOpts) {
+  const set = vi.fn();
+  const clip = {
+    id: "clip-1",
+    getProperty: vi.fn((p: string) => opts.props[p]),
+    set,
+  } as unknown as LiveAPI;
+
+  const spy = vi
+    .spyOn(tilingHelpers, "createAudioClipInSession")
+    .mockReturnValue({
+      clip: {
+        getProperty: vi.fn((p: string) =>
+          p === "end_marker" ? opts.fileContentBoundary : undefined,
+        ),
+      } as unknown as LiveAPI,
+      slot: { call: vi.fn() } as unknown as LiveAPI,
+    });
+
+  const result = handleUnloopedLengthening({
+    clip,
+    isAudioClip: opts.isAudioClip,
+    arrangementLengthBeats: opts.arrangementLengthBeats,
+    currentArrangementLength: opts.currentArrangementLength,
+    currentEndTime: opts.currentEndTime ?? 0,
+    clipStartMarker: opts.clipStartMarker,
+    track: {} as unknown as LiveAPI,
+  });
+
+  return { result, set, spy };
+}
+
+const AUDIO_PROPS = { warping: 0, end_marker: 10, loop_start: 2, loop_end: 10 };
+
+interface UnwarpedOpts {
+  end_time: number;
+  currentEndTime?: number;
+  currentArrangementLength?: number;
+  arrangementLengthBeats?: number;
+}
+
+/**
+ * Run the unwarped-audio path with shared clip props (content length 10).
+ * @param o - Per-test overrides for end_time and length parameters
+ * @returns Same shape as run()
+ */
+function unwarped(o: UnwarpedOpts) {
+  return run({
+    props: { ...AUDIO_PROPS, end_time: o.end_time },
+    isAudioClip: true,
+    clipStartMarker: 0,
+    currentEndTime: o.currentEndTime ?? 8,
+    currentArrangementLength: o.currentArrangementLength ?? 8,
+    arrangementLengthBeats: o.arrangementLengthBeats ?? 16,
+  });
+}
+
+interface WarpedOpts {
+  end_marker: number;
+  clipStartMarker: number;
+  fileContentBoundary: number;
+  currentArrangementLength: number;
+  arrangementLengthBeats: number;
+}
+
+/**
+ * Run the warped-audio path (warping=1, session boundary via spy).
+ * @param o - Per-test overrides for markers, boundary, and length parameters
+ * @returns Same shape as run()
+ */
+function warped(o: WarpedOpts) {
+  return run({
+    props: {
+      warping: 1,
+      end_marker: o.end_marker,
+      loop_start: 0,
+      file_path: "x.wav",
+    },
+    isAudioClip: true,
+    clipStartMarker: o.clipStartMarker,
+    currentArrangementLength: o.currentArrangementLength,
+    arrangementLengthBeats: o.arrangementLengthBeats,
+    fileContentBoundary: o.fileContentBoundary,
+  });
+}
+
+describe("handleUnloopedLengthening", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("MIDI clip", () => {
+    it("does not extend end_marker when targetEndMarker equals currentEndMarker", () => {
+      // clipStartMarker(0) + arrangementLengthBeats(8) == currentEndMarker(8)
+      const { result, set } = run({
+        props: { end_marker: 8, loop_start: 0 },
+        isAudioClip: false,
+        arrangementLengthBeats: 8,
+        currentArrangementLength: 0,
+        clipStartMarker: 0,
+      });
+
+      expect(set).not.toHaveBeenCalledWith("end_marker", expect.anything());
+      expect(set).toHaveBeenCalledWith("loop_end", 8); // loop_start(0) + 8
+      expect(result).toStrictEqual([{ id: "clip-1" }]);
+    });
+
+    it("extends end_marker and loop_end when target exceeds current", () => {
+      // targetEndMarker = 0 + 8 = 8 > currentEndMarker(4)
+      const { result, set } = run({
+        props: { end_marker: 4, loop_start: 2 },
+        isAudioClip: false,
+        arrangementLengthBeats: 8,
+        currentArrangementLength: 0,
+        clipStartMarker: 0,
+      });
+
+      expect(set).toHaveBeenCalledWith("end_marker", 8);
+      expect(set).toHaveBeenCalledWith("loop_end", 10); // loop_start(2) + 8
+      expect(result).toStrictEqual([{ id: "clip-1" }]);
+    });
+  });
+
+  describe("audio clip content-length gate", () => {
+    it("returns early without lengthening when content length is zero", () => {
+      // contentLength = end_marker(4) - clipStartMarker(4) = 0 <= EPSILON
+      const { result, set, spy } = run({
+        props: { warping: 1, end_marker: 4, loop_start: 0, file_path: "x.wav" },
+        isAudioClip: true,
+        arrangementLengthBeats: 16,
+        currentArrangementLength: 8,
+        clipStartMarker: 4,
+        fileContentBoundary: 99,
+      });
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(set).not.toHaveBeenCalledWith("loop_end", expect.anything());
+      expect(result).toStrictEqual([{ id: "clip-1" }]);
+    });
+
+    it("returns early when content length exactly equals EPSILON", () => {
+      // contentLength = EPSILON; `<= EPSILON` is true, `< EPSILON` would be false
+      const { result, spy } = run({
+        props: {
+          warping: 1,
+          end_marker: EPSILON,
+          loop_start: 0,
+          file_path: "x.wav",
+        },
+        isAudioClip: true,
+        arrangementLengthBeats: 16,
+        currentArrangementLength: 8,
+        clipStartMarker: 0,
+        fileContentBoundary: 99,
+      });
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(result).toStrictEqual([{ id: "clip-1" }]);
+    });
+  });
+
+  describe("warped unlooped audio", () => {
+    it("caps loop_end at the file content boundary and warns", () => {
+      // totalContentFromStart = 20 - 4 = 16, capped below requested 100
+      const { set } = warped({
+        end_marker: 20,
+        clipStartMarker: 4,
+        fileContentBoundary: 20,
+        currentArrangementLength: 8,
+        arrangementLengthBeats: 100,
+      });
+
+      expect(set).toHaveBeenCalledWith("loop_end", 16); // loop_start(0) + 16
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("capped at file content boundary"),
+      );
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("beats available"),
+      );
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("requested"),
+      );
+    });
+
+    it("warns and skips when no additional content is available", () => {
+      // totalContentFromStart(8) == currentArrangementLength(8)
+      const { set } = warped({
+        end_marker: 12,
+        clipStartMarker: 4,
+        fileContentBoundary: 12,
+        currentArrangementLength: 8,
+        arrangementLengthBeats: 50,
+      });
+
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("Cannot lengthen unlooped audio clip"),
+      );
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("beats available"),
+      );
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("currently shown"),
+      );
+      expect(set).not.toHaveBeenCalledWith("loop_end", expect.anything());
+    });
+
+    it("skips at the exact no-content boundary (content == current + EPSILON)", () => {
+      // totalContentFromStart == currentArrangementLength + EPSILON
+      const { set } = warped({
+        end_marker: 10,
+        clipStartMarker: 0,
+        fileContentBoundary: 8 + EPSILON,
+        currentArrangementLength: 8,
+        arrangementLengthBeats: 50,
+      });
+
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("no additional file content"),
+      );
+      expect(set).not.toHaveBeenCalledWith("loop_end", expect.anything());
+    });
+
+    it("does not warn when the full requested length is achievable", () => {
+      // effectiveTarget(16) == arrangementLengthBeats(16), no cap warning
+      const { set } = warped({
+        end_marker: 30,
+        clipStartMarker: 0,
+        fileContentBoundary: 30,
+        currentArrangementLength: 8,
+        arrangementLengthBeats: 16,
+      });
+
+      expect(set).toHaveBeenCalledWith("loop_end", 16);
+      expect(outlet).not.toHaveBeenCalledWith(1, expect.anything());
+    });
+
+    it("does not warn at the exact cap boundary (target == requested - EPSILON)", () => {
+      // effectiveTarget == arrangementLengthBeats - EPSILON; `<` is false there
+      const { set } = warped({
+        end_marker: 16,
+        clipStartMarker: 0,
+        fileContentBoundary: 16 - EPSILON,
+        currentArrangementLength: 4,
+        arrangementLengthBeats: 16,
+      });
+
+      expect(set).toHaveBeenCalledWith("loop_end", 16 - EPSILON);
+      expect(outlet).not.toHaveBeenCalledWith(1, expect.anything());
+    });
+
+    it("does not extend end_marker when target equals current end_marker", () => {
+      // targetEndMarker = clipStartMarker(4) + effectiveTarget(16) == currentEndMarker(20)
+      const { set } = warped({
+        end_marker: 20,
+        clipStartMarker: 4,
+        fileContentBoundary: 20,
+        currentArrangementLength: 8,
+        arrangementLengthBeats: 16,
+      });
+
+      expect(set).toHaveBeenCalledWith("loop_end", 16);
+      expect(set).not.toHaveBeenCalledWith("end_marker", expect.anything());
+    });
+  });
+
+  describe("unwarped unlooped audio", () => {
+    it("sets loop_end derived from the current beats-per-second ratio", () => {
+      // currentDurationSec = loop_end(10) - loop_start(2) = 8; bps = 8/8 = 1
+      // targetDurationSec = 16/1 = 16; targetLoopEnd = loop_start(2) + 16 = 18
+      const { set } = unwarped({ end_time: 24 });
+
+      expect(set).toHaveBeenCalledWith("loop_end", 18);
+    });
+
+    it("warns at the file boundary when no additional length is achieved", () => {
+      // actualArrangementLength == currentArrangementLength(8)
+      unwarped({ end_time: 8 });
+
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("Cannot lengthen unlooped audio clip"),
+      );
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("at file boundary"),
+      );
+    });
+
+    it("warns at the exact no-content boundary (actual == current + EPSILON)", () => {
+      // actualArrangementLength == currentArrangementLength + EPSILON
+      unwarped({ end_time: 8 + EPSILON });
+
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("Cannot lengthen unlooped audio clip"),
+      );
+    });
+
+    it("warns that the clip was capped when it falls short of the request", () => {
+      // actual(12) is between current(8) and requested(16)
+      unwarped({ end_time: 12 });
+
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("capped at file content boundary"),
+      );
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("beats achieved"),
+      );
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("requested"),
+      );
+      expect(outlet).not.toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("Cannot lengthen"),
+      );
+    });
+
+    it("does not warn when the requested length is fully achieved", () => {
+      // actualArrangementLength(16) == requested(16)
+      unwarped({ end_time: 16 });
+
+      expect(outlet).not.toHaveBeenCalledWith(1, expect.anything());
+    });
+
+    it("does not warn at the exact cap boundary (actual == requested - EPSILON)", () => {
+      // actualArrangementLength == arrangementLengthBeats - EPSILON; `<` is false
+      unwarped({ end_time: 16 - EPSILON });
+
+      expect(outlet).not.toHaveBeenCalledWith(1, expect.anything());
+    });
+
+    it("computes clip start time by subtracting current length from end time", () => {
+      // clipStartTime = currentEndTime(12) - current(8) = 4; actual = 20 - 4 = 16 -> capped
+      unwarped({
+        end_time: 20,
+        currentEndTime: 12,
+        arrangementLengthBeats: 100,
+      });
+
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("capped at file content boundary"),
+      );
+      expect(outlet).not.toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("at file boundary"),
+      );
+    });
+
+    it("computes achieved length by subtracting start time from new end time", () => {
+      // clipStartTime = 10 - 8 = 2; actual = 18 - 2 = 16 -> capped below requested 18
+      unwarped({
+        end_time: 18,
+        currentEndTime: 10,
+        arrangementLengthBeats: 18,
+      });
+
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("capped at file content boundary"),
+      );
+    });
+  });
+});

--- a/src/tools/clip/code-exec/tests/code-exec-helpers-coverage.test.ts
+++ b/src/tools/clip/code-exec/tests/code-exec-helpers-coverage.test.ts
@@ -1,0 +1,281 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
+import * as v8Console from "#src/shared/v8-max-console.ts";
+import { describe, expect, it, vi } from "vitest";
+import { type CodeNote } from "../code-exec-types.ts";
+import {
+  applyNotesToClip,
+  buildCodeExecutionContext,
+  getClipLocationInfo,
+} from "../code-exec-helpers.ts";
+
+/**
+ * Register the Live Set object used by buildCodeExecutionContext / -Location.
+ * @param props - Property overrides (tempo, time signature, scale_mode, ...)
+ */
+function registerLiveSet(props: Record<string, unknown> = {}): void {
+  registerMockObject("live-set", {
+    path: livePath.liveSet,
+    type: "Song",
+    properties: {
+      tempo: 120,
+      signature_numerator: 4,
+      signature_denominator: 4,
+      scale_mode: 0,
+      ...props,
+    },
+  });
+}
+
+/**
+ * Register a track object at the given index.
+ * @param index - Track index
+ * @param props - Property overrides (name, has_midi_input, ...)
+ */
+function registerTrack(
+  index: number,
+  props: Record<string, unknown> = {},
+): void {
+  registerMockObject(livePath.track(index), {
+    path: livePath.track(index),
+    type: "Track",
+    properties: { name: `Track ${index}`, has_midi_input: 1, ...props },
+  });
+}
+
+/**
+ * Build a minimal clip mock (plain object) for the context builders.
+ * @param path - The clip path (parsed for track/scene index)
+ * @param opts - Optional trackIndex and getProperty overrides
+ * @param opts.trackIndex - Value for clip.trackIndex
+ * @param opts.props - Property overrides returned by getProperty
+ * @returns A LiveAPI-shaped clip mock
+ */
+function makeClip(
+  path: string,
+  opts: { trackIndex?: number; props?: Record<string, unknown> } = {},
+): LiveAPI {
+  const props: Record<string, unknown> = {
+    name: "Clip",
+    signature_numerator: 4,
+    signature_denominator: 4,
+    length: 4,
+    looping: 1,
+    ...opts.props,
+  };
+
+  return {
+    id: "clip-1",
+    path,
+    trackIndex: opts.trackIndex,
+    getProperty: vi.fn((prop: string) => props[prop]),
+  } as unknown as LiveAPI;
+}
+
+describe("applyNotesToClip collision warning", () => {
+  function note(start: number, duration: number, velocity: number): CodeNote {
+    return {
+      pitch: 60,
+      start,
+      duration,
+      velocity,
+      velocityDeviation: 0,
+      probability: 1,
+    };
+  }
+
+  it("emits no warning when there are no collisions", () => {
+    // Two distinct onsets → collisions === 0 → the `collisions > 0` guard must
+    // stay closed (kills the >=0 and forced-true mutants).
+    const warn = vi.spyOn(v8Console, "warn").mockImplementation(() => {});
+    const mockClip = {
+      getProperty: vi.fn().mockReturnValue(4),
+      call: vi.fn(),
+    };
+
+    applyNotesToClip(mockClip as unknown as LiveAPI, [
+      note(0, 1, 100),
+      note(1, 1, 100),
+    ]);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("uses the singular noun for exactly one collision", () => {
+    // Two same-pitch+start notes → 1 collision → "1 duplicate note" (no "s").
+    // Full-string assertion kills the plural-forcing and "s"-blanking mutants.
+    const warn = vi.spyOn(v8Console, "warn").mockImplementation(() => {});
+    const mockClip = {
+      getProperty: vi.fn().mockReturnValue(4),
+      call: vi.fn(),
+    };
+
+    applyNotesToClip(mockClip as unknown as LiveAPI, [
+      note(0, 1, 100),
+      note(0, 2, 80),
+    ]);
+
+    expect(warn).toHaveBeenCalledWith(
+      "Dropped 1 duplicate note at the same pitch and start",
+    );
+  });
+
+  it("uses the plural noun for more than one collision", () => {
+    // Three same-pitch+start notes → 2 collisions → "2 duplicate notes".
+    // Kills the singular-forcing, blanked-"s", and "Stryker was here!" mutants.
+    const warn = vi.spyOn(v8Console, "warn").mockImplementation(() => {});
+    const mockClip = {
+      getProperty: vi.fn().mockReturnValue(4),
+      call: vi.fn(),
+    };
+
+    applyNotesToClip(mockClip as unknown as LiveAPI, [
+      note(0, 1, 100),
+      note(0, 2, 90),
+      note(0, 3, 80),
+    ]);
+
+    expect(warn).toHaveBeenCalledWith(
+      "Dropped 2 duplicate notes at the same pitch and start",
+    );
+  });
+});
+
+describe("buildCodeExecutionContext", () => {
+  it("scales clip length by denominator/4 (musical beats)", () => {
+    // 6/8, raw length 8 → 8 * (8/4) = 16 musical beats. A `/` mutant → 4.
+    registerLiveSet();
+    registerTrack(0);
+    const clip = makeClip(livePath.track(0).clipSlot(0).clip(), {
+      trackIndex: 0,
+      props: { signature_numerator: 6, signature_denominator: 8, length: 8 },
+    });
+
+    const result = buildCodeExecutionContext(clip, "session", 0, 1, 0);
+    const clipLengthBeats = result.clip.length;
+
+    expect(clipLengthBeats).toBe(16);
+  });
+
+  it("parses a two-digit track index from the clip path", () => {
+    // `/tracks (\d)/` (no +) would capture "1" from "tracks 10" and read Track 1.
+    registerLiveSet();
+    registerTrack(10, { name: "Track Ten" });
+    const clip = makeClip(livePath.track(10).clipSlot(0).clip(), {
+      trackIndex: 10,
+    });
+
+    const result = buildCodeExecutionContext(clip, "session", 0, 1, 0);
+
+    expect(result.track.index).toBe(10);
+    expect(result.track.name).toBe("Track Ten");
+  });
+
+  it("falls back to track 0 when the path has no track segment", () => {
+    // Removing the optional chaining (`trackMatch[1]`) would throw on the null
+    // match; the original returns index 0.
+    registerLiveSet();
+    registerTrack(0, { name: "Track Zero", has_midi_input: 0 });
+    const clip = makeClip("live_set");
+
+    const result = buildCodeExecutionContext(clip, "session", 0, 1);
+
+    expect(result.track.index).toBe(0);
+    expect(result.track.name).toBe("Track Zero");
+    expect(result.track.type).toBe("audio");
+  });
+
+  it("omits the slot for a session clip without a scene index", () => {
+    // Kills the `&&`→`||` and forced-true mutants on the session-slot guard:
+    // view is "session" but sceneIndex is undefined, so no slot is set.
+    registerLiveSet();
+    registerTrack(2);
+    const clip = makeClip(livePath.track(2).clipSlot(3).clip(), {
+      trackIndex: 2,
+    });
+
+    const result = buildCodeExecutionContext(clip, "session", 0, 1, undefined);
+
+    expect(result.location).toStrictEqual({ view: "session" });
+  });
+
+  it("omits arrangementStart for an arrangement clip without a start", () => {
+    // Kills the `&&`→`||` and forced-true mutants on the arrangement guard:
+    // view is "arrangement" but arrangementStartBeats is undefined.
+    registerLiveSet();
+    registerTrack(0);
+    const clip = makeClip(livePath.track(0).arrangementClip(0), {
+      trackIndex: 0,
+    });
+
+    const result = buildCodeExecutionContext(
+      clip,
+      "arrangement",
+      0,
+      1,
+      undefined,
+      undefined,
+    );
+
+    expect(result.location).toStrictEqual({ view: "arrangement" });
+  });
+
+  it("scales arrangementStart by the song denominator/4", () => {
+    // Song is 4/8, start 16 Ableton beats → 16 * (8/4) = 32 musical beats.
+    // A `/` mutant → 8.
+    registerLiveSet({ signature_denominator: 8 });
+    registerTrack(0);
+    const clip = makeClip(livePath.track(0).arrangementClip(0), {
+      trackIndex: 0,
+    });
+
+    const result = buildCodeExecutionContext(
+      clip,
+      "arrangement",
+      0,
+      1,
+      undefined,
+      16,
+    );
+
+    expect(result.location.arrangementStart).toBe(32);
+  });
+});
+
+describe("getClipLocationInfo", () => {
+  it("parses a two-digit scene index from a session clip path", () => {
+    // `/clip_slots (\d)/` (no +) would capture "1" from "clip_slots 12".
+    const clip = {
+      path: livePath.track(0).clipSlot(12).clip(),
+      getProperty: vi.fn((prop: string) =>
+        prop === "is_arrangement_clip" ? 0 : undefined,
+      ),
+    } as unknown as LiveAPI;
+
+    expect(getClipLocationInfo(clip)).toStrictEqual({
+      view: "session",
+      sceneIndex: 12,
+    });
+  });
+
+  it("returns an undefined scene index when the path has no clip slot", () => {
+    // Removing the optional chaining (`slotMatch[1]`) would throw on the null
+    // match; the original returns sceneIndex undefined.
+    const clip = {
+      path: "live_set tracks 0",
+      getProperty: vi.fn((prop: string) =>
+        prop === "is_arrangement_clip" ? 0 : undefined,
+      ),
+    } as unknown as LiveAPI;
+
+    expect(getClipLocationInfo(clip)).toStrictEqual({
+      view: "session",
+      sceneIndex: undefined,
+    });
+  });
+});

--- a/src/tools/clip/create/tests/create-clip-advanced.test.ts
+++ b/src/tools/clip/create/tests/create-clip-advanced.test.ts
@@ -14,6 +14,10 @@ import {
 import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
 import { createClip } from "../create-clip.ts";
 import {
+  buildClipProperties,
+  buildClipResult,
+} from "../helpers/create-clip-result-helpers.ts";
+import {
   expectClipCreated,
   expectNotesAdded,
   note,
@@ -434,5 +438,122 @@ describe("createClip - advanced features", () => {
 
       expect(result).toMatchObject({ noteCount: 2 });
     });
+  });
+
+  describe("normalizeTransforms", () => {
+    it("treats a whitespace-only transforms string as no transform", async () => {
+      // A whitespace-only transforms string trims to "", so normalizeTransforms
+      // returns null and no transform runs (result has no `transformed` field).
+      // The `transformString?.trim()` → `transformString` mutant keeps "   ",
+      // routing it through resolveClipTransform which reports `transformed`.
+      const { clip } = setupSessionMocks({
+        liveSet: {
+          signature_numerator: 4,
+          signature_denominator: 4,
+          scale_mode: 0,
+        },
+        clip: { length: 4 },
+      });
+
+      const result = await createClip({
+        slot: "0/0",
+        notes: "C3 1|1",
+        transforms: "   ",
+      });
+
+      expect((result as { transformed?: number }).transformed).toBeUndefined();
+      expectNotesAdded(clip, [note(60, 0, 1)]);
+    });
+  });
+});
+
+describe("buildClipProperties (unit)", () => {
+  it("sets playing_position only when the clip is looping AND firstStart is set", () => {
+    // Looping + firstStart → playing_position is set.
+    expect(
+      buildClipProperties(0, 4, 5, true, undefined, null, 4, 4, 4)
+        .playing_position,
+    ).toBe(5);
+
+    // Not looping (with firstStart) → no playing_position. Kills the
+    // whole-condition → true and the && → || mutants (|| would set it).
+    expect(
+      buildClipProperties(0, 4, 5, false, undefined, null, 4, 4, 4)
+        .playing_position,
+    ).toBeUndefined();
+
+    // Looping but firstStart null → no playing_position. Kills the
+    // `firstStartBeats != null` → true mutant.
+    expect(
+      buildClipProperties(0, 4, null, true, undefined, null, 4, 4, 4)
+        .playing_position,
+    ).toBeUndefined();
+  });
+
+  it("includes name only when clipName is truthy", () => {
+    expect(
+      buildClipProperties(0, 4, null, null, "Riff", null, 4, 4, 4).name,
+    ).toBe("Riff");
+    // Property must be ABSENT (not present-with-undefined) so the `if (clipName)`
+    // guard forced to `true` is caught — a plain `.name` access can't tell
+    // "absent" from "= undefined".
+    expect(
+      buildClipProperties(0, 4, null, null, undefined, null, 4, 4, 4),
+    ).not.toHaveProperty("name");
+    expect(
+      buildClipProperties(0, 4, null, null, "", null, 4, 4, 4),
+    ).not.toHaveProperty("name");
+  });
+
+  it("includes color only when color is non-null", () => {
+    expect(
+      buildClipProperties(0, 4, null, null, undefined, "#FF0000", 4, 4, 4)
+        .color,
+    ).toBe("#FF0000");
+    expect(
+      buildClipProperties(0, 4, null, null, undefined, null, 4, 4, 4).color,
+    ).toBeUndefined();
+  });
+
+  it("includes looping only when looping is non-null", () => {
+    expect(
+      buildClipProperties(0, 4, null, true, undefined, null, 4, 4, 4).looping,
+    ).toBe(1);
+    expect(
+      buildClipProperties(0, 4, null, false, undefined, null, 4, 4, 4).looping,
+    ).toBe(0);
+    expect(
+      buildClipProperties(0, 4, null, null, undefined, null, 4, 4, 4).looping,
+    ).toBeUndefined();
+  });
+});
+
+describe("buildClipResult (unit)", () => {
+  it("omits the calculated length when a length parameter was provided", () => {
+    // With notationString set and an explicit length, the `length == null` guard
+    // is false so no calculated length is added. The → true mutant would read
+    // clip length back and populate `length`.
+    const clip = {
+      id: "clip-x",
+      getProperty: vi.fn(() => 8),
+      call: vi.fn(() => JSON.stringify({ notes: [] })),
+    } as unknown as LiveAPI;
+
+    const result = buildClipResult(
+      clip,
+      0,
+      "session",
+      0,
+      null,
+      "C3 1|1",
+      "2bar",
+      4,
+      4,
+      null,
+    );
+
+    expect(result.length).toBeUndefined();
+    expect(result.noteCount).toBe(0);
+    expect(result.slot).toBe("0/0");
   });
 });

--- a/src/tools/clip/create/tests/create-clip-arrangement.test.ts
+++ b/src/tools/clip/create/tests/create-clip-arrangement.test.ts
@@ -11,7 +11,52 @@ import {
 } from "#src/test/mocks/mock-registry.ts";
 import { createNote } from "#src/test/test-data-builders.ts";
 import { createClip } from "../create-clip.ts";
-import { setupArrangementClipMocks } from "./create-clip-test-helpers.ts";
+import { processClipIteration } from "../helpers/create-clip-helpers.ts";
+import {
+  setupArrangementClipMocks,
+  setupAudioArrangementClipMocks,
+} from "./create-clip-test-helpers.ts";
+
+/**
+ * Call processClipIteration for a single arrangement position with sensible
+ * defaults, overriding only the fields a test cares about.
+ * @param opts - Overrides for the iteration
+ * @param opts.sampleFile - Audio file path (audio clip) or null for MIDI
+ * @param opts.clipName - Clip name to apply
+ * @param opts.color - Clip color to apply
+ * @returns The clip result object from processClipIteration
+ */
+function callArrangementIteration(opts: {
+  sampleFile?: string | null;
+  clipName?: string | undefined;
+  color?: string | null;
+}): object {
+  const liveSet = LiveAPI.from(livePath.liveSet);
+
+  return processClipIteration(
+    "arrangement", // view
+    0, // trackIndex
+    null, // sceneIndex
+    0, // arrangementStartBeats
+    "1|1", // arrangementStart
+    4, // clipLength
+    liveSet,
+    null, // startBeats
+    null, // endBeats
+    null, // firstStartBeats
+    null, // looping
+    opts.clipName, // clipName
+    opts.color ?? null, // color
+    4, // timeSigNumerator
+    4, // timeSigDenominator
+    null, // notationString
+    [], // notes
+    null, // length
+    opts.sampleFile ?? null, // sampleFile
+    undefined, // transformedCount
+    null, // takeLane
+  );
+}
 
 describe("createClip - arrangement view", () => {
   it("should create a single clip in arrangement", async () => {
@@ -161,5 +206,110 @@ describe("createClip - arrangement view", () => {
     expect(track.call).toHaveBeenCalledWith("create_midi_clip", 0, 4);
     expect(track.call).toHaveBeenCalledWith("create_midi_clip", 4, 4);
     expect(track.call).toHaveBeenCalledWith("create_midi_clip", 8, 4);
+  });
+
+  it("distributes comma-separated names and colors across arrangement positions", async () => {
+    // Two positions with two names and two colors. The count is
+    // sessionSlots.length + arrangementStarts.length (0 + 2 = 2). The `+` → `-`,
+    // the `name ?? undefined` / `color ?? undefined` → `&&`, and the returned
+    // `{ parsedNames, parsedColors }` → `{}` mutants all collapse the per-position
+    // distribution so the second name/color never lands.
+    const { clip } = setupArrangementClipMocks();
+
+    await createClip({
+      trackIndex: 0,
+      arrangementStart: "1|1,2|1",
+      name: "Alpha,Beta",
+      color: "#FF0000,#00FF00",
+    });
+
+    expect(clip.set).toHaveBeenCalledWith("name", "Alpha");
+    expect(clip.set).toHaveBeenCalledWith("name", "Beta");
+    expect(clip.set).toHaveBeenCalledWith("color", 16711680); // #FF0000
+    expect(clip.set).toHaveBeenCalledWith("color", 65280); // #00FF00
+  });
+
+  it("warns with the tool name when more names than positions are provided", async () => {
+    // 3 names for 2 positions → warnExtraNames warns. The blanked tool-name
+    // string mutant would drop the "createClip:" prefix from the warning.
+    setupArrangementClipMocks();
+
+    await createClip({
+      trackIndex: 0,
+      arrangementStart: "1|1,2|1",
+      name: "A,B,C",
+    });
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("createClip: 3 names provided"),
+    );
+  });
+
+  it("creates the arrangement clip on the requested track (not defaulting to 0)", async () => {
+    // The `trackIndex ?? 0` → `trackIndex && 0` mutant would coerce any track
+    // index to 0, creating the clip on the wrong track.
+    registerMockObject("live-set", {
+      path: livePath.liveSet,
+      properties: { signature_numerator: 4, signature_denominator: 4 },
+    });
+    const track2 = registerMockObject("track-2", {
+      path: livePath.track(2),
+      methods: { create_midi_clip: () => ["id", "arr_clip_t2"] },
+    });
+
+    registerMockObject("arr_clip_t2", { properties: { length: 4 } });
+
+    await createClip({
+      trackIndex: 2,
+      arrangementStart: "1|1",
+      notes: "C3 1|1",
+    });
+
+    expect(track2.call).toHaveBeenCalledWith("create_midi_clip", 0, 4);
+  });
+});
+
+describe("processClipIteration (unit)", () => {
+  it("throws when the MIDI arrangement clip fails to be created", () => {
+    // create_midi_clip returns the "no object" ref, so the created clip does not
+    // exist. Kills the `!clip.exists()` guard's condition/block/message mutants.
+    registerMockObject("live-set", {
+      path: livePath.liveSet,
+      properties: { signature_numerator: 4, signature_denominator: 4 },
+    });
+    registerMockObject("track-0", {
+      path: livePath.track(0),
+      methods: { create_midi_clip: () => ["id", "0"] },
+    });
+
+    expect(() => callArrangementIteration({})).toThrow(
+      "failed to create Arrangement clip",
+    );
+  });
+
+  it("does NOT set an empty name on an audio clip", () => {
+    // clipName "" is falsy, so `if (clipName)` skips it. The → true mutant would
+    // add name:"" and setAll (which keeps "") would write it.
+    const { clip } = setupAudioArrangementClipMocks();
+
+    callArrangementIteration({
+      sampleFile: "/samples/loop.wav",
+      clipName: "",
+      color: "#FF0000",
+    });
+
+    expect(clip.set).not.toHaveBeenCalledWith("name", expect.anything());
+  });
+
+  it("does NOT call setAll on an audio clip with no name or color", () => {
+    // Empty propsToSet → the `length > 0` guard skips setAll. The → true and
+    // > → >= mutants would call setAll({}).
+    setupAudioArrangementClipMocks();
+    const setAllSpy = vi.spyOn(LiveAPI.prototype, "setAll");
+
+    callArrangementIteration({ sampleFile: "/samples/loop.wav" });
+
+    expect(setAllSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/tools/clip/create/tests/create-clip-audio.test.ts
+++ b/src/tools/clip/create/tests/create-clip-audio.test.ts
@@ -10,8 +10,12 @@ import {
   mockNonExistentObjects,
   registerMockObject,
 } from "#src/test/mocks/mock-registry.ts";
-import { MAX_AUTO_CREATED_SCENES } from "#src/tools/constants.ts";
+import {
+  MAX_ARRANGEMENT_POSITION_BEATS,
+  MAX_AUTO_CREATED_SCENES,
+} from "#src/tools/constants.ts";
 import { createClip } from "../create-clip.ts";
+import { createAudioArrangementClip } from "../helpers/create-clip-audio-helpers.ts";
 import {
   expectNoTimingProperties,
   setupAudioArrangementClipMocks,
@@ -457,5 +461,47 @@ describe("createClip - audio clips", () => {
         expect.anything(),
       );
     });
+  });
+});
+
+describe("createAudioArrangementClip (unit)", () => {
+  it("throws when arrangementStartBeats exceeds the maximum position", () => {
+    // A valid track is registered, so if the max-position guard were removed the
+    // clip would be created without throwing. Kills the guard's
+    // ConditionalExpression / EqualityOperator / block / message mutants.
+    setupAudioArrangementClipMocks();
+
+    expect(() =>
+      createAudioArrangementClip(
+        0,
+        MAX_ARRANGEMENT_POSITION_BEATS + 1,
+        "/samples/loop.wav",
+      ),
+    ).toThrow(/exceeds maximum/);
+  });
+
+  it("does NOT throw at exactly the maximum position (boundary: > not >=)", () => {
+    setupAudioArrangementClipMocks();
+
+    const result = createAudioArrangementClip(
+      0,
+      MAX_ARRANGEMENT_POSITION_BEATS,
+      "/samples/loop.wav",
+    );
+
+    expect(result.arrangementStartBeats).toBe(MAX_ARRANGEMENT_POSITION_BEATS);
+  });
+
+  it("throws when the created audio arrangement clip does not exist", () => {
+    registerMockObject("track-0", {
+      path: livePath.track(0),
+      methods: {
+        create_audio_clip: () => ["id", "0"], // "no object" ref → exists() false
+      },
+    });
+
+    expect(() => createAudioArrangementClip(0, 0, "/samples/loop.wav")).toThrow(
+      "failed to create audio Arrangement clip",
+    );
   });
 });

--- a/src/tools/clip/create/tests/create-clip-basic.test.ts
+++ b/src/tools/clip/create/tests/create-clip-basic.test.ts
@@ -4,7 +4,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
+import { type MidiNote } from "#src/tools/clip/helpers/clip-result-helpers.ts";
+import { type SlotPosition } from "#src/tools/shared/validation/position-parsing.ts";
 import { createClip } from "../create-clip.ts";
+import { convertTimingParameters } from "../helpers/create-clip-helpers.ts";
+import {
+  calculateClipLength,
+  handleAutoPlayback,
+} from "../helpers/create-clip-validation-helpers.ts";
 import {
   expectClipCreated,
   expectNotesAdded,
@@ -272,5 +279,109 @@ describe("createClip - basic validation and time signatures", () => {
 
     // 1|2 = 1 beat in 4/4 time
     expect(clip.set).toHaveBeenCalledWith("playing_position", 1);
+  });
+});
+
+describe("convertTimingParameters (unit)", () => {
+  it("warns when firstStart is used with a non-looping clip", () => {
+    convertTimingParameters(null, null, "1|2", null, false, 4, 4, 4, 4);
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("firstStart parameter ignored"),
+    );
+  });
+
+  it("does NOT warn when firstStart is used with a looping clip", () => {
+    // looping === true: the firstStart-ignored warning must not fire. Kills the
+    // `looping === false` → true and whole-condition → true / && → || mutants.
+    convertTimingParameters(null, null, "1|2", null, true, 4, 4, 4, 4);
+
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("firstStart parameter ignored"),
+    );
+  });
+
+  it("does NOT warn when firstStart is set but looping is unset (null)", () => {
+    // looping is null (not false), so `firstStart != null && looping === false`
+    // is false; the && → || mutant would make it warn.
+    convertTimingParameters(null, null, "1|2", null, null, 4, 4, 4, 4);
+
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("firstStart parameter ignored"),
+    );
+  });
+
+  it("adds startBeats to the length when computing endBeats (?? 0 fallback)", () => {
+    // start "2|1" = 4 beats, length "1bar" = 4 beats → endBeats = 4 + 4 = 8.
+    // The `startBeats ?? 0` → `startBeats && 0` mutant would zero the offset (→ 4).
+    const result = convertTimingParameters(
+      null,
+      "2|1",
+      null,
+      "1bar",
+      null,
+      4,
+      4,
+      4,
+      4,
+    );
+
+    expect(result.startBeats).toBe(4);
+    expect(result.endBeats).toBe(8);
+  });
+
+  it("falls back to 0 for the start offset when start is not provided", () => {
+    const result = convertTimingParameters(
+      null,
+      null,
+      null,
+      "1bar",
+      null,
+      4,
+      4,
+      4,
+      4,
+    );
+
+    expect(result.startBeats).toBeNull();
+    expect(result.endBeats).toBe(4);
+  });
+});
+
+describe("calculateClipLength (unit)", () => {
+  it("sizes an empty-marker clip from the LATEST (max) note start, not the earliest", () => {
+    // Notes at beats 0 and 5 in 4/4 (4 Ableton beats/bar). Max start 5 rounds up
+    // to 2 bars = 8 beats; the Math.max → Math.min mutant would use start 0 → 4.
+    const notes = [{ start_time: 0 }, { start_time: 5 }] as MidiNote[];
+
+    expect(calculateClipLength(null, notes, 4, 4)).toBe(8);
+  });
+
+  it("uses the explicit endBeats when provided", () => {
+    expect(calculateClipLength(10, [], 4, 4)).toBe(10);
+  });
+});
+
+describe("handleAutoPlayback (unit)", () => {
+  const slot = (): SlotPosition => ({ trackIndex: 0, sceneIndex: 0 });
+
+  it("no-ops (does not reach the switch) when view is not session", () => {
+    // auto is truthy + view arrangement → the guard returns early. The
+    // `view !== "session"` → false mutant would fall through to the switch and
+    // throw on the unknown auto value.
+    expect(() =>
+      handleAutoPlayback("unknown-mode", "arrangement", [slot()]),
+    ).not.toThrow();
+  });
+
+  it("no-ops (does not reach the switch) when there are no session slots", () => {
+    // Empty slots → guard returns early. The `sessionSlots.length === 0` → false
+    // mutant would fall through to the switch and throw on the unknown auto value.
+    expect(() =>
+      handleAutoPlayback("unknown-mode", "session", []),
+    ).not.toThrow();
   });
 });

--- a/src/tools/clip/create/tests/create-clip-loop-helpers.test.ts
+++ b/src/tools/clip/create/tests/create-clip-loop-helpers.test.ts
@@ -1,0 +1,203 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import { children } from "#src/test/mocks/mock-live-api.ts";
+import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
+import { prepareClipData } from "../helpers/create-clip-loop-helpers.ts";
+import { createClip } from "../create-clip.ts";
+import { setupSessionMocks } from "./create-clip-test-helpers.ts";
+
+// Mock the scale-mask read so we can assert exactly when createClips reads it
+// (the transformString != null ? readLiveSetScaleMask() : undefined ternary).
+vi.mock(import("#src/tools/clip/helpers/scale-mask.ts"), () => ({
+  readLiveSetScaleMask: vi.fn(),
+}));
+
+// Mock code application so we can assert whether/how createClipAtIndex invokes it
+// without needing the full code-exec V8 round-trip.
+vi.mock(import("#src/tools/clip/code-exec/apply-code-to-clip.ts"), () => ({
+  applyCodeToSingleClip: vi.fn(),
+}));
+
+import { applyCodeToSingleClip } from "#src/tools/clip/code-exec/apply-code-to-clip.ts";
+import { readLiveSetScaleMask } from "#src/tools/clip/helpers/scale-mask.ts";
+
+const FOUR_FOUR = { signature_numerator: 4, signature_denominator: 4 };
+
+describe("prepareClipData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the sample-derived length (1 beat) for audio clips", () => {
+    const result = prepareClipData(
+      "sample.wav",
+      null,
+      null,
+      4,
+      4,
+      undefined,
+      null,
+    );
+
+    // Audio clips take their length from the sample file, not calculateClipLength
+    // (which would return a 1-bar = 4-beat default for empty notes).
+    expect(result.clipLength).toBe(1);
+    expect(result.notes).toStrictEqual([]);
+  });
+
+  it("computes MIDI clip length from notes (not the audio path)", () => {
+    const result = prepareClipData(null, "C3 1|1", null, 4, 4, undefined, null);
+
+    expect(result.clipLength).toBe(4); // 1 bar in 4/4
+  });
+
+  it("does not warn when interpreted notes have no same-pitch collisions", () => {
+    prepareClipData(null, "C3 1|1 D3 1|1", null, 4, 4, undefined, null);
+
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("Dropped"),
+    );
+  });
+
+  it("warns with singular wording for exactly one dropped duplicate", () => {
+    prepareClipData(null, "C3 1|1 C3 1|1", null, 4, 4, undefined, null);
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "Dropped 1 duplicate note at the same pitch and start",
+    );
+  });
+
+  it("warns with plural wording for multiple dropped duplicates", () => {
+    prepareClipData(null, "C3 1|1 C3 1|1 C3 1|1", null, 4, 4, undefined, null);
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "Dropped 2 duplicate notes at the same pitch and start",
+    );
+  });
+});
+
+describe("createClip - failure warnings (createClipAtIndex catch)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("warns with the session slot position when a session clip fails to create", async () => {
+    registerMockObject("live-set", {
+      path: livePath.liveSet,
+      properties: { ...FOUR_FOUR, scenes: children("scene_0") },
+    });
+    registerMockObject("track-0", { path: livePath.track(0) });
+    // has_clip: 1 makes prepareSessionClipSlot throw inside processClipIteration.
+    registerMockObject("clip-slot-0-0", {
+      path: livePath.track(0).clipSlot(0),
+      properties: { has_clip: 1 },
+    });
+
+    await createClip({ slot: "0/0", notes: "C3 1|1" });
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("Failed to create clip at slot=0/0:"),
+    );
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("trackIndex="),
+    );
+  });
+
+  it("warns with the arrangement position when an arrangement clip fails to create", async () => {
+    registerMockObject("live-set", {
+      path: livePath.liveSet,
+      properties: FOUR_FOUR,
+    });
+    registerMockObject("track-0", {
+      path: livePath.track(0),
+      methods: {
+        create_midi_clip: () => {
+          throw new Error("boom");
+        },
+      },
+    });
+
+    await createClip({
+      trackIndex: 0,
+      arrangementStart: "1|1",
+      notes: "C3 1|1",
+    });
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining(
+        "Failed to create clip at trackIndex=0, arrangementStart=",
+      ),
+    );
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("slot="),
+    );
+  });
+});
+
+describe("createClip - code execution wiring (createClipAtIndex)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not invoke code execution when no code is provided", async () => {
+    setupSessionMocks({ liveSet: FOUR_FOUR });
+
+    await createClip({ slot: "0/0", notes: "C3 1|1" });
+
+    expect(applyCodeToSingleClip).not.toHaveBeenCalled();
+  });
+
+  it("keeps the read-back noteCount when code execution reports no count", async () => {
+    setupSessionMocks({ liveSet: FOUR_FOUR });
+    // null => clip lookup found no note count; noteCount must not be overwritten.
+    vi.mocked(applyCodeToSingleClip).mockResolvedValue(null);
+
+    const result = await createClip({
+      slot: "0/0",
+      notes: "C3 1|1",
+      code: "return notes",
+    });
+
+    expect(applyCodeToSingleClip).toHaveBeenCalledOnce();
+    // buildClipResult read back 1 note; the null code result leaves it intact.
+    expect((result as { noteCount?: number }).noteCount).toBe(1);
+  });
+});
+
+describe("createClip - scale mask wiring (createClips)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reads the Live Set scale mask when a transform is present", async () => {
+    setupSessionMocks({ liveSet: FOUR_FOUR });
+
+    await createClip({
+      slot: "0/0",
+      notes: "C3 1|1",
+      transforms: "velocity = 100",
+    });
+
+    expect(readLiveSetScaleMask).toHaveBeenCalled();
+  });
+
+  it("does not read the scale mask when no transform is present", async () => {
+    setupSessionMocks({ liveSet: FOUR_FOUR });
+
+    await createClip({ slot: "0/0", notes: "C3 1|1" });
+
+    expect(readLiveSetScaleMask).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/clip/create/tests/create-clip-session.test.ts
+++ b/src/tools/clip/create/tests/create-clip-session.test.ts
@@ -359,6 +359,19 @@ describe("createClip - session view", () => {
 
     expect(result).toStrictEqual([]);
   });
+
+  it("returns an empty array (does not select) when focus=true but no clips are created", async () => {
+    // The existing clip makes creation warn-and-skip, so 0 clips are created.
+    // The focus guard `createdClips.length > 0` (→ true / → >= 0 mutants) would
+    // then select createdClips.at(-1) — which is undefined — and throw.
+    setupLiveSet();
+    setupTrack(0);
+    setupSessionClip(0, 0, { hasClip: 1 });
+
+    const result = await createClip({ slot: "0/0", focus: true });
+
+    expect(result).toStrictEqual([]);
+  });
 });
 
 describe("createClip - session view - per-clip transforms", () => {

--- a/src/tools/clip/create/tests/create-clip-take-lanes.test.ts
+++ b/src/tools/clip/create/tests/create-clip-take-lanes.test.ts
@@ -19,6 +19,7 @@ vi.mock(import("#src/shared/v8-max-console.ts"), () => ({
 }));
 
 import { createClip } from "#src/tools/clip/create/create-clip.ts";
+import { resolveCreateClipTakeLane } from "#src/tools/clip/create/helpers/create-clip-prep-helpers.ts";
 import * as consoleMock from "#src/shared/v8-max-console.ts";
 
 /** Register the live_set time signature mock used by createClip. */
@@ -191,6 +192,63 @@ describe("createClip take lanes", () => {
 
     expect(consoleMock.warn).toHaveBeenCalledWith(
       expect.stringContaining("takeLane ignored for session clips"),
+    );
+  });
+});
+
+describe("resolveCreateClipTakeLane (unit)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null and warns for a session-only request (no arrangement positions)", () => {
+    // A track is registered so that, if the guard were skipped, the mutant path
+    // would resolve a real lane (non-null) instead of returning null. Kills the
+    // `arrangementStarts.length === 0` → false and the || → && mutants.
+    registerTakeLaneTrack({ initialLanes: 0 });
+
+    const result = resolveCreateClipTakeLane("new", null, 0, [], 0);
+
+    expect(result).toBeNull();
+    expect(consoleMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining("takeLane ignored for session clips"),
+    );
+  });
+
+  it("returns null and warns when trackIndex is null despite arrangement positions", () => {
+    // Kills the `trackIndex == null` → false mutant: with it removed the guard
+    // would fall through and try to resolve a lane instead of returning null.
+    const result = resolveCreateClipTakeLane("new", null, 0, ["1|1"], null);
+
+    expect(result).toBeNull();
+    expect(consoleMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining("takeLane ignored for session clips"),
+    );
+  });
+
+  it("returns null WITHOUT warning when a session-only request did not request a take lane", () => {
+    // takeLane 0 = main lane (not requested). The `isTakeLaneRequested(...)` →
+    // true mutant would emit the ignored-warning even though none was requested.
+    const result = resolveCreateClipTakeLane(0, null, 0, [], 0);
+
+    expect(result).toBeNull();
+    expect(consoleMock.warn).not.toHaveBeenCalled();
+  });
+
+  it("targets a take lane (no session-ignore warning) for an arrangement-only request", () => {
+    // sessionSlotCount is 0, so the ignored-warning must NOT fire (kills the
+    // `sessionSlotCount > 0` → true and > → >= mutants), and the targeting-hint
+    // warning must fire (kills the blanked-string mutant).
+    registerTakeLaneTrack({ initialLanes: 0 });
+
+    const result = resolveCreateClipTakeLane("new", null, 0, ["1|1"], 0);
+
+    expect(result).not.toBeNull();
+    expect(consoleMock.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("ignored for session clips"),
+    );
+    expect(consoleMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining("targeting take lane"),
     );
   });
 });

--- a/src/tools/clip/create/tests/create-clip-transform-helpers.test.ts
+++ b/src/tools/clip/create/tests/create-clip-transform-helpers.test.ts
@@ -1,0 +1,138 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type MidiNote } from "#src/tools/clip/helpers/clip-result-helpers.ts";
+import {
+  type ClipTransformInputs,
+  resolveClipTransform,
+} from "../helpers/create-clip-transform-helpers.ts";
+
+// Mock applyTransforms so we can (a) detect whether the guard let the transform
+// run and (b) capture the ClipContext the helper builds (clipDuration /
+// arrangementStart), which is otherwise internal to buildCreateClipContext.
+vi.mock(
+  import("#src/notation/transform/transform-evaluator.ts"),
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    applyTransforms: vi.fn(() => 3),
+  }),
+);
+
+import { applyTransforms } from "#src/notation/transform/transform-evaluator.ts";
+
+/**
+ * Build ClipTransformInputs whose guard operands are all "transform runs"
+ * (transform present, MIDI, non-empty notes) unless overridden.
+ * @param overrides - Fields to override on the default inputs
+ * @returns Complete ClipTransformInputs for resolveClipTransform
+ */
+function makeInputs(
+  overrides: Partial<ClipTransformInputs> = {},
+): ClipTransformInputs {
+  const notes: MidiNote[] = [
+    { pitch: 60, start_time: 0, duration: 1, velocity: 100 },
+  ];
+
+  return {
+    notes,
+    clipLength: 4,
+    transformString: "velocity = 100",
+    isAudio: false,
+    endBeats: null,
+    timeSigNumerator: 4,
+    timeSigDenominator: 4,
+    scaleMask: undefined,
+    ...overrides,
+  };
+}
+
+/**
+ * Read the ClipContext passed to the (mocked) applyTransforms on its first call.
+ * @returns The captured clip context, or undefined if not called
+ */
+function capturedContext() {
+  return vi.mocked(applyTransforms).mock.calls[0]?.[4];
+}
+
+describe("resolveClipTransform", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(applyTransforms).mockReturnValue(3);
+  });
+
+  describe("early-return guard", () => {
+    it("returns the shared notes/length unchanged when there is no transform", () => {
+      const inputs = makeInputs({ transformString: null });
+
+      const result = resolveClipTransform(inputs, 0, 1, null);
+
+      expect(result.transformedCount).toBeUndefined();
+      // Early return hands back the exact shared array, not a sorted clone.
+      expect(result.notes).toBe(inputs.notes);
+      expect(result.clipLength).toBe(4);
+      expect(applyTransforms).not.toHaveBeenCalled();
+    });
+
+    it("skips the transform for audio clips", () => {
+      const inputs = makeInputs({ isAudio: true });
+
+      const result = resolveClipTransform(inputs, 0, 1, null);
+
+      expect(result.transformedCount).toBeUndefined();
+      expect(result.notes).toBe(inputs.notes);
+      expect(applyTransforms).not.toHaveBeenCalled();
+    });
+
+    it("skips the transform when there are no notes", () => {
+      const inputs = makeInputs({ notes: [] });
+
+      const result = resolveClipTransform(inputs, 0, 1, null);
+
+      expect(result.transformedCount).toBeUndefined();
+      expect(result.notes).toBe(inputs.notes);
+      expect(applyTransforms).not.toHaveBeenCalled();
+    });
+
+    it("runs the transform when transform present, MIDI, and notes non-empty", () => {
+      const inputs = makeInputs();
+
+      const result = resolveClipTransform(inputs, 0, 1, null);
+
+      expect(applyTransforms).toHaveBeenCalledOnce();
+      expect(result.transformedCount).toBe(3);
+      // A fresh sorted clone is returned, not the shared input array.
+      expect(result.notes).not.toBe(inputs.notes);
+    });
+  });
+
+  describe("clip context beat-scaling (buildCreateClipContext)", () => {
+    it("scales clipDuration by timeSigDenominator/4", () => {
+      // 8/4 denominator => beatScale 2; clipLength 4 => clipDuration 8.
+      const inputs = makeInputs({ timeSigDenominator: 8, clipLength: 4 });
+
+      resolveClipTransform(inputs, 0, 1, null);
+
+      expect(capturedContext()?.clipDuration).toBe(8);
+    });
+
+    it("scales arrangementStart by the beatScale when provided", () => {
+      // beatScale 2; arrangementStartBeats 16 => arrangementStart 32.
+      const inputs = makeInputs({ timeSigDenominator: 8 });
+
+      resolveClipTransform(inputs, 0, 1, 16);
+
+      expect(capturedContext()?.arrangementStart).toBe(32);
+    });
+
+    it("leaves arrangementStart undefined for session clips (null start)", () => {
+      const inputs = makeInputs({ timeSigDenominator: 8 });
+
+      resolveClipTransform(inputs, 0, 1, null);
+
+      expect(capturedContext()?.arrangementStart).toBeUndefined();
+    });
+  });
+});

--- a/src/tools/clip/helpers/clip-result-helpers.test.ts
+++ b/src/tools/clip/helpers/clip-result-helpers.test.ts
@@ -10,6 +10,7 @@ import { validateBarBeatPosition } from "#src/notation/barbeat/time/barbeat-time
 import {
   buildClipResultObject,
   emitArrangementWarnings,
+  prepareSessionClipSlot,
   validateAndParseArrangementParams,
 } from "./clip-result-helpers.ts";
 
@@ -174,6 +175,14 @@ describe("clip-result-helpers", () => {
       expect(console.error).not.toHaveBeenCalled();
     });
 
+    it("emits no warning when arrangementStartBeats is null even with an overlapping track", () => {
+      // The early return must fire: a track with 3 clips would otherwise warn.
+      // Guards the `if (arrangementStartBeats == null) return` block and branch.
+      emitArrangementWarnings(null, new Map([[0, 3]]));
+
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
     it("does nothing when no track has more than 1 clip", () => {
       const tracksWithMovedClips = new Map([
         [0, 1],
@@ -211,6 +220,75 @@ describe("clip-result-helpers", () => {
       expect(console.warn).toHaveBeenCalledWith(
         "4 clips on track 2 moved to the same position - later clips will overwrite earlier ones",
       );
+    });
+  });
+
+  describe("prepareSessionClipSlot", () => {
+    function registerLiveSet(sceneCount: number): void {
+      const scenes: (string | number)[] = [];
+
+      for (let i = 0; i < sceneCount; i++) {
+        scenes.push("id", i + 1);
+      }
+
+      registerMockObject("live-set", {
+        path: livePath.liveSet,
+        type: "Song",
+        properties: { scenes },
+      });
+    }
+
+    it("throws at the boundary sceneIndex === maxAutoCreatedScenes", () => {
+      // 1000 >= 1000 must throw. A `>` mutant (strict) would fall through at the
+      // exact boundary; the message pins both the blanked-string and the
+      // `MAX_AUTO_CREATED_SCENES - 1` (=999) arithmetic mutants.
+      registerLiveSet(3);
+
+      expect(() =>
+        prepareSessionClipSlot(0, 1000, LiveAPI.from(livePath.liveSet), 1000),
+      ).toThrow("sceneIndex 1000 exceeds the maximum allowed value of 999");
+    });
+
+    it("does not auto-create scenes when the slot already exists", () => {
+      // sceneIndex 1 < currentSceneCount 3 → no scenes created; the slot is empty.
+      const liveSet = registerMockObject("live-set", {
+        path: livePath.liveSet,
+        type: "Song",
+        properties: { scenes: ["id", 1, "id", 2, "id", 3] },
+      });
+
+      registerMockObject(livePath.track(0).clipSlot(1), {
+        path: livePath.track(0).clipSlot(1),
+        type: "ClipSlot",
+        properties: { has_clip: 0 },
+      });
+
+      const slot = prepareSessionClipSlot(
+        0,
+        1,
+        LiveAPI.from(livePath.liveSet),
+        1000,
+      );
+
+      expect(liveSet.call).not.toHaveBeenCalledWith("create_scene", -1);
+      expect(slot.path).toBe(String(livePath.track(0).clipSlot(1)));
+    });
+
+    it("throws when a clip already exists in the target slot", () => {
+      registerMockObject("live-set", {
+        path: livePath.liveSet,
+        type: "Song",
+        properties: { scenes: ["id", 1, "id", 2, "id", 3] },
+      });
+      registerMockObject(livePath.track(0).clipSlot(1), {
+        path: livePath.track(0).clipSlot(1),
+        type: "ClipSlot",
+        properties: { has_clip: 1 },
+      });
+
+      expect(() =>
+        prepareSessionClipSlot(0, 1, LiveAPI.from(livePath.liveSet), 1000),
+      ).toThrow("a clip already exists at track 0, clip slot 1");
     });
   });
 });

--- a/src/tools/clip/helpers/loop-deadline.test.ts
+++ b/src/tools/clip/helpers/loop-deadline.test.ts
@@ -3,12 +3,22 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import { CODE_EXEC_TIMEOUT_MS } from "#src/tools/clip/code-exec/code-exec-types.ts";
 import { describe, expect, it, vi } from "vitest";
 import {
   computeLoopDeadline,
   isDeadlineExceeded,
   LOOP_DEADLINE_BUFFER_MS,
 } from "./loop-deadline.ts";
+
+describe("LOOP_DEADLINE_BUFFER_MS", () => {
+  it("is exactly twice the per-clip code execution timeout", () => {
+    // Pin the multiplication: 2000 * 2 = 4000. A division mutant would yield
+    // 1000, so assert both the derived relationship and the exact constant.
+    expect(LOOP_DEADLINE_BUFFER_MS).toBe(CODE_EXEC_TIMEOUT_MS * 2);
+    expect(LOOP_DEADLINE_BUFFER_MS).toBe(4000);
+  });
+});
 
 describe("computeLoopDeadline", () => {
   it("should return null when timeoutMs is undefined", () => {

--- a/src/tools/clip/helpers/scale-mask.test.ts
+++ b/src/tools/clip/helpers/scale-mask.test.ts
@@ -1,0 +1,56 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
+import { describe, expect, it } from "vitest";
+import { readLiveSetScaleMask } from "./scale-mask.ts";
+
+describe("readLiveSetScaleMask", () => {
+  it("returns undefined when scale_mode is 0 (no scale active)", () => {
+    // A concrete, non-chromatic scale is registered so that if the scaleMode===0
+    // short-circuit is skipped the function would compute a real mask (2741).
+    // The short-circuit must win: the result is undefined.
+    registerMockObject("live-set", {
+      path: livePath.liveSet,
+      type: "Song",
+      properties: {
+        scale_mode: 0,
+        root_note: 0,
+        scale_intervals: [0, 2, 4, 5, 7, 9, 11], // C major
+      },
+    });
+
+    expect(readLiveSetScaleMask()).toBeUndefined();
+  });
+
+  it("returns the pitch-class mask when a non-chromatic scale is active", () => {
+    registerMockObject("live-set", {
+      path: livePath.liveSet,
+      type: "Song",
+      properties: {
+        scale_mode: 1,
+        root_note: 0,
+        scale_intervals: [0, 2, 4, 5, 7, 9, 11], // C major
+      },
+    });
+
+    expect(readLiveSetScaleMask()).toBe(2741);
+  });
+
+  it("returns undefined for a chromatic scale (a chromatic mask is a no-op)", () => {
+    registerMockObject("live-set", {
+      path: livePath.liveSet,
+      type: "Song",
+      properties: {
+        scale_mode: 1,
+        root_note: 0,
+        scale_intervals: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+      },
+    });
+
+    expect(readLiveSetScaleMask()).toBeUndefined();
+  });
+});

--- a/src/tools/clip/read/tests/read-clip-coverage.test.ts
+++ b/src/tools/clip/read/tests/read-clip-coverage.test.ts
@@ -1,0 +1,376 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import * as consoleModule from "#src/shared/v8-max-console.ts";
+import { children } from "#src/test/mocks/mock-live-api.ts";
+import {
+  clearMockRegistry,
+  registerMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+import { readClip } from "#src/tools/clip/read/read-clip.ts";
+import {
+  createTestNote,
+  setupAudioClipMock,
+  setupMidiClipMock,
+  setupNotesMock,
+} from "./read-clip-test-helpers.ts";
+
+// Chord (two pitches at time 0) plus a repeat of one pitch at time 2. Drum mode
+// groups by pitch ("C1 1|1,3\nE1 1|1"); melodic groups by time, emitting the
+// chord on one line ("C1 E1 1|1\nC1 1|3"). The two outputs differ, so notes
+// pin the resolved drumMode value.
+const DRUM_CHORD_NOTES = [
+  createTestNote({ pitch: 36, startTime: 0, duration: 0.25 }),
+  createTestNote({ pitch: 40, startTime: 0, duration: 0.25 }),
+  createTestNote({ pitch: 36, startTime: 2, duration: 0.25 }),
+];
+const DRUM_MODE_OUTPUT = "v100 n/16 C1 1|1,3\nE1 1|1";
+const MELODIC_MODE_OUTPUT = "v100 n/16 C1 E1 1|1\nC1 1|3";
+
+describe("readClip - include flag gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearMockRegistry();
+  });
+
+  it("suppresses the empty-slot warning when suppressEmptyWarning is set", () => {
+    const consoleSpy = vi.spyOn(consoleModule, "warn");
+
+    // Track and scene exist, clip slot is empty (clip id "0" => !exists()).
+    registerMockObject("track4", { path: livePath.track(4), type: "Track" });
+    registerMockObject("scene5", { path: livePath.scene(5), type: "Scene" });
+    registerMockObject("0", {
+      path: livePath.track(4).clipSlot(5).clip(),
+      type: "Clip",
+    });
+
+    const result = readClip({
+      trackIndex: 4,
+      sceneIndex: 5,
+      suppressEmptyWarning: true,
+    });
+
+    expect(result).toStrictEqual({
+      id: null,
+      type: null,
+      name: null,
+      slot: "4/5",
+    });
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it("includes color only when color is requested", () => {
+    setupMidiClipMock({
+      trackIndex: 0,
+      sceneIndex: 0,
+      clipProps: {
+        is_midi_clip: 1,
+        color: 16711680, // 0xFF0000
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+      },
+    });
+
+    const withColor = readClip({
+      trackIndex: 0,
+      sceneIndex: 0,
+      include: ["color"],
+    });
+
+    expect(withColor.color).toBe("#FF0000");
+  });
+
+  it("omits color when color is not requested", () => {
+    setupMidiClipMock({
+      trackIndex: 0,
+      sceneIndex: 0,
+      clipProps: {
+        is_midi_clip: 1,
+        color: 16711680,
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+      },
+    });
+
+    const result = readClip({ trackIndex: 0, sceneIndex: 0, include: [] });
+
+    expect(result.color).toBeUndefined();
+  });
+
+  it("does not process notes for an audio clip even when notes are requested", () => {
+    // Audio clip whose get_notes_extended returns real notes. The MIDI-only
+    // note processing must be skipped because the clip is audio.
+    const clip = setupAudioClipMock({
+      trackIndex: 0,
+      sceneIndex: 0,
+      clipProps: {
+        is_midi_clip: 0,
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+      },
+    });
+
+    setupNotesMock(clip, [createTestNote({ pitch: 60, startTime: 0 })]);
+
+    const result = readClip({
+      trackIndex: 0,
+      sceneIndex: 0,
+      include: ["notes"],
+    });
+
+    expect(result.type).toBe("audio");
+    expect(result.notes).toBeUndefined();
+  });
+
+  it("does not read audio properties for a MIDI clip", () => {
+    // MIDI clip with audio-only backing props registered. The audio-processing
+    // branch is gated on type==="audio", so none of them must surface.
+    setupMidiClipMock({
+      trackIndex: 0,
+      sceneIndex: 0,
+      clipProps: {
+        is_midi_clip: 1,
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+        gain: 0.9,
+        file_path: "/Users/x/kick.wav",
+        pitch_coarse: 3,
+        pitch_fine: 0,
+      },
+    });
+
+    const result = readClip({
+      trackIndex: 0,
+      sceneIndex: 0,
+      include: ["sample"],
+    });
+
+    expect(result.type).toBe("midi");
+    expect(result.sampleFile).toBeUndefined();
+    expect(result.gainDb).toBeUndefined();
+    expect(result.pitchShift).toBeUndefined();
+  });
+
+  it("omits firstStart when the start-marker offset is exactly the epsilon", () => {
+    // SAME_TIME_EPSILON is 0.001. With the difference AT the epsilon, `> epsilon`
+    // must be false (no firstStart); `>= epsilon` would wrongly include it.
+    setupMidiClipMock({
+      trackIndex: 0,
+      sceneIndex: 0,
+      clipProps: {
+        is_midi_clip: 1,
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+        looping: 1,
+        loop_start: 0,
+        loop_end: 4,
+        start_marker: 0.001, // |0.001 - 0| === SAME_TIME_EPSILON
+        end_marker: 4,
+      },
+    });
+
+    const result = readClip({
+      trackIndex: 0,
+      sceneIndex: 0,
+      include: ["timing"],
+    });
+
+    expect(result.start).toBe("1|1");
+    expect(result.firstStart).toBeUndefined();
+  });
+
+  it("does not process notes when notes are not requested", () => {
+    // Clip has real notes, but include omits "notes": the early-return guard
+    // must prevent any note formatting.
+    setupMidiClipMock({
+      trackIndex: 0,
+      sceneIndex: 0,
+      notes: [createTestNote({ pitch: 60, startTime: 0 })],
+      clipProps: {
+        is_midi_clip: 1,
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+      },
+    });
+
+    const result = readClip({ trackIndex: 0, sceneIndex: 0, include: [] });
+
+    expect(result.notes).toBeUndefined();
+  });
+
+  it("does not read base sample properties when only warp is requested", () => {
+    // includeSample is false; the base-audio branch must be skipped even though
+    // gain/file_path/pitch are present.
+    setupAudioClipMock({
+      trackIndex: 0,
+      sceneIndex: 0,
+      clipProps: {
+        is_midi_clip: 0,
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+        gain: 0.9,
+        file_path: "/Users/x/kick.wav",
+        pitch_coarse: 3,
+        pitch_fine: 0,
+        warp_mode: 0,
+        warping: 1,
+      },
+    });
+
+    const result = readClip({
+      trackIndex: 0,
+      sceneIndex: 0,
+      include: ["warp"],
+    });
+
+    expect(result.sampleFile).toBeUndefined();
+    expect(result.gainDb).toBeUndefined();
+    expect(result.pitchShift).toBeUndefined();
+    // Warp props ARE present (proves processAudioClip ran).
+    expect(result.warping).toBe(true);
+  });
+
+  it("omits gainDb when the gain maps to exactly 0 dB (unity)", () => {
+    // gain 0.4 => 0.00 dB. `gainDb !== 0` must be false so the field is omitted.
+    setupAudioClipMock({
+      trackIndex: 0,
+      sceneIndex: 0,
+      clipProps: {
+        is_midi_clip: 0,
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+        gain: 0.4,
+      },
+    });
+
+    const result = readClip({
+      trackIndex: 0,
+      sceneIndex: 0,
+      include: ["sample"],
+    });
+
+    expect(result.gainDb).toBeUndefined();
+  });
+
+  it("omits arrangementLength for an arrangement clip when timing is not requested", () => {
+    setupMidiClipMock({
+      clipId: "arr_clip",
+      path: livePath.track(2).arrangementClip(0),
+      clipProps: {
+        is_midi_clip: 1,
+        is_arrangement_clip: 1,
+        start_time: 8,
+        end_time: 12,
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+      },
+    });
+    registerMockObject("live-set", {
+      path: "live_set",
+      properties: { signature_numerator: 4, signature_denominator: 4 },
+    });
+
+    const result = readClip({ clipId: "id arr_clip", include: [] });
+
+    expect(result.view).toBe("arrangement");
+    expect(result.arrangementStart).toBe("3|1"); // start_time 8 in 4/4
+    expect(result.arrangementLength).toBeUndefined();
+  });
+});
+
+describe("readClip - drum mode resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearMockRegistry();
+  });
+
+  it("uses drum notation for a standalone read of a Drum Rack track", () => {
+    registerMockObject("track-0", {
+      path: livePath.track(0),
+      properties: { devices: children("drumRack") },
+    });
+    registerMockObject("drumRack", {
+      type: "Device",
+      properties: { can_have_drum_pads: 1 },
+    });
+    setupMidiClipMock({
+      trackIndex: 0,
+      sceneIndex: 0,
+      notes: DRUM_CHORD_NOTES,
+      clipProps: {
+        is_midi_clip: 1,
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+      },
+    });
+
+    const result = readClip({
+      trackIndex: 0,
+      sceneIndex: 0,
+      include: ["notes"],
+    });
+
+    expect(result.notes).toBe(DRUM_MODE_OUTPUT);
+  });
+
+  it("uses melodic notation for a standalone read of a non-drum track", () => {
+    setupMidiClipMock({
+      trackIndex: 0,
+      sceneIndex: 0,
+      notes: DRUM_CHORD_NOTES,
+      clipProps: {
+        is_midi_clip: 1,
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+      },
+    });
+
+    const result = readClip({
+      trackIndex: 0,
+      sceneIndex: 0,
+      include: ["notes"],
+    });
+
+    expect(result.notes).toBe(MELODIC_MODE_OUTPUT);
+  });
+
+  it("honors an explicit precomputed drumMode over the track scan", () => {
+    // drumMode:true is passed even though the track is NOT a drum rack. The
+    // precomputed value must win (nullish-coalesce), yielding drum notation.
+    setupMidiClipMock({
+      trackIndex: 0,
+      sceneIndex: 0,
+      notes: DRUM_CHORD_NOTES,
+      clipProps: {
+        is_midi_clip: 1,
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+      },
+    });
+
+    const result = readClip({
+      trackIndex: 0,
+      sceneIndex: 0,
+      include: ["notes"],
+      drumMode: true,
+    });
+
+    expect(result.notes).toBe(DRUM_MODE_OUTPUT);
+  });
+});

--- a/src/tools/clip/read/tests/read-clip-helpers.test.ts
+++ b/src/tools/clip/read/tests/read-clip-helpers.test.ts
@@ -1,0 +1,172 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import * as consoleModule from "#src/shared/v8-max-console.ts";
+import { children } from "#src/test/mocks/mock-live-api.ts";
+import {
+  clearMockRegistry,
+  registerMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+import {
+  isDrumRackTrack,
+  processWarpMarkers,
+  resolveClip,
+} from "#src/tools/clip/read/helpers/read-clip-helpers.ts";
+
+/**
+ * Build a minimal clip stub whose warp_markers property returns `value`.
+ * @param value - The value getProperty("warp_markers") should return
+ * @returns A LiveAPI-shaped stub for processWarpMarkers
+ */
+function warpClip(value: unknown): LiveAPI {
+  return {
+    id: "clip1",
+    getProperty: vi.fn((prop: string) =>
+      prop === "warp_markers" ? value : undefined,
+    ),
+  } as unknown as LiveAPI;
+}
+
+describe("resolveClip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearMockRegistry();
+  });
+
+  it("includes the tool name in the validation error for a non-clip id", () => {
+    // clipId resolves to a Track, not a Clip. The thrown message must be tagged
+    // with the "readClip" tool name.
+    registerMockObject("faketrack", {
+      path: livePath.track(7),
+      type: "Track",
+    });
+
+    expect(() => resolveClip("id faketrack", null, null)).toThrow(
+      /readClip failed/,
+    );
+  });
+});
+
+describe("processWarpMarkers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearMockRegistry();
+  });
+
+  it("returns markers for a direct array without warning", () => {
+    const consoleSpy = vi.spyOn(consoleModule, "warn");
+
+    const result = processWarpMarkers(
+      warpClip(JSON.stringify([{ sample_time: 44100, beat_time: 1 }])),
+    );
+
+    expect(result).toStrictEqual([{ sampleTime: 44100, beatTime: 1 }]);
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined without warning when warp_markers is an empty string", () => {
+    const consoleSpy = vi.spyOn(consoleModule, "warn");
+
+    expect(processWarpMarkers(warpClip(""))).toBeUndefined();
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined without warning when warp_markers is missing", () => {
+    const consoleSpy = vi.spyOn(consoleModule, "warn");
+
+    expect(processWarpMarkers(warpClip(undefined))).toBeUndefined();
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined without warning for an object with no warp_markers key", () => {
+    const consoleSpy = vi.spyOn(consoleModule, "warn");
+
+    expect(processWarpMarkers(warpClip("{}"))).toBeUndefined();
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined without warning when warp_markers is a non-array value", () => {
+    const consoleSpy = vi.spyOn(consoleModule, "warn");
+
+    expect(
+      processWarpMarkers(warpClip(JSON.stringify({ warp_markers: 42 }))),
+    ).toBeUndefined();
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns with a descriptive message when the JSON cannot be parsed", () => {
+    const consoleSpy = vi.spyOn(consoleModule, "warn");
+
+    const result = processWarpMarkers(warpClip("invalid json{"));
+
+    expect(result).toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to read warp markers for clip clip1"),
+    );
+  });
+});
+
+describe("isDrumRackTrack - chain descent guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearMockRegistry();
+  });
+
+  it("does not descend into the chains of a device that reports no chains", () => {
+    // The device has chain children holding a Drum Rack, but can_have_chains is
+    // 0 — the recursion must NOT descend, so the track is not a drum track.
+    registerMockObject("track-0", {
+      path: livePath.track(0),
+      properties: { devices: children("fakeRack") },
+    });
+    registerMockObject("fakeRack", {
+      type: "Device",
+      properties: {
+        can_have_drum_pads: 0,
+        can_have_chains: 0,
+        chains: children("innerChain"),
+      },
+    });
+    registerMockObject("innerChain", {
+      type: "Chain",
+      properties: { devices: children("drumRack") },
+    });
+    registerMockObject("drumRack", {
+      type: "Device",
+      properties: { can_have_drum_pads: 1 },
+    });
+
+    expect(isDrumRackTrack(0)).toBe(false);
+  });
+
+  it("descends into the chains of a real rack (can_have_chains > 0)", () => {
+    // Same chain layout, but the rack reports can_have_chains: 1, so the nested
+    // Drum Rack IS found. Pins the guard's true branch against the false one.
+    registerMockObject("track-0", {
+      path: livePath.track(0),
+      properties: { devices: children("realRack") },
+    });
+    registerMockObject("realRack", {
+      type: "Device",
+      properties: {
+        can_have_drum_pads: 0,
+        can_have_chains: 1,
+        chains: children("innerChain"),
+      },
+    });
+    registerMockObject("innerChain", {
+      type: "Chain",
+      properties: { devices: children("drumRack") },
+    });
+    registerMockObject("drumRack", {
+      type: "Device",
+      properties: { can_have_drum_pads: 1 },
+    });
+
+    expect(isDrumRackTrack(0)).toBe(true);
+  });
+});

--- a/src/tools/clip/read/tests/read-clip-warp.test.ts
+++ b/src/tools/clip/read/tests/read-clip-warp.test.ts
@@ -121,4 +121,89 @@ describe("readClip - warp markers", () => {
     });
     expect(readClipWithWarp().warpMarkers).toBeUndefined();
   });
+
+  it("reports warping=false when the clip is not warped", () => {
+    // Boundary: warping property === 0. `> 0` must yield false, and the value
+    // must not be forced to a constant true.
+    setupAudioClipMock({
+      trackIndex: 0,
+      sceneIndex: 0,
+      clipProps: {
+        is_midi_clip: 0,
+        name: "Unwarped Audio",
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+        warp_mode: 0,
+        warping: 0,
+      },
+    });
+
+    expect(readClipWithWarp().warping).toBe(false);
+  });
+
+  it("omits warp properties when warp is not requested (sample only)", () => {
+    // includeWarp is false here, so the warp branch must be skipped entirely:
+    // no sampleLength/sampleRate/warping/warpMode even though the props exist.
+    setupAudioClipMock({
+      trackIndex: 0,
+      sceneIndex: 0,
+      clipProps: {
+        is_midi_clip: 0,
+        name: "Audio Sample",
+        signature_numerator: 4,
+        signature_denominator: 4,
+        length: 4,
+        sample_length: 88200,
+        sample_rate: 44100,
+        warp_mode: 4,
+        warping: 1,
+      },
+    });
+
+    const result = readClip({
+      trackIndex: 0,
+      sceneIndex: 0,
+      include: ["sample"],
+    });
+
+    expect(result.sampleLength).toBeUndefined();
+    expect(result.sampleRate).toBeUndefined();
+    expect(result.warping).toBeUndefined();
+    expect(result.warpMode).toBeUndefined();
+  });
+
+  it("omits warp markers when ENABLE_WARP_MARKERS is not 'true'", () => {
+    // The warp-marker block is gated on the env flag. With the flag off, markers
+    // must not be read even for a warped clip that has warp_markers data.
+    const original = process.env.ENABLE_WARP_MARKERS;
+
+    process.env.ENABLE_WARP_MARKERS = "false";
+
+    try {
+      setupAudioClipMock({
+        trackIndex: 0,
+        sceneIndex: 0,
+        clipProps: {
+          is_midi_clip: 0,
+          name: "Warped Audio",
+          signature_numerator: 4,
+          signature_denominator: 4,
+          length: 4,
+          warp_mode: 4,
+          warping: 1,
+          warp_markers: JSON.stringify([{ sample_time: 0, beat_time: 0 }]),
+        },
+      });
+
+      const result = readClipWithWarp();
+
+      expect(result.warpMarkers).toBeUndefined();
+      // Other warp properties are still read (proves the clip is warped and the
+      // block ran up to the marker gate).
+      expect(result.warping).toBe(true);
+    } finally {
+      process.env.ENABLE_WARP_MARKERS = original;
+    }
+  });
 });

--- a/src/tools/clip/update/tests/notes/update-clip-notes-helpers.test.ts
+++ b/src/tools/clip/update/tests/notes/update-clip-notes-helpers.test.ts
@@ -1,0 +1,229 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type ClipContext } from "#src/notation/transform/helpers/transform-evaluator-helpers.ts";
+import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
+import {
+  handleDuplicateLoopWithEdits,
+  handleNoteUpdates,
+} from "../../helpers/update-clip-notes-helpers.ts";
+
+// Raw note as returned by the Live API (extra props stripped before re-add).
+function rawNote(pitch: number, startTime: number, noteId: number) {
+  return {
+    note_id: noteId,
+    pitch,
+    start_time: startTime,
+    duration: 1,
+    velocity: 100,
+    mute: 0,
+    probability: 1,
+    velocity_deviation: 0,
+    release_velocity: 64,
+  };
+}
+
+// Minimal ClipContext for handleNoteUpdates (only used by transform variables,
+// which the tests below don't exercise beyond a bare delete).
+function makeCtx(overrides: Partial<ClipContext> = {}): ClipContext {
+  return {
+    clipDuration: 4,
+    clipIndex: 0,
+    clipCount: 1,
+    barDuration: 4,
+    timeSigDenominator: 4,
+    ...overrides,
+  };
+}
+
+// Mock clip that returns `existingNotes` from get_notes_extended and captures
+// every note passed to add_new_notes into the returned `addedNotes` array.
+function makeNotesMockClip<T extends object = Record<string, number>>(
+  existingNotes: object[],
+  length = 4,
+): {
+  mockClip: {
+    getProperty: ReturnType<typeof vi.fn>;
+    call: ReturnType<typeof vi.fn>;
+  };
+  addedNotes: T[];
+} {
+  const addedNotes: T[] = [];
+  const mockClip = {
+    getProperty: vi.fn((prop: string) => (prop === "length" ? length : 0)),
+    call: vi.fn((method: string, ...args: unknown[]) => {
+      if (method === "get_notes_extended") {
+        return JSON.stringify({ notes: existingNotes });
+      }
+
+      if (method === "add_new_notes") {
+        addedNotes.push(...(args[0] as { notes: T[] }).notes);
+      }
+
+      return "[]";
+    }),
+  };
+
+  return { mockClip, addedNotes };
+}
+
+// Register a MIDI clip (by id) with two existing notes so LiveAPI.from(id)
+// inside handleDuplicateLoop* resolves to the same call/get mocks.
+function setupMidiClip(id: string) {
+  return registerMockObject(id, {
+    path: "live_set tracks 0 clip_slots 0 clip",
+    type: "Clip",
+    properties: {
+      is_midi_clip: 1,
+      is_arrangement_clip: 0,
+      length: 4,
+      signature_numerator: 4,
+      signature_denominator: 4,
+    },
+    methods: {
+      get_notes_extended: () =>
+        JSON.stringify({ notes: [rawNote(60, 0, 1), rawNote(64, 1, 2)] }),
+    },
+  });
+}
+
+function removeNoteCalls(clip: {
+  call: ReturnType<typeof vi.fn>;
+}): unknown[][] {
+  return clip.call.mock.calls.filter(
+    (c: unknown[]) => c[0] === "remove_notes_extended",
+  );
+}
+
+describe("update-clip-notes-helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("handleNoteUpdates", () => {
+    it("reports transformed undefined for a notes+preTransforms update on an empty clip", () => {
+      // No existing notes + a preTransform string: applyPreTransformsToExisting
+      // must early-return matchCount undefined (guarding on existingNotes.length
+      // === 0 || preTransformString == null). Any mutation that instead runs
+      // applyTransforms on the empty array reports matchCount 0.
+      const { mockClip } = makeNotesMockClip([]);
+
+      const result = handleNoteUpdates(
+        mockClip as unknown as LiveAPI,
+        "1|1 C3", // new notes to merge
+        undefined, // no post-transform
+        "v0", // preTransform present, but no existing notes to match
+        4,
+        4,
+        makeCtx(),
+        undefined,
+      );
+
+      expect(result?.transformed).toBeUndefined();
+    });
+
+    it("threads the time signature into formatNotation when merging existing notes", () => {
+      // At 4/8 an existing note at Ableton beat 2 formats to bar 2 beat 1 and
+      // round-trips back to beat 2. Dropping the time-sig options (formatting as
+      // the 4/4 default) would round-trip it to a different beat.
+      const { mockClip, addedNotes } = makeNotesMockClip<{
+        pitch: number;
+        start_time: number;
+      }>([rawNote(60, 2, 1)]);
+
+      handleNoteUpdates(
+        mockClip as unknown as LiveAPI,
+        "1|1 D3", // new note at Ableton beat 0
+        undefined,
+        undefined,
+        4,
+        8, // non-4 denominator
+        makeCtx({ timeSigDenominator: 8 }),
+        undefined,
+      );
+
+      // The pre-existing C3 (pitch 60) must survive at its original beat 2.
+      expect(
+        addedNotes.some(
+          (n) => n.pitch === 60 && Math.abs(n.start_time - 2) < 1e-6,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("handleDuplicateLoopWithEdits", () => {
+    function callWithEdits(
+      overrides: {
+        notationString?: string;
+        transformString?: string;
+        preTransformString?: string;
+      } = {},
+    ) {
+      const clip = LiveAPI.from("id 100");
+
+      return handleDuplicateLoopWithEdits({
+        clip,
+        notationString: overrides.notationString,
+        transformString: overrides.transformString,
+        preTransformString: overrides.preTransformString,
+        timeSigNumerator: 4,
+        timeSigDenominator: 4,
+        clipIndex: 0,
+        clipCount: 1,
+        notation: undefined,
+      });
+    }
+
+    it("skips the pre-double stage entirely when preTransforms is absent", () => {
+      // Stage 1 only runs when preTransformString != null. With no edits at all
+      // the function just doubles; forcing the guard true would flush the
+      // existing notes (a remove_notes_extended) before doubling.
+      const clip = setupMidiClip("100");
+
+      callWithEdits();
+
+      expect(removeNoteCalls(clip)).toHaveLength(0);
+      expect(clip.call).toHaveBeenCalledWith("duplicate_loop");
+    });
+
+    it("merges after doubling when only notes are given", () => {
+      // notation != null → both operands of `== null && == null` false → NOT an
+      // early return → the merge runs (a remove_notes_extended). Kills the
+      // always-early-return / || / first-operand mutations.
+      const clip = setupMidiClip("100");
+
+      callWithEdits({ notationString: "1|1 C3" });
+
+      expect(removeNoteCalls(clip).length).toBeGreaterThan(0);
+    });
+
+    it("returns dupResult without merging when neither notes nor transforms are given", () => {
+      // Both null → early return dupResult → NO merge (no remove_notes_extended).
+      // Behavioral guard for the early-return branch. (Forcing the guard false or
+      // emptying its block is an equivalent mutant here: handleNoteUpdates called
+      // with all-null strings is itself a no-op returning null, so the fall-
+      // through path produces the identical dupResult with no note writes.)
+      const clip = setupMidiClip("100");
+
+      callWithEdits();
+
+      expect(removeNoteCalls(clip)).toHaveLength(0);
+    });
+
+    it("merges after doubling when only transforms are given, and returns the merge result", () => {
+      // transform != null (notes null) → NOT an early return → the transform
+      // runs across the doubled clip. The returned result carries `transformed`
+      // (from the merge), which `mergeResult ?? dupResult` preserves; a
+      // `mergeResult && dupResult` mutation would drop it back to dupResult.
+      const clip = setupMidiClip("100");
+
+      const result = callWithEdits({ transformString: "pitch += 12" });
+
+      expect(removeNoteCalls(clip).length).toBeGreaterThan(0);
+      expect(result?.transformed).toBe(2);
+    });
+  });
+});

--- a/src/tools/clip/update/tests/notes/update-clip-transform-helpers.test.ts
+++ b/src/tools/clip/update/tests/notes/update-clip-transform-helpers.test.ts
@@ -100,6 +100,44 @@ describe("update-clip-transform-helpers", () => {
       expect(ctx.scalePitchClassMask).toBe(2741);
     });
 
+    it("scales clipDuration by timeSigDenominator/4 for a non-4 denominator (session)", () => {
+      // At 4/8, a content length of 6 Ableton (quarter-note) beats is 6 * (8/4)
+      // = 12 musical beats. A `/` mutation would give 6 / 2 = 3.
+      const mockClip = {
+        getProperty: vi.fn((prop: string) => {
+          if (prop === "length") return 6;
+          if (prop === "is_arrangement_clip") return 0;
+
+          return 0;
+        }),
+      };
+
+      const ctx = buildClipContext(mockClip as unknown as LiveAPI, 0, 1, 4, 8);
+
+      expect(ctx.clipDuration).toBe(12);
+      expect(ctx.arrangementStart).toBeUndefined();
+    });
+
+    it("scales clipDuration and arrangementStart by timeSigDenominator/4 (arrangement)", () => {
+      // At 4/8: arrangementStart = start_time 4 * (8/4) = 8 (a `/` gives 2);
+      // clipDuration = (end_time 10 - start_time 4) * 2 = 12 (a `/` gives 3).
+      const mockClip = {
+        getProperty: vi.fn((prop: string) => {
+          if (prop === "is_arrangement_clip") return 1;
+          if (prop === "start_time") return 4;
+          if (prop === "end_time") return 10;
+          if (prop === "length") return 8;
+
+          return 0;
+        }),
+      };
+
+      const ctx = buildClipContext(mockClip as unknown as LiveAPI, 0, 1, 4, 8);
+
+      expect(ctx.clipDuration).toBe(12);
+      expect(ctx.arrangementStart).toBe(8);
+    });
+
     it("uses arrangement length (end_time - start_time) for arrangement clips", () => {
       const mockClip = {
         getProperty: vi.fn((prop: string) => {

--- a/src/tools/clip/update/tests/update-clip-arrangement-helpers.test.ts
+++ b/src/tools/clip/update/tests/update-clip-arrangement-helpers.test.ts
@@ -6,7 +6,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
-import { handleArrangementStartOperation } from "../helpers/update-clip-arrangement-helpers.ts";
+import * as arrangementWorkaround from "#src/tools/shared/arrangement/arrangement-tiling-workaround.ts";
+import {
+  handleArrangementOperations,
+  handleArrangementStartOperation,
+} from "../helpers/update-clip-arrangement-helpers.ts";
 
 const mockContext = { silenceWavPath: "/tmp/test-silence.wav" } as const;
 
@@ -69,6 +73,10 @@ describe("update-clip-arrangement-helpers", () => {
         context: mockContext,
       });
 
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        "could not determine trackIndex for clip 456",
+      );
       expect(result).toBe("456");
     });
 
@@ -350,6 +358,139 @@ describe("update-clip-arrangement-helpers", () => {
       expect(trackMock.call).not.toHaveBeenCalled();
       // Also: do not increment the move count for a skipped take-lane clip.
       expect(tracksWithMovedClips.get(trackIndex)).toBeUndefined();
+    });
+
+    it("does not re-delete the original when the move was unsafe and the clip is already gone", () => {
+      const trackIndex = 0;
+      const trackMock = registerMockObject(`live_set/tracks/${trackIndex}`, {
+        path: `live_set tracks ${trackIndex}`,
+      });
+
+      // Unsafe move (self-overlap): the holding round-trip already trimmed/replaced
+      // the original, so clip.exists() is false and delete must be skipped.
+      const clearSpy = vi
+        .spyOn(arrangementWorkaround, "clearClipAtDuplicateTarget")
+        .mockReturnValue(false);
+      const dupSpy = vi
+        .spyOn(arrangementWorkaround, "duplicateSelfOverlappingClip")
+        .mockReturnValue({
+          id: "new999",
+          exists: () => true,
+        } as unknown as LiveAPI);
+
+      const mockClip = {
+        id: "888",
+        getProperty: vi.fn((prop) =>
+          prop === "is_arrangement_clip" ? 1 : null,
+        ),
+        trackIndex,
+        exists: () => false,
+      };
+
+      const result = handleArrangementStartOperation({
+        clip: mockClip as unknown as LiveAPI,
+        arrangementStartBeats: 16,
+        tracksWithMovedClips: new Map(),
+        isMidiClip: true,
+        context: mockContext,
+      });
+
+      // safeToMove(false) || clip.exists()(false) === false → no delete.
+      expect(trackMock.call).not.toHaveBeenCalledWith(
+        "delete_clip",
+        expect.anything(),
+      );
+      expect(result).toBe("new999");
+
+      clearSpy.mockRestore();
+      dupSpy.mockRestore();
+    });
+  });
+
+  describe("handleArrangementOperations", () => {
+    it("passes isMidiClip as the negation of isAudioClip into the move operation", () => {
+      const trackIndex = 0;
+
+      registerMockObject(`live_set/tracks/${trackIndex}`, {
+        path: `live_set tracks ${trackIndex}`,
+        methods: {
+          duplicate_clip_to_arrangement: () => ["id", 999],
+        },
+      });
+      registerMockObject("999", {
+        path: livePath.track(trackIndex).arrangementClip(0),
+      });
+
+      const clearSpy = vi
+        .spyOn(arrangementWorkaround, "clearClipAtDuplicateTarget")
+        .mockReturnValue(true);
+
+      const mockClip = {
+        id: "789",
+        getProperty: vi.fn((prop) =>
+          prop === "is_arrangement_clip" ? 1 : null,
+        ),
+        trackIndex,
+      };
+
+      const updatedClips: { id: string }[] = [];
+
+      handleArrangementOperations({
+        clip: mockClip as unknown as LiveAPI,
+        isAudioClip: true,
+        arrangementStartBeats: 16,
+        arrangementLengthBeats: null,
+        tracksWithMovedClips: new Map(),
+        context: mockContext,
+        updatedClips,
+        noteResult: null,
+      });
+
+      // isAudioClip:true → isMidiClip must be false (4th arg).
+      expect(clearSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        "789",
+        16,
+        false,
+        expect.anything(),
+      );
+
+      clearSpy.mockRestore();
+    });
+
+    it("returns early without recording a result for a deleted non-survivor", () => {
+      const trackIndex = 0;
+      const trackMock = registerMockObject(`live_set/tracks/${trackIndex}`, {
+        path: `live_set tracks ${trackIndex}`,
+      });
+
+      const mockClip = {
+        id: "200",
+        getProperty: vi.fn((prop) =>
+          prop === "is_arrangement_clip" ? 1 : null,
+        ),
+        trackIndex,
+        exists: () => true,
+      };
+
+      const updatedClips: { id: string }[] = [];
+
+      handleArrangementOperations({
+        clip: mockClip as unknown as LiveAPI,
+        isAudioClip: false,
+        arrangementStartBeats: 16,
+        arrangementLengthBeats: null,
+        tracksWithMovedClips: new Map(),
+        context: mockContext,
+        updatedClips,
+        noteResult: null,
+        isNonSurvivor: true,
+      });
+
+      // Non-survivor is deleted and start-op returns null → early return, so
+      // nothing is pushed to updatedClips.
+      expect(trackMock.call).toHaveBeenCalledWith("delete_clip", "id 200");
+      expect(updatedClips).toStrictEqual([]);
     });
   });
 });

--- a/src/tools/clip/update/tests/update-clip-arrangement-optimizer.test.ts
+++ b/src/tools/clip/update/tests/update-clip-arrangement-optimizer.test.ts
@@ -79,6 +79,23 @@ function mockTakeLaneClip(
   return LiveAPI.from(`id ${clipId}`);
 }
 
+/**
+ * Register a mock clip with arbitrary options and return its LiveAPI handle.
+ * Used for clips that vary the standard shape (no track path, or non-arrangement
+ * clips on a track path).
+ * @param clipId - Clip ID
+ * @param options - registerMockObject options (path, properties, ...)
+ * @returns LiveAPI mock clip
+ */
+function mockClipRaw(
+  clipId: string,
+  options: Parameters<typeof registerMockObject>[1],
+): LiveAPI {
+  registerMockObject(clipId, options);
+
+  return LiveAPI.from(`id ${clipId}`);
+}
+
 describe("computeNonSurvivorClipIds", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -213,6 +230,70 @@ describe("computeNonSurvivorClipIds", () => {
     // so optimization doesn't apply and the result is null. Without filtering,
     // the take-lane clip's length (16) would have marked clip "1" non-survivor
     // and the harness would delete it — a real bug for users.
+    expect(computeNonSurvivorClipIds(clips, 32, null)).toBeNull();
+  });
+
+  it("short-circuits to null for a null arrangementStart even with multi-clip non-survivors", () => {
+    const clips = [
+      mockArrangementClip("1", 0, 0, 4), // 4 beats
+      mockArrangementClip("2", 0, 8, 16), // 8 beats
+    ];
+
+    // Track 0 would yield non-survivor "1", but a null arrangementStart must
+    // return null before any survivor analysis runs.
+    expect(computeNonSurvivorClipIds(clips, null, null)).toBeNull();
+  });
+
+  it("skips null-trackIndex clips so they never form a survivor group", () => {
+    const clips = [
+      mockClipRaw("501", {
+        properties: {
+          is_arrangement_clip: 1,
+          is_midi_clip: 1,
+          start_time: 0,
+          end_time: 4,
+        },
+      }),
+      mockClipRaw("502", {
+        properties: {
+          is_arrangement_clip: 1,
+          is_midi_clip: 1,
+          start_time: 8,
+          end_time: 16,
+        },
+      }),
+    ];
+
+    // Both clips lack a track path (trackIndex null). If they were grouped, the
+    // 4-beat clip would be a non-survivor; the null-trackIndex guard drops them.
+    expect(computeNonSurvivorClipIds(clips, 32, null)).toBeNull();
+  });
+
+  it("excludes session clips (is_arrangement_clip <= 0) from survivor grouping", () => {
+    const clips = [
+      mockClipRaw("601", {
+        path: livePath.track(0).arrangementClip(0),
+        properties: {
+          is_arrangement_clip: 0,
+          is_midi_clip: 1,
+          start_time: 0,
+          end_time: 4,
+        },
+      }),
+      mockClipRaw("602", {
+        path: livePath.track(0).arrangementClip(1),
+        properties: {
+          is_arrangement_clip: 0,
+          is_midi_clip: 1,
+          start_time: 8,
+          end_time: 16,
+        },
+      }),
+    ];
+
+    // Both are session clips (is_arrangement_clip 0) on track 0. Treated as
+    // eligible they would group and mark "601" a non-survivor; the eligibility
+    // gate drops them, so no optimization applies.
     expect(computeNonSurvivorClipIds(clips, 32, null)).toBeNull();
   });
 

--- a/src/tools/clip/update/tests/update-clip-audio-helpers.test.ts
+++ b/src/tools/clip/update/tests/update-clip-audio-helpers.test.ts
@@ -123,6 +123,15 @@ describe("setAudioParameters", () => {
     );
   });
 
+  it("does not call set at all for an invalid warpMode", () => {
+    // Forcing the lookup guard true would call set("warp_mode", undefined) — a
+    // call the expect.anything() assertion above cannot catch (undefined is not
+    // "anything"). Asserting no set call at all pins it.
+    setAudioParameters(mockClip, { warpMode: "invalid" });
+
+    expect(mockClip.set).not.toHaveBeenCalled();
+  });
+
   it("should set warping to 1 when true", () => {
     setAudioParameters(mockClip, { warping: true });
 
@@ -263,6 +272,28 @@ describe("applyAudioTransforms", () => {
     expect(mockClip.set).toHaveBeenCalledWith("pitch_coarse", 5);
     expect(mockClip.set).toHaveBeenCalledWith("pitch_fine", 0);
   });
+
+  it("reads currentPitchShift as coarse + fine/100 (exact arithmetic)", () => {
+    // pitch_coarse 3 + pitch_fine 50/100 = 3.5. Setting pitchShift to exactly
+    // 3.5 is therefore a no-op → returns false. A `-` (→ 2.5) or `* 100`
+    // (→ 5003) mutation of the currentPitchShift formula makes 3.5 look like a
+    // change and would write pitch_coarse.
+    mockClip.getProperty.mockImplementation((prop: string) => {
+      if (prop === "gain") return 0.4;
+      if (prop === "pitch_coarse") return 3;
+      if (prop === "pitch_fine") return 50;
+
+      return null;
+    });
+
+    const result = applyAudioTransforms(mockClip, "pitchShift = 3.5");
+
+    expect(result).toBe(false);
+    expect(mockClip.set).not.toHaveBeenCalledWith(
+      "pitch_coarse",
+      expect.anything(),
+    );
+  });
 });
 
 describe("handleWarpMarkerOperation", () => {
@@ -296,6 +327,46 @@ describe("handleWarpMarkerOperation", () => {
     expect(mockClip.call).not.toHaveBeenCalled();
   });
 
+  it("warns with the audio-clip message when the clip has no file", () => {
+    // Pins the actual warning text so a blanked string literal is caught.
+    mockClip.getProperty.mockReturnValue(null);
+
+    handleWarpMarkerOperation(mockClip, "add", 1.0, 44100);
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("warp markers only available on audio clips"),
+    );
+  });
+
+  it("reads file_path specifically to detect an audio clip", () => {
+    // Only "file_path" yields a path; any other key (e.g. the "" a
+    // string-literal mutation would read) returns null → treated as non-audio,
+    // which would warn-and-skip instead of performing the operation.
+    mockClip.getProperty.mockImplementation((prop: string) =>
+      prop === "file_path" ? "/path/to/audio.wav" : null,
+    );
+
+    handleWarpMarkerOperation(mockClip, "remove", 4.0);
+
+    expect(mockClip.call).toHaveBeenCalledWith("remove_warp_marker", 4.0);
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("warp markers only available"),
+    );
+  });
+
+  it("warns with the warpBeatTime message when it is missing", () => {
+    mockClip.getProperty.mockReturnValue("/path/to/audio.wav");
+
+    handleWarpMarkerOperation(mockClip, "add", undefined, 44100);
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("warpBeatTime required for"),
+    );
+  });
+
   describe("add operation", () => {
     beforeEach(() => {
       mockClip.getProperty.mockReturnValue("/path/to/audio.wav");
@@ -317,6 +388,19 @@ describe("handleWarpMarkerOperation", () => {
         beat_time: 4.0,
       });
     });
+
+    it("omits the sample_time key entirely when warpSampleTime is undefined", () => {
+      // toHaveBeenCalledWith treats { beat_time } and { beat_time, sample_time:
+      // undefined } as equal, so it can't catch the ternary being forced true.
+      // Inspect the args object for the key's presence directly.
+      handleWarpMarkerOperation(mockClip, "add", 4.0, undefined);
+
+      const addCall = mockClip.call.mock.calls.find(
+        (c: unknown[]) => c[0] === "add_warp_marker",
+      );
+
+      expect(addCall?.[1]).not.toHaveProperty("sample_time");
+    });
   });
 
   describe("move operation", () => {
@@ -329,6 +413,16 @@ describe("handleWarpMarkerOperation", () => {
       handleWarpMarkerOperation(mockClip, "move", 4.0, undefined, undefined);
 
       expect(mockClip.call).not.toHaveBeenCalled();
+    });
+
+    it("warns with the warpDistance message when it is missing", () => {
+      // Pins the actual warning text so a blanked string literal is caught.
+      handleWarpMarkerOperation(mockClip, "move", 4.0, undefined, undefined);
+
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("warpDistance required for move"),
+      );
     });
 
     it("should move warp marker by specified distance", () => {

--- a/src/tools/clip/update/tests/update-clip-basic.test.ts
+++ b/src/tools/clip/update/tests/update-clip-basic.test.ts
@@ -5,11 +5,19 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
-import { mockNonExistentObjects } from "#src/test/mocks/mock-registry.ts";
+import {
+  lookupMockObject,
+  mockNonExistentObjects,
+  registerMockObject,
+} from "#src/test/mocks/mock-registry.ts";
 import {
   createNote,
   expectedDrumPatternNotes,
 } from "#src/test/test-data-builders.ts";
+import { setupClipSplittingMocks } from "#src/tools/shared/arrangement/tests/arrangement-splitting-test-helpers.ts";
+import { applyCodeToSingleClip } from "#src/tools/clip/code-exec/apply-code-to-clip.ts";
+import { processSingleClipUpdate } from "#src/tools/clip/update/helpers/update-clip-helpers.ts";
+import * as sessionHelpers from "#src/tools/clip/update/helpers/update-clip-session-helpers.ts";
 import {
   mockMergeNoteTracking,
   setupAudioClipMock,
@@ -18,6 +26,13 @@ import {
   type UpdateClipMocks,
 } from "#src/tools/clip/update/helpers/update-clip-test-helpers.ts";
 import { updateClip } from "#src/tools/clip/update/update-clip.ts";
+import * as selectModule from "#src/tools/session/select.ts";
+
+// applyCodeToSingleClip is mocked so the code-exec loop in update-clip.ts can be
+// driven in isolation (return value / call count) without real note execution.
+vi.mock(import("#src/tools/clip/code-exec/apply-code-to-clip.ts"), () => ({
+  applyCodeToSingleClip: vi.fn(),
+}));
 
 describe("updateClip - Basic operations", () => {
   let mocks: UpdateClipMocks;
@@ -263,10 +278,7 @@ describe("updateClip - Basic operations", () => {
   /**
    * Register mock objects for toSlot tests (source clip slot + target slot + target clip).
    */
-  async function setupToSlotMocks(): Promise<void> {
-    const { registerMockObject } =
-      await import("#src/test/mocks/mock-registry.ts");
-
+  function setupToSlotMocks(): void {
     registerMockObject("live_set/tracks/0/clip_slots/0", {
       path: livePath.track(0).clipSlot(0),
     });
@@ -283,7 +295,7 @@ describe("updateClip - Basic operations", () => {
 
   it("should move session clip with toSlot", async () => {
     setupMidiClipMock(mocks.clip123);
-    await setupToSlotMocks();
+    setupToSlotMocks();
 
     const result = await updateClip({ ids: "123", toSlot: "1/2" });
 
@@ -295,7 +307,7 @@ describe("updateClip - Basic operations", () => {
 
   it("should warn and use first slot when toSlot has multiple values", async () => {
     setupMidiClipMock(mocks.clip123);
-    await setupToSlotMocks();
+    setupToSlotMocks();
 
     const consoleModule = await import("#src/shared/v8-max-console.ts");
     const warnSpy = vi.spyOn(consoleModule, "warn");
@@ -310,5 +322,252 @@ describe("updateClip - Basic operations", () => {
       id: "live_set/tracks/1/clip_slots/2/clip",
       slot: "1/2",
     });
+  });
+
+  it("should NOT warn about multiple destinations for a single toSlot", async () => {
+    setupMidiClipMock(mocks.clip123);
+    setupToSlotMocks();
+
+    await updateClip({ ids: "123", toSlot: "1/2" });
+
+    // slots.length is exactly 1 here: the > 1 guard must stay false so no
+    // "using first" warning fires (kills > 1 -> >= 1 and the forced-true mutant).
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      "toSlot only supports a single destination - using first",
+    );
+  });
+
+  it("should include the tool name when more names than clips are provided", async () => {
+    setupMidiClipMock(mocks.clip123);
+    setupMidiClipMock(mocks.clip456);
+
+    await updateClip({ ids: "123, 456", name: "A, B, C" });
+
+    // The "updateClip" tool-name literal must be preserved in the warning.
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "updateClip: 3 names provided but only 2 items — ignoring extra",
+    );
+  });
+
+  describe("focus", () => {
+    it("should select the last updated clip when focus is set", async () => {
+      setupMidiClipMock(mocks.clip123);
+      const selectSpy = vi
+        .spyOn(selectModule, "select")
+        .mockReturnValue({} as never);
+
+      await updateClip({ ids: "123", focus: true });
+
+      expect(selectSpy).toHaveBeenCalledWith({
+        clipId: "123",
+        detailView: "clip",
+      });
+    });
+
+    it("should NOT select when focus is omitted", async () => {
+      setupMidiClipMock(mocks.clip123);
+      const selectSpy = vi
+        .spyOn(selectModule, "select")
+        .mockReturnValue({} as never);
+
+      await updateClip({ ids: "123" });
+
+      // focus is falsy so the whole guard must be false (kills forced-true).
+      expect(selectSpy).not.toHaveBeenCalled();
+    });
+
+    it("should NOT select or throw when focus is set but nothing was updated", async () => {
+      mockNonExistentObjects();
+      const selectSpy = vi
+        .spyOn(selectModule, "select")
+        .mockReturnValue({} as never);
+
+      // updatedClips.length is 0; the > 0 guard must stay false (kills >= 0,
+      // which would read updatedClips.at(-1).id on an empty array and throw).
+      const result = await updateClip({ ids: "nonexistent", focus: true });
+
+      expect(result).toStrictEqual([]);
+      expect(selectSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("should quantize a MIDI clip via the call-site options object", async () => {
+    setupMidiClipMock(mocks.clip123);
+
+    await updateClip({ ids: "123", quantize: 1 });
+
+    // The options object passed to handleQuantization must carry quantize;
+    // blanking it to {} would skip quantization entirely. 5 == QUANTIZE_GRID 1/16.
+    expect(mocks.clip123.call).toHaveBeenCalledWith("quantize", 5, 1);
+  });
+
+  it("should run warp marker operations when warpOp is provided", async () => {
+    setupAudioClipMock(mocks.clip456, { file_path: "/audio/test.wav" });
+
+    await updateClip({ ids: "456", warpOp: "add" });
+
+    // handleWarpMarkerOperation runs only inside the warpOp != null guard; with
+    // no warpBeatTime it warns, proving the guarded block executed.
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "warpBeatTime required for add operation",
+    );
+  });
+
+  it("should write notes and not treat a MIDI clip as audio", async () => {
+    setupMidiClipMock(mocks.clip123);
+
+    const result = await updateClip({ ids: "123", notes: "C3 1|1" });
+
+    // isAudioClip must be false: notes are written and the audio-only warning
+    // must not fire (forced-true would suppress notes and warn instead).
+    expect(mocks.clip123.call).toHaveBeenCalledWith(
+      "add_new_notes",
+      expect.anything(),
+    );
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      "notes parameter ignored for audio clip",
+    );
+    expect(result).toStrictEqual({ id: "123", noteCount: 1 });
+  });
+
+  it("should apply code exactly once per clip without a failure warning", async () => {
+    setupMidiClipMock(mocks.clip123);
+    vi.mocked(applyCodeToSingleClip).mockResolvedValue(3);
+
+    const result = await updateClip({ ids: "123", code: "return notes" });
+
+    // Loop bound is j < length: exactly one call, no extra iteration that would
+    // dereference undefined and emit a "Failed to update clip" warning.
+    expect(applyCodeToSingleClip).toHaveBeenCalledTimes(1);
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("Failed to update clip"),
+    );
+    expect(result).toStrictEqual({ id: "123", noteCount: 3 });
+  });
+
+  it("should omit noteCount when code exec returns null", async () => {
+    setupMidiClipMock(mocks.clip123);
+    vi.mocked(applyCodeToSingleClip).mockResolvedValue(null);
+
+    const result = await updateClip({ ids: "123", code: "return notes" });
+
+    // noteCount != null guard: a null result must not set the field.
+    expect(result).toStrictEqual({ id: "123" });
+    expect(result).not.toHaveProperty("noteCount");
+  });
+
+  it("should thread isNonSurvivor from nonSurvivorClipIds into position ops", async () => {
+    setupMidiClipMock(mocks.clip123);
+    const clip = LiveAPI.from("id 123");
+    const posSpy = vi
+      .spyOn(sessionHelpers, "handlePositionOperations")
+      .mockImplementation(() => {
+        /* intercept only */
+      });
+
+    processSingleClipUpdate({
+      clip,
+      clipIndex: 0,
+      clipCount: 1,
+      context: {},
+      updatedClips: [],
+      tracksWithMovedClips: new Map(),
+      nonSurvivorClipIds: new Set(["123"]),
+    });
+
+    // clip.id "123" is in the set, so isNonSurvivor must be true (?? false, not
+    // && false which would force it false).
+    expect(posSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ isNonSurvivor: true }),
+    );
+  });
+});
+
+describe("updateClip - splitting mutation coverage", () => {
+  it("should warn when split targets a non-arrangement clip", async () => {
+    const mocks = setupUpdateClipMocks();
+
+    setupMidiClipMock(mocks.clip123); // session clip: is_arrangement_clip = 0
+
+    const result = await updateClip({ ids: "123", split: "2|1" });
+
+    // Session clips are excluded from arrangementClips, so prepareSplitParams
+    // sees an empty list and warns. The <= 0 guard must return false for them
+    // (forced-true / never-false mutants would include the clip and split it).
+    expect(outlet).toHaveBeenCalledWith(1, "split requires arrangement clips");
+    expect(result).toStrictEqual({ id: "123" });
+  });
+
+  it("should split an arrangement clip and return the fresh clips only", async () => {
+    const clipId = "clip_1";
+    const { callState } = setupClipSplittingMocks(clipId);
+
+    // rescanSplitClips reads arrangement_clips: return one real fresh clip plus
+    // a non-existent one (id "0") that clip.exists() must filter out.
+    const freshClipId = "fresh_clip";
+
+    registerMockObject(freshClipId, {
+      path: livePath.track(0).arrangementClip(2),
+      type: "Clip",
+      properties: {
+        start_time: 0.0,
+        is_midi_clip: 1,
+        is_arrangement_clip: 1,
+      },
+    });
+
+    const trackMock = lookupMockObject("track_0", livePath.track(0));
+    const origGet = trackMock?.get.getMockImplementation();
+
+    trackMock?.get.mockImplementation((prop: string) => {
+      if (prop === "arrangement_clips") return ["id", freshClipId, "id", "0"];
+
+      return origGet ? origGet(prop) : [0];
+    });
+
+    const result = await updateClip(
+      { ids: clipId, split: "2|1" },
+      { holdingAreaStartBeats: 40000 },
+    );
+
+    // Splitting ran (arrangement clip kept by the <= 0 / >= 0 boundary)...
+    expect(callState.trackMock.call).toHaveBeenCalledWith(
+      "duplicate_clip_to_arrangement",
+      expect.any(String),
+      expect.any(Number),
+    );
+
+    const resultIds = (Array.isArray(result) ? result : [result]).map(
+      (r) => r.id,
+    );
+
+    // ...and the exists() filter keeps the fresh clip, drops the missing "0".
+    expect(resultIds).toContain(freshClipId);
+    expect(resultIds).not.toContain("0");
+  });
+
+  it("should not split (or throw) when the split format is invalid", async () => {
+    const clipId = "clip_1";
+    const { callState } = setupClipSplittingMocks(clipId);
+
+    // split is provided but unparseable, so splitPoints is null. The guard's
+    // splitPoints != null term must stay honored (forced-true / || mutants
+    // would call performSplitting with null and throw).
+    const result = await updateClip(
+      { ids: clipId, split: "not-a-position" },
+      { holdingAreaStartBeats: 40000 },
+    );
+
+    expect(result).toBeDefined();
+    expect(callState.trackMock.call).not.toHaveBeenCalledWith(
+      "duplicate_clip_to_arrangement",
+      expect.anything(),
+      expect.anything(),
+    );
   });
 });

--- a/src/tools/clip/update/tests/update-clip-properties.test.ts
+++ b/src/tools/clip/update/tests/update-clip-properties.test.ts
@@ -12,6 +12,11 @@ import {
   type UpdateClipMocks,
 } from "#src/tools/clip/update/helpers/update-clip-test-helpers.ts";
 import { updateClip } from "#src/tools/clip/update/update-clip.ts";
+import {
+  buildClipPropertiesToSet,
+  type BuildClipPropertiesArgs,
+  type ClipPropsToSet,
+} from "#src/tools/clip/update/helpers/update-clip-properties-helpers.ts";
 import "#src/live-api-adapter/live-api-extensions.ts";
 
 vi.mock(import("#src/tools/session/select.ts"), () => ({
@@ -251,5 +256,299 @@ describe("updateClip - focus functionality", () => {
     await updateClip({ ids: "123", name: "Test" });
 
     expect(selectMock.get()).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildClipPropertiesToSet", () => {
+  const BASE: BuildClipPropertiesArgs = {
+    name: "clip",
+    color: "#000000",
+    timeSignature: undefined,
+    timeSigNumerator: 4,
+    timeSigDenominator: 4,
+    startMarkerBeats: null,
+    looping: undefined,
+    isLooping: false,
+    startBeats: null,
+    endBeats: null,
+    currentLoopEnd: null,
+  };
+
+  const build = (overrides: Partial<BuildClipPropertiesArgs>): ClipPropsToSet =>
+    buildClipPropertiesToSet({ ...BASE, ...overrides });
+
+  it("sets signature numerator/denominator from the time sig when timeSignature is present", () => {
+    const result = build({
+      timeSignature: "3/8",
+      timeSigNumerator: 3,
+      timeSigDenominator: 8,
+    });
+
+    expect(result).toStrictEqual({
+      name: "clip",
+      color: "#000000",
+      signature_numerator: 3,
+      signature_denominator: 8,
+      looping: undefined,
+    });
+  });
+
+  it("sets signature numerator/denominator to null when timeSignature is absent", () => {
+    const result = build({ timeSigNumerator: 3, timeSigDenominator: 8 });
+
+    expect(result).toStrictEqual({
+      name: "clip",
+      color: "#000000",
+      signature_numerator: null,
+      signature_denominator: null,
+      looping: undefined,
+    });
+  });
+
+  it("sets loop_end before loop_start when expanding (startBeats > currentLoopEnd)", () => {
+    const result = build({
+      isLooping: true,
+      looping: true,
+      startBeats: 8,
+      endBeats: 16,
+      currentLoopEnd: 4,
+    });
+
+    expect(result).toStrictEqual({
+      name: "clip",
+      color: "#000000",
+      signature_numerator: null,
+      signature_denominator: null,
+      looping: true,
+      loop_end: 16,
+      loop_start: 8,
+    });
+    // Order matters: loop_end is set first when expanding.
+    expect(Object.keys(result)).toStrictEqual([
+      "name",
+      "color",
+      "signature_numerator",
+      "signature_denominator",
+      "looping",
+      "loop_end",
+      "loop_start",
+    ]);
+  });
+
+  it("sets loop_start before loop_end when not expanding (startBeats < currentLoopEnd)", () => {
+    const result = build({
+      isLooping: true,
+      looping: true,
+      startBeats: 2,
+      endBeats: 16,
+      currentLoopEnd: 4,
+    });
+
+    expect(result).toStrictEqual({
+      name: "clip",
+      color: "#000000",
+      signature_numerator: null,
+      signature_denominator: null,
+      looping: true,
+      loop_start: 2,
+      loop_end: 16,
+    });
+    expect(Object.keys(result)).toStrictEqual([
+      "name",
+      "color",
+      "signature_numerator",
+      "signature_denominator",
+      "looping",
+      "loop_start",
+      "loop_end",
+    ]);
+  });
+
+  it("expands (loop_end first) when startBeats exactly equals currentLoopEnd", () => {
+    const result = build({
+      isLooping: true,
+      looping: true,
+      startBeats: 4,
+      endBeats: 16,
+      currentLoopEnd: 4,
+    });
+
+    // Boundary: >= means equal still counts as expanding.
+    expect(Object.keys(result)).toStrictEqual([
+      "name",
+      "color",
+      "signature_numerator",
+      "signature_denominator",
+      "looping",
+      "loop_end",
+      "loop_start",
+    ]);
+    expect(result).toStrictEqual({
+      name: "clip",
+      color: "#000000",
+      signature_numerator: null,
+      signature_denominator: null,
+      looping: true,
+      loop_end: 16,
+      loop_start: 4,
+    });
+  });
+
+  it("does not expand (loop_start first) when currentLoopEnd is null", () => {
+    const result = build({
+      isLooping: true,
+      looping: true,
+      startBeats: 4,
+      endBeats: 16,
+      currentLoopEnd: null,
+    });
+
+    expect(Object.keys(result)).toStrictEqual([
+      "name",
+      "color",
+      "signature_numerator",
+      "signature_denominator",
+      "looping",
+      "loop_start",
+      "loop_end",
+    ]);
+    expect(result).toStrictEqual({
+      name: "clip",
+      color: "#000000",
+      signature_numerator: null,
+      signature_denominator: null,
+      looping: true,
+      loop_start: 4,
+      loop_end: 16,
+    });
+  });
+
+  it("uses the current isLooping state (not requested looping) to decide expansion order", () => {
+    // isLooping is false so setEndFirst is false -> loop_start before loop_end,
+    // and end_marker is set because the clip is currently non-looping.
+    const result = build({
+      isLooping: false,
+      looping: undefined,
+      startBeats: 8,
+      endBeats: 16,
+      currentLoopEnd: 4,
+    });
+
+    expect(Object.keys(result)).toStrictEqual([
+      "name",
+      "color",
+      "signature_numerator",
+      "signature_denominator",
+      "looping",
+      "loop_start",
+      "loop_end",
+      "end_marker",
+    ]);
+    expect(result).toStrictEqual({
+      name: "clip",
+      color: "#000000",
+      signature_numerator: null,
+      signature_denominator: null,
+      looping: undefined,
+      loop_start: 8,
+      loop_end: 16,
+      end_marker: 16,
+    });
+  });
+
+  it("sets only end_marker (no loop props) when turning looping off, expanding case", () => {
+    const result = build({
+      isLooping: true,
+      looping: false,
+      startBeats: 8,
+      endBeats: 16,
+      currentLoopEnd: 4,
+    });
+
+    expect(result).toStrictEqual({
+      name: "clip",
+      color: "#000000",
+      signature_numerator: null,
+      signature_denominator: null,
+      looping: false,
+      end_marker: 16,
+    });
+  });
+
+  it("sets only end_marker (no loop props) when turning looping off, non-expanding case", () => {
+    const result = build({
+      isLooping: true,
+      looping: false,
+      startBeats: 2,
+      endBeats: 16,
+      currentLoopEnd: 4,
+    });
+
+    expect(result).toStrictEqual({
+      name: "clip",
+      color: "#000000",
+      signature_numerator: null,
+      signature_denominator: null,
+      looping: false,
+      end_marker: 16,
+    });
+  });
+
+  it("does not set loop props for a currently non-looping clip when looping is explicitly true", () => {
+    const result = build({
+      isLooping: false,
+      looping: true,
+      startBeats: 8,
+      endBeats: 16,
+      currentLoopEnd: 4,
+    });
+
+    expect(result).toStrictEqual({
+      name: "clip",
+      color: "#000000",
+      signature_numerator: null,
+      signature_denominator: null,
+      looping: true,
+      end_marker: 16,
+    });
+  });
+
+  it("sets start_marker (not end_marker) for a non-looping clip with a start marker and no endBeats", () => {
+    const result = build({
+      isLooping: false,
+      looping: false,
+      startMarkerBeats: 8,
+      startBeats: null,
+      endBeats: null,
+      currentLoopEnd: null,
+    });
+
+    expect(result).toStrictEqual({
+      name: "clip",
+      color: "#000000",
+      signature_numerator: null,
+      signature_denominator: null,
+      looping: false,
+      start_marker: 8,
+    });
+  });
+
+  it("does not set loop_end when endBeats is null for a looping clip", () => {
+    const result = build({
+      isLooping: true,
+      looping: true,
+      startBeats: 4,
+      endBeats: null,
+      currentLoopEnd: null,
+    });
+
+    expect(result).toStrictEqual({
+      name: "clip",
+      color: "#000000",
+      signature_numerator: null,
+      signature_denominator: null,
+      looping: true,
+      loop_start: 4,
+    });
   });
 });

--- a/src/tools/clip/update/tests/update-clip-session-move.test.ts
+++ b/src/tools/clip/update/tests/update-clip-session-move.test.ts
@@ -152,6 +152,83 @@ describe("handleSessionSlotMove", () => {
     expect(updatedClips[0]).toMatchObject({ id: "123" });
   });
 
+  it("should warn when only the track index is unknown", () => {
+    const updatedClips: ClipResult[] = [];
+
+    // sceneIndex is a real number: the guard must still fire (|| not &&, and the
+    // whole conditional must not be forced false).
+    handleSessionSlotMove({
+      clip: {
+        id: "123",
+        trackIndex: null,
+        sceneIndex: 0,
+        getProperty: vi.fn(),
+      } as unknown as LiveAPI,
+      toSlot: { trackIndex: 1, sceneIndex: 2 },
+      updatedClips,
+      noteResult: null,
+    });
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "could not determine slot position for clip 123",
+    );
+  });
+
+  it("should warn when only the scene index is unknown", () => {
+    const updatedClips: ClipResult[] = [];
+
+    // trackIndex is a real number, sceneIndex is null: the second operand of the
+    // guard must stay live (kills the srcSceneIndex == null -> false mutant).
+    handleSessionSlotMove({
+      clip: {
+        id: "123",
+        trackIndex: 0,
+        sceneIndex: null,
+        getProperty: vi.fn(),
+      } as unknown as LiveAPI,
+      toSlot: { trackIndex: 1, sceneIndex: 2 },
+      updatedClips,
+      noteResult: null,
+    });
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "could not determine slot position for clip 123",
+    );
+  });
+
+  it("should move (not no-op) when only the scene index matches", () => {
+    const { updatedClips, sourceSlot } = runSessionMove({
+      trackIndex: 0,
+      sceneIndex: 1,
+      toTrackIndex: 2,
+      toSceneIndex: 1,
+    });
+
+    // Same-scene but different track is NOT the same slot: the trackIndex ===
+    // comparison must stay live (forced-true would treat it as a no-op).
+    expect(sourceSlot.call).toHaveBeenCalledWith(
+      "duplicate_clip_to",
+      expect.any(String),
+    );
+    expect(updatedClips[0]).toMatchObject({
+      id: "live_set/tracks/2/clip_slots/1/clip",
+      slot: "2/1",
+    });
+  });
+
+  it("should not warn about overwriting when the destination is empty", () => {
+    runSessionMove({ toTrackIndex: 1, toSceneIndex: 5, destHasClip: 0 });
+
+    // has_clip is falsy, so the overwrite warning must not fire (kills the
+    // forced-true mutant on the has_clip guard).
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("overwriting existing clip"),
+    );
+  });
+
   it("should no-op when moving to same slot", () => {
     const { updatedClips } = runSessionMove({
       trackIndex: 2,
@@ -290,6 +367,56 @@ describe("handlePositionOperations", () => {
     expect(outlet).toHaveBeenCalledWith(
       1,
       "toSlot ignored when arrangement parameters are specified",
+    );
+  });
+
+  it("should warn when toSlot used with arrangement LENGTH only", () => {
+    const updatedClips: ClipResult[] = [];
+
+    // Only arrangementLengthBeats is set (no start): the second operand of the
+    // arrangement-params guard must stay live (kills its -> false mutant).
+    handlePositionOperations({
+      clip: { id: "123", getProperty: vi.fn(() => 0) } as unknown as LiveAPI,
+      isAudioClip: false,
+      toSlot: { trackIndex: 1, sceneIndex: 2 },
+      arrangementLengthBeats: 8,
+      tracksWithMovedClips: new Map(),
+      context: {},
+      updatedClips,
+      noteResult: null,
+      isNonSurvivor: false,
+    });
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "toSlot ignored when arrangement parameters are specified",
+    );
+  });
+
+  it("should not warn about arrangement toSlot when no toSlot is given", () => {
+    const updatedClips: ClipResult[] = [];
+
+    // Arrangement clip but no toSlot: the else-if (toSlot != null && isArrangement)
+    // must stay false (kills forced-true and the && -> || mutant).
+    handlePositionOperations({
+      clip: {
+        id: "789",
+        getProperty: vi.fn((prop: string) =>
+          prop === "is_arrangement_clip" ? 1 : 0,
+        ),
+      } as unknown as LiveAPI,
+      isAudioClip: false,
+      arrangementStartBeats: 8,
+      tracksWithMovedClips: new Map(),
+      context: {},
+      updatedClips,
+      noteResult: null,
+      isNonSurvivor: false,
+    });
+
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("toSlot parameter ignored for arrangement clip"),
     );
   });
 });

--- a/src/tools/clip/update/tests/update-clip-timing-helpers.test.ts
+++ b/src/tools/clip/update/tests/update-clip-timing-helpers.test.ts
@@ -120,5 +120,104 @@ describe("update-clip-timing-helpers", () => {
       expect(result.startMarkerBeats).toBeNull();
       expect(result.startBeats).toBe(8);
     });
+
+    it("treats firstStart AT the end_marker as out of bounds (strict <, not <=)", () => {
+      // firstStartBeats === end_marker: the strict `<` rejects it, warns, and
+      // leaves start_marker unset. `<=` would wrongly accept it and return the
+      // value with no warning.
+      const mockClip = {
+        getProperty: vi.fn((prop: string) => (prop === "end_marker" ? 4 : 0)),
+      };
+
+      const result = calculateBeatPositions({
+        firstStart: "2|1", // exactly 4 beats == end_marker (4)
+        timeSigNumerator: 4,
+        timeSigDenominator: 4,
+        clip: mockClip as unknown as LiveAPI,
+        isLooping: true,
+      });
+
+      expect(result.firstStartBeats).toBe(4);
+      expect(result.startMarkerBeats).toBeNull();
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("firstStart parameter ignored"),
+      );
+    });
+
+    it("treats start AT the end_marker as out of bounds (strict <, not <=)", () => {
+      // startBeats === end_marker (no firstStart): strict `<` rejects it, so
+      // start_marker stays null. Both `<=` and forcing the whole guard true
+      // would return the start value instead.
+      const mockClip = {
+        getProperty: vi.fn((prop: string) => (prop === "end_marker" ? 4 : 0)),
+      };
+
+      const result = calculateBeatPositions({
+        start: "2|1", // exactly 4 beats == end_marker (4)
+        timeSigNumerator: 4,
+        timeSigDenominator: 4,
+        clip: mockClip as unknown as LiveAPI,
+        isLooping: false,
+      });
+
+      expect(result.startBeats).toBe(4);
+      expect(result.startMarkerBeats).toBeNull();
+      expect(outlet).not.toHaveBeenCalledWith(1, expect.anything());
+    });
+
+    it("derives start from end_marker - length on non-looping clips (no drift warn)", () => {
+      // start omitted + length given on a non-looping MIDI clip: startBeats =
+      // end_marker - lengthBeats = 8 - 4 = 4 (a `+` gives 12). With start_marker
+      // matching the derived start, abs diff is 0 so there is no drift warning
+      // (a `+` inside abs(), or forcing the guard true, would warn).
+      const mockClip = {
+        getProperty: vi.fn((prop: string) => {
+          if (prop === "end_marker") return 8;
+          if (prop === "start_marker") return 4;
+          if (prop === "is_midi_clip") return 1;
+
+          return 0;
+        }),
+      };
+
+      const result = calculateBeatPositions({
+        length: "1bar", // 4 beats at 4/4
+        timeSigNumerator: 4,
+        timeSigDenominator: 4,
+        clip: mockClip as unknown as LiveAPI,
+        isLooping: false,
+      });
+
+      expect(result.startBeats).toBe(4);
+      expect(result.endBeats).toBe(8);
+      expect(outlet).not.toHaveBeenCalledWith(1, expect.anything());
+    });
+
+    it("does not warn when derived-start drift is exactly SAME_TIME_EPSILON (strict >)", () => {
+      // Derived start = 4 - 4 = 0; start_marker = -0.001 → abs diff == 0.001 ==
+      // SAME_TIME_EPSILON exactly. The strict `>` does NOT warn at the boundary;
+      // `>=` would.
+      const mockClip = {
+        getProperty: vi.fn((prop: string) => {
+          if (prop === "end_marker") return 4;
+          if (prop === "start_marker") return -0.001;
+          if (prop === "is_midi_clip") return 1;
+
+          return 0;
+        }),
+      };
+
+      const result = calculateBeatPositions({
+        length: "1bar", // 4 beats → derived start = 4 - 4 = 0
+        timeSigNumerator: 4,
+        timeSigDenominator: 4,
+        clip: mockClip as unknown as LiveAPI,
+        isLooping: false,
+      });
+
+      expect(result.startBeats).toBe(0);
+      expect(outlet).not.toHaveBeenCalledWith(1, expect.anything());
+    });
   });
 });


### PR DESCRIPTION
Fifth and largest AJM-668 write-op domain triaged (after `track`, `session`, `actions`, `device`) — **completes the write-op tier**.

## Result

`src/tools/clip/` mutation score **80.23% → 97.48%** — killed ~297 additional mutants (338 → 45 survivors) with **test-only** changes; **no product code touched**. Gate set to `break: 96` in `TOOL_DOMAIN_BREAKS.clip` (~1.5 below the score for timeout-classification variance). This was by far the biggest domain (28 mutated files, 1787 mutants — more than `track` + `session` + `actions` combined) yet finished with the **highest** final score of the five, because the clip helpers are mostly pure functions with tight, directly-unit-testable contracts. Baseline recorded in `dev/Mutation-Testing.md`.

Verified: `npm run mutation -- clip` → exit 0, "Final mutation score of 97.48 is greater than or equal to break threshold 96". `npm run check` (9606 passed, Functions 100%) and `npm run check:build` both green.

## Config change

`toolDomain()` in `config/mutation-scopes.mjs` now excludes `*-disabled.ts` — the build-time substitution stubs rollup swaps in when a feature flag is off (e.g. `ENABLE_CODE_EXEC`). Tests run with the feature enabled, so the stubs are never imported: 14 all-`NoCoverage` mutants that can never be killed (already coverage-excluded in `vitest.config.ts`; this mirrors it).

## Per-file (files with remaining survivors; 12 more hit 100%)

| File | Score | Survived |
| --- | --- | --- |
| `update-clip-arrangement-optimizer.ts` | 90.32% | 6 |
| `update-clip-notes-helpers.ts` | 91.82% | 9 |
| `create-clip-loop-helpers.ts` | 93.02% | 6 |
| `update-clip.ts` | 93.75% | 6 |
| `create-clip-audio-helpers.ts` | 95.45% | 1 |
| `update-clip-properties-helpers.ts` | 96.47% | 3 |
| `read-clip-helpers.ts` | 97.30% | 2 |
| `code-exec-helpers.ts` | 97.75% | 2 |
| `read-clip.ts` | 98.31% | 3 |

## Notable gaps closed

- **Arrangement clip property math (0 → 100%):** the unlooped-clip helpers (43 mutants) had no direct unit test; added a full boundary/loop-flag matrix over `buildClipPropertiesToSet` and the unlooped helpers.
- **Note transform / timing / audio helpers:** conditionals and warn-and-skip guards now assert the emitted warning and the exact written values, not just the return.
- **read-clip:** warp-marker and notation-resolution branches.
- **Empty `clipName` must not write a `name` property** — see gotcha below.

## Durable gotcha (also in the docs)

Same class as the device pass: a `.name` → `toBeUndefined()` assertion **cannot** distinguish an absent property from one written as `undefined`, so `buildClipProperties`'s `if (clipName)` guard forced to `true` (writing `name: undefined`) survived. Fixed with `not.toHaveProperty("name")`.

## Remaining survivors

The 45 leftovers are overwhelmingly **bucket 2 (equivalent)**: redundant fast-path guards duplicating a guard `applyTransforms` already performs, merge-group length boundaries only ever entered with ≥1 element, the `parseToSlotParam` dual null-returns converging on the same `null`, and never-nullish fallbacks (`?? "barbeat"`, view strings never surfaced in results). The only weak-not-equivalent leftovers are the arrangement-splitting branch (`update-clip.ts` L353) and the `buildCodeLocationContext` view guards — low-value defensive paths left for a future integration pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)