### PR TITLE
test(mutation): triage shared arrangement helpers subarea

### DIFF
--- a/src/tools/shared/arrangement/tests/arrangement-duplicate-workaround.test.ts
+++ b/src/tools/shared/arrangement/tests/arrangement-duplicate-workaround.test.ts
@@ -9,12 +9,11 @@ import {
   setupArrangementClip,
   setupClip,
   setupTrack,
+  tilingTrackMethods,
 } from "./arrangement-tiling-test-helpers.ts";
 import {
   clearClipAtDuplicateTarget,
-  duplicateSelfOverlappingClip,
   setArrangementDuplicateCrashWorkaround,
-  sourceOverlapsTarget,
 } from "../arrangement-tiling-workaround.ts";
 
 beforeEach(() => {
@@ -25,25 +24,6 @@ beforeEach(() => {
 afterEach(() => {
   setArrangementDuplicateCrashWorkaround(true);
 });
-
-/**
- * The duplicate/create/delete method stubs shared by the tiling setups. The
- * duplicate op returns clip 400 on its first call and 500 thereafter.
- * @returns Method stubs for setupTrack
- */
-function tilingTrackMethods() {
-  let dupCount = 0;
-
-  return {
-    duplicate_clip_to_arrangement: () => {
-      dupCount++;
-
-      return dupCount === 1 ? ["id", "400"] : ["id", "500"];
-    },
-    create_midi_clip: () => ["id", "300"],
-    delete_clip: () => null,
-  };
-}
 
 /**
  * Sets up a source clip, existing arrangement clip, and holding clip with
@@ -290,6 +270,101 @@ describe("clearClipAtDuplicateTarget", () => {
     expect(trackMock.call).not.toHaveBeenCalled();
   });
 
+  it("returns true (safe to duplicate) when the workaround is disabled", () => {
+    // With the workaround off we defer to Live entirely — the early return must
+    // report `true`, even for a source that would otherwise self-overlap [0,4].
+    setArrangementDuplicateCrashWorkaround(false);
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 0, end_time: 4 },
+    });
+    const trackMock = setupTrack(0);
+
+    const safe = clearClipAtDuplicateTarget(
+      LiveAPI.from(trackMock.path),
+      "100",
+      0,
+      true,
+      mockContext,
+    );
+
+    expect(safe).toBe(true);
+  });
+
+  it("returns true (safe to duplicate) for a session-clip source", () => {
+    // A session-clip source is a no-op that must report `true`. Give it a range
+    // that would self-overlap if the early return were skipped, so the guard is
+    // observable through the return value, not just the absence of calls.
+    setupClip("100", {
+      properties: { is_arrangement_clip: 0, start_time: 0, end_time: 4 },
+    });
+    const trackMock = setupTrack(0);
+
+    const safe = clearClipAtDuplicateTarget(
+      LiveAPI.from(trackMock.path),
+      "100",
+      0,
+      true,
+      mockContext,
+    );
+
+    expect(safe).toBe(true);
+  });
+
+  it("does not treat an adjacent-before placement as a self-overlap", () => {
+    // Source [10,12] duplicated to target 8 places the copy at [8,10] — its right
+    // edge (targetEnd 10) touches the source's start (10) but does not cross it.
+    // The self-overlap test is strictly `sourceStart < targetEnd`, so this must be
+    // reported safe (true), not a self-overlap.
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 10, end_time: 12 },
+    });
+    const trackMock = setupTrack(0, {
+      properties: { arrangement_clips: ["id", "100"] },
+      methods: { delete_clip: () => null },
+    });
+
+    const safe = clearClipAtDuplicateTarget(
+      LiveAPI.from(trackMock.path),
+      "100",
+      8,
+      true,
+      mockContext,
+    );
+
+    expect(safe).toBe(true);
+  });
+
+  it("does not clear an existing clip that only abuts the target range", () => {
+    // Source [20,24] (len 4) to target 6 clears [6,10]. An existing clip [10,14]
+    // starts exactly at targetEnd (10) — adjacent, not overlapping — so the loop's
+    // strict `clipStart < targetEnd` must leave it untouched (no track calls).
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 20, end_time: 24 },
+    });
+    const existingClip = setupArrangementClip("200", 0, {
+      start_time: 10,
+      end_time: 14,
+    });
+    const trackMock = setupTrack(0, {
+      properties: { arrangement_clips: ["id", existingClip.id] },
+      methods: {
+        duplicate_clip_to_arrangement: () => ["id", "400"],
+        create_midi_clip: () => ["id", "300"],
+        delete_clip: () => null,
+      },
+    });
+
+    clearClipAtDuplicateTarget(
+      LiveAPI.from(trackMock.path),
+      "100",
+      6,
+      true,
+      mockContext,
+    );
+
+    expect(trackMock.call).not.toHaveBeenCalled();
+  });
+
   it("right-trims clip for before-only overlap", () => {
     // Source: 4 beats long (start_time=20, end_time=24), target position=8
     // Target range: 8 to 12. Existing clip at 4-10 starts before target,
@@ -468,6 +543,87 @@ describe("clearClipAtDuplicateTarget", () => {
     expect(trackMock.call).toHaveBeenCalledWith("delete_clip", "id 200");
   });
 
+  it("does not treat a clip ending exactly at the target end as having an after portion", () => {
+    // Existing clip [4,12], target [8,12]: it starts before the target and ends
+    // exactly at targetEnd. hasAfter is strictly `clipEnd > targetEnd` (12 > 12 =
+    // false), so this is a before-only right-trim (one create_midi_clip, no
+    // holding dup) — not the dup-to-holding after path.
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 20, end_time: 24 },
+    });
+    const existingClip = setupArrangementClip("200", 0, {
+      start_time: 4,
+      end_time: 12,
+    });
+    const trackMock = setupTrack(0, {
+      properties: { arrangement_clips: ["id", existingClip.id] },
+      methods: {
+        create_midi_clip: () => ["id", "300"],
+        delete_clip: () => null,
+      },
+    });
+
+    clearClipAtDuplicateTarget(
+      LiveAPI.from(trackMock.path),
+      "100",
+      8,
+      true,
+      mockContext,
+    );
+
+    expect(trackMock.call).toHaveBeenCalledWith("create_midi_clip", 8, 4);
+    expect(trackMock.call).not.toHaveBeenCalledWith(
+      "duplicate_clip_to_arrangement",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("computes the holding area from the furthest clip end (not the last one listed)", () => {
+    // clearOverlappingClip's dup-to-holding must land past the furthest-right
+    // clip. With clips listed end-descending [far 300, overlapping 20], the max
+    // end is 300 → holding at 400. If it took the last clip's end instead it
+    // would land at 120 and could collide with the far clip.
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 50, end_time: 54 },
+    });
+    const far = setupArrangementClip("900", 0, {
+      start_time: 100,
+      end_time: 300,
+    });
+    const overlapping = setupArrangementClip(
+      "200",
+      0,
+      { start_time: 10, end_time: 20 },
+      1,
+    );
+
+    setupClip("400", {
+      properties: { is_arrangement_clip: 1, start_time: 400, end_time: 410 },
+    });
+    const trackMock = setupTrack(0, {
+      properties: {
+        arrangement_clips: ["id", far.id, "id", overlapping.id],
+      },
+      methods: tilingTrackMethods(),
+    });
+
+    clearClipAtDuplicateTarget(
+      LiveAPI.from(trackMock.path),
+      "100",
+      8,
+      true,
+      mockContext,
+    );
+
+    // After-only overlap on [10,20] → dup to holding at max(300,20) + 100 = 400.
+    expect(trackMock.call).toHaveBeenCalledWith(
+      "duplicate_clip_to_arrangement",
+      "id 200",
+      400,
+    );
+  });
+
   it("throws and leaves original intact when dup-to-holding silently fails (after-only)", () => {
     // After-only overlap: existing [10,14], target [8,12].
     // Without protection, the original would be deleted with no replacement
@@ -488,7 +644,7 @@ describe("clearClipAtDuplicateTarget", () => {
         true,
         mockContext,
       ),
-    ).toThrow(/duplicate_clip_to_arrangement returned no clip/);
+    ).toThrow(/dup-to-holding for clip 200/);
 
     expect(trackMock.call).not.toHaveBeenCalledWith("delete_clip", "id 200");
     expect(trackMock.call).not.toHaveBeenCalledWith(
@@ -527,165 +683,6 @@ describe("clearClipAtDuplicateTarget", () => {
     expect(trackMock.call).not.toHaveBeenCalledWith("delete_clip", "id 200");
   });
 });
-
-describe("sourceOverlapsTarget", () => {
-  it("returns false when the crash workaround is disabled", () => {
-    setArrangementDuplicateCrashWorkaround(false);
-    setupClip("100", {
-      properties: { is_arrangement_clip: 1, start_time: 0, end_time: 4 },
-    });
-
-    // Source [0,4] would overlap a placement at [2,6], but with the workaround
-    // off we defer to Live entirely (matches clearClipAtDuplicateTarget's no-op).
-    expect(sourceOverlapsTarget("100", 2, 4)).toBe(false);
-  });
-
-  it("returns false when the source is a session clip", () => {
-    setupClip("100", { properties: { is_arrangement_clip: 0 } });
-
-    expect(sourceOverlapsTarget("100", 0, 4)).toBe(false);
-  });
-
-  it("returns true when the source overlaps the target placement range", () => {
-    // Source [0,16] (4-bar clip); a partial tile of length 4 at position 4
-    // covers [4,8], which is inside the source — placing it would trim the source.
-    setupClip("100", {
-      properties: { is_arrangement_clip: 1, start_time: 0, end_time: 16 },
-    });
-
-    expect(sourceOverlapsTarget("100", 4, 4)).toBe(true);
-  });
-
-  it("returns false when the placement abuts the source's end (the tiling case)", () => {
-    // Source [0,4]; tiling always starts at the source's end, so a tile at
-    // position 4 (range [4,8]) is adjacent, not overlapping — the common path.
-    setupClip("100", {
-      properties: { is_arrangement_clip: 1, start_time: 0, end_time: 4 },
-    });
-
-    expect(sourceOverlapsTarget("100", 4, 4)).toBe(false);
-  });
-});
-
-describe("duplicateSelfOverlappingClip", () => {
-  it("copies the source to holding, then overwrites the original with a full copy", () => {
-    // Source [0,16] (a 4-bar clip in 4/4) duplicated to target 4 — one bar
-    // forward, so it overlaps its own target range [4,20]. Direct duplication is
-    // impossible (Ableton crashes; trimming the source first would truncate the
-    // content). Routing through the holding area trims the original to its first
-    // bar [0,4] and places a full 4-bar copy at [4,20].
-    setupClip("100", {
-      properties: { is_arrangement_clip: 1, start_time: 0, end_time: 16 },
-    });
-
-    // The holding copy the first duplicate creates. The holding area clears the
-    // target placement (target 4 + length 16 = 20) as well as the existing clips
-    // (maxEnd 16), so it starts at max(16, 20) + 100 = 120.
-    setupClip("400", {
-      properties: { is_arrangement_clip: 1, start_time: 120, end_time: 136 },
-    });
-
-    // The full copy the second duplicate places at the target ("500").
-    const { trackMock, result } = runTwoDupSelfOverlap(4);
-
-    // Step 1: copy the source to the holding area, past both the existing clips
-    // (maxEnd 16) and the target placement (4 + 16 = 20): max(16, 20) + 100 = 120.
-    expect(trackMock.call).toHaveBeenCalledWith(
-      "duplicate_clip_to_arrangement",
-      "id 100",
-      120,
-    );
-
-    // Step 2: trim the ORIGINAL to its "before" portion (right-trim at target 4,
-    // length clipEnd 16 - target 4 = 12) so the full copy can overwrite [4,20].
-    expect(trackMock.call).toHaveBeenCalledWith("create_midi_clip", 4, 12);
-
-    // Step 3: place the full copy at the target from the untouched holding clip.
-    expect(trackMock.call).toHaveBeenCalledWith(
-      "duplicate_clip_to_arrangement",
-      "id 400",
-      4,
-    );
-
-    // Step 4: clean up the holding clip.
-    expect(trackMock.call).toHaveBeenCalledWith("delete_clip", "id 400");
-
-    // The placed full-length copy is returned (never the trimmed original).
-    expect(result.id).toBe("500");
-  });
-
-  it("pushes the holding area past the target placement for a clip longer than the gap", () => {
-    // Regression: a clip longer than HOLDING_AREA_GAP_BEATS (100) moved far
-    // enough forward that its full-length target copy would reach a holding area
-    // pinned only to maxEnd. Source [0,200] (50 bars) duplicated to target 199
-    // self-overlaps [199,399]. With the old `maxEnd + 100` holding position
-    // (300), the placed copy [199,399] overlaps the holding clip [300,500];
-    // moveClipFromHolding's clearClipAtDuplicateTarget would then read the
-    // holding clip as self-overlapping, skip clearing the original [0,200], and
-    // duplicate onto a still-overlapping clip — exactly Ableton's crash. The
-    // holding area must clear the target extent: max(200, 199 + 200) + 100 = 499.
-    setupClip("100", {
-      properties: { is_arrangement_clip: 1, start_time: 0, end_time: 200 },
-    });
-
-    // The holding copy at the corrected position (past the target extent 399).
-    setupClip("400", {
-      properties: { is_arrangement_clip: 1, start_time: 499, end_time: 699 },
-    });
-    const { trackMock, result } = runTwoDupSelfOverlap(199);
-
-    // The holding copy lands past the target placement (399), not at maxEnd + 100
-    // (300) — so the holding clip cannot overlap the target copy.
-    expect(trackMock.call).toHaveBeenCalledWith(
-      "duplicate_clip_to_arrangement",
-      "id 100",
-      499,
-    );
-
-    // Because the holding area cleared the target, the ORIGINAL is recognized as
-    // an "other" overlapping clip and right-trimmed at 199 (length 200 - 199 = 1)
-    // — it is no longer left in place to overlap the target and crash Ableton.
-    expect(trackMock.call).toHaveBeenCalledWith("create_midi_clip", 199, 1);
-
-    // The full copy is then placed at the target and the holding clip removed.
-    expect(trackMock.call).toHaveBeenCalledWith(
-      "duplicate_clip_to_arrangement",
-      "id 400",
-      199,
-    );
-    expect(trackMock.call).toHaveBeenCalledWith("delete_clip", "id 400");
-    expect(result.id).toBe("500");
-  });
-});
-
-/**
- * Run the two-duplicate self-overlap workaround. The caller registers the source
- * ("100") and holding ("400") clips; this sets up "500" (the placed full copy),
- * the track with its dup/create/delete methods, and invokes the workaround.
- * @param target - Target arrangement position for the duplicate
- * @returns The track mock and the resulting clip
- */
-function runTwoDupSelfOverlap(target: number): {
-  trackMock: ReturnType<typeof setupTrack>;
-  result: ReturnType<typeof duplicateSelfOverlappingClip>;
-} {
-  setupClip("500", { properties: { is_arrangement_clip: 1 } });
-
-  const trackMock = setupTrack(0, {
-    properties: { arrangement_clips: ["id", "100"] },
-    methods: tilingTrackMethods(),
-  });
-
-  const result = duplicateSelfOverlappingClip(
-    LiveAPI.from(trackMock.path),
-    "100",
-    target,
-    true,
-    mockContext,
-  );
-
-  return { trackMock, result };
-}
 
 /**
  * Set up mocks for a clearClipAtDuplicateTarget test that expects no track calls.

--- a/src/tools/shared/arrangement/tests/arrangement-self-overlap.test.ts
+++ b/src/tools/shared/arrangement/tests/arrangement-self-overlap.test.ts
@@ -1,0 +1,286 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mockContext,
+  setupArrangementClip,
+  setupClip,
+  setupTrack,
+  tilingTrackMethods,
+} from "./arrangement-tiling-test-helpers.ts";
+import {
+  duplicateSelfOverlappingClip,
+  setArrangementDuplicateCrashWorkaround,
+  sourceOverlapsTarget,
+} from "../arrangement-tiling-workaround.ts";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setArrangementDuplicateCrashWorkaround(true);
+});
+
+afterEach(() => {
+  setArrangementDuplicateCrashWorkaround(true);
+});
+
+describe("sourceOverlapsTarget", () => {
+  it("returns false when the crash workaround is disabled", () => {
+    setArrangementDuplicateCrashWorkaround(false);
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 0, end_time: 4 },
+    });
+
+    // Source [0,4] would overlap a placement at [2,6], but with the workaround
+    // off we defer to Live entirely (matches clearClipAtDuplicateTarget's no-op).
+    expect(sourceOverlapsTarget("100", 2, 4)).toBe(false);
+  });
+
+  it("returns false when the source is a session clip", () => {
+    // Give the session clip a range that WOULD overlap [0,4] if the guard were
+    // skipped, so the is_arrangement_clip check is observable via the result.
+    setupClip("100", {
+      properties: { is_arrangement_clip: 0, start_time: 0, end_time: 4 },
+    });
+
+    expect(sourceOverlapsTarget("100", 0, 4)).toBe(false);
+  });
+
+  it("returns false when the source lies entirely after the placement range", () => {
+    // Source [10,14]; a placement at [0,4] ends before the source starts, so
+    // `sourceStart < targetEnd` (10 < 4) is false — no overlap.
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 10, end_time: 14 },
+    });
+
+    expect(sourceOverlapsTarget("100", 0, 4)).toBe(false);
+  });
+
+  it("returns false when the source starts exactly at the placement's end", () => {
+    // Source [4,8]; placement [0,4] ends exactly where the source starts. The
+    // strict `sourceStart < targetEnd` (4 < 4) makes this adjacent, not overlap.
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 4, end_time: 8 },
+    });
+
+    expect(sourceOverlapsTarget("100", 0, 4)).toBe(false);
+  });
+
+  it("returns true when the source overlaps the target placement range", () => {
+    // Source [0,16] (4-bar clip); a partial tile of length 4 at position 4
+    // covers [4,8], which is inside the source — placing it would trim the source.
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 0, end_time: 16 },
+    });
+
+    expect(sourceOverlapsTarget("100", 4, 4)).toBe(true);
+  });
+
+  it("returns false when the placement abuts the source's end (the tiling case)", () => {
+    // Source [0,4]; tiling always starts at the source's end, so a tile at
+    // position 4 (range [4,8]) is adjacent, not overlapping — the common path.
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 0, end_time: 4 },
+    });
+
+    expect(sourceOverlapsTarget("100", 4, 4)).toBe(false);
+  });
+});
+
+describe("duplicateSelfOverlappingClip", () => {
+  it("copies the source to holding, then overwrites the original with a full copy", () => {
+    // Source [0,16] (a 4-bar clip in 4/4) duplicated to target 4 — one bar
+    // forward, so it overlaps its own target range [4,20]. Direct duplication is
+    // impossible (Ableton crashes; trimming the source first would truncate the
+    // content). Routing through the holding area trims the original to its first
+    // bar [0,4] and places a full 4-bar copy at [4,20].
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 0, end_time: 16 },
+    });
+
+    // The holding copy the first duplicate creates. The holding area clears the
+    // target placement (target 4 + length 16 = 20) as well as the existing clips
+    // (maxEnd 16), so it starts at max(16, 20) + 100 = 120.
+    setupClip("400", {
+      properties: { is_arrangement_clip: 1, start_time: 120, end_time: 136 },
+    });
+
+    // The full copy the second duplicate places at the target ("500").
+    const { trackMock, result } = runTwoDupSelfOverlap(4);
+
+    // Step 1: copy the source to the holding area, past both the existing clips
+    // (maxEnd 16) and the target placement (4 + 16 = 20): max(16, 20) + 100 = 120.
+    expect(trackMock.call).toHaveBeenCalledWith(
+      "duplicate_clip_to_arrangement",
+      "id 100",
+      120,
+    );
+
+    // Step 2: trim the ORIGINAL to its "before" portion (right-trim at target 4,
+    // length clipEnd 16 - target 4 = 12) so the full copy can overwrite [4,20].
+    expect(trackMock.call).toHaveBeenCalledWith("create_midi_clip", 4, 12);
+
+    // Step 3: place the full copy at the target from the untouched holding clip.
+    expect(trackMock.call).toHaveBeenCalledWith(
+      "duplicate_clip_to_arrangement",
+      "id 400",
+      4,
+    );
+
+    // Step 4: clean up the holding clip.
+    expect(trackMock.call).toHaveBeenCalledWith("delete_clip", "id 400");
+
+    // The placed full-length copy is returned (never the trimmed original).
+    expect(result.id).toBe("500");
+  });
+
+  it("pushes the holding area past the target placement for a clip longer than the gap", () => {
+    // Regression: a clip longer than HOLDING_AREA_GAP_BEATS (100) moved far
+    // enough forward that its full-length target copy would reach a holding area
+    // pinned only to maxEnd. Source [0,200] (50 bars) duplicated to target 199
+    // self-overlaps [199,399]. With the old `maxEnd + 100` holding position
+    // (300), the placed copy [199,399] overlaps the holding clip [300,500];
+    // moveClipFromHolding's clearClipAtDuplicateTarget would then read the
+    // holding clip as self-overlapping, skip clearing the original [0,200], and
+    // duplicate onto a still-overlapping clip — exactly Ableton's crash. The
+    // holding area must clear the target extent: max(200, 199 + 200) + 100 = 499.
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 0, end_time: 200 },
+    });
+
+    // The holding copy at the corrected position (past the target extent 399).
+    setupClip("400", {
+      properties: { is_arrangement_clip: 1, start_time: 499, end_time: 699 },
+    });
+    const { trackMock, result } = runTwoDupSelfOverlap(199);
+
+    // The holding copy lands past the target placement (399), not at maxEnd + 100
+    // (300) — so the holding clip cannot overlap the target copy.
+    expect(trackMock.call).toHaveBeenCalledWith(
+      "duplicate_clip_to_arrangement",
+      "id 100",
+      499,
+    );
+
+    // Because the holding area cleared the target, the ORIGINAL is recognized as
+    // an "other" overlapping clip and right-trimmed at 199 (length 200 - 199 = 1)
+    // — it is no longer left in place to overlap the target and crash Ableton.
+    expect(trackMock.call).toHaveBeenCalledWith("create_midi_clip", 199, 1);
+
+    // The full copy is then placed at the target and the holding clip removed.
+    expect(trackMock.call).toHaveBeenCalledWith(
+      "duplicate_clip_to_arrangement",
+      "id 400",
+      199,
+    );
+    expect(trackMock.call).toHaveBeenCalledWith("delete_clip", "id 400");
+    expect(result.id).toBe("500");
+  });
+
+  it("derives the source length from end minus start for a non-zero-start clip", () => {
+    // Source [10,26] (length 16, start_time 10) self-overlaps target 12. The
+    // holding area must clear target + length (12 + 16 = 28): max(maxEnd 26, 28) +
+    // 100 = 128. A start+end length (36) would push it to 148 instead.
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 10, end_time: 26 },
+    });
+    setupClip("400", {
+      properties: { is_arrangement_clip: 1, start_time: 128, end_time: 144 },
+    });
+    const { trackMock } = runTwoDupSelfOverlap(12);
+
+    expect(trackMock.call).toHaveBeenCalledWith(
+      "duplicate_clip_to_arrangement",
+      "id 100",
+      128,
+    );
+  });
+
+  it("computes the holding area from the track's real arrangement clips", () => {
+    // A far existing clip [100,500] must push the holding area past it: max(500,
+    // target 2 + length 4 = 6) + 100 = 600. Reading the wrong child list would
+    // collapse maxEnd to 0 and land the holding copy at 106.
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 0, end_time: 4 },
+    });
+    setupArrangementClip("900", 0, { start_time: 100, end_time: 500 }, 1);
+    setupClip("400", {
+      properties: { is_arrangement_clip: 1, start_time: 600, end_time: 604 },
+    });
+    setupClip("500", { properties: { is_arrangement_clip: 1 } });
+    const trackMock = setupTrack(0, {
+      properties: { arrangement_clips: ["id", "100", "id", "900"] },
+      methods: tilingTrackMethods(),
+    });
+
+    duplicateSelfOverlappingClip(
+      LiveAPI.from(trackMock.path),
+      "100",
+      2,
+      true,
+      mockContext,
+    );
+
+    expect(trackMock.call).toHaveBeenCalledWith(
+      "duplicate_clip_to_arrangement",
+      "id 100",
+      600,
+    );
+  });
+
+  it("throws with a self-overlap context when the holding dup silently fails", () => {
+    // The first dup (source → holding) failing must abort with a context that
+    // names the self-overlap operation, so the source is never mutated.
+    setupClip("100", {
+      properties: { is_arrangement_clip: 1, start_time: 0, end_time: 16 },
+    });
+    const trackMock = setupTrack(0, {
+      properties: { arrangement_clips: ["id", "100"] },
+      methods: {
+        duplicate_clip_to_arrangement: () => ["id", 0],
+        delete_clip: () => null,
+      },
+    });
+
+    expect(() =>
+      duplicateSelfOverlappingClip(
+        LiveAPI.from(trackMock.path),
+        "100",
+        4,
+        true,
+        mockContext,
+      ),
+    ).toThrow(/self-overlap dup-to-holding/);
+  });
+});
+
+/**
+ * Run the two-duplicate self-overlap workaround. The caller registers the source
+ * ("100") and holding ("400") clips; this sets up "500" (the placed full copy),
+ * the track with its dup/create/delete methods, and invokes the workaround.
+ * @param target - Target arrangement position for the duplicate
+ * @returns The track mock and the resulting clip
+ */
+function runTwoDupSelfOverlap(target: number): {
+  trackMock: ReturnType<typeof setupTrack>;
+  result: ReturnType<typeof duplicateSelfOverlappingClip>;
+} {
+  setupClip("500", { properties: { is_arrangement_clip: 1 } });
+
+  const trackMock = setupTrack(0, {
+    properties: { arrangement_clips: ["id", "100"] },
+    methods: tilingTrackMethods(),
+  });
+
+  const result = duplicateSelfOverlappingClip(
+    LiveAPI.from(trackMock.path),
+    "100",
+    target,
+    true,
+    mockContext,
+  );
+
+  return { trackMock, result };
+}

--- a/src/tools/shared/arrangement/tests/arrangement-splitting.test.ts
+++ b/src/tools/shared/arrangement/tests/arrangement-splitting.test.ts
@@ -3,7 +3,7 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { describe, expect, it, type Mock } from "vitest";
+import { describe, expect, it, type Mock, vi } from "vitest";
 import {
   registerMockObject,
   type RegisteredMockObject,
@@ -98,6 +98,95 @@ describe("prepareSplitParams", () => {
 
     expect(result).toBeNull();
     expect(warnings.has("split-invalid-format")).toBe(true);
+    // The warning text names the problem so the model can correct it.
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining('Invalid split format: "invalid"'),
+    );
+  });
+
+  it("treats an all-empty split spec as invalid format", () => {
+    const { mockClip, warnings } = setupPrepareTest();
+
+    // "," has only empty parts, so parseSplitPoints returns [] (empty, not null).
+    // That must be reported as invalid format, not silently accepted as no-op.
+    const result = prepareSplitParams(",", [mockClip], warnings);
+
+    expect(result).toBeNull();
+    expect(warnings.has("split-invalid-format")).toBe(true);
+  });
+
+  it("should reject the whole split when any point is malformed", () => {
+    const { mockClip, warnings } = setupPrepareTest();
+
+    // "2|1" alone is valid, but a single malformed part must invalidate the whole
+    // list (return null) rather than silently dropping it and splitting anyway.
+    const result = prepareSplitParams(
+      "2|1, notaposition",
+      [mockClip],
+      warnings,
+    );
+
+    expect(result).toBeNull();
+    expect(warnings.has("split-invalid-format")).toBe(true);
+  });
+
+  it("should not re-warn about invalid format when already warned", () => {
+    const { mockClip } = setupPrepareTest();
+    const warnings = new Set(["split-invalid-format"]);
+
+    vi.clearAllMocks();
+
+    prepareSplitParams("invalid", [mockClip], warnings);
+
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("Invalid split format"),
+    );
+  });
+
+  it("should not re-warn about too many points when already warned", () => {
+    const { mockClip } = setupPrepareTest();
+    const warnings = new Set(["split-max-exceeded"]);
+    const manyPoints = Array.from({ length: 33 }, (_, i) => `${i + 2}|1`).join(
+      ", ",
+    );
+
+    vi.clearAllMocks();
+
+    prepareSplitParams(manyPoints, [mockClip], warnings);
+
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("Too many split points"),
+    );
+  });
+
+  it("should not re-warn about no valid points when already warned", () => {
+    const { mockClip } = setupPrepareTest();
+    const warnings = new Set(["split-no-valid-points"]);
+
+    vi.clearAllMocks();
+
+    prepareSplitParams("1|1", [mockClip], warnings);
+
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("No valid split points"),
+    );
+  });
+
+  it("should allow exactly MAX_SPLIT_POINTS points (boundary is > not >=)", () => {
+    const { mockClip, warnings } = setupPrepareTest();
+
+    // 32 points is at the cap, not over it — it must be accepted, not rejected.
+    const points = Array.from({ length: 32 }, (_, i) => `${i + 2}|1`).join(
+      ", ",
+    );
+    const result = prepareSplitParams(points, [mockClip], warnings);
+
+    expect(result).toHaveLength(32);
+    expect(warnings.has("split-max-exceeded")).toBe(false);
   });
 
   it("should parse valid bar|beat positions", () => {
@@ -135,6 +224,10 @@ describe("prepareSplitParams", () => {
 
     expect(result).toBeNull();
     expect(warnings.has("split-no-valid-points")).toBe(true);
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("No valid split points"),
+    );
   });
 
   it("should warn when too many split points", () => {
@@ -148,6 +241,10 @@ describe("prepareSplitParams", () => {
 
     expect(result).toBeNull();
     expect(warnings.has("split-max-exceeded")).toBe(true);
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("Too many split points"),
+    );
   });
 
   it("should handle trailing commas in split string", () => {
@@ -349,6 +446,9 @@ describe("performSplitting", () => {
 
     // Should duplicate for audio content
     expectDuplicateCalled(callState.trackMock);
+    // Audio trims route through create_audio_clip in a session slot, never
+    // create_midi_clip — so a MIDI-vs-audio misdetection would show up here.
+    expectCreateMidiClipCount(callState.trackMock, 0);
   });
 
   it("should split into 3 segments exercising middle segment extraction", () => {
@@ -370,6 +470,72 @@ describe("performSplitting", () => {
     // Step 4: 1 moveClipFromHolding (last segment)
     // Total: 4 duplicates
     expect(callState.duplicateCount).toBe(4);
+  });
+
+  it("places every segment at its exact arrangement position (3-segment split)", () => {
+    const clipId = "clip_1";
+
+    // start_time 100, end_time 112 → clipLength 12, so `end - start` (not
+    // `end + start`) is exercised. Split at 4 and 8 → boundaries [0,4,8,12].
+    const { callState } = setupClipSplittingMocks(clipId, {
+      looping: true,
+      startTime: 100,
+      endTime: 112,
+      loopEnd: 4,
+    });
+    const { mockClip, clips } = createPerformContext(clipId);
+
+    performSplitting([mockClip], [4, 8], clips, HOLDING_AREA);
+
+    const calls = callState.trackMock.call.mock.calls;
+    const dupPositions = calls
+      .filter((c: unknown[]) => c[0] === "duplicate_clip_to_arrangement")
+      .map((c: unknown[]) => c[2]);
+
+    // Step 1 source→holding at 40000; Step 3 middle works at
+    // holdingAreaStart + 1*(clipLength 12 + 4) = 40016, then moves to
+    // clipArrangementStart 100 + segStart 4 = 104; Step 4 last moves to
+    // clipArrangementStart 100 + lastSegStart 8 = 108.
+    expect(dupPositions).toStrictEqual([40000, 40016, 104, 108]);
+
+    // Step 2 right-trim seg0: temp at start 100 + seg0End 4 = 104, length
+    // clipLength 12 - seg0End 4 = 8.
+    expect(calls).toContainEqual(["create_midi_clip", 104, 8]);
+    // Step 3 middle left-trim at workPos 40016, length segStart 4; right-trim at
+    // workPos 40016 + segEnd 8 = 40024, length clipLength 12 - segEnd 8 = 4.
+    expect(calls).toContainEqual(["create_midi_clip", 40016, 4]);
+    expect(calls).toContainEqual(["create_midi_clip", 40024, 4]);
+    // Step 4 last-segment left-trim at sourcePos 40000, length lastSegStart 8.
+    expect(calls).toContainEqual(["create_midi_clip", 40000, 8]);
+  });
+
+  it("excludes a split point that lands exactly on the clip end", () => {
+    const clipId = "clip_1";
+    let duplicateCount = 0;
+
+    // 8-beat clip. A split at 8 is the clip's very end (p < clipLength, not <=),
+    // so it must be dropped, leaving a single valid point at 4 → 2 duplicates.
+    const { callState } = setupClipSplittingMocks(clipId, {
+      looping: true,
+      endTime: 8.0,
+      loopEnd: 4.0,
+    });
+
+    callState.trackMock.call.mockImplementation((method: string) => {
+      if (method === "duplicate_clip_to_arrangement") {
+        duplicateCount++;
+
+        return ["id", `dup_${duplicateCount}`];
+      }
+
+      if (method === "create_midi_clip") return ["id", "temp_1"];
+    });
+
+    const { mockClip, clips } = createPerformContext(clipId);
+
+    performSplitting([mockClip], [4, 8], clips, HOLDING_AREA);
+
+    expect(duplicateCount).toBe(2);
   });
 
   it("should warn and skip when middle segment duplication fails", () => {
@@ -492,6 +658,72 @@ describe("performSplitting", () => {
 
     // clips array should remain empty since stale clip was not found
     expect(clips).toHaveLength(0);
+  });
+
+  it("keeps only fresh clips whose start falls inside the original clip's range", () => {
+    const clipId = "clip_1";
+
+    // Original clip_1 occupies [0,16), so only fresh clips starting in that
+    // half-open range survive the rescan filter.
+    const { callState } = setupClipSplittingMocks(clipId);
+
+    const freshDefs: Array<[string, number]> = [
+      ["fresh_in1", 0], // at range start → included
+      ["fresh_in2", 8], // mid-range → included
+      ["fresh_below", -5], // before range start → excluded (lower bound)
+      ["fresh_at_end", 16], // exactly at range end → excluded (upper is `<`)
+      ["fresh_above", 100], // past range end → excluded (upper bound)
+    ];
+
+    for (const [i, [id, start]] of freshDefs.entries()) {
+      registerMockObject(id, {
+        path: `live_set tracks 0 arrangement_clips ${String(i)}`,
+        type: "Clip",
+        properties: { start_time: start },
+      });
+    }
+
+    callState.trackMock.get.mockImplementation((prop: string) => {
+      if (prop === "arrangement_clips") {
+        return freshDefs.flatMap(([id]) => ["id", id]);
+      }
+
+      return [0];
+    });
+
+    const mockClip = LiveAPI.from(`id ${clipId}`);
+    const clips = [mockClip];
+
+    performSplitting([mockClip], [4], clips, { holdingAreaStartBeats: 40000 });
+
+    expect(clips.map((c) => c.id)).toStrictEqual(["fresh_in1", "fresh_in2"]);
+  });
+
+  it("replaces only the stale clip, leaving unrelated clips in place", () => {
+    const clipId = "clip_1";
+
+    const { callState } = setupClipSplittingMocks(clipId);
+
+    registerMockObject("fresh_1", {
+      path: "live_set tracks 0 arrangement_clips 0",
+      type: "Clip",
+      properties: { start_time: 0.0 },
+    });
+
+    callState.trackMock.get.mockImplementation((prop: string) =>
+      prop === "arrangement_clips" ? ["id", "fresh_1"] : [0],
+    );
+
+    const decoy = LiveAPI.from("id decoy");
+    const mockClip = LiveAPI.from(`id ${clipId}`);
+    // The stale clip is at index 1; the decoy at index 0 must be untouched.
+    const clips = [decoy, mockClip];
+
+    performSplitting([mockClip], [4], clips, { holdingAreaStartBeats: 40000 });
+
+    expect(clips[0]!.id).toBe("decoy");
+    expect(clips.some((c) => c.id === "fresh_1")).toBe(true);
+    expect(clips.some((c) => c.id === clipId)).toBe(false);
   });
 
   it("should skip right-trim when split point is within EPSILON of clip end", () => {

--- a/src/tools/shared/arrangement/tests/arrangement-tiling-advanced.test.ts
+++ b/src/tools/shared/arrangement/tests/arrangement-tiling-advanced.test.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,7 +10,10 @@ import {
   mockContext,
   setupArrangementClip,
   setupClip,
+  setupClipSlot,
+  setupLiveSet,
   setupMidiSourceClip,
+  setupScene,
   setupTileClip,
   setupTrackWithQueuedMethods,
 } from "./arrangement-tiling-test-helpers.ts";
@@ -98,6 +102,81 @@ describe("createPartialTile", () => {
     );
 
     expect(track.call).toHaveBeenCalledTimes(5);
+  });
+
+  it("adjusts pre-roll on the created tile when adjustPreRoll defaults to true", () => {
+    // adjustPreRoll is omitted → defaults to true. The moved tile (clip 400) has
+    // pre-roll (start_marker 2 < loop_start 6), so the default path must snap its
+    // start_marker up to loop_start (6). Source loop_start is 1 so the earlier
+    // content-offset set("start_marker", 1) can't be confused with this snap.
+    const { sourceClip, track } = setupPartialTileMocks({
+      loopStart: 1,
+      loopEnd: 11,
+      holdingEndTime: 1010,
+      finalClipProps: { start_marker: 2, loop_start: 6, end_time: 100 },
+    });
+
+    const result = createPartialTile(
+      sourceClip,
+      track,
+      500,
+      6,
+      1000,
+      true,
+      mockContext,
+    );
+
+    expect(result.set).toHaveBeenCalledWith("start_marker", 6);
+  });
+
+  it("does not adjust pre-roll when adjustPreRoll is false even if the tile has pre-roll", () => {
+    // The tile has pre-roll (start_marker 2 < loop_start 6), but adjustPreRoll is
+    // explicitly false, so it must be left untouched (no snap to loop_start).
+    const { sourceClip, track } = setupPartialTileMocks({
+      loopStart: 1,
+      loopEnd: 11,
+      holdingEndTime: 1010,
+      finalClipProps: { start_marker: 2, loop_start: 6, end_time: 100 },
+    });
+
+    const result = createPartialTile(
+      sourceClip,
+      track,
+      500,
+      6,
+      1000,
+      true,
+      mockContext,
+      false,
+    );
+
+    expect(result.set).not.toHaveBeenCalledWith("start_marker", 6);
+  });
+
+  it("sets the tile start_marker from source loop_start plus content offset", () => {
+    // clipLength = loopEnd 10 - loopStart 2 = 8; contentOffset 10 → 10 % 8 = 2 →
+    // start_marker = loopStart 2 + 2 = 4. The tile has no pre-roll (start_marker
+    // 4 >= loop_start 2) and adjustPreRoll is false, isolating the offset math.
+    const { sourceClip, track } = setupPartialTileMocks({
+      loopStart: 2,
+      loopEnd: 10,
+      holdingEndTime: 1008,
+      finalClipProps: { start_marker: 4, loop_start: 2, end_time: 100 },
+    });
+
+    const result = createPartialTile(
+      sourceClip,
+      track,
+      500,
+      6,
+      1000,
+      true,
+      mockContext,
+      false,
+      10,
+    );
+
+    expect(result.set).toHaveBeenCalledWith("start_marker", 4);
   });
 });
 
@@ -376,6 +455,84 @@ describe("tileClipToRange", () => {
     expect(sourceClip.set).toHaveBeenCalledWith("end_marker", 4);
   });
 
+  it("does not touch end_marker when it already equals loop_end", () => {
+    // Default setupMidiSourceClip has end_marker 4 === loop_end 4, so the safety
+    // set must be skipped entirely (no needless set that could shift markers).
+    const sourceClip = setupMidiSourceClip("100", 0);
+    const track = setupTrackWithQueuedMethods(0, {
+      duplicate_clip_to_arrangement: [["id", "200"]],
+    });
+
+    setupTileClip("200");
+
+    tileClipToRange(sourceClip, track, 100, 4, 1000, mockContext);
+
+    expect(sourceClip.set).not.toHaveBeenCalledWith(
+      "end_marker",
+      expect.anything(),
+    );
+  });
+
+  it("adjusts pre-roll on a full tile when adjustPreRoll defaults to true", () => {
+    // adjustPreRoll is omitted → defaults to true. The created tile (clip 200)
+    // has pre-roll (start_marker 2 < loop_start 4), so the default path must snap
+    // its start_marker up to loop_start (4). The source loop_start is 0, so the
+    // earlier content set("start_marker", 0) can't be mistaken for this snap.
+    const sourceClip = setupMidiSourceClip("100", 0);
+    const track = setupTrackWithQueuedMethods(0, {
+      duplicate_clip_to_arrangement: [["id", "200"]],
+      create_midi_clip: [["id", "300"]],
+      delete_clip: [null],
+    });
+
+    const tile = setupTileClip("200", {
+      start_marker: 2,
+      loop_start: 4,
+      end_time: 100,
+    });
+
+    tileClipToRange(sourceClip, track, 100, 4, 1000, mockContext);
+
+    expect(tile.set).toHaveBeenCalledWith("start_marker", 4);
+  });
+
+  it("routes the partial tile through the MIDI holding path and returns its id", () => {
+    // A MIDI source with a remainder tile must build the shortened holding copy
+    // with create_midi_clip (the audio path would need session scenes). The
+    // returned entry must carry the partial tile's id, not an empty object.
+    const sourceClip = setupMidiSourceClip("100", 0, {
+      loop_end: 8,
+      end_marker: 8,
+    });
+    const track = setupTrackWithQueuedMethods(0, {
+      duplicate_clip_to_arrangement: [
+        ["id", "300"],
+        ["id", "301"],
+      ],
+      create_midi_clip: [["id", "302"]],
+      delete_clip: [null, null],
+    });
+
+    setupClip("300", { properties: { end_time: 1008 } });
+    setupTileClip("301");
+
+    const result = tileClipToRange(
+      sourceClip,
+      track,
+      100,
+      3,
+      1000,
+      mockContext,
+    );
+
+    expect(track.call).toHaveBeenCalledWith(
+      "create_midi_clip",
+      expect.any(Number),
+      expect.any(Number),
+    );
+    expect(result).toStrictEqual([{ id: "301" }]);
+  });
+
   it("advances content offset correctly with custom tileLength", () => {
     const { sourceClip, track, tiles } = setupThreeTileMocks();
 
@@ -418,6 +575,102 @@ describe("tileClipToRange", () => {
     expect(tiles[1]!.set).toHaveBeenCalledWith("start_marker", 0);
     expect(tiles[2]!.set).toHaveBeenCalledWith("start_marker", 0);
     expect(result).toHaveLength(3);
+  });
+
+  it("uses the audio (session) path when tiling an audio source", () => {
+    // An audio source must build its pre-roll trim through the session
+    // (create_audio_clip), never create_midi_clip. The full tile carries pre-roll
+    // (start_marker 2 < loop_start 4) to force adjustClipPreRoll down the audio
+    // branch — a MIDI/audio misdetection would call create_midi_clip instead.
+    const sourceClip = setupMidiSourceClip("100", 0, {
+      is_midi_clip: 0,
+      is_audio_clip: 1,
+    });
+    const track = setupTrackWithQueuedMethods(0, {
+      duplicate_clip_to_arrangement: [
+        ["id", "200"],
+        ["id", "600"],
+      ],
+      delete_clip: [null, null],
+    });
+
+    setupTileClip("200", { start_marker: 2, loop_start: 4, end_time: 100 });
+    setupLiveSet({ properties: { scenes: ["id", "s1"] } });
+    setupScene("s1", 0, { properties: { is_empty: 1 } });
+    const slot = setupClipSlot(0, 0, {
+      methods: {
+        create_audio_clip: () => null,
+        delete_clip: () => null,
+      },
+    });
+
+    setupClip("700", { path: "live_set tracks 0 clip_slots 0 clip" });
+
+    tileClipToRange(sourceClip, track, 100, 4, 1000, mockContext);
+
+    expect(slot.call).toHaveBeenCalledWith(
+      "create_audio_clip",
+      "/tmp/test-silence.wav",
+    );
+    expect(track.call).not.toHaveBeenCalledWith(
+      "create_midi_clip",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("advances position and content offset past a self-overlapping full tile", () => {
+    // The source occupies arrangement [100,104]; tiling starts on top of it, so
+    // tile 0 self-overlaps and is skipped. With tileLength 6 (≠ clipLength 4) the
+    // next tile must land at 100 + 6 = 106 and read content at offset 6 (6 % 4 = 2)
+    // — proving both the position and the content-offset advance in the skip path.
+    const sourceClip = setupMidiSourceClip("100", 0, {
+      is_arrangement_clip: 1,
+      start_time: 100,
+      end_time: 104,
+    });
+    const track = setupTrackWithQueuedMethods(0, {
+      duplicate_clip_to_arrangement: [["id", "200"]],
+    });
+    const tile = setupTileClip("200");
+
+    tileClipToRange(sourceClip, track, 100, 12, 1000, mockContext, {
+      tileLength: 6,
+    });
+
+    expect(track.call).toHaveBeenCalledWith(
+      "duplicate_clip_to_arrangement",
+      "id 100",
+      106,
+    );
+    expect(tile.set).toHaveBeenCalledWith("start_marker", 2);
+  });
+
+  it("advances content offset past a silently-failed full tile", () => {
+    // clipLength 5 with tileLength 6 (≠) makes the content offset observable via
+    // start_marker. The middle tile's dup silently fails and is skipped; the tile
+    // after it must still read content at the advanced offset (12 % 5 = 2), not a
+    // rewound one.
+    const sourceClip = setupMidiSourceClip("100", 0, {
+      loop_end: 5,
+      end_marker: 5,
+    });
+    const track = setupTrackWithQueuedMethods(0, {
+      duplicate_clip_to_arrangement: [
+        ["id", "200"],
+        ["id", 0],
+        ["id", "202"],
+      ],
+    });
+
+    setupTileClip("200");
+    const tile2 = setupTileClip("202");
+
+    tileClipToRange(sourceClip, track, 200, 18, 1000, mockContext, {
+      tileLength: 6,
+    });
+
+    expect(tile2.set).toHaveBeenCalledWith("start_marker", 2);
   });
 
   it("warns and skips a tile when its dup silently fails, advancing position", () => {

--- a/src/tools/shared/arrangement/tests/arrangement-tiling-basic.test.ts
+++ b/src/tools/shared/arrangement/tests/arrangement-tiling-basic.test.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -81,6 +82,17 @@ describe("createAudioClipInSession", () => {
     expect(result.clip).toBeDefined();
     expect(result.slot).toBeDefined();
   });
+
+  it("throws a descriptive error when the set has no scenes", () => {
+    // With no scenes, sceneIds.at(-1) is undefined and the assertion must throw
+    // with the "last scene ID" label (not a blank message).
+    setupLiveSet({ properties: { scenes: [] } });
+    const track = setupTrackWithQueuedMethods(0, {});
+
+    expect(() =>
+      createAudioClipInSession(track, 8, "/tmp/test-silence.wav"),
+    ).toThrow(/last scene ID/);
+  });
 });
 
 describe("createShortenedClipInHolding", () => {
@@ -158,6 +170,23 @@ describe("createShortenedClipInHolding", () => {
     );
 
     expect(track.call).toHaveBeenNthCalledWith(2, "create_midi_clip", 2012, 20);
+  });
+
+  it("does not create a temp clip when the holding copy is already the target length", () => {
+    // holdingAreaStart 1000 + targetLength 8 = 1008 exactly equals the holding
+    // copy's end_time, so tempLength is 0 and the truncation step must be skipped.
+    const { sourceClip, track } = setupShorteningMocks({
+      loopEnd: 16,
+      holdingEndTime: 1008,
+    });
+
+    createShortenedClipInHolding(sourceClip, track, 8, 1000, true, mockContext);
+
+    expect(track.call).not.toHaveBeenCalledWith(
+      "create_midi_clip",
+      expect.anything(),
+      expect.anything(),
+    );
   });
 
   it("creates audio clip in session for audio clip shortening", () => {
@@ -327,7 +356,7 @@ describe("moveClipFromHolding", () => {
 
     expect(() =>
       moveClipFromHolding("200", track, 500, true, mockContext),
-    ).toThrow(/duplicate_clip_to_arrangement returned no clip/);
+    ).toThrow(/move from holding \(id 200\) to 500/);
 
     expect(track.call).not.toHaveBeenCalledWith("delete_clip", "id 200");
   });

--- a/src/tools/shared/arrangement/tests/arrangement-tiling-test-helpers.ts
+++ b/src/tools/shared/arrangement/tests/arrangement-tiling-test-helpers.ts
@@ -236,3 +236,27 @@ export function setupArrangementClip(
 
   return LiveAPI.from(`id ${clipId}`);
 }
+
+/**
+ * Standard duplicate/create/delete method stubs for tiling and self-overlap
+ * workaround tests. duplicate_clip_to_arrangement returns clip 400 on the first
+ * call and 500 thereafter; create_midi_clip returns clip 300; delete_clip is a
+ * no-op.
+ * @returns Method stubs for setupTrack
+ */
+export function tilingTrackMethods(): Record<
+  string,
+  (...args: unknown[]) => unknown
+> {
+  let dupCount = 0;
+
+  return {
+    duplicate_clip_to_arrangement: () => {
+      dupCount++;
+
+      return dupCount === 1 ? ["id", "400"] : ["id", "500"];
+    },
+    create_midi_clip: () => ["id", "300"],
+    delete_clip: () => null,
+  };
+}

--- a/src/tools/shared/arrangement/tests/take-lane-helpers.test.ts
+++ b/src/tools/shared/arrangement/tests/take-lane-helpers.test.ts
@@ -3,15 +3,90 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import {
+  isTakeLaneClip,
   isTakeLaneRequested,
   MAX_TAKE_LANES,
   normalizeTakeLaneTarget,
   resolveTakeLane,
+  resolveTakeLaneForDuplicate,
 } from "#src/tools/shared/arrangement/take-lane-helpers.ts";
 import { registerTakeLaneTrack } from "./take-lane-test-helpers.ts";
+
+describe("isTakeLaneClip", () => {
+  it("matches a take-lane clip path (single- and multi-digit lane index)", () => {
+    // Multi-digit index proves the `\d+` quantifier (not a single `\d`) — a
+    // two-digit lane like `take_lanes 12` must still match.
+    expect(
+      isTakeLaneClip(
+        LiveAPI.from("live_set tracks 0 take_lanes 12 arrangement_clips 0"),
+      ),
+    ).toBe(true);
+    expect(
+      isTakeLaneClip(
+        LiveAPI.from("live_set tracks 0 take_lanes 0 arrangement_clips 3"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match a main-lane arrangement clip path", () => {
+    expect(
+      isTakeLaneClip(LiveAPI.from("live_set tracks 0 arrangement_clips 0")),
+    ).toBe(false);
+  });
+});
+
+describe("resolveTakeLaneForDuplicate", () => {
+  it("ignores (and warns for) takeLane on a non-clip duplicate", () => {
+    const warn = vi.fn();
+
+    expect(
+      resolveTakeLaneForDuplicate("track", "arrangement", 2, warn),
+    ).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("only supported when duplicating clips"),
+    );
+  });
+
+  it("does not warn for a non-clip duplicate when no take lane was requested", () => {
+    const warn = vi.fn();
+
+    expect(
+      resolveTakeLaneForDuplicate("track", "arrangement", 0, warn),
+    ).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("ignores (and warns for) takeLane on a session-destination clip duplicate", () => {
+    const warn = vi.fn();
+
+    expect(resolveTakeLaneForDuplicate("clip", "session", 3, warn)).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("session destination"),
+    );
+  });
+
+  it("does not warn for a session clip duplicate when no take lane was requested", () => {
+    const warn = vi.fn();
+
+    expect(
+      resolveTakeLaneForDuplicate("clip", "session", null, warn),
+    ).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("normalizes the target for an arrangement clip duplicate", () => {
+    const warn = vi.fn();
+
+    expect(resolveTakeLaneForDuplicate("clip", "arrangement", 2, warn)).toBe(2);
+    expect(
+      resolveTakeLaneForDuplicate("clip", "arrangement", "new", warn),
+    ).toBe("new");
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
 
 describe("isTakeLaneRequested", () => {
   it("is false for main-lane values", () => {
@@ -119,5 +194,28 @@ describe("resolveTakeLane", () => {
     expect(() => resolveTakeLane(trackApi, MAX_TAKE_LANES + 1)).toThrow(
       /reached the 8 take lane limit/,
     );
+  });
+
+  it("allows targeting exactly the cap-numbered lane (boundary is > not >=)", () => {
+    // Targeting lane MAX_TAKE_LANES (8) when 8 already exist is at the cap, not
+    // over it — it must resolve, not throw. Guards the `>` vs `>=` boundary.
+    registerTakeLaneTrack({ initialLanes: MAX_TAKE_LANES });
+    const trackApi = LiveAPI.from(livePath.track(0));
+
+    const { laneNumber } = resolveTakeLane(trackApi, MAX_TAKE_LANES);
+
+    expect(laneNumber).toBe(MAX_TAKE_LANES);
+  });
+
+  it("does not name a newly created lane when the name is empty string", () => {
+    // An empty takeLaneName must be treated as "no name" — the created lane is
+    // left unnamed (guards the `!== ""` check, distinct from a non-empty name).
+    const track = registerTakeLaneTrack({ initialLanes: 0 });
+    const trackApi = LiveAPI.from(livePath.track(0));
+
+    const { lane } = resolveTakeLane(trackApi, "new", "");
+
+    expect(lane.set).not.toHaveBeenCalledWith("name", expect.anything());
+    expect(track.call).toHaveBeenCalledWith("create_take_lane");
   });
 });


### PR DESCRIPTION
Mutation-testing triage of the `src/tools/shared/arrangement` subarea (subtask 2 of 4 for the shared-tools mutation triage). Test-only; the `shared` scope stays in baseline mode (`break: null`), so there is no gate change or doc baseline here — those land in the final subtask.

## Result

Narrowed mutation score for the 8 arrangement source files: **81.30% → 95.98%** (survivors 97 → 20).

| File | before | after |
|---|---|---|
| arrangement-splitting.ts | 75.27% | 93.55% |
| arrangement-tiling.ts | 64.71% | 94.03% |
| arrangement-tiling-workaround.ts | 85.05% | 99.07% |
| arrangement-tiling-holding.ts | 91.67% | 95.83% |
| arrangement-tiling-helpers.ts | 96.30% | 100% |
| take-lane-helpers.ts | 91.26% | 97.09% |
| arrangement-duplicate-target.ts / get-host-track-index.ts | 100% | 100% |

## What the tests cover

- **Splitting** — warning dedup/content guards, whole-list rejection on a malformed point, the `MAX_SPLIT_POINTS` boundary, exact per-segment arrangement positions for a 3-segment split (kills a swath of position/length arithmetic mutants), the split-at-clip-end boundary, the audio-vs-MIDI trim path, and the rescan range filter.
- **Tiling** — content-offset/`start_marker` math, default pre-roll behavior, the `end_marker` safety-set skip, skip-path position/offset advances (self-overlap and silent-fail), and the audio session path.
- **Workaround** — disabled / session-clip return values, self-overlap and overlap-loop boundaries, holding-area position arithmetic, and error-context messages.
- **Take lanes** — `isTakeLaneClip` regex, `resolveTakeLaneForDuplicate` branches, the lane-cap boundary, and empty-name handling.

## Residual survivors (20, all equivalent / marginal)

- **Unreachable defensive branches** — the tiling `start_marker >= clipLoopEnd` wrap can never fire (`start_marker` is always `< clipLoopEnd`).
- **Ignored return values** — `splitSingleClip`'s boolean is discarded by `performSplitting`.
- **Redundant guards** — the `p > 0` filter in `splitSingleClip` is already pre-filtered by `prepareSplitParams`.
- **`> EPSILON` → `>=` boundaries** — observable only at an exact `0.001` float.

Each was confirmed uncaught (not a false-survivor) by applying the mutant and running the suite.

## Refactor

`arrangement-duplicate-workaround.test.ts` grew past the 650-line test cap, so the `sourceOverlapsTarget` and `duplicateSelfOverlappingClip` describes moved to `arrangement-self-overlap.test.ts`; the shared `tilingTrackMethods` stub moved to the test-helper.

`npm run check` and `npm run check:build` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)