### PR TITLE
test(mutation): triage device reader & helpers subarea

### DIFF
--- a/src/tools/shared/device/device-reader.test.ts
+++ b/src/tools/shared/device/device-reader.test.ts
@@ -280,6 +280,17 @@ describe("device-reader", () => {
         ],
       });
     });
+
+    it("returns a non-object chain entry unchanged", () => {
+      // The `typeof chain === "object"` test must short-circuit: probing a
+      // primitive with the `in` operator would throw.
+      const obj = { type: "audio-effect-rack", chains: ["raw-entry"] };
+
+      expect(cleanupInternalDrumPads(obj)).toStrictEqual({
+        type: "audio-effect-rack",
+        chains: ["raw-entry"],
+      });
+    });
   });
 
   describe("getDrumMap", () => {
@@ -290,6 +301,33 @@ describe("device-reader", () => {
       ];
 
       expect(getDrumMap(devices)).toBe(null);
+    });
+
+    it("ignores a drum rack that has no processed pads", () => {
+      // Both halves must hold: a drum-rack-typed device without
+      // _processedDrumPads carries no map and must not be collected.
+      expect(getDrumMap([{ type: "drum-rack" }])).toBe(null);
+    });
+
+    it("ignores a nested chain that has no devices", () => {
+      // The `chain.devices` guard protects the recursive descent — without it,
+      // iterating an absent device list would throw.
+      const devices = [{ type: "instrument-rack", chains: [{}] }];
+
+      expect(getDrumMap(devices)).toBe(null);
+    });
+
+    it("keys a note-0 pad by MIDI number for midi-json notation", () => {
+      // MIDI note 0 is a real note, not a catch-all: the catch-all test is
+      // `midi < 0`, so 0 must fall through to the notation-specific key.
+      const devices = [
+        {
+          type: "drum-rack",
+          _processedDrumPads: [{ note: 0, pitch: "C-2", name: "Sub" }],
+        },
+      ];
+
+      expect(getDrumMap(devices, "midi-json")).toStrictEqual({ 0: "Sub" });
     });
 
     it("returns empty object when drum rack has no playable chains", () => {

--- a/src/tools/shared/device/helpers/path/device-drumpad-navigation.test.ts
+++ b/src/tools/shared/device/helpers/path/device-drumpad-navigation.test.ts
@@ -1,0 +1,200 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import "#src/live-api-adapter/live-api-extensions.ts";
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearMockRegistry,
+  registerMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+import {
+  navigateRemainingSegments,
+  resolveDrumPadFromPath,
+} from "./device-drumpad-navigation.ts";
+
+const RACK_PATH = "live_set tracks 0 devices 0";
+
+/**
+ * Register a rack device plus a single C1 (in_note 36) drum chain that holds two
+ * devices. Enough surface to drive both navigators: the rack exposes chains,
+ * return_chains, and devices; the chain exposes its own devices.
+ * @returns The rack LiveAPI handle
+ */
+function registerRackWithChain(): LiveAPI {
+  registerMockObject("rack", {
+    path: RACK_PATH,
+    type: "RackDevice",
+    properties: {
+      chains: ["id", "chain0"],
+      return_chains: ["id", "rchain0"],
+      devices: ["id", "dev0", "id", "dev1"],
+    },
+  });
+  registerMockObject("chain0", {
+    type: "DrumChain",
+    properties: {
+      in_note: 36,
+      devices: ["id", "cdev0", "id", "cdev1"],
+    },
+  });
+  registerMockObject("rchain0", { type: "Chain" });
+  registerMockObject("dev0", { type: "Device" });
+  registerMockObject("dev1", { type: "Device" });
+  registerMockObject("cdev0", { type: "Device" });
+  registerMockObject("cdev1", { type: "Device" });
+
+  return LiveAPI.from(RACK_PATH);
+}
+
+describe("navigateRemainingSegments", () => {
+  beforeEach(() => {
+    clearMockRegistry();
+  });
+
+  it("returns the start device unchanged for empty segments", () => {
+    const rack = registerRackWithChain();
+
+    expect(navigateRemainingSegments(rack, [])).toStrictEqual({
+      target: rack,
+      targetType: "device",
+    });
+  });
+
+  it("resolves a chain segment and reports the chain target type", () => {
+    const rack = registerRackWithChain();
+
+    const result = navigateRemainingSegments(rack, ["c0"]);
+
+    expect(result.targetType).toBe("chain");
+    expect(result.target?.id).toBe("chain0");
+  });
+
+  it("resolves a return-chain segment", () => {
+    const rack = registerRackWithChain();
+
+    const result = navigateRemainingSegments(rack, ["rc0"]);
+
+    expect(result.targetType).toBe("chain");
+    expect(result.target?.id).toBe("rchain0");
+  });
+
+  it("resolves a device segment", () => {
+    const rack = registerRackWithChain();
+
+    const result = navigateRemainingSegments(rack, ["d1"]);
+
+    expect(result.targetType).toBe("device");
+    expect(result.target?.id).toBe("dev1");
+  });
+
+  it("returns a null chain target for a bare 'p' with no note", () => {
+    const rack = registerRackWithChain();
+
+    expect(navigateRemainingSegments(rack, ["p"])).toStrictEqual({
+      target: null,
+      targetType: "chain",
+    });
+  });
+
+  it("returns the current (chain) target type for an unrecognized trailing segment", () => {
+    // After a valid chain, an unknown segment falls to the else branch, which
+    // reports the *current* target type ("chain"), not the initial "device".
+    const rack = registerRackWithChain();
+
+    expect(navigateRemainingSegments(rack, ["c0", "zz"])).toStrictEqual({
+      target: null,
+      targetType: "chain",
+    });
+  });
+
+  it("stops at a missing chain without dereferencing a following segment", () => {
+    // Chain index 9 is out of range → null. A trailing "d0" must NOT be
+    // navigated off the null chain (would throw); resolution returns null chain.
+    const rack = registerRackWithChain();
+
+    expect(navigateRemainingSegments(rack, ["c9", "d0"])).toStrictEqual({
+      target: null,
+      targetType: "chain",
+    });
+  });
+
+  it("reports a device target type for a missing device index", () => {
+    const rack = registerRackWithChain();
+
+    expect(navigateRemainingSegments(rack, ["d9"])).toStrictEqual({
+      target: null,
+      targetType: "device",
+    });
+  });
+
+  it("stops at a missing device without dereferencing a following segment", () => {
+    const rack = registerRackWithChain();
+
+    expect(navigateRemainingSegments(rack, ["d9", "d0"])).toStrictEqual({
+      target: null,
+      targetType: "device",
+    });
+  });
+});
+
+describe("resolveDrumPadFromPath", () => {
+  beforeEach(() => {
+    clearMockRegistry();
+  });
+
+  it("returns a null chain target when the rack device does not exist", () => {
+    registerMockObject("0", { path: RACK_PATH });
+
+    expect(resolveDrumPadFromPath(RACK_PATH, "C1", [])).toStrictEqual({
+      target: null,
+      targetType: "chain",
+    });
+  });
+
+  it("resolves the pad's chain when no further segments are given", () => {
+    registerRackWithChain();
+
+    const result = resolveDrumPadFromPath(RACK_PATH, "C1", []);
+
+    expect(result.targetType).toBe("chain");
+    expect(result.target?.id).toBe("chain0");
+  });
+
+  it("resolves a device inside the pad chain", () => {
+    registerRackWithChain();
+
+    const result = resolveDrumPadFromPath(RACK_PATH, "C1", ["c0", "d1"]);
+
+    expect(result.targetType).toBe("device");
+    expect(result.target?.id).toBe("cdev1");
+  });
+
+  it("returns a null device target when the post-chain segment is not a device", () => {
+    // nextSegment "x1" does not start with "d"; even though the chain holds a
+    // device at index 1, resolution must NOT treat "x1" as device index 1.
+    registerRackWithChain();
+
+    expect(resolveDrumPadFromPath(RACK_PATH, "C1", ["c0", "x1"])).toStrictEqual(
+      {
+        target: null,
+        targetType: "device",
+      },
+    );
+  });
+
+  it("returns a null device target for a negative device index without throwing", () => {
+    // "d-1" parses to -1; the guard must catch it and return null rather than
+    // indexing devices[-1] (which would throw on the assertDefined below it).
+    registerRackWithChain();
+
+    expect(
+      resolveDrumPadFromPath(RACK_PATH, "C1", ["c0", "d-1"]),
+    ).toStrictEqual({
+      target: null,
+      targetType: "device",
+    });
+  });
+});

--- a/src/tools/shared/device/helpers/path/device-path-helpers.test.ts
+++ b/src/tools/shared/device/helpers/path/device-path-helpers.test.ts
@@ -61,6 +61,13 @@ describe("device-path-helpers", () => {
           "t1/d0/c2",
         );
       });
+
+      it("keeps every digit of a multi-digit device index", () => {
+        // Guards the `\d+` (not `\d`) quantifier on the devices/chains matcher.
+        expect(extractDevicePath("live_set tracks 0 devices 12")).toBe(
+          "t0/d12",
+        );
+      });
     });
 
     describe("return track devices", () => {
@@ -76,6 +83,13 @@ describe("device-path-helpers", () => {
             "live_set return_tracks 1 devices 0 chains 0 devices 1",
           ),
         ).toBe("rt1/d0/c0/d1");
+      });
+
+      it("keeps every digit of a multi-digit return track index", () => {
+        // Guards the `(\d+)` (not `(\d)`) capture on the return-track prefix.
+        expect(extractDevicePath("live_set return_tracks 12 devices 0")).toBe(
+          "rt12/d0",
+        );
       });
     });
 
@@ -133,6 +147,18 @@ describe("device-path-helpers", () => {
 
       it("returns null for empty string", () => {
         expect(extractDevicePath("")).toBe(null);
+      });
+
+      it("requires the track prefix to anchor at the start of the path", () => {
+        // The prefix matchers are `^`-anchored: a live_set path buried after
+        // other text is not a valid device path.
+        expect(extractDevicePath("x live_set tracks 1 devices 0")).toBe(null);
+        expect(extractDevicePath("x live_set return_tracks 0 devices 0")).toBe(
+          null,
+        );
+        expect(extractDevicePath("x live_set master_track devices 0")).toBe(
+          null,
+        );
       });
     });
   });
@@ -352,6 +378,15 @@ describe("device-path-helpers", () => {
         );
       });
 
+      it("throws on a non-string path", () => {
+        // A truthy non-string trips the `typeof !== "string"` half of the guard
+        // (not the `!path` half), so removing it would let `.split` throw a
+        // different, less useful error.
+        expect(() => resolvePathToLiveApi(123 as unknown as string)).toThrow(
+          "Path must be a non-empty string",
+        );
+      });
+
       it("throws on track-only path", () => {
         expect(() => resolvePathToLiveApi("t1")).toThrow(
           "Path must include at least a device index",
@@ -473,6 +508,9 @@ describe("device-path-helpers", () => {
         "Path must be a non-empty string",
       );
       expect(() => resolveInsertionPath(null as unknown as string)).toThrow(
+        "Path must be a non-empty string",
+      );
+      expect(() => resolveInsertionPath(123 as unknown as string)).toThrow(
         "Path must be a non-empty string",
       );
       expect(() => resolveInsertionPath("t0/dabc")).toThrow(

--- a/src/tools/shared/device/helpers/tests/device-chain-creation-helpers.test.ts
+++ b/src/tools/shared/device/helpers/tests/device-chain-creation-helpers.test.ts
@@ -1,0 +1,195 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import "#src/live-api-adapter/live-api-extensions.ts";
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import {
+  clearMockRegistry,
+  type RegisteredMockObject,
+  registerMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+import {
+  resolveContainerWithAutoCreate,
+  resolveOrCreateDrumPadChain,
+} from "../device-chain-creation-helpers.ts";
+
+const DEVICE_PATH = "live_set tracks 0 devices 0";
+
+/**
+ * Register a chain-capable (non-drum) rack on track 0 whose insert_chain grows
+ * its own chain list, so auto-creation sees the list advance.
+ * @param existingChainCount - Chains present before auto-creation
+ * @param insertChain - Optional insert_chain override (defaults to a growing stub)
+ * @returns The rack mock
+ */
+function registerGrowingRack(
+  existingChainCount = 0,
+  insertChain?: () => unknown,
+): RegisteredMockObject {
+  const chainIds: string[] = [];
+
+  for (let i = 0; i < existingChainCount; i++) {
+    chainIds.push("id", `chain-${String(i)}`);
+  }
+
+  registerMockObject("track-0", { path: livePath.track(0), type: "Track" });
+
+  return registerMockObject("rack", {
+    path: DEVICE_PATH,
+    type: "RackDevice",
+    properties: {
+      chains: chainIds,
+      can_have_chains: 1,
+      can_have_drum_pads: 0,
+    },
+    methods: {
+      insert_chain:
+        insertChain ??
+        (() => {
+          const id = `chain-${String(chainIds.length / 2)}`;
+
+          chainIds.push("id", id);
+
+          return ["id", id];
+        }),
+    },
+  });
+}
+
+describe("resolveContainerWithAutoCreate", () => {
+  beforeEach(() => {
+    clearMockRegistry();
+  });
+
+  it("creates only the chains that are missing when some already exist", () => {
+    // 2 chains exist and c4 is requested → exactly 3 new chains (indices 2-4).
+    // The count is targetIndex + 1 - existing, read from the live chain list.
+    const rack = registerGrowingRack(2);
+
+    resolveContainerWithAutoCreate(["t0", "d0", "c4"], "t0/d0/c4");
+
+    expect(rack.call).toHaveBeenCalledTimes(3);
+  });
+
+  it("auto-creates up to exactly the maximum without throwing", () => {
+    // c15 on an empty rack needs 16 chains — exactly the cap, which must
+    // succeed (the guard is `> MAX`, not `>= MAX`).
+    const rack = registerGrowingRack(0);
+
+    expect(() =>
+      resolveContainerWithAutoCreate(["t0", "d0", "c15"], "t0/d0/c15"),
+    ).not.toThrow();
+    expect(rack.call).toHaveBeenCalledTimes(16);
+  });
+
+  it("throws when insert_chain returns an array without an id tag", () => {
+    // Live signals success with ["id", <id>]; any other array shape is a
+    // failure and must abort rather than be treated as a created chain.
+    registerGrowingRack(0, () => ["error", "5"]);
+
+    expect(() =>
+      resolveContainerWithAutoCreate(["t0", "d0", "c0"], "t0/d0/c0"),
+    ).toThrow("Failed to create chain 1/1");
+  });
+
+  it("ignores a segment that is neither a device nor a chain", () => {
+    // Only d / c / rc prefixes navigate; an unrecognized segment leaves the
+    // container where it was rather than being coerced into a chain lookup.
+    const rack = registerGrowingRack(0);
+
+    const container = resolveContainerWithAutoCreate(
+      ["t0", "d0", "zz"],
+      "t0/d0/zz",
+    );
+
+    expect(container.path).toBe(DEVICE_PATH);
+    expect(rack.call).not.toHaveBeenCalledWith("insert_chain");
+  });
+});
+
+describe("resolveOrCreateDrumPadChain", () => {
+  beforeEach(() => {
+    clearMockRegistry();
+  });
+
+  /**
+   * Register a Drum Rack whose insert_chain is a no-op stub (chains never grow),
+   * plus the given note-mapped chains.
+   * @param chains - [id, in_note] pairs to register as the rack's chains
+   * @returns The rack mock
+   */
+  function registerDrumRack(chains: [string, number][]): RegisteredMockObject {
+    const chainIds = chains.flatMap(([id]) => ["id", id]);
+
+    for (const [id, inNote] of chains) {
+      registerMockObject(id, {
+        type: "DrumChain",
+        properties: { in_note: inNote },
+      });
+    }
+
+    return registerMockObject("drum-rack", {
+      path: DEVICE_PATH,
+      type: "RackDevice",
+      properties: { chains: chainIds, can_have_drum_pads: 1 },
+      methods: { insert_chain: () => ["id", "new-chain"] },
+    });
+  }
+
+  it("returns null without touching a rack that does not exist", () => {
+    const rack = registerMockObject("0", { path: DEVICE_PATH });
+
+    expect(
+      resolveOrCreateDrumPadChain(LiveAPI.from(DEVICE_PATH), "C1", []),
+    ).toBeNull();
+    expect(rack.call).not.toHaveBeenCalledWith("insert_chain");
+  });
+
+  it("returns an existing pad chain without creating one", () => {
+    const rack = registerDrumRack([["drum-chain-36", 36]]);
+
+    const chain = resolveOrCreateDrumPadChain(
+      LiveAPI.from(DEVICE_PATH),
+      "C1",
+      [],
+    );
+
+    expect(chain?.id).toBe("drum-chain-36");
+    expect(rack.call).not.toHaveBeenCalledWith("insert_chain");
+  });
+
+  it("resolves an explicitly addressed chain 0 within the pad", () => {
+    registerDrumRack([["drum-chain-36", 36]]);
+
+    const chain = resolveOrCreateDrumPadChain(LiveAPI.from(DEVICE_PATH), "C1", [
+      "c0",
+    ]);
+
+    expect(chain?.id).toBe("drum-chain-36");
+  });
+
+  it("auto-creates the pad chain when c0 is addressed but missing", () => {
+    // The pad has no chain yet, so "c0" must parse to index 0 and drive
+    // creation — the reject boundary is `< 0`, not `<= 0`, which would discard
+    // the (valid) index 0 and silently create nothing.
+    const rack = registerDrumRack([["other-chain", 40]]);
+
+    resolveOrCreateDrumPadChain(LiveAPI.from(DEVICE_PATH), "C1", ["c0"]);
+
+    expect(rack.call).toHaveBeenCalledWith("insert_chain");
+  });
+
+  it("auto-creates up to exactly the maximum pad chains without throwing", () => {
+    // c15 with no chains in the note group needs 16 — exactly the cap.
+    const rack = registerDrumRack([]);
+
+    expect(() =>
+      resolveOrCreateDrumPadChain(LiveAPI.from(DEVICE_PATH), "C1", ["c15"]),
+    ).not.toThrow();
+    expect(rack.call).toHaveBeenCalledTimes(16);
+  });
+});

--- a/src/tools/shared/device/helpers/tests/device-display-helpers-labels.test.ts
+++ b/src/tools/shared/device/helpers/tests/device-display-helpers-labels.test.ts
@@ -1,0 +1,121 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Robustness of the display-label lexer: anchoring, optional whitespace, and
+// optional sign/quantifier handling. Split from device-display-helpers.test.ts
+// (unit-by-unit value parsing) to keep both files under the line limit.
+
+import { describe, expect, it } from "vitest";
+import {
+  extractMaxPanValue,
+  isDivisionLabel,
+  isPanLabel,
+  normalizePan,
+  parseLabel,
+} from "../device-display-helpers.ts";
+
+// One well-formed label per LABEL_PATTERNS entry.
+const UNIT_LABELS = [
+  "1.00 kHz",
+  "440 Hz",
+  "100 ms",
+  "1.00 s",
+  "-6 dB",
+  "-inf dB",
+  "50 %",
+  "180 °",
+  "+12 st",
+  "C4",
+  "50L",
+  "C",
+];
+
+describe("parseLabel anchoring", () => {
+  it.each(UNIT_LABELS)(
+    "does not read a unit from '%s' when other text precedes it",
+    (label) => {
+      // Every pattern is `^`-anchored: a label is a value, not a haystack.
+      expect(parseLabel(`x ${label}`).unit).toBeNull();
+    },
+  );
+
+  it.each(UNIT_LABELS)(
+    "does not read a unit from '%s' when other text follows it",
+    (label) => {
+      // Every pattern is `$`-anchored, so trailing text disqualifies the match.
+      expect(parseLabel(`${label} x`).unit).toBeNull();
+    },
+  );
+
+  it("does not extract a bare number that is not at the start", () => {
+    expect(parseLabel("abc123")).toStrictEqual({ value: null, unit: null });
+  });
+});
+
+describe("parseLabel optional whitespace", () => {
+  it.each([
+    { label: "5kHz", value: 5000, unit: "Hz" },
+    { label: "100ms", value: 100, unit: "ms" },
+    { label: "2s", value: 2000, unit: "ms" },
+    { label: "-6dB", value: -6, unit: "dB" },
+    { label: "-infdB", value: -70, unit: "dB" },
+  ])(
+    "parses '$label' with no space before the unit",
+    ({ label, value, unit }) => {
+      // The separator is `\s*` (zero or more), so a space is optional.
+      expect(parseLabel(label)).toStrictEqual({ value, unit });
+    },
+  );
+});
+
+describe("parseLabel optional sign and multi-digit tokens", () => {
+  it("parses an unsigned 'inf dB' as the -inf floor", () => {
+    // The sign is optional (`-?inf`), so a bare "inf dB" still maps to -70.
+    expect(parseLabel("inf dB")).toStrictEqual({ value: -70, unit: "dB" });
+  });
+
+  it("parses a note name with a multi-digit octave", () => {
+    // The octave is `\d+`, not a single digit.
+    expect(parseLabel("C10")).toStrictEqual({ value: "C10", unit: "note" });
+  });
+});
+
+describe("isPanLabel anchoring", () => {
+  it.each(["x50L", "50Lx", "xC", "Cx"])(
+    "returns false for the unanchored label '%s'",
+    (label) => {
+      expect(isPanLabel(label)).toBe(false);
+    },
+  );
+});
+
+describe("isDivisionLabel anchoring", () => {
+  it.each(["x1/8", "1/8x"])(
+    "returns false for the unanchored label '%s'",
+    (label) => {
+      expect(isDivisionLabel(label)).toBe(false);
+    },
+  );
+});
+
+describe("normalizePan anchoring", () => {
+  it.each(["x50L", "50Lx"])(
+    "returns 0 (no match) for the unanchored label '%s'",
+    (label) => {
+      expect(normalizePan(label, 50)).toBe(0);
+    },
+  );
+});
+
+describe("extractMaxPanValue anchoring", () => {
+  it.each(["x64L", "64Lx"])(
+    "falls back to the default 50 for the unanchored label '%s'",
+    (label) => {
+      // A non-50 magnitude proves the fallback fired rather than the label
+      // being matched unanchored.
+      expect(extractMaxPanValue(label)).toBe(50);
+    },
+  );
+});

--- a/src/tools/shared/device/helpers/tests/device-display-helpers.test.ts
+++ b/src/tools/shared/device/helpers/tests/device-display-helpers.test.ts
@@ -620,6 +620,29 @@ describe("device-display-helpers", () => {
       });
     });
 
+    it("takes the unit from the value label when min and max have none", () => {
+      // unit resolves value ?? min ?? max — the value label alone must be able
+      // to supply it.
+      setupParamMock({ name: "Amount", value: 0.5 });
+      setupValueLabels({ 0.5: "50 %", 0: "0", 1: "100" });
+
+      const result = readParameter(createMockParamApi("param_unit_value_only"));
+
+      expect(result.unit).toBe("%");
+    });
+
+    it("normalizes pan against a non-default max pan value", () => {
+      // maxPanValue comes from the max label (64), not the 50 default: 32 of 64
+      // is half-left.
+      setupParamMock({ name: "Pan", value: 0.25 });
+      setupValueLabels({ 0.25: "32L", 0: "0L", 1: "64R" });
+
+      const result = readParameter(createMockParamApi("param_pan_64"));
+
+      expect(result.unit).toBe("pan");
+      expect(result.value).toBe(-0.5);
+    });
+
     it("reads parameter with no unit detected", () => {
       setupParamMock({ name: "Amount", value: 0.5 });
       setupValueLabels({ 0.5: "50", 0: "0", 1: "100" });

--- a/src/tools/shared/device/helpers/tests/device-reader-chains.test.ts
+++ b/src/tools/shared/device/helpers/tests/device-reader-chains.test.ts
@@ -22,6 +22,20 @@ interface DeviceInfoResult {
 type MockChainOverrides = { devices?: unknown[] };
 
 describe("processDeviceChains", () => {
+  // A chain whose `solo` property is configurable, for hasSoloedChain coverage.
+  const createSoloChain = (name: string, solo: number) => ({
+    id: `chain-${name}`,
+    type: "Chain",
+    getProperty: (prop: string) => {
+      if (prop === "name") return name;
+      if (prop === "solo") return solo;
+
+      return 0;
+    },
+    getColor: () => null,
+    getChildren: () => [],
+  });
+
   const createMockChain = (
     name: string,
     overrides: MockChainOverrides = {},
@@ -181,6 +195,8 @@ describe("processDeviceChains", () => {
     const firstCall = readDeviceCalls[0] as (typeof readDeviceCalls)[0];
 
     expect(firstCall.options.parentPath).toBe("t0/d0/rc0/d0");
+    // Nested devices are read one level deeper than the chain (depth + 1).
+    expect(firstCall.options.depth).toBe(1);
   });
 
   it("returns deviceCount instead of expanding devices when depth >= maxDepth", () => {
@@ -298,6 +314,10 @@ describe("processDeviceChains", () => {
     expect(chains[0]?.path).toBeUndefined();
     // Nested device path is null too (chainPath was null).
     expect(readDeviceCalls[0]?.parentPath).toBeNull();
+    // Regular-chain nested devices carry the full recursion options: one level
+    // deeper (depth + 1) and the propagated include flags.
+    expect(readDeviceCalls[0]?.depth).toBe(1);
+    expect(readDeviceCalls[0]?.includeChains).toBe(true);
   });
 
   it("builds null return-chain paths when devicePath is omitted", () => {
@@ -321,19 +341,6 @@ describe("processDeviceChains", () => {
   });
 
   it("sets hasSoloedChain when a rack chain is soloed", () => {
-    const createSoloChain = (name: string, solo: number) => ({
-      id: `chain-${name}`,
-      type: "Chain",
-      getProperty: (prop: string) => {
-        if (prop === "name") return name;
-        if (prop === "solo") return solo;
-
-        return 0;
-      },
-      getColor: () => null,
-      getChildren: () => [],
-    });
-
     const mockDevice = {
       getChildren: (child: string) => {
         if (child === "chains") {
@@ -364,5 +371,70 @@ describe("processDeviceChains", () => {
     );
 
     expect(deviceInfo.hasSoloedChain).toBe(true);
+  });
+
+  it("omits hasSoloedChain when no rack chain is soloed", () => {
+    const mockDevice = {
+      getChildren: (child: string) => {
+        if (child === "chains") {
+          return [createSoloChain("Chain A", 0), createSoloChain("Chain B", 0)];
+        }
+
+        return [];
+      },
+    };
+
+    const deviceInfo: Record<string, unknown> = {};
+
+    processDeviceChains(
+      mockDevice as unknown as LiveAPI,
+      deviceInfo,
+      DEVICE_TYPE.AUDIO_EFFECT_RACK,
+      {
+        includeChains: true,
+        includeReturnChains: false,
+        includeDrumPads: false,
+        depth: 0,
+        maxDepth: 1,
+        readDeviceFn: () => ({}),
+        devicePath: "t0/d0",
+      },
+    );
+
+    expect(deviceInfo.hasSoloedChain).toBeUndefined();
+  });
+
+  it("does not build chains when includeChains is false (drum-pad-only read of a plain rack)", () => {
+    const mockChain = createMockChain("Chain A", {
+      devices: [{ id: "dev-1" }],
+    });
+    const mockDevice = {
+      getChildren: (child: string) => {
+        if (child === "chains") return [mockChain];
+
+        return [];
+      },
+    };
+
+    const deviceInfo: Record<string, unknown> = {};
+
+    // A non-drum rack asked only for drum pads still runs processRegularChains,
+    // but the `if (includeChains)` guard must keep `chains` out of the output.
+    processDeviceChains(
+      mockDevice as unknown as LiveAPI,
+      deviceInfo,
+      DEVICE_TYPE.AUDIO_EFFECT_RACK,
+      {
+        includeChains: false,
+        includeReturnChains: false,
+        includeDrumPads: true,
+        depth: 0,
+        maxDepth: 2,
+        readDeviceFn: () => ({}),
+        devicePath: "t0/d0",
+      },
+    );
+
+    expect(deviceInfo.chains).toBeUndefined();
   });
 });

--- a/src/tools/shared/device/helpers/tests/device-reader-drum-helpers.test.ts
+++ b/src/tools/shared/device/helpers/tests/device-reader-drum-helpers.test.ts
@@ -9,6 +9,7 @@ import {
   processDrumPads,
   updateDrumPadSoloStates,
 } from "../device-reader-drum-helpers.ts";
+import { hasInstrumentInDevices } from "../device-state-helpers.ts";
 
 // Mock device-path-helpers
 vi.mock(import("../path/device-path-helpers.ts"), () => ({
@@ -115,6 +116,7 @@ describe("device-reader-drum-helpers", () => {
       pitch: string | null;
       name?: string;
       state?: string;
+      hasInstrument?: boolean;
       chains?: unknown[];
     }
 
@@ -331,6 +333,22 @@ describe("device-reader-drum-helpers", () => {
       },
     );
 
+    it.each([
+      { order: "already-ascending", notes: [36, 48] },
+      { order: "reversed", notes: [48, 36] },
+    ])(
+      "sorts note pads by note from $order input",
+      ({ notes }: { notes: number[] }) => {
+        // Both insertion orders matter: the comparator must fall through to the
+        // note-difference tail rather than answering from a catch-all check.
+        const deviceInfo = setupAndProcess(
+          notes.map((inNote) => ({ inNote, name: `Pad ${String(inNote)}` })),
+        );
+
+        expect(deviceInfo.drumPads!.map((p) => p.note)).toStrictEqual([36, 48]);
+      },
+    );
+
     it("sorts a catch-all pad after a note pad when it is not first (aNote===-1 branch)", () => {
       // Insertion order note-first, catch-all-second forces the sort comparator
       // to be called with the catch-all as its first argument.
@@ -353,6 +371,134 @@ describe("device-reader-drum-helpers", () => {
       expect(deviceInfo.drumPads![0]!.note).toBe(200);
       // midiToNoteName returns null for invalid MIDI notes
       expect(deviceInfo.drumPads![0]!.pitch).toBeNull();
+    });
+
+    // The mocked extractDevicePath is the identity, so parentPath is the mock
+    // device's raw Live API path and chain paths are built onto it.
+    const PARENT = "live_set tracks 0 devices 0";
+
+    /**
+     * Read the `path` of a pad's chain at the given index.
+     * @param deviceInfo - processDrumPads output
+     * @param chainIndex - Index within the pad's chains
+     * @returns The chain's path
+     */
+    const chainPathAt = (deviceInfo: DeviceInfoResult, chainIndex: number) =>
+      (deviceInfo.drumPads![0]!.chains![chainIndex] as { path: string }).path;
+
+    it("builds a note-named chain path for a note-specific pad", () => {
+      const deviceInfo = setupAndProcess([{ inNote: 36, name: "Kick" }], true);
+
+      expect(chainPathAt(deviceInfo, 0)).toBe(`${PARENT}/pC1/c0`);
+    });
+
+    it("builds a catch-all chain path for the catch-all pad", () => {
+      const deviceInfo = setupAndProcess([{ inNote: -1, name: "All" }], true);
+
+      expect(chainPathAt(deviceInfo, 0)).toBe(`${PARENT}/p*/c0`);
+    });
+
+    it("falls back to a catch-all chain path when the note is out of MIDI range", () => {
+      // midiToNoteName(200) is null — the path must degrade to the catch-all
+      // form rather than interpolating a null note name.
+      const deviceInfo = setupAndProcess([{ inNote: 200, name: "Bad" }], true);
+
+      expect(chainPathAt(deviceInfo, 0)).toBe(`${PARENT}/p*/c0`);
+    });
+
+    it("indexes layered chains of one pad by their position within the note group", () => {
+      const deviceInfo = setupAndProcess(
+        [
+          { inNote: 36, name: "Kick Layer 1" },
+          { inNote: 36, name: "Kick Layer 2" },
+        ],
+        true,
+      );
+
+      expect(deviceInfo.drumPads).toHaveLength(1);
+      expect(deviceInfo.drumPads![0]!.chains).toHaveLength(2);
+      expect(chainPathAt(deviceInfo, 0)).toBe(`${PARENT}/pC1/c0`);
+      expect(chainPathAt(deviceInfo, 1)).toBe(`${PARENT}/pC1/c1`);
+    });
+
+    it("strips internal tracking properties from exposed pad chains", () => {
+      const deviceInfo = setupAndProcess([{ inNote: 36, name: "Kick" }], true);
+
+      const chain = deviceInfo.drumPads![0]!.chains![0] as Record<
+        string,
+        unknown
+      >;
+
+      expect(chain).not.toHaveProperty("_inNote");
+      expect(chain).not.toHaveProperty("_hasInstrument");
+      expect(chain.name).toBe("Kick");
+    });
+
+    it("omits pad chains when includeChains is false", () => {
+      const deviceInfo = setupAndProcess([{ inNote: 36, name: "Kick" }], false);
+
+      expect(deviceInfo.drumPads![0]!.chains).toBeUndefined();
+    });
+
+    it("reports deviceCount and no-instrument for pad chains at the depth limit", () => {
+      const device = createMockDevice([{ inNote: 36, name: "Kick" }]);
+      const deviceInfo: DeviceInfoResult = {};
+
+      // depth === maxDepth → chains report deviceCount instead of expanding,
+      // and cannot know whether an instrument is present.
+      processDrumPads(
+        device as unknown as LiveAPI,
+        deviceInfo,
+        true,
+        true,
+        2,
+        2,
+        vi.fn(() => ({ type: "instrument: Simpler" })),
+      );
+
+      expect(chainPathAt(deviceInfo, 0)).toBe(`${PARENT}/pC1/c0`);
+      expect(deviceInfo.drumPads![0]!.hasInstrument).toBe(false);
+    });
+
+    it("passes the nested device path and incremented depth to readDevice", () => {
+      const readDeviceFn = vi.fn(() => ({ type: "instrument: Simpler" }));
+      const device = {
+        path: PARENT,
+        getChildren: vi.fn(() => [createChainWithDevice(36)]),
+      };
+
+      processDrumPads(
+        device as unknown as LiveAPI,
+        {},
+        true,
+        true,
+        0,
+        2,
+        readDeviceFn,
+      );
+
+      expect(readDeviceFn).toHaveBeenCalledWith(
+        { id: "nested" },
+        expect.objectContaining({
+          parentPath: `${PARENT}/pC1/c0/d0`,
+          depth: 1,
+        }),
+      );
+    });
+
+    it("keeps hasInstrument unset when only some layered chains have an instrument", () => {
+      // some() semantics: one instrument anywhere on the pad is enough, so the
+      // pad must NOT be flagged hasInstrument: false.
+      vi.mocked(hasInstrumentInDevices)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+
+      const deviceInfo = setupAndProcess([
+        { inNote: 36, name: "Kick Layer 1" },
+        { inNote: 36, name: "Kick Layer 2" },
+      ]);
+
+      expect(deviceInfo.drumPads![0]!.hasInstrument).toBeUndefined();
     });
   });
 });

--- a/src/tools/shared/device/helpers/tests/device-reader-helpers.test.ts
+++ b/src/tools/shared/device/helpers/tests/device-reader-helpers.test.ts
@@ -21,6 +21,7 @@ interface DrumPadInfo {
 import {
   buildChainInfo,
   isRedundantDeviceClassName,
+  readDeviceParameters,
   readMacroVariations,
   readABCompare,
 } from "../device-reader-helpers.ts";
@@ -135,6 +136,16 @@ describe("device-reader-helpers", () => {
       expect(result.mappedPitch).toBeUndefined();
     });
 
+    it("omits mappedPitch for a DrumChain whose out_note is out of MIDI range", () => {
+      // out_note 200 → midiToNoteName returns null, so mappedPitch must be
+      // omitted (not set to null) — guards the `noteName != null` check.
+      const chain = createMockChain({ type: "DrumChain", out_note: 200 });
+      const result = buildChainInfo(chain);
+
+      expect(result.mappedPitch).toBeUndefined();
+      expect("mappedPitch" in result).toBe(false);
+    });
+
     it("includes state when muted", () => {
       const chain = createMockChain({ mute: 1 });
       const result = buildChainInfo(chain);
@@ -236,6 +247,15 @@ describe("device-reader-helpers", () => {
         isRedundantDeviceClassName(DEVICE_TYPE.AUDIO_EFFECT, "Reverb"),
       ).toBe(false);
     });
+
+    it("does not match a rack class name against a mismatched device type", () => {
+      // A non-MIDI-effect-rack device type must not be judged redundant just
+      // because its class name happens to read "MIDI Effect Rack" — each check
+      // is gated on the specific device type, not any rack.
+      expect(
+        isRedundantDeviceClassName(DEVICE_TYPE.INSTRUMENT, "MIDI Effect Rack"),
+      ).toBe(false);
+    });
   });
 
   describe("computeState", () => {
@@ -251,6 +271,12 @@ describe("device-reader-helpers", () => {
     const stateCases: [string, StatePropConfig, string | undefined, string][] =
       [
         ["ACTIVE for master category", {}, "master", STATE.ACTIVE],
+        [
+          "ACTIVE for master category even when mute is set",
+          { mute: 1 },
+          "master",
+          STATE.ACTIVE,
+        ],
         [
           "MUTED_AND_SOLOED when both muted and soloed",
           { mute: 1, solo: 1 },
@@ -528,6 +554,43 @@ describe("device-reader-helpers", () => {
         variations: { count: 3, selected: 1 },
         macros: { count: 4, hasMappings: false },
       });
+    });
+  });
+
+  describe("readDeviceParameters", () => {
+    const mockParam = (id: string, name: string) =>
+      ({
+        id,
+        getProperty: (prop: string) =>
+          prop === "name" || prop === "original_name" ? name : undefined,
+      }) as unknown as LiveAPI;
+
+    const mockDeviceWithParams = (params: LiveAPI[]) =>
+      ({
+        getChildren: (child: string) => (child === "parameters" ? params : []),
+      }) as unknown as LiveAPI;
+
+    it("reads basic (id + name only) parameters by default", () => {
+      // No options → includeValues defaults false → readParameterBasic, so the
+      // result must NOT carry value/min/max fields.
+      const device = mockDeviceWithParams([mockParam("p1", "Cutoff")]);
+
+      expect(readDeviceParameters(device)).toStrictEqual([
+        { id: "p1", name: "Cutoff" },
+      ]);
+    });
+
+    it("trims the search term before matching parameter names", () => {
+      // A padded search ("  rev  ") must still match "Reverb"; without the trim
+      // the padded term would never be a substring of any name.
+      const device = mockDeviceWithParams([
+        mockParam("p1", "Reverb"),
+        mockParam("p2", "Cutoff"),
+      ]);
+
+      const result = readDeviceParameters(device, { search: "  rev  " });
+
+      expect(result).toStrictEqual([{ id: "p1", name: "Reverb" }]);
     });
   });
 

--- a/src/tools/shared/device/helpers/tests/nested-param-target.test.ts
+++ b/src/tools/shared/device/helpers/tests/nested-param-target.test.ts
@@ -278,6 +278,46 @@ describe("resolveNestedParamTarget", () => {
       expect(target).toBeNull();
     });
 
+    it("accepts an explicit chain 0 in the prefix", () => {
+      // "c0" is a valid chain index (the boundary is `< 0`, not `<= 0`): the
+      // prefix must still parse as a pad slot rather than falling through to
+      // general resolution.
+      registerRack(["chain-c1"]);
+      registerDrumChain("chain-c1", 36, ["existing-simpler"]);
+      registerDevice("existing-simpler", "Simpler", "SimplerDevice");
+
+      const target = resolveNestedParamTarget(
+        rack(),
+        "pC1/c0",
+        "sample",
+        "createDevice",
+      );
+
+      expect(target?.id).toBe("existing-simpler");
+    });
+
+    it("warns when Simpler creation returns nothing at all", () => {
+      // insert_device returning undefined (not a tuple) must warn-skip, not
+      // throw while indexing the missing result.
+      registerRack(["chain-c1"]);
+      registerDrumChain("chain-c1", 36, [], {
+        insert_device: () => null,
+      });
+
+      const target = resolveNestedParamTarget(
+        rack(),
+        "pC1/d0",
+        "sample",
+        "createDevice",
+      );
+
+      expect(target).toBeNull();
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("failed to create a Simpler"),
+      );
+    });
+
     it("defaults the device slot to 0 when only the pad is given", () => {
       registerRack(["chain-c1"]);
       registerDrumChain("chain-c1", 36, ["existing-simpler"]);
@@ -385,6 +425,7 @@ describe("resolveNestedParamTarget", () => {
       ["pC1/cX", "no device at"],
       ["pC1/c-1", "no device at"],
       ["pC1/dX", "no device at"],
+      ["pC1/d-1", "no device at"],
       ["pC1/d0/x", "no device at"],
     ])("does not pad-create for prefix '%s'", (prefix, message) => {
       const target = resolveNestedParamTarget(

--- a/src/tools/shared/device/tests/device-reader-options.test.ts
+++ b/src/tools/shared/device/tests/device-reader-options.test.ts
@@ -1,0 +1,150 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import "#src/live-api-adapter/live-api-extensions.ts";
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearMockRegistry,
+  registerMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+import {
+  LIVE_API_DEVICE_TYPE_INSTRUMENT,
+  LIVE_API_DEVICE_TYPE_AUDIO_EFFECT,
+} from "#src/tools/constants.ts";
+import { readDevice } from "../device-reader.ts";
+
+const DEVICE_PATH = "live_set tracks 0 devices 0";
+
+/**
+ * Register a chain-holding rack on track 0 with one chain (optionally a return
+ * chain and drum-pad capability), so the include-flag defaults are observable.
+ * @param opts - Rack shape options
+ * @param opts.drumPads - Register as a Drum Rack (chain carries an in_note)
+ * @param opts.returnChains - Give the rack a return chain
+ */
+function registerRack(
+  opts: { drumPads?: boolean; returnChains?: boolean } = {},
+): void {
+  registerMockObject("chain0", {
+    type: opts.drumPads ? "DrumChain" : "Chain",
+    properties: { name: "Chain 1", in_note: 36 },
+  });
+  registerMockObject("rchain0", {
+    type: "Chain",
+    properties: { name: "Return Chain" },
+  });
+
+  registerMockObject("rack", {
+    path: DEVICE_PATH,
+    type: "RackDevice",
+    properties: {
+      type: LIVE_API_DEVICE_TYPE_INSTRUMENT,
+      class_display_name: "Drum Rack",
+      name: "Drum Rack",
+      can_have_chains: 1,
+      can_have_drum_pads: opts.drumPads ? 1 : 0,
+      is_active: 1,
+      chains: ["id", "chain0"],
+      return_chains: opts.returnChains ? ["id", "rchain0"] : [],
+    },
+  });
+}
+
+describe("readDevice option defaults", () => {
+  beforeEach(() => {
+    clearMockRegistry();
+  });
+
+  it("includes chains by default", () => {
+    registerRack();
+
+    const result = readDevice(LiveAPI.from(DEVICE_PATH));
+
+    expect(result.chains).toHaveLength(1);
+  });
+
+  it("resolves the device path and threads it into nested chain paths", () => {
+    // The device path is extracted from the Live API path and passed down, so
+    // each chain reports an addressable path rather than null.
+    registerRack();
+
+    const result = readDevice(LiveAPI.from(DEVICE_PATH));
+
+    expect(result.path).toBe("t0/d0");
+    expect((result.chains as { path: string }[])[0]?.path).toBe("t0/d0/c0");
+  });
+
+  it("omits return chains by default", () => {
+    registerRack({ returnChains: true });
+
+    expect(readDevice(LiveAPI.from(DEVICE_PATH)).returnChains).toBeUndefined();
+  });
+
+  it("includes return chains when requested", () => {
+    registerRack({ returnChains: true });
+
+    const result = readDevice(LiveAPI.from(DEVICE_PATH), {
+      includeReturnChains: true,
+    });
+
+    expect(result.returnChains).toHaveLength(1);
+  });
+
+  it("omits drum pads by default", () => {
+    registerRack({ drumPads: true });
+
+    expect(readDevice(LiveAPI.from(DEVICE_PATH)).drumPads).toBeUndefined();
+  });
+
+  it("reads parameters without values when includeParams is set alone", () => {
+    // includeParamValues defaults false → basic (id + name) entries only.
+    registerMockObject("param0", {
+      type: "DeviceParameter",
+      properties: { name: "Cutoff", original_name: "Cutoff" },
+    });
+    registerMockObject("dev", {
+      path: DEVICE_PATH,
+      type: "Device",
+      properties: {
+        type: LIVE_API_DEVICE_TYPE_AUDIO_EFFECT,
+        class_display_name: "Reverb",
+        name: "Reverb",
+        is_active: 1,
+        parameters: ["id", "param0"],
+      },
+    });
+
+    const result = readDevice(LiveAPI.from(DEVICE_PATH), {
+      includeParams: true,
+    });
+
+    expect(result.parameters).toStrictEqual([{ id: "param0", name: "Cutoff" }]);
+  });
+
+  it("omits the focused sample field by default for a loaded Simpler", () => {
+    registerMockObject("sample0", {
+      type: "Sample",
+      properties: { file_path: "/tmp/kick.wav", gain: 1 },
+    });
+    registerMockObject("simpler", {
+      path: DEVICE_PATH,
+      type: "SimplerDevice",
+      properties: {
+        type: LIVE_API_DEVICE_TYPE_INSTRUMENT,
+        class_display_name: "Simpler",
+        name: "Simpler",
+        is_active: 1,
+        multi_sample_mode: 0,
+        sample: ["id", "sample0"],
+      },
+    });
+
+    expect(readDevice(LiveAPI.from(DEVICE_PATH)).sample).toBeUndefined();
+    expect(
+      readDevice(LiveAPI.from(DEVICE_PATH), { includeSample: true }).sample,
+    ).toBe("/tmp/kick.wav");
+  });
+});

--- a/src/tools/shared/device/tests/simpler-sample.test.ts
+++ b/src/tools/shared/device/tests/simpler-sample.test.ts
@@ -164,6 +164,27 @@ describe("setSimplerSample", () => {
     );
   });
 
+  it("rejects a relative path even when a drive-letter appears mid-string", () => {
+    // The absolute-path test is anchored (`^`): a drive-letter sequence buried
+    // inside a relative path must NOT read as absolute.
+    const device = registerSimpler();
+
+    setSimplerSample(
+      LiveAPI.from("id simpler-1"),
+      "relative/C:/kick.wav",
+      "updateDevice",
+    );
+
+    expect(device.call).not.toHaveBeenCalledWith(
+      "replace_sample",
+      expect.anything(),
+    );
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("absolute file path"),
+    );
+  });
+
   it("trims surrounding whitespace before passing the path to Live", () => {
     const device = registerSimpler();
 
@@ -211,6 +232,36 @@ describe("setSimplerSample", () => {
 });
 
 describe("probeSimplerSample", () => {
+  it("reports not-simpler for a non-Simpler device class", () => {
+    const device = registerMockObject("op-1", {
+      path: livePath.track(0).device(0),
+      type: "Device",
+      properties: { class_display_name: "Operator" },
+    });
+
+    expect(
+      probeSimplerSample(LiveAPI.from("id op-1"), "Operator"),
+    ).toStrictEqual({ kind: "not-simpler" });
+    // Short-circuits before touching the device's sample state.
+    expect(device.get).not.toHaveBeenCalledWith("multi_sample_mode");
+  });
+
+  it("reports multisample for a Simpler in multi-sample mode", () => {
+    registerSimpler({ multiSampleMode: 1 });
+
+    expect(
+      probeSimplerSample(LiveAPI.from("id simpler-1"), "Simpler"),
+    ).toStrictEqual({ kind: "multisample" });
+  });
+
+  it("reports empty when no sample child is loaded", () => {
+    registerSimpler();
+
+    expect(
+      probeSimplerSample(LiveAPI.from("id simpler-1"), "Simpler"),
+    ).toStrictEqual({ kind: "empty" });
+  });
+
   it("reports empty when the loaded sample has no file path", () => {
     registerMockObject("sample-1", {
       type: "Sample",
@@ -230,6 +281,14 @@ describe("probeSimplerSample", () => {
     expect(
       probeSimplerSample(LiveAPI.from("id simpler-1"), "Simpler"),
     ).toStrictEqual({ kind: "empty" });
+  });
+
+  it("reports single with the sample path and gain when a sample is loaded", () => {
+    registerSimplerWithSample({ gain: 0.5 });
+
+    expect(
+      probeSimplerSample(LiveAPI.from("id simpler-1"), "Simpler"),
+    ).toStrictEqual({ kind: "single", path: "/tmp/kick.wav", gain: 0.5 });
   });
 });
 
@@ -286,6 +345,12 @@ describe("setSimplerGain", () => {
     expect(outlet).toHaveBeenCalledWith(
       1,
       expect.stringContaining("multi-sample mode"),
+    );
+    // The multi-sample guard must RETURN, not fall through into the loaded-sample
+    // probe below it (which would emit a second, misleading warning).
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("requires a loaded sample"),
     );
   });
 


### PR DESCRIPTION
Third subarea of the `src/tools/shared` mutation triage: `device/` excluding `device/specialized/` (12 source files, ~2,948 LOC).

**Test-only.** The `shared` scope stays in baseline mode (`break: null`), so there is no gate flip and no doc baseline here — those land once, with the final subarea.

## Result

Narrowed mutation score for the 12 device source files: **87.10% → 95.14%** (survivors 213 → 80).

| File | before → after | survivors |
|---|---|---|
| device-display-helpers.ts | 82.07 → **96.55** | 52 → 10 |
| device-reader-drum-helpers.ts | 73.17 → **90.24** | 33 → 12 |
| device-drumpad-navigation.ts | 81.76 → **89.31** | 29 → 17 |
| device-chain-creation-helpers.ts | 87.43 → **94.24** | 24 → 11 |
| device-reader.ts | 88.71 → **94.62** | 21 → 10 |
| device-reader-helpers.ts | 90.44 → **98.53** | 13 → 2 |
| nested-param-target.ts | 92.25 → **94.57** | 10 → 7 |
| device-state-helpers.ts | 92.59 → **96.30** | 8 → 4 |
| device-path-to-live-api.ts | 95.04 → **95.87** | 6 → 5 |
| device-path-helpers.ts | 94.94 → **96.20** | 4 → 3 |
| simpler-sample.ts | 89.01 → **100.00** | 10 → 0 |
| device-path-builders.ts | 90.74 → **100.00** | 5 → 0 |

## New tests

Four modules had no direct unit test (transitive coverage only) — each now has one:

- **`device-drumpad-navigation.test.ts`** — path navigation targets and target types: missing chain/device indices must not be dereferenced by a following segment, a non-`d` post-chain segment must not be read as a device index, and a negative index must return null rather than throw.
- **`device-chain-creation-helpers.test.ts`** — auto-create counts (only the missing chains), the exact-at-cap boundary (`> MAX`, not `>=`), and `insert_chain` returning a non-`id` tuple.
- **`device-reader-options.test.ts`** — `readDevice` include-flag defaults and device-path threading into nested chain paths.
- **`device-display-helpers-labels.test.ts`** — display-label lexer robustness: `^`/`$` anchoring per pattern, optional whitespace before the unit, optional `inf` sign, multi-digit octaves.

Plus targeted additions to the existing device tests (probe kinds, drum-pad chain path construction, `hasSoloedChain` absence, search trimming, muted-master state, sort ordering).

## Residual survivors

All 80 were individually verified uncatchable — each mutant was applied to the source and the suite re-run. Recurring equivalence classes:

- **Redundant guards** — `getChildAtIndex`'s bounds checks are subsumed by its `c[index] ?? null` tail (any out-of-range or NaN index yields null either way); `segments.length === 0` after a `split()`; the `startsWith(INSTRUMENT_RACK)` clause already implied by `startsWith("instrument")`.
- **`assertDefined` messages** that can never be thrown (loop bounds or a preceding guard guarantee the value).
- **Same-result fallthroughs** — a non-existent device or unresolvable note reaches the identical null-chain return via the empty-match path.
- **Dead values** — a `remainingSegments: []` the caller never reads, `?? []` / `?? -1` defaults that cannot be reached, and `unit:` pattern fields shadowed by hardcoded returns.
- **Sort comparator** — the both-catch-all branch is unreachable (grouping yields one pad per `in_note`), and the `aNote === -1` shadow was verified to produce identical output with the catch-all in every position.

Three mutants gating `applySpecializedInactiveStates` on `includeValues` are only observable with a specialized-device fixture; they belong to the `specialized/` subarea and are deferred to it.

## Verification

`npm run check` and `npm run check:build` both green (9866 tests, functions 100%, tests-duplication 1.96%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)