### PR TITLE
test(mutation): triage mcpServer (src/mcp-server), add scope + ratchet break

### DIFF
--- a/config/mutation-scopes.mjs
+++ b/config/mutation-scopes.mjs
@@ -76,6 +76,31 @@ const SHARED_RUNTIME_GLOBS = [
   "!src/shared/**/types.ts",
 ];
 
+// src/mcp-server is the Node-for-Max side: the Express app, MCP server wiring,
+// REST routes, the live-library SQLite reader, markdown/memory/skill override
+// stores, and the RPC protocol to the V8 runtime. It is NOT under src/tools/ so
+// toolDomain() can't build its globs; its scope key is `mcpServer` (camelCase,
+// non-colliding with any tool domain). Same exclusions as sharedRuntime (tests,
+// test/mock helpers, types-only) minus `.def.ts`/`*-disabled.ts` (no tool defs
+// or feature-flag stubs live here). `library-types.ts` is intentionally NOT
+// excluded — it carries real logic (clampLibraryLimit + limit constants), not
+// just type aliases.
+const MCP_SERVER_GLOBS = [
+  "src/mcp-server/**/*.ts",
+  "!src/mcp-server/**/*.test.ts",
+  "!src/mcp-server/**/tests/**",
+  "!src/mcp-server/**/*-test-helpers.ts",
+  "!src/mcp-server/**/*-mock-helpers.ts",
+  "!src/mcp-server/**/types.ts",
+  // mcp-server.ts is the Node-for-Max bundle entry point: importing it runs
+  // module-load side effects (imports `max-api`, registers Node routes, binds
+  // `.listen()`), so it's exercised by the e2e suites, not unit tests, and is
+  // already coverage-excluded in vitest.config.ts. Exclude it here too (same
+  // rationale as `.def.ts`/`*-disabled.ts` in toolDomain) — its ~57 mutants are
+  // all NoCoverage bootstrap wiring, not assertable behavior.
+  "!src/mcp-server/mcp-server.ts",
+];
+
 // Tool domains: one subdirectory each under src/tools/ (src/tools/constants.ts
 // is a plain root-level constants module, intentionally left unscoped).
 const TOOL_DOMAINS = [
@@ -114,10 +139,20 @@ const TOOL_DOMAIN_BREAKS = {
 // defensive / static-init mutants (see dev/Mutation-Testing.md).
 const SHARED_RUNTIME_BREAK = 94;
 
+// The mcpServer (src/mcp-server) break gate. Triaged 2026-07-15 at 88.51% (the
+// bundle entry point mcp-server.ts is excluded); the floor sits ~1.5 points
+// below — this domain is infra-heavy (Express wiring, Max.outlet device
+// notifications, dynamic SQL) with several timeout-prone SQLite/fs tests, so it
+// carries a slightly wider buffer than the pure-logic scopes. Remaining
+// survivors are overwhelmingly bucket 2/3: device-notification side-effects,
+// dynamic SQL builders, log/header strings, readdir-order-equivalent sorts, and
+// the perTest guard-attribution quirk (see dev/Mutation-Testing.md).
+const MCP_SERVER_BREAK = 87;
+
 export const SCOPES = {
   notation: { mutate: NOTATION_GLOBS, break: 86 },
-  // src/shared: baseline mode (break: null) until triaged, then earns a floor.
   sharedRuntime: { mutate: SHARED_RUNTIME_GLOBS, break: SHARED_RUNTIME_BREAK },
+  mcpServer: { mutate: MCP_SERVER_GLOBS, break: MCP_SERVER_BREAK },
   ...Object.fromEntries(
     TOOL_DOMAINS.map((name) => [
       name,
@@ -129,5 +164,5 @@ export const SCOPES = {
 // Named groups the runner expands into multiple scopes.
 export const SCOPE_GROUPS = {
   tools: [...TOOL_DOMAINS],
-  all: ["notation", "sharedRuntime", ...TOOL_DOMAINS],
+  all: ["notation", "sharedRuntime", "mcpServer", ...TOOL_DOMAINS],
 };

--- a/dev/Mutation-Testing.md
+++ b/dev/Mutation-Testing.md
@@ -18,9 +18,10 @@ steps" below.
 npm run mutation                 # default scope: notation
 npm run mutation -- clip         # one src/tools/ domain
 npm run mutation -- sharedRuntime # src/shared (cross-cutting utilities)
+npm run mutation -- mcpServer    # src/mcp-server (Node-for-Max server)
 npm run mutation -- tools        # every tool domain (group)
 npm run mutation -- notation clip
-npm run mutation -- all          # notation + sharedRuntime + every tool domain
+npm run mutation -- all          # notation + sharedRuntime + mcpServer + every tool domain
 ```
 
 Mutation testing is **scoped** and deliberately **not** part of `npm run check`
@@ -46,8 +47,16 @@ Scopes are defined in `config/mutation-scopes.mjs`:
   sleep, silent-wav, version-check). It is **not** under `src/tools/`, so it
   uses its own glob const (`SHARED_RUNTIME_GLOBS`), and its scope key can't be
   `shared` — that already means `src/tools/shared`. Triaged: `break: 94`.
+- **`mcpServer`** — `src/mcp-server/` (the Node-for-Max side: the Express app,
+  MCP server wiring, REST routes, the live-library SQLite reader, the
+  markdown/memory/skill override stores, and the RPC protocol to the V8
+  runtime). Also **not** under `src/tools/`, so it uses its own glob const
+  (`MCP_SERVER_GLOBS`) and the camelCase key `mcpServer`. The bundle entry point
+  `mcp-server.ts` is excluded (it runs module-load side effects wired to
+  `max-api` and is already coverage-excluded). Triaged: `break: 87`.
 - **Groups** — `tools` (all ten tool domains) and `all` (notation +
-  `sharedRuntime` + tools), expanded by the runner into their member scopes.
+  `sharedRuntime` + `mcpServer` + tools), expanded by the runner into their
+  member scopes.
 
 Mechanics:
 
@@ -681,6 +690,79 @@ Stryker-limited), no real gaps:
 | `warn` multi-arg outlet join + Dict-without-`stringify` optional chaining           | `v8-max-console.test.ts`       |
 | `waitUntil` schedules a Task delay between polls (not a busy loop)                  | `v8-sleep.test.ts`             |
 
+## Baseline (2026-07-15, `mcpServer` — `src/mcp-server/`)
+
+The Node-for-Max server layer (58 mutated files) — the Express app, MCP server
+wiring, REST routes, the live-library SQLite reader, the markdown/memory/skill
+override stores, and the RPC protocol to the V8 runtime. Full pass — Stryker
+9.6.1, Node 24, `coverageAnalysis: "perTest"`:
+
+| Metric    | Baseline | Triaged    | Gate (`break`) |
+| --------- | -------- | ---------- | -------------- |
+| mcpServer | 88.14%   | **88.51%** | 87             |
+
+The raw all-files run scores 86.31%, but the bundle entry point `mcp-server.ts`
+(0% covered, 57 all-NoCoverage mutants) is **excluded** from the scope:
+importing it runs module-load side effects wired to `max-api` (registers Node
+routes, binds `.listen()`), so it's e2e-territory and is already
+coverage-excluded in `vitest.config.ts` — the same rationale `toolDomain()` uses
+for `.def.ts` / `*-disabled.ts`. Excluding it puts the honest baseline at
+88.14%; the triage below lifts it to 88.51%, all test-only.
+
+This is the most infrastructure-heavy domain triaged so far, so the clean-gap
+ceiling is low and the surviving mutants are dominated by bucket 2/3 categories
+rather than real gaps:
+
+- **Device-notification side effects.** `create-express-app.ts` alone holds 60
+  survivors, almost all `Max.outlet("config", <key>, <value>)` emissions and the
+  `outlets.push(() => …)` arrows that batch them. Tests assert the resulting
+  config **state**, not that each notification fires with an exact channel/key
+  string — asserting those would over-fit the device-sync protocol.
+- **Dynamic SQL builders.** The live-library query files (`candidate-query`,
+  `find-similar`, `find-duplicates`, `library-search`) build `WHERE` clauses and
+  `?`-placeholder lists by string concatenation; the
+  `where.length > 0 ? "WHERE " + … : ""` conditionals and placeholder joins
+  survive because the tests assert query **results** against a fixture DB, not
+  the exact SQL text.
+- **The `perTest` guard-attribution quirk** (also seen in `sharedRuntime`).
+  Stryker does not attribute a test to an `if`-guard mutant when that test
+  early-returns at the guard, so several guards whose behavior _is_ directly
+  unit-tested stay unkillable — confirmed via `coveredBy`:
+  `resolveClipSubtype`'s `fileType !== ALC || subtype == null` guard
+  (library-filters L141) lists only the `librarySearch` integration tests, not
+  the direct `resolveClipSubtype(wav, alcM) === null` unit test that would kill
+  it; likewise `resolveAbsolutePaths([])` (reconstruct-path L73) and
+  `clampLibraryLimit`'s null/`≤0` guard.
+- **`readdir`-order-equivalent sorts.** The store `sortByName`
+  (`entries.sort((a,b) => a.name.localeCompare(b.name))`, global-memory L123 +
+  custom-skills L133) is a no-op on the test platform because macOS APFS
+  `readdirSync` already returns lexicographic order, and all slugs are
+  lowercase-ascii (byte order == locale order). The sort is cross-platform
+  defensive; killing it would require forging an unsorted `readdir`, i.e.
+  over-fitting to filesystem order.
+- **Static regex module-init, log/header strings, `finally`/`catch`
+  block-empties.** `WINDOWS_DRIVE_ROOT` / `Live-files-(\d+)` regexes (0-coverage
+  static initializers, a known Stryker limitation),
+  `console.info`/`warn`/`error` message literals,
+  `res.set("Cache-Control", "no-store")` header strings, and `} finally { … }`
+  cleanup blocks whose emptying is behaviorally invisible.
+- **Genuine equivalents.** `writeSkillOverride(name, "")` ≡ deleting the slot
+  (an empty-body override file is dropped on read, so both yield
+  `override: ""`); the `> 0` / `>= 0` length guards on already-non-empty
+  collections.
+
+### Gaps closed (`mcpServer`)
+
+| Gap (now killed)                                                                | Test added / strengthened     |
+| ------------------------------------------------------------------------------- | ----------------------------- |
+| `requireString`/`optionalString` null-args `?.[key]` guard + field-named errors | `route-args.test.ts` (new)    |
+| `clampLibraryLimit` non-positive request → default (the `<= 0` branch)          | `library-filters.test.ts`     |
+| `parseFrontmatter` body: anchored `^\n` strip preserves interior newlines       | `frontmatter.test.ts`         |
+| `cosineSimilarity` bounded by the shorter vector (no read past the end)         | `fe-values-helpers.test.ts`   |
+| `rejectCrossOriginWrite`: foreign origin → 403 + returns `true`                 | `request-origin.test.ts`      |
+| `resolveAbsolutePaths`: 3-segment path sets `folder` (the `>= 3` boundary)      | `reconstruct-path.test.ts`    |
+| Custom-skills index emits no `## Disabled` section when all skills are enabled  | `custom-skills-store.test.ts` |
+
 ## Interpreting survivors
 
 Each survivor falls into one of three buckets — triage before acting:
@@ -700,15 +782,16 @@ wins, and a cross-check against the line-coverage gate.
 ## Status & next steps
 
 The `notation` scope is **ratcheted** (`thresholds.break = 86`), as is
-`sharedRuntime` (`src/shared/`, `break: 94`) and all nine triaged tool domains:
-the write-op tier `track` (`break: 85`), `session` (`break: 89`), `actions`
-(`break: 90`), `device` (`break: 90`), `clip` (`break: 96`), and the read-op /
-small tier `advanced` (`break: 97`), `core` (`break: 99`), `scene`
-(`break: 96`), `live-set` (`break: 98`). Only `shared` (`src/tools/shared`)
-remains in **baseline mode** (`break: null`, measure-only). The per-domain scope
-mechanism (`config/mutation-scopes.mjs` + the runner) is in place, so each area
-can be mutated on its own. Mutation testing stays off the per-PR hot path (a
-full pass is minutes). Remaining work (later releases):
+`sharedRuntime` (`src/shared/`, `break: 94`), `mcpServer` (`src/mcp-server/`,
+`break: 87`), and all nine triaged tool domains: the write-op tier `track`
+(`break: 85`), `session` (`break: 89`), `actions` (`break: 90`), `device`
+(`break: 90`), `clip` (`break: 96`), and the read-op / small tier `advanced`
+(`break: 97`), `core` (`break: 99`), `scene` (`break: 96`), `live-set`
+(`break: 98`). Only `shared` (`src/tools/shared`) remains in **baseline mode**
+(`break: null`, measure-only). The per-domain scope mechanism
+(`config/mutation-scopes.mjs` + the runner) is in place, so each area can be
+mutated on its own. Mutation testing stays off the per-PR hot path (a full pass
+is minutes). Remaining work (later releases):
 
 - Keep triaging the ~588 notation survivors, but expect diminishing returns: the
   dense clusters left are epsilon-boundary / warning-string / equivalent mutants
@@ -723,9 +806,13 @@ full pass is minutes). Remaining work (later releases):
   to `TOOL_DOMAIN_BREAKS`). The big clean wins tend to be untested lookup/enum
   tables (as in notation's chord table) and warn-and-skip guards whose tests
   assert only the result, never the warning or the skipped write.
-- Two more non-`src/tools/` trees remain unmutated and would each need a fresh
-  glob set (not `toolDomain()`): `src/mcp-server/` and the V8 adapter code.
-  Model them on `SHARED_RUNTIME_GLOBS` and give each a non-colliding scope key.
+- One non-`src/tools/` tree remains unmutated and would need a fresh glob set
+  (not `toolDomain()`): the V8 adapter code (`src/live-api-adapter/`). Model it
+  on `SHARED_RUNTIME_GLOBS` / `MCP_SERVER_GLOBS` and give it a non-colliding
+  scope key. Expect a low ceiling and a heavy entry-point exclusion —
+  `live-api-adapter.ts` runs `outlet(0, "started")` + registers handlers at
+  import and is already coverage-excluded (exclude it as `mcpServer` does its
+  entry point).
 - Optionally wire a scheduled (nightly/weekly) non-blocking CI job once several
   domains have floors — full-tree runtime is hours, not minutes.
 

--- a/src/mcp-server/helpers/skills-custom/tests/custom-skills-store.test.ts
+++ b/src/mcp-server/helpers/skills-custom/tests/custom-skills-store.test.ts
@@ -326,6 +326,15 @@ describe("regenerateSkillsIndex / SKILLS.md", () => {
     expect(regenerateSkillsIndex()).toContain("- `bare`\n");
   });
 
+  it("emits no Disabled section when every skill is enabled", () => {
+    // The `## Disabled` section is only appended when disabled.length > 0 — with
+    // all skills enabled the section must be absent entirely, not a bare header.
+    rememberCustomSkill({ name: "one", description: "d", body: "b" });
+    rememberCustomSkill({ name: "two", description: "d", body: "b" });
+
+    expect(regenerateSkillsIndex()).not.toContain("## Disabled");
+  });
+
   it("deletes the index and returns '' when the last skill is forgotten", () => {
     rememberCustomSkill({ name: "solo", description: "d", body: "b" });
     forgetCustomSkill("solo");

--- a/src/mcp-server/live-library/tests/library-filters.test.ts
+++ b/src/mcp-server/live-library/tests/library-filters.test.ts
@@ -15,6 +15,10 @@ import {
   resolveKind,
   resolveSource,
 } from "../library-filters.ts";
+// clampLibraryLimit lives in the sibling library-types.ts (the same pure
+// library-DB coercion layer); its tests live here rather than in a separate file
+// to stay under the tests/ folder-item cap.
+import { clampLibraryLimit, MAX_LIBRARY_LIMIT } from "../library-types.ts";
 
 describe("fourCC", () => {
   it("encodes 'fldr' as 1718379634 (matches Live's spike-confirmed value)", () => {
@@ -258,5 +262,42 @@ describe("deriveItemType", () => {
 
   it("prefers loop over oneshot when a file carries both", () => {
     expect(deriveItemType(["One Shot", "Loop"])).toBe("loop");
+  });
+});
+
+describe("clampLibraryLimit", () => {
+  const DEFAULT = 50;
+
+  it("returns a valid in-range integer unchanged", () => {
+    expect(clampLibraryLimit(25, DEFAULT)).toBe(25);
+    expect(clampLibraryLimit(1, DEFAULT)).toBe(1);
+  });
+
+  it("floors a fractional request", () => {
+    expect(clampLibraryLimit(5.9, DEFAULT)).toBe(5);
+  });
+
+  it("caps a request above MAX_LIBRARY_LIMIT", () => {
+    expect(clampLibraryLimit(MAX_LIBRARY_LIMIT + 500, DEFAULT)).toBe(
+      MAX_LIBRARY_LIMIT,
+    );
+  });
+
+  it("falls back to the default when the request is missing", () => {
+    // Guards the `requested == null` branch of the coercion.
+    expect(clampLibraryLimit(undefined, DEFAULT)).toBe(DEFAULT);
+  });
+
+  it("falls back to the default for a non-finite request", () => {
+    // Guards the `!Number.isFinite(requested)` branch (NaN / ±Infinity).
+    expect(clampLibraryLimit(Number.NaN, DEFAULT)).toBe(DEFAULT);
+    expect(clampLibraryLimit(Number.POSITIVE_INFINITY, DEFAULT)).toBe(DEFAULT);
+  });
+
+  it("falls back to the default for a non-positive request", () => {
+    // Guards the `requested <= 0` branch — 0 and negatives are meaningless
+    // limits, so they coerce to the default rather than to 0 rows.
+    expect(clampLibraryLimit(0, DEFAULT)).toBe(DEFAULT);
+    expect(clampLibraryLimit(-5, DEFAULT)).toBe(DEFAULT);
   });
 });

--- a/src/mcp-server/live-library/tests/query/fe-values-helpers.test.ts
+++ b/src/mcp-server/live-library/tests/query/fe-values-helpers.test.ts
@@ -132,4 +132,19 @@ describe("cosineSimilarity", () => {
     expect(cosineSimilarity(a, a, 0, vectorNorm(a))).toBe(0);
     expect(cosineSimilarity(a, a, vectorNorm(a), 0)).toBe(0);
   });
+
+  it("bounds the dot product by the shorter vector (no read past the end)", () => {
+    // The loop runs to `Math.min(a.length, b.length)`, never the max — a read
+    // past the shorter array would be `undefined`, poisoning the dot product to
+    // NaN. Feed mismatched lengths (the extra `b` component is ignored, not
+    // multiplied by a missing `a` component).
+    const a = new Float32Array([1, 0]);
+    const b = new Float32Array([1, 0, 999]);
+
+    const sim = cosineSimilarity(a, b, vectorNorm(a), vectorNorm(b));
+
+    expect(Number.isNaN(sim)).toBe(false);
+    // dot = 1*1 + 0*0 = 1; norms = 1 and sqrt(1+0+999^2).
+    expect(sim).toBeCloseTo(1 / Math.sqrt(1 + 999 * 999), 6);
+  });
 });

--- a/src/mcp-server/live-library/tests/reconstruct-path.test.ts
+++ b/src/mcp-server/live-library/tests/reconstruct-path.test.ts
@@ -149,6 +149,21 @@ describe("resolveAbsolutePaths", () => {
     expect(resolveAbsolutePaths(db, [4]).get(4)?.folder).toBe("Drums");
   });
 
+  it("captures the folder for the minimal 3-segment path (root/folder/file)", () => {
+    // The folder is assigned when there are >= 3 segments (root, folder, leaf) —
+    // exactly 3 is the boundary. With only root + leaf (2 segments) the parent
+    // is the root itself, so folder stays unset (see the next test).
+    insertRow(1, 0, "/");
+    insertRow(2, 1, "Samples");
+    insertRow(3, 2, "kick.wav");
+
+    expect(resolveAbsolutePaths(db, [3]).get(3)).toStrictEqual({
+      path: "/Samples/kick.wav",
+      truncated: false,
+      folder: "Samples",
+    });
+  });
+
   it("omits folder for a file directly at the root", () => {
     insertRow(1, 0, "/");
     insertRow(2, 1, "loop.wav");

--- a/src/mcp-server/rpc/route-args.test.ts
+++ b/src/mcp-server/rpc/route-args.test.ts
@@ -1,0 +1,62 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { optionalString, requireString } from "./route-args.ts";
+
+describe("requireString", () => {
+  it("returns the string value of a present field", () => {
+    expect(requireString({ name: "kick" }, "name")).toBe("kick");
+  });
+
+  it("throws a clean, field-named message when the field is missing", () => {
+    expect(() => requireString({ other: "x" }, "name")).toThrow(
+      "name must be a string",
+    );
+  });
+
+  it("throws when the field is present but not a string", () => {
+    expect(() => requireString({ count: 3 }, "count")).toThrow(
+      "count must be a string",
+    );
+  });
+
+  it("throws the clean message (not a TypeError) when args is null", () => {
+    // The `?.[key]` guard must short-circuit to undefined so the string check
+    // renders the intended message; without it, `null[key]` would TypeError.
+    expect(() => requireString(null, "name")).toThrow("name must be a string");
+  });
+
+  it("throws the clean message when args is undefined", () => {
+    expect(() => requireString(undefined, "name")).toThrow(
+      "name must be a string",
+    );
+  });
+});
+
+describe("optionalString", () => {
+  it("returns the string value of a present field", () => {
+    expect(optionalString({ description: "warm pad" }, "description")).toBe(
+      "warm pad",
+    );
+  });
+
+  it('defaults to "" when the field is absent', () => {
+    expect(optionalString({ other: "x" }, "description")).toBe("");
+  });
+
+  it('defaults to "" when the field is present but not a string', () => {
+    expect(optionalString({ enabled: true }, "enabled")).toBe("");
+  });
+
+  it('returns "" (not a TypeError) when args is null', () => {
+    // Same `?.[key]` guard: a null blob must read as an absent field, not throw.
+    expect(optionalString(null, "description")).toBe("");
+  });
+
+  it('returns "" when args is undefined', () => {
+    expect(optionalString(undefined, "description")).toBe("");
+  });
+});

--- a/src/mcp-server/tests/http/request-origin.test.ts
+++ b/src/mcp-server/tests/http/request-origin.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   isLocalOrigin,
   isSameOriginRequest,
+  rejectCrossOriginWrite,
   rejectForeignOriginWrite,
 } from "../../helpers/http/request-origin.ts";
 
@@ -124,6 +125,49 @@ describe("isSameOriginRequest", () => {
     expect(isSameOriginRequest("not a url", mockReq({ host: "x" }))).toBe(
       false,
     );
+  });
+});
+
+describe("rejectCrossOriginWrite", () => {
+  it("allows a non-browser (Origin-less) request", () => {
+    const { res, state } = mockRes();
+
+    expect(rejectCrossOriginWrite(mockReq({}), res, "nope")).toBe(false);
+    expect(state.status).toBeNull();
+  });
+
+  it("allows a localhost Origin", () => {
+    const { res, state } = mockRes();
+    const req = mockReq({ origin: "http://localhost:3350" });
+
+    expect(rejectCrossOriginWrite(req, res, "nope")).toBe(false);
+    expect(state.status).toBeNull();
+  });
+
+  it("rejects a non-localhost browser origin with 403, returning true", () => {
+    // Unlike rejectForeignOriginWrite, this gate is localhost-ONLY: even a
+    // same-origin LAN/tunnel write is rejected (it guards /config + token
+    // minting). The `true` return tells the caller to bail after the 403.
+    const { res, state } = mockRes();
+    const req = mockReq({
+      origin: "https://demo.trycloudflare.com",
+      host: "demo.trycloudflare.com",
+    });
+
+    expect(rejectCrossOriginWrite(req, res, "config writes blocked")).toBe(
+      true,
+    );
+    expect(state.status).toBe(403);
+    expect(state.body).toStrictEqual({ error: "config writes blocked" });
+  });
+
+  it("rejects an unparseable Origin (treated as non-local)", () => {
+    const { res, state } = mockRes();
+
+    expect(
+      rejectCrossOriginWrite(mockReq({ origin: "garbage" }), res, "x"),
+    ).toBe(true);
+    expect(state.status).toBe(403);
   });
 });
 

--- a/src/mcp-server/tests/skill-overrides/frontmatter.test.ts
+++ b/src/mcp-server/tests/skill-overrides/frontmatter.test.ts
@@ -119,6 +119,18 @@ describe("parseFrontmatter", () => {
     expect(parseFrontmatter(raw, PROV)).toStrictEqual({ data: {}, body: raw });
   });
 
+  it("strips only the leading blank line, preserving interior newlines in the body", () => {
+    // The body join re-adds `\n` between lines, then a single leading `\n` is
+    // stripped (the blank line after the close fence). The strip must be
+    // anchored (`/^\n/`): a body with no blank line after the fence but interior
+    // newlines must keep every one of them.
+    const raw = "---\ndescription: d\n---\nLine 1\nLine 2\nLine 3";
+
+    expect(parseFrontmatter(raw, ["description"]).body).toBe(
+      "Line 1\nLine 2\nLine 3",
+    );
+  });
+
   it("parses a CRLF file (Windows line endings) the same as LF", () => {
     // Regression: the close fence "---\r" never matched "---", so the whole
     // file (provenance block included) was returned as body and drift detection


### PR DESCRIPTION
Widens Stryker mutation testing to the Node-for-Max server layer (`src/mcp-server/`) — the Express app, MCP server wiring, REST routes, the live-library SQLite reader, the markdown/memory/skill override stores, and the RPC protocol to the V8 runtime.

## What

- **New `mcpServer` scope** in `config/mutation-scopes.mjs` — its own `MCP_SERVER_GLOBS` (not `toolDomain()`, since `src/mcp-server` isn't under `src/tools/`) and a camelCase key (`shared` already means `src/tools/shared`). Added to the `all` group.
- **Entry-point excluded.** `mcp-server.ts` runs module-load side effects wired to `max-api` (registers Node routes, binds `.listen()`) and is already coverage-excluded in `vitest.config.ts`; its 57 all-NoCoverage mutants are untestable wiring — same rationale `toolDomain()` uses for `.def.ts`/`*-disabled.ts`.
- **`break: 87`** — triaged at 88.51%, floor ~1.5pt below (this domain has timeout-prone SQLite/fs tests, so a slightly wider buffer than the pure-logic scopes).

## Score

| Metric | Baseline (after entry-point exclusion) | Triaged | Gate |
| --- | --- | --- | --- |
| mcpServer | 88.14% | **88.51%** | 87 |

Test/config/docs only — **no product code**.

## Gaps closed (direct unit tests)

- `route-args` null-arg `?.[key]` guards + field-named error messages (new test file → 100%)
- `clampLibraryLimit` coercion branches (missing / non-finite / non-positive → default)
- `parseFrontmatter` anchored `^\n` strip preserves interior body newlines
- `cosineSimilarity` bounded by the shorter vector (no read past the end)
- `rejectCrossOriginWrite` foreign origin → 403 + returns `true` (function was never directly tested)
- `resolveAbsolutePaths` 3-segment path sets `folder` (the `>= 3` boundary)
- custom-skills index emits no `## Disabled` section when all skills enabled

## Why the remaining ~302 survivors stay

Overwhelmingly bucket 2/3, documented in `dev/Mutation-Testing.md`: `Max.outlet(...)` device notifications (asserting exact channel strings over-fits the sync protocol), dynamic SQL builders (results tested, not SQL text), log/header strings, `readdir`-order-equivalent sorts (APFS returns lexicographic order, so the explicit sort is a platform no-op), static regex module-init (Stryker limitation), and the **perTest guard-attribution quirk** — when a guard's killing unit test early-returns at the guard, Stryker never attributes it (confirmed via `coveredBy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)