### PR TITLE
test(mutation): triage shared utilities & framework subarea

### DIFF
--- a/src/tools/shared/locator/locator-helpers.test.ts
+++ b/src/tools/shared/locator/locator-helpers.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { LiveAPI as MockLiveAPI } from "#src/test/mocks/mock-live-api.ts";
 import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
 import {
+  findLocator,
   getLocatorId,
   isLocatorId,
   resolveLocatorListToBeats,
@@ -52,6 +53,39 @@ describe("locator-helpers", () => {
       expect(getLocatorId(0)).toBe("locator-0");
       expect(getLocatorId(5)).toBe("locator-5");
       expect(getLocatorId(99)).toBe("locator-99");
+    });
+  });
+
+  describe("findLocator", () => {
+    it("returns the match for a locator ID", () => {
+      const liveSet = setupMockLocators(
+        { id: "loc0", time: 0 },
+        { id: "loc1", time: 16 },
+      );
+
+      expect(findLocator(liveSet, { locatorId: "locator-1" })?.index).toBe(1);
+    });
+
+    it("returns null for a locator ID that does not match", () => {
+      const liveSet = setupMockLocators(
+        { id: "loc0", time: 0 },
+        { id: "loc1", time: 16 },
+      );
+
+      // An id guard mutated to always match would wrongly return index 0.
+      expect(findLocator(liveSet, { locatorId: "locator-9" })).toBeNull();
+    });
+
+    it("finds a non-first locator by exact time", () => {
+      const liveSet = setupMockLocators(
+        { id: "loc0", time: 0 },
+        { id: "loc1", time: 16 },
+        { id: "loc2", time: 32 },
+      );
+
+      // Searching by time (no locatorId): the id branch must be skipped so the
+      // match lands on index 2, not on the first locator.
+      expect(findLocator(liveSet, { timeInBeats: 32 })?.index).toBe(2);
     });
   });
 
@@ -144,6 +178,22 @@ describe("locator-helpers", () => {
         );
       }).toThrow(
         'ppal-playback failed: no locator found with name "NonExistent"',
+      );
+    });
+
+    it("appends the context suffix to the name-not-found message", () => {
+      const liveSet = setupMockLocators({ id: "loc0", name: "Verse", time: 8 });
+
+      // The " ${context}" suffix (leading space) must be preserved verbatim.
+      expect(() => {
+        resolveLocatorToBeats(
+          liveSet,
+          { locatorName: "Missing" },
+          "ppal-playback",
+          "for start",
+        );
+      }).toThrow(
+        'ppal-playback failed: no locator found with name "Missing" for start',
       );
     });
   });
@@ -274,6 +324,9 @@ describe("locator-helpers", () => {
       expect(isLocatorId("locator-")).toBe(false);
       expect(isLocatorId("locator-abc")).toBe(false);
       expect(isLocatorId("LOCATOR-0")).toBe(false);
+      // Anchored on both ends: reject leading/trailing junk around a valid core.
+      expect(isLocatorId("xlocator-0")).toBe(false);
+      expect(isLocatorId("locator-0x")).toBe(false);
     });
   });
 

--- a/src/tools/shared/tests/gain-utils.test.ts
+++ b/src/tools/shared/tests/gain-utils.test.ts
@@ -110,6 +110,18 @@ describe("gain-utils", () => {
       expect(dbToLiveGain(-100)).toBe(0);
     });
 
+    it("should return a positive gain at the lowest table dB (-69.7)", () => {
+      // -69.7 is the lowest non-null dB in the table (duplicated across the two
+      // lowest entries). The linear search must include it as a lower bound
+      // (entry.dB <= dB) rather than skip the null entry into it — either bug
+      // makes lowerIndex stay -1 and returns 0.
+      expect(dbToLiveGain(-69.7)).toBeGreaterThan(0);
+    });
+
+    it("should clamp +Infinity dB to 1.0 (not treat it as -Infinity)", () => {
+      expect(dbToLiveGain(Infinity)).toBe(1.0);
+    });
+
     it("should handle extreme high dB values", () => {
       expect(dbToLiveGain(50)).toBe(1.0);
       expect(dbToLiveGain(1000)).toBe(1.0);

--- a/src/tools/shared/tool-framework/tests/filter-schema.test.ts
+++ b/src/tools/shared/tool-framework/tests/filter-schema.test.ts
@@ -121,6 +121,18 @@ describe("filterSchemaForSmallModel", () => {
     expect(filtered.param2!.description).toBe("another description");
   });
 
+  it("should apply description overrides when excludeParams is null", () => {
+    // Overrides alone get past the early return, so the exclude check runs with
+    // a null excludeParams — the optional-chaining guard must tolerate it.
+    const schema = { param1: z.string().describe("original") };
+
+    const filtered = filterSchemaForSmallModel(schema, null, {
+      param1: "simplified",
+    });
+
+    expect(filtered.param1!.description).toBe("simplified");
+  });
+
   it("should combine exclusions and description overrides", () => {
     const schema = {
       keep: z.string().describe("original"),

--- a/src/tools/shared/tool-framework/tests/include-params.test.ts
+++ b/src/tools/shared/tool-framework/tests/include-params.test.ts
@@ -10,6 +10,7 @@ import {
   READ_TRACK_DEFAULTS,
   READ_SCENE_DEFAULTS,
   READ_CLIP_DEFAULTS,
+  type IncludeFlags,
 } from "../include-params.ts";
 
 const ALL_FLAGS_FALSE = {
@@ -71,19 +72,21 @@ describe("parseIncludeArray", () => {
     expect(result.includeSessionClips).toBe(false);
   });
 
+  it("keeps explicit non-tool-type options alongside the wildcard", () => {
+    // "notes" is not a song option, so it must survive the '*' expansion (the
+    // '*' is filtered out, the rest are kept and merged with the song options).
+    const result = parseIncludeArray(["*", "notes"], READ_SONG_DEFAULTS);
+
+    expect(result.includeClipNotes).toBe(true);
+    expect(result.includeTracks).toBe(true);
+  });
+
   it("handles track defaults correctly", () => {
     const result = parseIncludeArray(undefined, READ_TRACK_DEFAULTS);
 
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        includeClipNotes: false,
-        includeDrumMap: false,
-        includeDevices: false,
-        includeInstruments: false,
-        includeSessionClips: false,
-        includeArrangementClips: false,
-      }),
-    );
+    // Full-object match so every default flag is asserted false (a default that
+    // silently flipped to true would otherwise slip through).
+    expect(result).toStrictEqual(ALL_FLAGS_FALSE);
   });
 
   it("recognizes devices include for track", () => {
@@ -111,25 +114,13 @@ describe("parseIncludeArray", () => {
   it("handles scene defaults correctly", () => {
     const result = parseIncludeArray(undefined, READ_SCENE_DEFAULTS);
 
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        includeClips: false,
-        includeClipNotes: false,
-      }),
-    );
+    expect(result).toStrictEqual(ALL_FLAGS_FALSE);
   });
 
   it("handles clip defaults correctly", () => {
     const result = parseIncludeArray(undefined, READ_CLIP_DEFAULTS);
 
-    expect(result).toStrictEqual(
-      expect.objectContaining({
-        includeClipNotes: false,
-        includeSample: false,
-        includeTiming: false,
-        includeWarp: false,
-      }),
-    );
+    expect(result).toStrictEqual(ALL_FLAGS_FALSE);
   });
 
   it("expands wildcard for clip tool type", () => {
@@ -255,5 +246,44 @@ describe("includeArrayFromFlags", () => {
       expect(result.includeTracks).toBe(true);
       expect(result.includeScenes).toBe(true);
     });
+  });
+});
+
+// Exhaustive option ↔ flag mapping: every option string maps to exactly one
+// flag in both directions. Locks each option constant and each FLAG_TO_OPTION
+// entry so a blanked string or dropped tuple can't slip through untested.
+describe("option ↔ flag round-trip (every option)", () => {
+  const PAIRS: [keyof IncludeFlags, string][] = [
+    ["includeDrumMap", "drum-map"],
+    ["includeClipNotes", "notes"],
+    ["includeScenes", "scenes"],
+    ["includeMidiEffects", "midi-effects"],
+    ["includeInstruments", "instruments"],
+    ["includeAudioEffects", "audio-effects"],
+    ["includeDevices", "devices"],
+    ["includeRoutings", "routings"],
+    ["includeAvailableRoutings", "available-routings"],
+    ["includeSessionClips", "session-clips"],
+    ["includeArrangementClips", "arrangement-clips"],
+    ["includeClips", "clips"],
+    ["includeTracks", "tracks"],
+    ["includeSample", "sample"],
+    ["includeColor", "color"],
+    ["includeTiming", "timing"],
+    ["includeWarp", "warp"],
+    ["includeMixer", "mixer"],
+    ["includeLocators", "locators"],
+  ];
+
+  it.each(PAIRS)("parse: flag %s comes from option %s", (flag, option) => {
+    expect(parseIncludeArray([option], {})[flag]).toBe(true);
+  });
+
+  it.each(PAIRS)("fromFlags: flag %s maps to option %s", (flag, option) => {
+    const flags: Partial<IncludeFlags> = {};
+
+    flags[flag] = true;
+
+    expect(includeArrayFromFlags(flags)).toStrictEqual([option]);
   });
 });

--- a/src/tools/shared/validation/tests/color-utils.test.ts
+++ b/src/tools/shared/validation/tests/color-utils.test.ts
@@ -36,6 +36,8 @@ describe("color-utils", () => {
   describe("getColorForIndex", () => {
     it("returns undefined when color is undefined", () => {
       expect(getColorForIndex(undefined, 0, null)).toBeUndefined();
+      // The color guard must win even when parsedColors could supply a value.
+      expect(getColorForIndex(undefined, 0, ["#FF0000"])).toBeUndefined();
     });
 
     it("returns color as-is when parsedColors is null", () => {

--- a/src/tools/shared/validation/tests/id-validation.test.ts
+++ b/src/tools/shared/validation/tests/id-validation.test.ts
@@ -116,6 +116,28 @@ describe("validateIdType", () => {
 
     expect(() => validateIdType(id, "drum-pad", "testTool")).not.toThrow();
   });
+
+  it("should reject a Track against every non-track expected type", () => {
+    // A single Track exercises the negative branch of each isTypeMatch case:
+    // "scene"/"clip" strict equality, "device" endsWith, "drum-pad" OR, and the
+    // default (unknown type) — each must NOT match a Track.
+    registerMockObject("track_1", {
+      path: "live_set tracks 0",
+      type: "Track",
+    });
+
+    for (const expectedType of [
+      "scene",
+      "clip",
+      "device",
+      "drum-pad",
+      "mystery-type",
+    ]) {
+      expect(() => validateIdType("track_1", expectedType, "testTool")).toThrow(
+        `testTool failed: id "track_1" is not a ${expectedType} (found Track)`,
+      );
+    }
+  });
 });
 
 describe("validateIdTypes", () => {

--- a/src/tools/shared/validation/tests/name-utils.test.ts
+++ b/src/tools/shared/validation/tests/name-utils.test.ts
@@ -57,6 +57,8 @@ describe("name-utils", () => {
   describe("getNameForIndex", () => {
     it("returns undefined when baseName is undefined", () => {
       expect(getNameForIndex(undefined, 0, null)).toBeUndefined();
+      // The baseName guard must win even when parsedNames could supply a value.
+      expect(getNameForIndex(undefined, 0, ["A"])).toBeUndefined();
     });
 
     it("returns baseName when parsedNames is null", () => {

--- a/src/tools/shared/validation/tests/position-parsing.test.ts
+++ b/src/tools/shared/validation/tests/position-parsing.test.ts
@@ -84,6 +84,16 @@ describe("parseSlotList", () => {
     );
   });
 
+  it("should not warn for a clean two-part slot", () => {
+    parseSlotList("0/1");
+
+    // Exactly two parts must not trigger the extra-parts warning.
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("has extra parts"),
+    );
+  });
+
   it("should throw for non-integer values", () => {
     expect(() => parseSlotList("a/b")).toThrow(
       'invalid toSlot "a/b" - trackIndex and sceneIndex must be integers',
@@ -133,6 +143,17 @@ describe("parseSlot", () => {
   it("should throw for non-integer values", () => {
     expect(() => parseSlot("a/b")).toThrow(
       'invalid slot "a/b" - trackIndex and sceneIndex must be integers',
+    );
+  });
+
+  it("should throw when only one part is non-integer", () => {
+    // Each NaN check is independent (OR), so a single bad part must still throw
+    // — "a/b" alone can't prove that (both parts are NaN).
+    expect(() => parseSlot("5/x")).toThrow(
+      'invalid slot "5/x" - trackIndex and sceneIndex must be integers',
+    );
+    expect(() => parseSlot("x/5")).toThrow(
+      'invalid slot "x/5" - trackIndex and sceneIndex must be integers',
     );
   });
 


### PR DESCRIPTION
First of four subtasks triaging the `src/tools/shared` mutation domain — the utilities & framework subarea (tool-framework, validation, locator, root utils, clip-gain-lookup). **Test-only**: the `shared` scope stays in baseline mode (`break: null`), so this touches no config or docs — the gate flip and the doc baseline happen once, in the final device-specialized subtask, after all four subareas are triaged.

## Result

Narrowed-scope mutation score (these 14 files) **87.28% → 92.78%**, ~52 mutants killed. Per-file highlights: include-params 73.6→95.4%, position-parsing/color-utils → 100%, validation dir → 98.5%, filter-schema → 98.9%.

## What changed (all test-only)

- **include-params**: exhaustive option↔flag round-trip table (locks every option constant and `FLAG_TO_OPTION` entry in both directions); full-object default-flag assertions; wildcard keeps explicit non-tool-type options.
- **gain-utils**: lowest-table-dB (-69.7) returns a positive gain (linear-search lower-bound / null-entry handling); +Infinity clamps to 1.0 rather than being treated as -Infinity.
- **locator-helpers**: `findLocator` by non-matching id / by time; context suffix preserved in the not-found message; `isLocatorId` anchors reject leading/trailing junk.
- **id-validation**: reject a Track against every non-track expected type (scene/clip/device/drum-pad/default).
- **filter-schema**: description overrides tolerate a null `excludeParams`.
- **name-utils / color-utils**: the baseName/color guard wins over a supplied parsed list.
- **position-parsing**: a clean two-part slot does not warn; a single non-integer part still throws.

## Remaining survivors (all bucket 2)

Every survivor left is either an **equivalent mutant** (gain interpolation continuity, defensive `v8-ignore` blocks, `descriptionOf`/`enumValuesOf` always-object type guards, `barbeat` is never a mode-map key, `define-tool`'s defense-in-depth enum filter that Zod's rebuilt schema makes a no-op) or a **Stryker perTest false-survivor** — killed by an existing/added test but unattributed because the killing path short-circuits the mutated guard (confirmed empirically for locator L102/L162, gain L116, id-validation L135, modal-config L173). No new tests can close these under `coverageAnalysis: perTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)