### PR TITLE
test(mutation): triage read-op/small tool domains (AJM-670)

### DIFF
--- a/config/mutation-scopes.mjs
+++ b/config/mutation-scopes.mjs
@@ -84,6 +84,10 @@ const TOOL_DOMAIN_BREAKS = {
   actions: 90, // triaged 2026-07-15 at 91.79% (see dev/Mutation-Testing.md)
   device: 90, // triaged 2026-07-15 at 91.18% (see dev/Mutation-Testing.md)
   clip: 96, // triaged 2026-07-15 at 97.48% (see dev/Mutation-Testing.md)
+  advanced: 97, // triaged 2026-07-15 at 98.60% (see dev/Mutation-Testing.md)
+  core: 99, // triaged 2026-07-15 at 100.00% (see dev/Mutation-Testing.md)
+  scene: 96, // triaged 2026-07-15 at 97.66% (see dev/Mutation-Testing.md)
+  "live-set": 98, // triaged 2026-07-15 at 99.07% (see dev/Mutation-Testing.md)
 };
 
 export const SCOPES = {

--- a/dev/Mutation-Testing.md
+++ b/dev/Mutation-Testing.md
@@ -37,7 +37,8 @@ Scopes are defined in `config/mutation-scopes.mjs`:
   survivors are triaged in its own PR and it earns a floor in
   `TOOL_DOMAIN_BREAKS`; triaged so far: `track` (`break: 85`), `session`
   (`break: 89`), `actions` (`break: 90`), `device` (`break: 90`), `clip`
-  (`break: 96`).
+  (`break: 96`), `advanced` (`break: 97`), `core` (`break: 99`), `scene`
+  (`break: 96`), `live-set` (`break: 98`). Only `shared` remains untriaged.
 - **Groups** — `tools` (all ten tool domains) and `all` (notation + tools),
   expanded by the runner into their member scopes.
 
@@ -529,6 +530,68 @@ distinguish from an absent property. Fixed with `not.toHaveProperty("name")`.
 | create-clip name/color distribution + take-lane resolution          | `create-clip-*.test.ts` (basic/advanced/…)         |
 | Empty `clipName` must not write a `name` property                   | `create-clip-advanced.test.ts`                     |
 
+## Baseline (2026-07-15, read-op / small tier: `advanced`, `core`, `scene`, `live-set`)
+
+The four read-op / small tool domains, triaged together in one PR (they total 13
+mutated files — roughly a third of `clip` alone). Full passes — Stryker 9.6.1,
+Node 24, `coverageAnalysis: "perTest"`:
+
+| Domain     | Baseline | Triaged     | Gate (`break`) | Survivors (from) | Files |
+| ---------- | -------- | ----------- | -------------- | ---------------- | ----- |
+| `advanced` | 96.50%   | **98.60%**  | 97             | 2 (from 5)       | 1     |
+| `core`     | 94.53%   | **100.00%** | 99             | 0 (from 7)       | 3     |
+| `scene`    | 88.63%   | **97.66%**  | 96             | 7 (from 34)      | 5     |
+| `live-set` | 87.38%   | **99.07%**  | 98             | 4 (from 54)      | 4     |
+
+All test-only changes — no product code touched. Each floor sits ~1–1.6 points
+below its score for timeout-classification variance. `core` reached a clean
+100%; `live-set` (99.07%) is the highest of the whole read-op/write-op set after
+`core`.
+
+The dominant lever, seen across `scene` and `live-set`, was the **warn-and-skip
+message gap** (the same shape as `device`/`track`): update tools `console.warn`
+then return a `{operation:"skipped", reason}` object, but the tests asserted
+only the returned object — never the warning text. Adding
+`expect(outlet).toHaveBeenCalledWith(1, expect.stringContaining(...))` to each
+skip test killed ~16 blanked-message survivors in `live-set` locators alone. The
+second lever was **direct unit tests of exported helpers** only ever exercised
+transitively: `stopPlaybackIfNeeded` and `waitForPlayheadPosition` (polling
+predicate, success/failure warn, epsilon boundary) took
+`update-live-set-locator-helpers.ts` from 75.8% to 98.7%.
+
+Remaining survivors are bucket 2/3:
+
+- **`advanced`** — the `default:` throw in the non-exported `executeOperation`
+  switch is unreachable (`validateOperationParameters` rejects unknown types
+  first); the two `NoCoverage` mutants there can't be killed without exporting
+  internal API.
+- **`scene`** — always-≥1 length guards (`createdScenes.length > 0` after a
+  `count ≥ 1` loop), a pad loop that self-guards on a non-positive count, the
+  all-null capture-property no-op, `parseInt("")` vs `parseInt("Stryker…")`
+  (both `NaN`), and the undefined-notation passthrough to `readClip`.
+- **`live-set`** — `waitUntil({})` (its defaults _are_
+  `{pollingInterval:10, maxRetries:10}`), the `locatorName != null` operand
+  whose only differing input is caught by the earlier all-null guard, a
+  return-track-names arrow only observable through mixer sends, and an
+  unknown-include string ignored downstream.
+
+### Gaps closed (read-op / small tier)
+
+| Gap (now killed)                                                                           | Test strengthened / added                       |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------- |
+| `liveApi` `> MAX_OPERATIONS` boundary + wrapped-error `cause` + no-args `call_method`      | `live-api.test.ts`                              |
+| `connect` stopped-set `isPlaying` boundary, live_app version path, return-track count      | `connect-core.test.ts`                          |
+| `callNodeMemoryRoute` `                                                                    |                                                 | `guard +`"unknown error"` default | `context-memory.test.ts` |
+| captureScene sceneIndex/name guards + two-digit selected-scene regex                       | `capture-scene.test.ts`                         |
+| createScene capture-focus, extra-names label, MAX boundary, single-property capture guard  | `create-scene.test.ts`                          |
+| readScene color-include gate, empty-clip filter + suppressed warning                       | `read-scene.test.ts`                            |
+| scene-helpers tempo 20/999/1000 boundaries; updateScene label + empty-focus guard          | `update-scene.test.ts`                          |
+| stopPlaybackIfNeeded / waitForPlayheadPosition direct unit tests                           | `update-live-set-locator-helpers.test.ts` (new) |
+| 16 blanked locator warn/skip messages + reverse-order delete sort                          | `update-live-set-locator-operations.test.ts`    |
+| updateLiveSet scale-absent no-warn + unknown-operation default throw                       | `update-live-set.test.ts`                       |
+| extendSong boundary + `"tracks"` child name; multi-word scale join; root/scale error lists | `update-live-set-helpers.test.ts`               |
+| readLiveSet mixer-include gate (full param mocks so it's observable)                       | `read-live-set-mixer.test.ts`                   |
+
 ## Interpreting survivors
 
 Each survivor falls into one of three buckets — triage before acting:
@@ -547,28 +610,30 @@ wins, and a cross-check against the line-coverage gate.
 
 ## Status & next steps
 
-The `notation` scope is **ratcheted** (`thresholds.break = 86`), as are `track`
-(`break: 85`), `session` (`break: 89`), `actions` (`break: 90`), `device`
-(`break: 90`), and `clip` (`break: 96`) — the five triaged write-op tool
-domains. The per-domain scope mechanism (`config/mutation-scopes.mjs` + the
-runner) is in place, so each `src/tools/` domain can be mutated on its own; the
-untriaged ones remain in **baseline mode** (`break: null`, measure-only).
-Mutation testing stays off the per-PR hot path (a full pass is minutes).
-Remaining work (later releases):
+The `notation` scope is **ratcheted** (`thresholds.break = 86`), as are all nine
+triaged tool domains: the write-op tier `track` (`break: 85`), `session`
+(`break: 89`), `actions` (`break: 90`), `device` (`break: 90`), `clip`
+(`break: 96`), and the read-op / small tier `advanced` (`break: 97`), `core`
+(`break: 99`), `scene` (`break: 96`), `live-set` (`break: 98`). Only `shared`
+(`src/tools/shared`) remains in **baseline mode** (`break: null`, measure-only).
+The per-domain scope mechanism (`config/mutation-scopes.mjs` + the runner) is in
+place, so each `src/tools/` domain can be mutated on its own. Mutation testing
+stays off the per-PR hot path (a full pass is minutes). Remaining work (later
+releases):
 
 - Keep triaging the ~588 notation survivors, but expect diminishing returns: the
   dense clusters left are epsilon-boundary / warning-string / equivalent mutants
   (bucket 2/3), so genuine bucket-1 gaps are now sparse.
 - Raise each scope's `break` as its score climbs.
-- Triage the remaining `src/tools/` domains one PR at a time. The write-op tier
-  is now complete (`track`, `session`, `actions`, `device`, `clip` done); the
-  read-op / shared domains (`advanced`, `core`, `live-set`, `scene`, `shared`)
-  remain in baseline mode. Per domain: run `npm run mutation -- <domain>`, close
-  real gaps, flip that domain's `break` from `null` to ~1 point below its
-  triaged score (add it to `TOOL_DOMAIN_BREAKS`). The big clean wins tend to be
-  untested lookup/enum tables (as in notation's chord table) and warn-and-skip
-  guards whose tests assert only the result, never the warning or the skipped
-  write.
+- Only one `src/tools/` domain is left: `shared` (`src/tools/shared`, the
+  biggest single domain — split by subarea rather than triaging in one PR). The
+  write-op tier (`track`, `session`, `actions`, `device`, `clip`) and the
+  read-op / small tier (`advanced`, `core`, `scene`, `live-set`) are done. Per
+  domain: run `npm run mutation -- <domain>`, close real gaps, flip that
+  domain's `break` from `null` to ~1 point below its triaged score (add it to
+  `TOOL_DOMAIN_BREAKS`). The big clean wins tend to be untested lookup/enum
+  tables (as in notation's chord table) and warn-and-skip guards whose tests
+  assert only the result, never the warning or the skipped write.
 - Optionally wire a scheduled (nightly/weekly) non-blocking CI job once several
   domains have floors — full-tree runtime is hours, not minutes.
 

--- a/src/tools/advanced/live-api.test.ts
+++ b/src/tools/advanced/live-api.test.ts
@@ -94,6 +94,17 @@ describe("liveApi", () => {
       );
     });
 
+    it("should not throw when operations array has exactly 50 operations", () => {
+      // Boundary: MAX_OPERATIONS is 50, so exactly 50 is allowed (> not >=).
+      const operations = Array(50).fill({
+        type: "exists",
+      }) as LiveApiOperation[];
+
+      const result = liveApi({ operations });
+
+      expect(result.results).toHaveLength(50);
+    });
+
     it("should throw error for unknown operation type", () => {
       expect(() =>
         liveApi({
@@ -159,6 +170,18 @@ describe("liveApi", () => {
       expect(result.results[0]!.operation.type).toBe("call_method");
       expect(result.results[0]!.result).toStrictEqual([120]);
       expect(defaultMock.get).toHaveBeenCalledWith("tempo");
+    });
+
+    it("should handle call_method operation without args", () => {
+      // No args → executeOperation applies the default [] (empty argument list).
+      defaultMock.get.mockReturnValueOnce([120]);
+
+      const result = liveApi({
+        operations: [{ type: "call_method", method: "get" }],
+      });
+
+      expect(result.results[0]!.result).toStrictEqual([120]);
+      expect(defaultMock.get).toHaveBeenCalledWith();
     });
 
     it("should throw error for call_method without method", () => {
@@ -471,6 +494,23 @@ describe("liveApi", () => {
           operations: [{ type: "unknown_operation" }],
         } as unknown as Parameters<typeof liveApi>[0]),
       ).toThrow("Unknown operation type: unknown_operation");
+    });
+
+    it("should wrap operation errors and preserve the original as cause", () => {
+      let caught: unknown;
+
+      try {
+        liveApi({ operations: [{ type: "get_property" }] });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toContain("Operation failed");
+      expect((caught as Error).cause).toBeInstanceOf(Error);
+      expect(((caught as Error).cause as Error).message).toContain(
+        "get_property operation requires property",
+      );
     });
   });
 });

--- a/src/tools/core/tests/connect-core.test.ts
+++ b/src/tools/core/tests/connect-core.test.ts
@@ -391,4 +391,33 @@ describe("connect", () => {
     expect(result.liveSet.name).toBeUndefined();
     expect(result.liveSet).not.toHaveProperty("name");
   });
+
+  it("omits isPlaying when the Live Set is stopped", () => {
+    // Boundary: is_playing 0 → not playing (> not >=), so the flag is absent.
+    const result = connectWithNullHostTrack(
+      createLiveSetConfig({ name: "Stopped Project", is_playing: 0 }),
+    );
+
+    expect(result.liveSet).not.toHaveProperty("isPlaying");
+  });
+
+  it("reports the Ableton Live version from the live_app object", () => {
+    // Distinct from the mock's unregistered "12.3" fallback so the live_app
+    // path string is load-bearing.
+    setupConnectScenario(createLiveSetConfig({ name: "Version Test" }), "12.5");
+    vi.mocked(getHostTrackIndex).mockReturnValue(0);
+
+    expect(connect().abletonLiveVersion).toBe("12.5");
+  });
+
+  it("counts return tracks from the return_tracks children", () => {
+    const result = connectWithNullHostTrack(
+      createLiveSetConfig({
+        name: "Return Tracks Project",
+        liveSetExtra: { return_tracks: children("return0", "return1") },
+      }),
+    );
+
+    expect(result.liveSet.returnTrackCount).toBe(2);
+  });
 });

--- a/src/tools/core/tests/context-memory.test.ts
+++ b/src/tools/core/tests/context-memory.test.ts
@@ -128,4 +128,17 @@ describe("context - memory scope", () => {
     );
     expect(protocolMock.requestNode).not.toHaveBeenCalled();
   });
+
+  it("throws when the node route reports failure, defaulting the error text", async () => {
+    // success:false with a truthy result still fails (|| not &&); the absent
+    // error field falls back to "unknown error".
+    vi.mocked(protocolMock.requestNode).mockResolvedValue({
+      success: false,
+      result: { content: "ignored" },
+    });
+
+    await expect(
+      context({ action: "read", scope: "memory", name: "x" }),
+    ).rejects.toThrow("memory.read failed: unknown error");
+  });
 });

--- a/src/tools/live-set/helpers/update-live-set-helpers.test.ts
+++ b/src/tools/live-set/helpers/update-live-set-helpers.test.ts
@@ -57,12 +57,47 @@ describe("update-live-set-helpers", () => {
       expect(mockLiveSet.getProperty).toHaveBeenCalledWith("song_length");
     });
 
+    it("should return null when targetBeats equals song_length (boundary)", () => {
+      // Boundary: targetBeats === song_length needs no extension (<= not <).
+      const mockLiveSet = {
+        getProperty: vi.fn().mockReturnValue(1000),
+        getChildIds: vi.fn().mockReturnValue([]),
+      } as unknown as LiveAPI;
+
+      expect(extendSongIfNeeded(mockLiveSet, 1000, {})).toBeNull();
+    });
+
     it("should throw error if no tracks available", () => {
       const mockLiveSet = mockLiveSetWithTracks([]);
 
       expect(() => extendSongIfNeeded(mockLiveSet, 200, {})).toThrow(
         "Cannot create locator past song end: no tracks available to extend song",
       );
+    });
+
+    it("reads the track list by the 'tracks' child name", () => {
+      const mockMidiTrack = {
+        getProperty: vi.fn().mockReturnValue(1), // has_midi_input = 1
+        call: vi.fn().mockReturnValue("id 999"),
+      };
+
+      g.LiveAPI = {
+        from: vi
+          .fn()
+          .mockImplementation((id) =>
+            id === "track-1" ? mockMidiTrack : { id: "999" },
+          ),
+      };
+
+      const mockLiveSet = {
+        getProperty: vi.fn().mockReturnValue(100), // song_length 100 < 200
+        getChildIds: vi.fn((name: string) =>
+          name === "tracks" ? ["track-1"] : [],
+        ),
+      } as unknown as LiveAPI;
+
+      // A wrong child name yields no tracks → the "no tracks available" throw.
+      expect(extendSongIfNeeded(mockLiveSet, 200, {})?.isMidiTrack).toBe(true);
     });
 
     it("should create MIDI clip when MIDI track is available", () => {
@@ -277,13 +312,23 @@ describe("update-live-set-helpers", () => {
       );
     });
 
-    it("should throw for invalid root note", () => {
-      expect(() => parseScale("X Major")).toThrow("Invalid scale root 'X'");
+    it("should join a multi-word scale name with a space", () => {
+      const result = parseScale("C Whole Tone");
+
+      expect(result).toStrictEqual({ scaleRoot: "C", scaleName: "Whole Tone" });
     });
 
-    it("should throw for invalid scale name", () => {
+    it("should throw for invalid root note, listing the valid roots", () => {
+      expect(() => parseScale("X Major")).toThrow("Invalid scale root 'X'");
+      expect(() => parseScale("X Major")).toThrow(/Valid roots: C, /);
+    });
+
+    it("should throw for invalid scale name, listing the valid scales", () => {
       expect(() => parseScale("C InvalidScale")).toThrow(
         "Invalid scale name 'InvalidScale'",
+      );
+      expect(() => parseScale("C InvalidScale")).toThrow(
+        /Valid scales: Major, /,
       );
     });
   });

--- a/src/tools/live-set/helpers/update-live-set-locator-helpers.test.ts
+++ b/src/tools/live-set/helpers/update-live-set-locator-helpers.test.ts
@@ -1,0 +1,88 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
+import {
+  stopPlaybackIfNeeded,
+  waitForPlayheadPosition,
+} from "./update-live-set-locator-helpers.ts";
+
+describe("stopPlaybackIfNeeded", () => {
+  it("stops playback and warns when the set is playing", () => {
+    const liveSet = registerMockObject("live_set", {
+      path: "live_set",
+      properties: { is_playing: 1 },
+    });
+
+    const stopped = stopPlaybackIfNeeded(LiveAPI.from("live_set"));
+
+    expect(stopped).toBe(true);
+    expect(liveSet.call).toHaveBeenCalledWith("stop_playing");
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "Playback stopped to modify locators",
+    );
+  });
+
+  it("does nothing when the set is stopped (is_playing 0 is not playing)", () => {
+    const liveSet = registerMockObject("live_set", {
+      path: "live_set",
+      properties: { is_playing: 0 },
+    });
+
+    const stopped = stopPlaybackIfNeeded(LiveAPI.from("live_set"));
+
+    expect(stopped).toBe(false);
+    expect(liveSet.call).not.toHaveBeenCalledWith("stop_playing");
+    expect(outlet).not.toHaveBeenCalled();
+  });
+});
+
+describe("waitForPlayheadPosition", () => {
+  /**
+   * Register a live_set whose current_song_time reads back as `position`.
+   * @param position - The value get("current_song_time") returns
+   * @returns A LiveAPI handle for the registered live_set
+   */
+  function liveSetAt(position: number): LiveAPI {
+    registerMockObject("live_set", {
+      path: "live_set",
+      properties: { current_song_time: position },
+    });
+
+    return LiveAPI.from("live_set");
+  }
+
+  beforeEach(() => {
+    // Clear any previous registration so each case controls the playhead.
+    registerMockObject("live_set", { path: "live_set" });
+  });
+
+  it("resolves without warning once the playhead reaches the target", async () => {
+    await waitForPlayheadPosition(liveSetAt(16), 16);
+
+    expect(outlet).not.toHaveBeenCalled();
+  });
+
+  it("warns when the playhead never reaches the target", async () => {
+    await waitForPlayheadPosition(liveSetAt(9999), 16);
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("Playhead position did not reach target 16"),
+    );
+  });
+
+  it("treats a difference of exactly the epsilon as not reached", async () => {
+    // SAME_TIME_EPSILON is 0.001; the tolerance is strict (< not <=).
+    await waitForPlayheadPosition(liveSetAt(0.001), 0);
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("did not reach target 0"),
+    );
+  });
+});

--- a/src/tools/live-set/tests/read-live-set-mixer.test.ts
+++ b/src/tools/live-set/tests/read-live-set-mixer.test.ts
@@ -81,33 +81,9 @@ describe("readLiveSet - mixer properties", () => {
   });
 
   it("excludes mixer properties from tracks when mixer is not included", () => {
-    setupLiveSetPathMappedMocks({
-      liveSetId: "live_set_id",
-      pathIdMap: {
-        "live_set tracks 0": "track1",
-        [String(livePath.masterTrack())]: "master",
-      },
-      objects: {
-        LiveSet: {
-          name: "Mixer Test Set",
-          tracks: children("track1"),
-          return_tracks: children(),
-          scenes: [],
-        },
-        "live_set tracks 0": {
-          has_midi_input: 1,
-          name: "Test Track",
-          mixer_device: children("mixer_1"),
-          clip_slots: [],
-          devices: [],
-        },
-        [String(livePath.masterTrack())]: {
-          has_midi_input: 0,
-          name: "Master",
-          devices: [],
-        },
-      },
-    });
+    // Full mixer-param mocks are registered, so gainDb/pan WOULD appear if the
+    // "mixer" include were (wrongly) propagated — guarding the includeMixer gate.
+    setupSingleTrackMixerMock({ displayValue: -6, panValue: 0.5 });
 
     const result = readLiveSet({
       include: ["tracks"],

--- a/src/tools/live-set/tests/update-live-set-locator-operations.test.ts
+++ b/src/tools/live-set/tests/update-live-set-locator-operations.test.ts
@@ -25,7 +25,7 @@ describe("updateLiveSet - locator operations", () => {
 
   describe("create locator", () => {
     it("should create locator at specified position", async () => {
-      setupLocatorCreationMocks(liveSet, { time: 0 }); // 1|1 = 0 beats
+      const { newCue } = setupLocatorCreationMocks(liveSet, { time: 0 }); // 1|1 = 0 beats
 
       const result = await updateLiveSet({
         locatorOperation: "create",
@@ -34,6 +34,10 @@ describe("updateLiveSet - locator operations", () => {
 
       expect(liveSet.set).toHaveBeenCalledWith("current_song_time", 0);
       expect(liveSet.call).toHaveBeenCalledWith("set_or_delete_cue");
+      // No name provided → the name is not set (guard is `found && name != null`).
+      expect(newCue.set.mock.calls.filter((c) => c[0] === "name")).toHaveLength(
+        0,
+      );
       expect(result.locator).toStrictEqual({
         operation: "created",
         time: "1|1",
@@ -101,6 +105,10 @@ describe("updateLiveSet - locator operations", () => {
         time: "5|1",
         existingId: "locator-0",
       });
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("Locator already exists at 5|1"),
+      );
     });
 
     it("should skip if locatorTime is missing for create", async () => {
@@ -112,6 +120,10 @@ describe("updateLiveSet - locator operations", () => {
         operation: "skipped",
         reason: "missing_locatorTime",
       });
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        "locatorTime is required for create operation",
+      );
     });
   });
 
@@ -182,10 +194,45 @@ describe("updateLiveSet - locator operations", () => {
       });
 
       expect(liveSet.call).toHaveBeenCalledWith("set_or_delete_cue");
+      // Deletes run in reverse time order (32 before 0) so earlier indices
+      // don't shift out from under later deletes.
+      const cueTimeSets = liveSet.set.mock.calls
+        .filter((c) => c[0] === "current_song_time")
+        .map((c) => c[1]);
+
+      expect(cueTimeSets).toStrictEqual([32, 0]);
       expect(result.locator).toStrictEqual({
         operation: "deleted",
         count: 2,
         name: "Verse",
+      });
+    });
+
+    it("prefers locatorId over locatorName when both are given", async () => {
+      // The name-delete branch requires BOTH id and time to be null; with an id
+      // present we delete that single locator, never every cue sharing the name.
+      const result = await updateLiveSet({
+        locatorOperation: "delete",
+        locatorId: "locator-0",
+        locatorName: "Verse", // cue2 is "Verse" — must be ignored
+      });
+
+      expect(result.locator).toStrictEqual({
+        operation: "deleted",
+        id: "locator-0",
+      });
+    });
+
+    it("prefers locatorTime over locatorName when both are given", async () => {
+      const result = await updateLiveSet({
+        locatorOperation: "delete",
+        locatorTime: "5|1", // 16 beats → cue2
+        locatorName: "Intro", // must be ignored
+      });
+
+      expect(result.locator).toStrictEqual({
+        operation: "deleted",
+        time: "5|1",
       });
     });
 
@@ -198,6 +245,10 @@ describe("updateLiveSet - locator operations", () => {
         operation: "skipped",
         reason: "missing_identifier",
       });
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        "delete requires locatorId, locatorTime, or locatorName",
+      );
     });
 
     it("should skip if locator ID not found", async () => {
@@ -212,6 +263,10 @@ describe("updateLiveSet - locator operations", () => {
         reason: "locator_not_found",
         id: "locator-99",
       });
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("Locator not found: locator-99"),
+      );
     });
 
     it("should skip if no locator at specified time", async () => {
@@ -226,6 +281,10 @@ describe("updateLiveSet - locator operations", () => {
         reason: "locator_not_found",
         time: "100|1",
       });
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("No locator found at position: 100|1"),
+      );
     });
 
     it("should skip if no locators match name", async () => {
@@ -240,6 +299,10 @@ describe("updateLiveSet - locator operations", () => {
         reason: "no_locators_found",
         name: "NonExistent",
       });
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("No locators found with name: NonExistent"),
+      );
     });
   });
 
@@ -295,6 +358,10 @@ describe("updateLiveSet - locator operations", () => {
         operation: "skipped",
         reason: "missing_locatorName",
       });
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        "locatorName is required for rename operation",
+      );
     });
 
     it("should skip if no identifier provided for rename", async () => {
@@ -307,6 +374,10 @@ describe("updateLiveSet - locator operations", () => {
         operation: "skipped",
         reason: "missing_identifier",
       });
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        "rename requires locatorId or locatorTime",
+      );
     });
 
     it("should skip if locator ID not found for rename", async () => {
@@ -321,6 +392,10 @@ describe("updateLiveSet - locator operations", () => {
         reason: "locator_not_found",
         id: "locator-99",
       });
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("locator not found: locator-99"),
+      );
     });
 
     it("should skip if no locator found at specified time for rename", async () => {
@@ -335,6 +410,10 @@ describe("updateLiveSet - locator operations", () => {
         reason: "locator_not_found",
         time: "100|1",
       });
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("no locator found at position: 100|1"),
+      );
     });
   });
 

--- a/src/tools/live-set/tests/update-live-set.test.ts
+++ b/src/tools/live-set/tests/update-live-set.test.ts
@@ -53,6 +53,15 @@ describe("updateLiveSet", () => {
       id: "live_set_id",
       tempo: 140,
     });
+    // scale was not provided → applyScale must not run (it would warn on the
+    // undefined scale via its parse-error path).
+    expect(outlet).not.toHaveBeenCalled();
+  });
+
+  it("throws for an unknown locator operation", async () => {
+    await expect(
+      updateLiveSet({ locatorOperation: "bogus" as never }),
+    ).rejects.toThrow("Unknown locator operation: bogus");
   });
 
   it("should warn and skip for invalid tempo", async () => {

--- a/src/tools/scene/tests/capture-scene.test.ts
+++ b/src/tools/scene/tests/capture-scene.test.ts
@@ -102,6 +102,61 @@ describe("captureScene", () => {
     );
   });
 
+  it("does not select a scene when sceneIndex is omitted", () => {
+    registerMockObject("live_set", {
+      path: livePath.liveSet,
+      properties: { tracks: [] },
+    });
+    const appView = registerMockObject("live_set/view", {
+      path: livePath.view.song,
+    });
+
+    registerMockObject("live_set/view/selected_scene", {
+      path: livePath.scene(1),
+    });
+    registerMockObject("live_set/scenes/2", { path: livePath.scene(2) });
+
+    captureScene();
+
+    expect(appView.set).not.toHaveBeenCalled();
+  });
+
+  it("does not set a name when none is provided", () => {
+    registerMockObject("live_set", {
+      path: livePath.liveSet,
+      properties: { tracks: [] },
+    });
+    registerMockObject("live_set/view/selected_scene", {
+      path: livePath.scene(1),
+    });
+    const newScene = registerMockObject("live_set/scenes/2", {
+      path: livePath.scene(2),
+    });
+
+    captureScene();
+
+    // A guard mutated to `if (true)` would call set("name", undefined); a
+    // plain not.toHaveBeenCalledWith(..., anything()) can't see undefined.
+    expect(newScene.set.mock.calls.filter((c) => c[0] === "name")).toHaveLength(
+      0,
+    );
+  });
+
+  it("parses a two-digit selected scene index", () => {
+    registerMockObject("live_set", {
+      path: livePath.liveSet,
+      properties: { tracks: [] },
+    });
+    registerMockObject("live_set/view/selected_scene", {
+      path: livePath.scene(12),
+    });
+    registerMockObject("live_set/scenes/13", { path: livePath.scene(13) });
+
+    const result = captureScene();
+
+    expect(result.sceneIndex).toBe(13);
+  });
+
   it("should return captured clips with their IDs and track indices", () => {
     registerMockObject("live_set", {
       path: livePath.liveSet,

--- a/src/tools/scene/tests/create-scene.test.ts
+++ b/src/tools/scene/tests/create-scene.test.ts
@@ -176,6 +176,13 @@ describe("createScene", () => {
     ).toThrow(/would exceed the maximum allowed scenes/);
   });
 
+  it("allows creating scenes up to exactly the maximum", () => {
+    // Boundary: sceneIndex + count === MAX is allowed (> not >=).
+    expect(() =>
+      createScene({ sceneIndex: MAX_AUTO_CREATED_SCENES - 1, count: 1 }),
+    ).not.toThrow();
+  });
+
   it("should return single object for count=1 and array for count>1", () => {
     const singleResult = createScene({
       sceneIndex: 0,
@@ -273,6 +280,11 @@ describe("createScene", () => {
       expect(scene0.set).toHaveBeenCalledWith("name", "Intro");
       expect(scene1.set).toHaveBeenCalledWith("name", "Verse");
       expect(result).toHaveLength(2);
+      // The tool label prefixes the "extra names ignored" warning.
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("createScene: 3 names provided"),
+      );
     });
 
     it("should preserve commas in name when count is 1", () => {
@@ -431,6 +443,24 @@ describe("createScene", () => {
       });
     });
 
+    it.each([
+      ["color only", { color: "#FF0000" }, "color", 16711680],
+      ["tempo only", { tempo: 140 }, "tempo", 140],
+      [
+        "timeSignature only",
+        { timeSignature: "3/4" },
+        "time_signature_numerator",
+        3,
+      ],
+    ])(
+      "applies %s after capture (each guard operand is load-bearing)",
+      (_label, props, setKey, setValue) => {
+        createScene({ capture: true, ...props });
+
+        expect(capturedScene.set).toHaveBeenCalledWith(setKey, setValue);
+      },
+    );
+
     it("should handle disabled tempo and timeSignature in capture mode", () => {
       const result = createScene({
         capture: true,
@@ -526,6 +556,20 @@ describe("createScene", () => {
         sceneIndex: 0,
         focus: false,
       });
+
+      expect(selectMockRef.get()).not.toHaveBeenCalled();
+    });
+
+    it("should not call select when capturing with focus omitted", () => {
+      registerMockObject("live_set", {
+        path: livePath.liveSet,
+        properties: { tracks: [] },
+      });
+      registerMockObject("live_set/view/selected_scene", {
+        path: livePath.scene(1),
+      });
+
+      createScene({ capture: true });
 
       expect(selectMockRef.get()).not.toHaveBeenCalled();
     });

--- a/src/tools/scene/tests/read-scene.test.ts
+++ b/src/tools/scene/tests/read-scene.test.ts
@@ -169,6 +169,40 @@ describe("readScene", () => {
     });
   });
 
+  it("includes the scene color only when color is requested", () => {
+    setupLiveSetTracks([]);
+    setupScene(
+      "scene_c",
+      0,
+      defaultSceneConfig({ name: "Colored", color: 65280 }),
+    );
+
+    const withColor = readScene({ sceneIndex: 0, include: ["color"] });
+    const withoutColor = readScene({ sceneIndex: 0 });
+
+    expect(withColor.color).toBe("#00FF00");
+    expect(withoutColor).not.toHaveProperty("color");
+  });
+
+  it("filters empty clip slots and suppresses their per-clip warnings", () => {
+    setupLiveSetTracks(["track1", "track2"]);
+    setupScene("scene_f", 0, defaultSceneConfig({ name: "Filtered" }));
+    setupSessionClip("clip_0_0", 0, 0);
+    // track 1's slot is empty (non-existent clip)
+    registerMockObject("0", {
+      path: livePath.track(1).clipSlot(0).clip(),
+      type: "Clip",
+    });
+
+    const result = readScene({ sceneIndex: 0, include: ["clips"] });
+
+    expect(result.clips).toHaveLength(1);
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("no clip at trackIndex"),
+    );
+  });
+
   it("includes clip information when includeClips is true", () => {
     setupLiveSetTracks(["track1", "track2"]);
     setupScene("scene_0", 0, defaultSceneConfig({ name: "Scene with Clips" }));

--- a/src/tools/scene/tests/update-scene.test.ts
+++ b/src/tools/scene/tests/update-scene.test.ts
@@ -125,6 +125,35 @@ describe("updateScene", () => {
     });
   });
 
+  it("accepts boundary tempos of exactly 20 and 999", () => {
+    // Boundaries: 20 and 999 are valid (< 20 / > 999 are the reject bounds).
+    updateScene({ ids: "123", tempo: 20 });
+    expect(scene1.set).toHaveBeenCalledWith("tempo", 20);
+
+    updateScene({ ids: "456", tempo: 999 });
+    expect(scene2.set).toHaveBeenCalledWith("tempo", 999);
+  });
+
+  it("warns and skips a tempo above the maximum", async () => {
+    await withConsoleSpy((consoleSpy) => {
+      updateScene({ ids: "123", tempo: 1000 });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "scene tempo must be between 20.0 and 999.0 BPM (or -1 to disable)",
+      );
+      expect(scene1.set).not.toHaveBeenCalledWith("tempo", expect.any(Number));
+    });
+  });
+
+  it("warns with the tool label when more names than scenes are given", () => {
+    updateScene({ ids: "123,456", name: "A,B,C,D" });
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("updateScene: 4 names provided"),
+    );
+  });
+
   it("should disable time signature when 'disabled' is passed", () => {
     const result = updateScene({
       ids: "123",
@@ -320,6 +349,17 @@ describe("updateScene", () => {
     it("should not call select when focus=false", () => {
       updateScene({ ids: "123", name: "Test", focus: false });
 
+      expect(selectMockRef.get()).not.toHaveBeenCalled();
+    });
+
+    it("does not focus when every id was skipped", () => {
+      mockNonExistentObjects();
+
+      // updatedScenes is empty, so `length > 0` guards the focus block; a
+      // mutated `>= 0`/`true` would enter it and crash on `.at(-1).id`.
+      const result = updateScene({ ids: "nonexistent", focus: true });
+
+      expect(result).toStrictEqual([]);
       expect(selectMockRef.get()).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
Triages the four read-op / small tool domains together — the AJM-670 follow-on to the write-op tier (AJM-668). **Test-only** changes plus per-domain `break` floors in `config/mutation-scopes.mjs` and a `dev/Mutation-Testing.md` baseline section. No product code touched.

## Results

| Domain      | Baseline | Triaged     | `break` | Survivors (from) | Files |
| ----------- | -------- | ----------- | ------- | ---------------- | ----- |
| `advanced`  | 96.50%   | **98.60%**  | 97      | 2 (from 5)       | 1     |
| `core`      | 94.53%   | **100.00%** | 99      | 0 (from 7)       | 3     |
| `scene`     | 88.63%   | **97.66%**  | 96      | 7 (from 34)      | 5     |
| `live-set`  | 87.38%   | **99.07%**  | 98      | 4 (from 54)      | 4     |

All four gates verified green (`npm run mutation -- advanced core scene live-set` exits 0).

## Dominant levers

- **Warn-and-skip message gaps** (same shape as `device`/`track`): update tools `console.warn` then return a `{operation:"skipped", reason}` object, but tests asserted only the returned object, never the warning text. Adding `expect(outlet).toHaveBeenCalledWith(1, expect.stringContaining(...))` killed ~16 blanked-message survivors in `live-set` locators alone.
- **Direct unit tests of exported helpers** only exercised transitively: `stopPlaybackIfNeeded` + `waitForPlayheadPosition` (polling predicate, success/failure warn, epsilon boundary) took `update-live-set-locator-helpers.ts` from 75.8% → 98.7%.

## Remaining survivors (bucket 2/3, documented)

`advanced`'s unreachable `default:` throw, `scene`'s always-≥1 length guards / self-guarding pad loop / `parseInt` NaN-equivalence, `live-set`'s `waitUntil({})` (defaults *are* 10/10) and the earlier-caught `locatorName != null` operand. Full triage in `dev/Mutation-Testing.md`.

Only the `shared` domain (`src/tools/shared`) remains untriaged after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)