### PR TITLE
test(mutation): triage sharedRuntime (src/shared) scope

### DIFF
--- a/config/mutation-scopes.mjs
+++ b/config/mutation-scopes.mjs
@@ -58,6 +58,24 @@ const NOTATION_GLOBS = [
   "!src/notation/**/peggy-parser-types.ts",
 ];
 
+// src/shared holds cross-cutting utility modules (pitch, notation, compact
+// serializer/parser, path builders, mcp-response, config, error-utils, v8
+// console/sleep, silent-wav, version-check) imported by both the Node MCP
+// server and the V8 Max runtime. It is NOT under src/tools/, so toolDomain()
+// can't build its globs; and its scope key can't be `shared` — that already
+// means src/tools/shared — hence `sharedRuntime`. Same exclusions as a tool
+// domain (tests, test/mock helpers, types-only) minus `.def.ts`/`*-disabled.ts`
+// (no tool defs or feature-flag stubs live here); all are future-proofing —
+// src/shared currently has none of them.
+const SHARED_RUNTIME_GLOBS = [
+  "src/shared/**/*.ts",
+  "!src/shared/**/*.test.ts",
+  "!src/shared/**/tests/**",
+  "!src/shared/**/*-test-helpers.ts",
+  "!src/shared/**/*-mock-helpers.ts",
+  "!src/shared/**/types.ts",
+];
+
 // Tool domains: one subdirectory each under src/tools/ (src/tools/constants.ts
 // is a plain root-level constants module, intentionally left unscoped).
 const TOOL_DOMAINS = [
@@ -90,8 +108,16 @@ const TOOL_DOMAIN_BREAKS = {
   "live-set": 98, // triaged 2026-07-15 at 99.07% (see dev/Mutation-Testing.md)
 };
 
+// The sharedRuntime (src/shared) break gate. Triaged 2026-07-15 at 94.94%; the
+// floor sits ~1 point below for run-to-run timeout-classification variance
+// (matching notation's ratchet). Remaining survivors are all equivalent /
+// defensive / static-init mutants (see dev/Mutation-Testing.md).
+const SHARED_RUNTIME_BREAK = 94;
+
 export const SCOPES = {
   notation: { mutate: NOTATION_GLOBS, break: 86 },
+  // src/shared: baseline mode (break: null) until triaged, then earns a floor.
+  sharedRuntime: { mutate: SHARED_RUNTIME_GLOBS, break: SHARED_RUNTIME_BREAK },
   ...Object.fromEntries(
     TOOL_DOMAINS.map((name) => [
       name,
@@ -103,5 +129,5 @@ export const SCOPES = {
 // Named groups the runner expands into multiple scopes.
 export const SCOPE_GROUPS = {
   tools: [...TOOL_DOMAINS],
-  all: ["notation", ...TOOL_DOMAINS],
+  all: ["notation", "sharedRuntime", ...TOOL_DOMAINS],
 };

--- a/dev/Mutation-Testing.md
+++ b/dev/Mutation-Testing.md
@@ -17,9 +17,10 @@ steps" below.
 ```bash
 npm run mutation                 # default scope: notation
 npm run mutation -- clip         # one src/tools/ domain
+npm run mutation -- sharedRuntime # src/shared (cross-cutting utilities)
 npm run mutation -- tools        # every tool domain (group)
 npm run mutation -- notation clip
-npm run mutation -- all          # notation + every tool domain
+npm run mutation -- all          # notation + sharedRuntime + every tool domain
 ```
 
 Mutation testing is **scoped** and deliberately **not** part of `npm run check`
@@ -39,8 +40,14 @@ Scopes are defined in `config/mutation-scopes.mjs`:
   (`break: 89`), `actions` (`break: 90`), `device` (`break: 90`), `clip`
   (`break: 96`), `advanced` (`break: 97`), `core` (`break: 99`), `scene`
   (`break: 96`), `live-set` (`break: 98`). Only `shared` remains untriaged.
-- **Groups** — `tools` (all ten tool domains) and `all` (notation + tools),
-  expanded by the runner into their member scopes.
+- **`sharedRuntime`** — `src/shared/` (cross-cutting utilities shared by the
+  Node MCP server and the V8 Max runtime: pitch, notation identity, compact
+  serializer/parser, path builders, config, error/response utils, v8 console /
+  sleep, silent-wav, version-check). It is **not** under `src/tools/`, so it
+  uses its own glob const (`SHARED_RUNTIME_GLOBS`), and its scope key can't be
+  `shared` — that already means `src/tools/shared`. Triaged: `break: 94`.
+- **Groups** — `tools` (all ten tool domains) and `all` (notation +
+  `sharedRuntime` + tools), expanded by the runner into their member scopes.
 
 Mechanics:
 
@@ -592,6 +599,88 @@ Remaining survivors are bucket 2/3:
 | extendSong boundary + `"tracks"` child name; multi-word scale join; root/scale error lists | `update-live-set-helpers.test.ts`               |
 | readLiveSet mixer-include gate (full param mocks so it's observable)                       | `read-live-set-mixer.test.ts`                   |
 
+## Baseline (2026-07-15, `sharedRuntime` — `src/shared/`)
+
+The cross-cutting utility layer (12 mutated files) shared by both runtimes: the
+last non-`src/tools/` code triaged this pass. Full pass — Stryker 9.6.1, Node
+24, `coverageAnalysis: "perTest"`:
+
+| Metric        | Baseline | Triaged    | Gate (`break`) |
+| ------------- | -------- | ---------- | -------------- |
+| sharedRuntime | 89.48%   | **94.94%** | 94             |
+
+All test-only. Per-file movement (survivors from → to): `silent-wav-generator`
+37.0% → 92.6% (17 → 2), `compact-parser` 90.9% → 98.9% (16 → 2), `config` 83.3%
+→ 100%, `v8-max-console` 97.2% → 100%, `v8-sleep` 92.3% → 100%, `pitch` 89.2% →
+91.8% (25 → 19), `version-check` 75.3% → 79.5% (18 → 15). `compact-serializer`,
+`error-utils`, `live-api-path-builders`, `mcp-response-utils` were already 100%.
+
+Two dominant levers here (different from the write/read tiers' warn-and-skip
+gap):
+
+- **A module-level cache defeating per-test coverage.** `silent-wav-generator`'s
+  `ensureSilenceWav` caches via a module flag + on-disk file, so
+  `createSilentWav` ran at most once across the whole test file — every
+  byte-layout assertion hit the cache and Stryker attributed none of them to the
+  code that produced the bytes. Rewriting the tests to `vi.resetModules()` +
+  re-import per case (cold flag) and deleting the file first made the generator
+  actually run under each WAV-header assertion, killing 15 arithmetic/string
+  mutants.
+- **A too-broad `toThrow` regex.** `compact-parser`'s malformed-input cases
+  asserted `toThrow(/invalid compact literal|.../)`, which matches the shared
+  `Invalid compact literal:` wrapper — so every blanked `fail(...)` message and
+  every guard that fell through to a _different_ error still "threw" and
+  survived. Asserting the **specific** reason per case
+  (`/expected ':' after object key/`, `/unexpected trailing content/`, …) killed
+  all 8 message mutants plus the missing-colon and object-key branch guards.
+
+Remaining survivors are all bucket 2/3 (verified equivalent / defensive /
+Stryker-limited), no real gaps:
+
+- **`pitch` (19)** — `PITCH_CLASS_VALUES_LOWERCASE`'s builder arrow is a
+  **static module-init mutant with 0 coverage** (Stryker can't cover static
+  initializers under `perTest`); guard clauses in `numberToPitchClass` are
+  redundant with the trailing `PITCH_CLASS_NAMES[num] ?? null` (out-of-range
+  indices are `undefined` anyway); `quantizePitchToScale` / `clampToScaleBounds`
+  boundary and modulo mutants are masked by the double normalization
+  (`((x%12)+12)%12`) plus residue periodicity (the outward search always finds a
+  match within ≤6 semitones); the `\d+`→`\d` octave mutant is masked by the MIDI
+  range check (no in-range note has a 2-digit octave). `isValidNoteName` — which
+  has _no_ range check — did kill both of its regex mutants.
+- **`version-check` (15)** — the `checkForUpdate` response-shape guard cluster
+  is fully masked by the outer `try/catch` (a bad `data.tag_name` access throws
+  → caught → `null`) plus the downstream `typeof tagName !== "string"` check, so
+  every relaxation still returns `null`; the `hasPreReleaseSuffix` `v`-strip
+  mutants can't change `includes("-")` (stripping a `v` never adds/removes a
+  dash).
+- **A `perTest` attribution quirk** — Stryker does **not** attribute a test to a
+  guard mutant when that test _early-returns at the guard_ (confirmed via
+  `coveredBy`: the "returns null for non-strings" test is absent from
+  `noteNameToMidi`'s guard mutant, and `numberToPitchClass("0")` from its
+  guard). Those guards (`pitch` L151/L186) are therefore unkillable via
+  coverage, though the behavior _is_ tested.
+- **`silent-wav-generator` (2)** — `÷numChannels` ≡ `×numChannels` because
+  `numChannels === 1`. **`compact-parser` (2)** — `defineProperty` ≡ `obj[key]=`
+  for a normal key; the `parseString` `< length` → `<= length` boundary reads
+  `""` past end then fails identically. **`notation` (1)** — the
+  `typeof value === "string"` guard is redundant with `NOTATIONS.includes`
+  (always `false` for a non-string).
+
+### Gaps closed (`sharedRuntime`)
+
+| Gap (now killed)                                                                    | Test strengthened / added      |
+| ----------------------------------------------------------------------------------- | ------------------------------ |
+| WAV byte layout (sizes, byte/sample rates, chunk labels) + two-level cache behavior | `silent-wav-generator.test.ts` |
+| 8 blanked parser error messages + missing-colon / object-key branch guards          | `compact-parser.test.ts`       |
+| `__proto__` descriptor flags (writable/enumerable/configurable)                     | `compact-parser.test.ts`       |
+| `MIN_LIVE_VERSION` shape (empty-string mutant)                                      | `config.test.ts` (new)         |
+| `checkForUpdate` non-ok guard (payload that would otherwise succeed)                | `version-check.test.ts`        |
+| `isNewerVersion` 4th-part loop bound + leading-space-`v` trim                       | `version-check.test.ts`        |
+| `isValidNoteName` / `noteNameToMidi` regex anchors + multi-digit octave             | `pitch.test.ts`                |
+| `stepInScale` strict `< 0` / `> 127` MIDI-boundary clamps (sparse-scale cases)      | `pitch.test.ts`                |
+| `warn` multi-arg outlet join + Dict-without-`stringify` optional chaining           | `v8-max-console.test.ts`       |
+| `waitUntil` schedules a Task delay between polls (not a busy loop)                  | `v8-sleep.test.ts`             |
+
 ## Interpreting survivors
 
 Each survivor falls into one of three buckets — triage before acting:
@@ -610,16 +699,16 @@ wins, and a cross-check against the line-coverage gate.
 
 ## Status & next steps
 
-The `notation` scope is **ratcheted** (`thresholds.break = 86`), as are all nine
-triaged tool domains: the write-op tier `track` (`break: 85`), `session`
-(`break: 89`), `actions` (`break: 90`), `device` (`break: 90`), `clip`
-(`break: 96`), and the read-op / small tier `advanced` (`break: 97`), `core`
-(`break: 99`), `scene` (`break: 96`), `live-set` (`break: 98`). Only `shared`
-(`src/tools/shared`) remains in **baseline mode** (`break: null`, measure-only).
-The per-domain scope mechanism (`config/mutation-scopes.mjs` + the runner) is in
-place, so each `src/tools/` domain can be mutated on its own. Mutation testing
-stays off the per-PR hot path (a full pass is minutes). Remaining work (later
-releases):
+The `notation` scope is **ratcheted** (`thresholds.break = 86`), as is
+`sharedRuntime` (`src/shared/`, `break: 94`) and all nine triaged tool domains:
+the write-op tier `track` (`break: 85`), `session` (`break: 89`), `actions`
+(`break: 90`), `device` (`break: 90`), `clip` (`break: 96`), and the read-op /
+small tier `advanced` (`break: 97`), `core` (`break: 99`), `scene`
+(`break: 96`), `live-set` (`break: 98`). Only `shared` (`src/tools/shared`)
+remains in **baseline mode** (`break: null`, measure-only). The per-domain scope
+mechanism (`config/mutation-scopes.mjs` + the runner) is in place, so each area
+can be mutated on its own. Mutation testing stays off the per-PR hot path (a
+full pass is minutes). Remaining work (later releases):
 
 - Keep triaging the ~588 notation survivors, but expect diminishing returns: the
   dense clusters left are epsilon-boundary / warning-string / equivalent mutants
@@ -627,13 +716,16 @@ releases):
 - Raise each scope's `break` as its score climbs.
 - Only one `src/tools/` domain is left: `shared` (`src/tools/shared`, the
   biggest single domain — split by subarea rather than triaging in one PR). The
-  write-op tier (`track`, `session`, `actions`, `device`, `clip`) and the
-  read-op / small tier (`advanced`, `core`, `scene`, `live-set`) are done. Per
-  domain: run `npm run mutation -- <domain>`, close real gaps, flip that
-  domain's `break` from `null` to ~1 point below its triaged score (add it to
-  `TOOL_DOMAIN_BREAKS`). The big clean wins tend to be untested lookup/enum
+  write-op tier (`track`, `session`, `actions`, `device`, `clip`), the read-op /
+  small tier (`advanced`, `core`, `scene`, `live-set`), and `sharedRuntime` are
+  done. Per domain: run `npm run mutation -- <domain>`, close real gaps, flip
+  that domain's `break` from `null` to ~1 point below its triaged score (add it
+  to `TOOL_DOMAIN_BREAKS`). The big clean wins tend to be untested lookup/enum
   tables (as in notation's chord table) and warn-and-skip guards whose tests
   assert only the result, never the warning or the skipped write.
+- Two more non-`src/tools/` trees remain unmutated and would each need a fresh
+  glob set (not `toolDomain()`): `src/mcp-server/` and the V8 adapter code.
+  Model them on `SHARED_RUNTIME_GLOBS` and give each a non-colliding scope key.
 - Optionally wire a scheduled (nightly/weekly) non-blocking CI job once several
   domains have floors — full-tree runtime is hours, not minutes.
 

--- a/src/shared/tests/compact-parser.test.ts
+++ b/src/shared/tests/compact-parser.test.ts
@@ -222,9 +222,17 @@ describe("parseCompactJSLiteral - prototype pollution guard", () => {
     // prototype stays Object.prototype (a plain obj[key]= would mutate it).
     expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
     expect(Object.hasOwn(result, "__proto__")).toBe(true);
-    expect(
-      Object.getOwnPropertyDescriptor(result, "__proto__")?.value,
-    ).toStrictEqual({ polluted: 1 });
+
+    // The descriptor must be a plain writable/enumerable/configurable data
+    // property — exactly what JSON.parse produces (and what obj[key]= cannot).
+    const descriptor = Object.getOwnPropertyDescriptor(result, "__proto__");
+
+    expect(descriptor).toMatchObject({
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    expect(descriptor?.value).toStrictEqual({ polluted: 1 });
   });
 
   it("does not pollute Object.prototype", () => {
@@ -235,25 +243,29 @@ describe("parseCompactJSLiteral - prototype pollution guard", () => {
 });
 
 describe("parseCompactJSLiteral - malformed input throws", () => {
-  const cases: Array<[string, string]> = [
-    ["empty string", ""],
-    ["unterminated string", '"abc'],
-    ["trailing backslash", '"abc\\'],
-    ["missing colon", "{a 1}"],
-    ["bad object key", "{:1}"],
-    ["unclosed object", "{a:1"],
-    ["unclosed array", "[1,2"],
-    ["trailing content", "{}x"],
-    ["unexpected token", "{a:xyz}"],
-    ["invalid number", "-"],
-    ["bare keyword typo", "tru"],
+  // Each case asserts the SPECIFIC failure reason, not just the shared
+  // "Invalid compact literal:" wrapper — otherwise a blanked message (or a
+  // guard that falls through to a different error) would slip past unnoticed.
+  const cases: Array<[string, string, RegExp]> = [
+    ["empty string", "", /unexpected token/],
+    ["unterminated string", '"abc', /unterminated string/],
+    ["trailing backslash", '"abc\\', /unterminated string/],
+    ["missing colon", "{a 1}", /expected ':' after object key/],
+    ["bad object key", "{:1}", /expected an object key/],
+    ["unclosed object", "{a:1", /expected ',' or '}' in object/],
+    ["unclosed array", "[1,2", /expected ',' or ']' in array/],
+    ["trailing content", "{}x", /unexpected trailing content/],
+    ["unexpected token", "{a:xyz}", /unexpected token/],
+    ["invalid number", "-", /invalid number/],
+    ["bare keyword typo", "tru", /unexpected token/],
   ];
 
-  for (const [label, input] of cases) {
+  for (const [label, input, reason] of cases) {
     it(`throws on ${label}`, () => {
       expect(() => parseCompactJSLiteral(input)).toThrow(
-        /invalid compact literal|unexpected|json/i,
+        /invalid compact literal/i,
       );
+      expect(() => parseCompactJSLiteral(input)).toThrow(reason);
     });
   }
 });

--- a/src/shared/tests/config.test.ts
+++ b/src/shared/tests/config.test.ts
@@ -1,0 +1,28 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import {
+  MIN_LIVE_VERSION,
+  SAME_TIME_EPSILON,
+  VERSION,
+} from "#src/shared/config.ts";
+
+describe("config constants", () => {
+  it("VERSION is a semver-shaped string", () => {
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("MIN_LIVE_VERSION is a 3-part version with no 'v' prefix", () => {
+    // Consumed by the Live-version gate; an empty or malformed value would
+    // silently break the "your Live is too old" check.
+    expect(MIN_LIVE_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("SAME_TIME_EPSILON is a small positive position tolerance", () => {
+    expect(SAME_TIME_EPSILON).toBeGreaterThan(0);
+    expect(SAME_TIME_EPSILON).toBeLessThan(0.01);
+  });
+});

--- a/src/shared/tests/pitch.test.ts
+++ b/src/shared/tests/pitch.test.ts
@@ -183,6 +183,19 @@ describe("isValidNoteName", () => {
   it("returns false for empty string", () => {
     expect(isValidNoteName("")).toBe(false);
   });
+
+  it("anchors the match to the whole string (rejects surrounding garbage)", () => {
+    // The trailing `$` anchor must reject extra characters after the octave.
+    expect(isValidNoteName("C3x")).toBe(false);
+    expect(isValidNoteName("C3 ")).toBe(false);
+  });
+
+  it("accepts a multi-digit octave (format check, not range check)", () => {
+    // `\d+` (not `\d`) must accept more than one octave digit; isValidNoteName
+    // validates shape only, so out-of-MIDI-range octaves are still well-formed.
+    expect(isValidNoteName("C10")).toBe(true);
+    expect(isValidNoteName("C-10")).toBe(true);
+  });
 });
 
 describe("isValidPitchClassName", () => {
@@ -417,6 +430,13 @@ describe("noteNameToMidi", () => {
   it("returns null for invalid formats", () => {
     expect(noteNameToMidi("")).toBe(null);
     expect(noteNameToMidi("C##3")).toBe(null);
+  });
+
+  it("anchors the match to the whole string (rejects surrounding garbage)", () => {
+    // The `^`/`$` anchors must reject leading or trailing characters; without
+    // them the regex would find "C3" inside the input and mis-parse it.
+    expect(noteNameToMidi("xC3")).toBe(null);
+    expect(noteNameToMidi("C3x")).toBe(null);
   });
 
   it("returns null for non-strings", () => {
@@ -657,6 +677,25 @@ describe("stepInScale", () => {
     it("clamps when stepping far beyond range", () => {
       expect(stepInScale(120, 100, cMajorMask)).toBe(127);
       expect(stepInScale(5, -100, cMajorMask)).toBe(0);
+    });
+
+    it("clamps to the lowest in-scale pitch when stepping below MIDI 0", () => {
+      // Sparse scale: only pitch class 11 (B). The lowest B is 11, so stepping
+      // down from it hits `current < 0` (strict) and clamps back to 11. If that
+      // boundary were `<= 0`, current === 0 would clamp early to 0 (out of scale).
+      const bOnlyMask = scaleIntervalsToPitchClassMask([0], 11);
+
+      expect(stepInScale(11, -1, bOnlyMask)).toBe(11);
+    });
+
+    it("clamps to the highest in-scale pitch when stepping above MIDI 127", () => {
+      // Sparse scale: only pitch class 11 (B). The highest B is 119, so stepping
+      // up from it hits `current > 127` (strict) and clamps back to 119. If that
+      // boundary were `>= 127`, current === 127 would clamp early to 127 (out of
+      // scale).
+      const bOnlyMask = scaleIntervalsToPitchClassMask([0], 11);
+
+      expect(stepInScale(119, 1, bOnlyMask)).toBe(119);
     });
   });
 

--- a/src/shared/tests/silent-wav-generator.test.ts
+++ b/src/shared/tests/silent-wav-generator.test.ts
@@ -1,78 +1,115 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import fs from "node:fs";
-import { describe, it, expect } from "vitest";
-import {
-  ensureSilenceWav,
-  SILENCE_WAV,
-} from "#src/shared/silent-wav-generator.ts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface WavModule {
+  ensureSilenceWav: () => string;
+  SILENCE_WAV: string;
+}
+
+// Reset the module registry so the module-level `silenceWavGenerated` flag
+// starts cold, then re-import. The two-level cache (in-memory flag + on-disk
+// file) otherwise makes `createSilentWav` run at most once across the whole
+// file, which hides every byte-layout assertion from the code that produced it.
+async function loadFresh(): Promise<WavModule> {
+  vi.resetModules();
+
+  return await import("#src/shared/silent-wav-generator.ts");
+}
 
 describe("silent-wav-generator", () => {
-  describe("ensureSilenceWav", () => {
-    it("should create file when it doesn't exist", () => {
-      // Delete the file to test creation path
-      if (fs.existsSync(SILENCE_WAV)) {
-        fs.unlinkSync(SILENCE_WAV);
-      }
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
-      const wavPath = ensureSilenceWav();
+  describe("createSilentWav byte layout", () => {
+    // Force createSilentWav to run under the assertions (cold flag + no file),
+    // then read back the bytes it wrote.
+    async function freshWavBuffer(): Promise<Buffer> {
+      const { ensureSilenceWav, SILENCE_WAV } = await loadFresh();
 
-      expect(wavPath).toBe(SILENCE_WAV);
-      expect(fs.existsSync(wavPath)).toBe(true);
-    });
+      if (fs.existsSync(SILENCE_WAV)) fs.unlinkSync(SILENCE_WAV);
 
-    it("should create and return path to silent WAV file", () => {
-      const wavPath = ensureSilenceWav();
+      return fs.readFileSync(ensureSilenceWav());
+    }
 
-      expect(wavPath).toBe(SILENCE_WAV);
-      expect(fs.existsSync(wavPath)).toBe(true);
-    });
+    it("writes an 8864-byte file with RIFF/WAVE/fmt/data chunks", async () => {
+      const buffer = await freshWavBuffer();
 
-    it("should create a valid WAV file with expected size", () => {
-      const wavPath = ensureSilenceWav();
-      const stats = fs.statSync(wavPath);
-
-      // Expected: 44 byte header + 8820 byte data = 8864 bytes total
-      expect(stats.size).toBe(8864);
-    });
-
-    it("should create a file with valid WAV header", () => {
-      const wavPath = ensureSilenceWav();
-      const buffer = fs.readFileSync(wavPath);
-
-      // Check RIFF header
+      // 44-byte header + 8820-byte data (4410 mono 16-bit samples).
+      expect(buffer).toHaveLength(8864);
       expect(buffer.toString("ascii", 0, 4)).toBe("RIFF");
+      expect(buffer.readUInt32LE(4)).toBe(8856); // 36 + dataSize
       expect(buffer.toString("ascii", 8, 12)).toBe("WAVE");
-
-      // Check fmt chunk
       expect(buffer.toString("ascii", 12, 16)).toBe("fmt ");
-
-      // Check data chunk
       expect(buffer.toString("ascii", 36, 40)).toBe("data");
+      expect(buffer.readUInt32LE(40)).toBe(8820); // dataSize
+      // Payload is silence (all zero bytes).
+      expect(buffer.subarray(44).every((byte) => byte === 0)).toBe(true);
     });
 
-    it("should return same path on subsequent calls", () => {
-      const firstPath = ensureSilenceWav();
-      const secondPath = ensureSilenceWav();
+    it("encodes the PCM fmt fields (rate, channels, byte/block sizes)", async () => {
+      const buffer = await freshWavBuffer();
 
-      expect(firstPath).toBe(secondPath);
-      expect(firstPath).toBe(SILENCE_WAV);
+      expect(buffer.readUInt32LE(16)).toBe(16); // PCM header size
+      expect(buffer.readUInt16LE(20)).toBe(1); // audio format PCM
+      expect(buffer.readUInt16LE(22)).toBe(1); // channels (mono)
+      expect(buffer.readUInt32LE(24)).toBe(44100); // sample rate
+      expect(buffer.readUInt32LE(28)).toBe(88200); // byte rate = 44100*1*16/8
+      expect(buffer.readUInt16LE(32)).toBe(2); // block align = 1*16/8
+      expect(buffer.readUInt16LE(34)).toBe(16); // bits per sample
+    });
+  });
+
+  describe("ensureSilenceWav two-level caching", () => {
+    it("creates the file when neither the flag nor the file is present", async () => {
+      const { ensureSilenceWav, SILENCE_WAV } = await loadFresh();
+
+      if (fs.existsSync(SILENCE_WAV)) fs.unlinkSync(SILENCE_WAV);
+
+      const writeSpy = vi.spyOn(fs, "writeFileSync");
+      const wavPath = ensureSilenceWav();
+
+      expect(writeSpy).toHaveBeenCalledTimes(1);
+      expect(wavPath).toBe(SILENCE_WAV);
+      expect(fs.existsSync(wavPath)).toBe(true);
     });
 
-    it("should use caching to avoid recreating file", () => {
-      // Call multiple times - all should succeed and return same path
-      const firstPath = ensureSilenceWav();
-      const secondPath = ensureSilenceWav();
-      const thirdPath = ensureSilenceWav();
+    it("skips all filesystem access once the in-memory flag is warm", async () => {
+      const { ensureSilenceWav, SILENCE_WAV } = await loadFresh();
 
-      expect(firstPath).toBe(SILENCE_WAV);
+      ensureSilenceWav(); // warms the in-memory flag (and writes the file)
+
+      const existsSpy = vi.spyOn(fs, "existsSync");
+      const writeSpy = vi.spyOn(fs, "writeFileSync");
+      const secondPath = ensureSilenceWav();
+
+      // The flag short-circuits before any fs access on the second call.
+      expect(existsSpy).not.toHaveBeenCalled();
+      expect(writeSpy).not.toHaveBeenCalled();
       expect(secondPath).toBe(SILENCE_WAV);
-      expect(thirdPath).toBe(SILENCE_WAV);
+    });
 
-      // File should exist
+    it("does not rewrite the file when it exists on disk but the flag is cold", async () => {
+      const warm = await loadFresh();
+
+      warm.ensureSilenceWav(); // ensure the file exists on disk
+
+      // Fresh module → flag cold again, but the file survives on disk.
+      const { ensureSilenceWav, SILENCE_WAV } = await loadFresh();
+
       expect(fs.existsSync(SILENCE_WAV)).toBe(true);
+
+      const writeSpy = vi.spyOn(fs, "writeFileSync");
+
+      ensureSilenceWav();
+
+      // File already present → the existsSync guard skips createSilentWav.
+      expect(writeSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/shared/tests/v8-max-console.test.ts
+++ b/src/shared/tests/v8-max-console.test.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import {
@@ -159,6 +160,21 @@ describe("v8-max-console", () => {
 
       delete g.Dict;
     });
+
+    it("tolerates a Dict without a stringify method (optional chaining)", () => {
+      // `stringify?.()` must short-circuit to undefined instead of throwing when
+      // a Dict-shaped object has no stringify method.
+      class Dict {
+        name = "emptyDict";
+      }
+
+      g.Dict = Dict;
+
+      log(new Dict());
+      expect(consoleLogSpy).toHaveBeenCalledWith('Dict("emptyDict") undefined');
+
+      delete g.Dict;
+    });
   });
 
   describe("error", () => {
@@ -234,6 +250,16 @@ describe("v8-max-console", () => {
       warn("test warning");
       expect(mockOutlet).toHaveBeenCalledWith(1, "test warning");
       expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it("joins multiple outlet arguments with spaces", () => {
+      const mockOutlet = vi.fn();
+
+      g.outlet = mockOutlet;
+
+      warn("first", 42, "third");
+      // Multiple args are join(" ")-ed into one outlet string, not concatenated.
+      expect(mockOutlet).toHaveBeenCalledWith(1, "first 42 third");
     });
   });
 });

--- a/src/shared/tests/v8-sleep.test.ts
+++ b/src/shared/tests/v8-sleep.test.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -78,6 +79,26 @@ describe("v8-sleep", () => {
       const result = await waitUntil(predicate);
 
       expect(result).toBe(true);
+    });
+
+    it("sleeps via a scheduled Task between polls (not a busy loop)", async () => {
+      // The private `sleep` must actually schedule a Task with the polling
+      // interval; a no-op sleep would poll synchronously and never schedule.
+      const scheduleSpy = vi.spyOn(MockTask.prototype, "schedule");
+      let callCount = 0;
+      const predicate = vi.fn().mockImplementation(() => {
+        callCount++;
+
+        return callCount >= 2;
+      });
+
+      const resultPromise = waitUntil(predicate, { pollingInterval: 25 });
+
+      await vi.runAllTimersAsync();
+      await resultPromise;
+
+      expect(scheduleSpy).toHaveBeenCalledWith(25);
+      scheduleSpy.mockRestore();
     });
   });
 });

--- a/src/shared/tests/version-check.test.ts
+++ b/src/shared/tests/version-check.test.ts
@@ -56,6 +56,20 @@ describe("isNewerVersion", () => {
     expect(isNewerVersion("12.0.1", "12")).toBe(false);
   });
 
+  it("ignores a 4th version part (comparison stops at major.minor.patch)", () => {
+    // The loop compares exactly 3 parts. A 4th component must not tip the
+    // result — otherwise `for (i < 3)` widening to `i <= 3` would leak in.
+    expect(isNewerVersion("1.2.3", "1.2.3.4")).toBe(false);
+    expect(isNewerVersion("1.2.3.9", "1.2.3")).toBe(false);
+  });
+
+  it("trims before stripping a 'v' prefix (leading whitespace + v)", () => {
+    // parseVersionParts must .trim() first so the "v" strip still fires; a
+    // leading space would otherwise leave "v2" → parseInt → 0 and flip the sign.
+    expect(isNewerVersion("1.0.0", " v2.0.0")).toBe(true);
+    expect(isNewerVersion(" v2.0.0", "1.0.0")).toBe(false);
+  });
+
   it("treats a malformed (non-numeric) part as 0, not as equal-to-anything", () => {
     // A part with no leading digits parses to NaN. NaN must normalize to 0 so the
     // comparison still resolves at that position — otherwise NaN makes both `l > c`
@@ -141,7 +155,10 @@ describe("checkForUpdate", () => {
   });
 
   it("returns null on non-200 response", async () => {
-    mockFetchResponse({}, false);
+    // Body carries a genuinely-newer tag: only the `!response.ok` guard keeps
+    // this null. A mutant that drops that guard would fall through and return
+    // the version, so the payload must be one that would otherwise "succeed".
+    mockFetchResponse({ tag_name: "v2.0.0" }, false);
     expect(await checkForUpdate("1.0.0")).toBeNull();
   });
 


### PR DESCRIPTION
Adds a `sharedRuntime` mutation-testing scope for `src/shared/` — the cross-cutting utility layer (pitch, notation identity, compact serializer/parser, path builders, config, error/response utils, v8 console/sleep, silent-wav, version-check) shared by both the Node MCP server and the V8 Max runtime. It's the last non-`src/tools/` tree triaged this pass.

Because `src/shared` isn't under `src/tools/`, it can't use `toolDomain()`; and its scope key can't be `shared` (that already means `src/tools/shared`), so it gets its own `SHARED_RUNTIME_GLOBS` const and a distinct key.

## Result
**89.48% → 94.94%** (`break: 94`), **test/config/docs only — no product code**.

Per-file movement (survivors from → to):
| File | Before | After |
| --- | --- | --- |
| `silent-wav-generator` | 37.0% | 92.6% (17 → 2) |
| `compact-parser` | 90.9% | 98.9% (16 → 2) |
| `config` | 83.3% | 100% |
| `v8-max-console` | 97.2% | 100% |
| `v8-sleep` | 92.3% | 100% |
| `pitch` | 89.2% | 91.8% (25 → 19) |
| `version-check` | 75.3% | 79.5% (18 → 15) |

## Dominant levers
- **A module-level cache defeating per-test coverage** — `ensureSilenceWav`'s flag + on-disk cache meant `createSilentWav` ran once across the whole test file, so every byte-layout assertion hit the cache and Stryker attributed none of them. Resetting the module per case makes the generator run under each WAV-header assertion.
- **A too-broad `toThrow` regex** — `compact-parser`'s malformed-input cases matched only the shared `Invalid compact literal:` wrapper, so blanked `fail(...)` messages and fall-through guards survived. Now each case asserts its specific reason.

## Remaining survivors
All bucket 2/3 (verified equivalent / defensive / static-init) or a Stryker `perTest` attribution quirk where a test that early-returns at a guard isn't attributed to that guard's mutant — documented in `dev/Mutation-Testing.md`.

## Verification
- `npm run check` ✓ (9650 tests, coverage above thresholds)
- `npm run check:build` ✓
- `npm run mutation -- sharedRuntime` ✓ — "Final mutation score of 94.94 is greater than or equal to break threshold 94"

🤖 Generated with [Claude Code](https://claude.com/claude-code)