### PR TITLE
test(mutation): triage specialized devices, ratchet shared scope

### DIFF
--- a/config/mutation-scopes.mjs
+++ b/config/mutation-scopes.mjs
@@ -131,6 +131,7 @@ const TOOL_DOMAIN_BREAKS = {
   core: 99, // triaged 2026-07-15 at 100.00% (see dev/Mutation-Testing.md)
   scene: 96, // triaged 2026-07-15 at 97.66% (see dev/Mutation-Testing.md)
   "live-set": 98, // triaged 2026-07-15 at 99.07% (see dev/Mutation-Testing.md)
+  shared: 94, // triaged 2026-07-16 at 95.25% (see dev/Mutation-Testing.md)
 };
 
 // The sharedRuntime (src/shared) break gate. Triaged 2026-07-15 at 94.94%; the

--- a/dev/Mutation-Testing.md
+++ b/dev/Mutation-Testing.md
@@ -37,10 +37,10 @@ Scopes are defined in `config/mutation-scopes.mjs`:
   build-time substitution stubs, and type-only modules (see `toolDomain()`). A
   domain starts in **baseline mode** (`break: null`, measure-only) until its
   survivors are triaged in its own PR and it earns a floor in
-  `TOOL_DOMAIN_BREAKS`; triaged so far: `track` (`break: 85`), `session`
-  (`break: 89`), `actions` (`break: 90`), `device` (`break: 90`), `clip`
-  (`break: 96`), `advanced` (`break: 97`), `core` (`break: 99`), `scene`
-  (`break: 96`), `live-set` (`break: 98`). Only `shared` remains untriaged.
+  `TOOL_DOMAIN_BREAKS`. All ten are now triaged: `track` (`break: 85`),
+  `session` (`break: 89`), `actions` (`break: 90`), `device` (`break: 90`),
+  `clip` (`break: 96`), `advanced` (`break: 97`), `core` (`break: 99`), `scene`
+  (`break: 96`), `live-set` (`break: 98`), `shared` (`break: 94`).
 - **`sharedRuntime`** — `src/shared/` (cross-cutting utilities shared by the
   Node MCP server and the V8 Max runtime: pitch, notation identity, compact
   serializer/parser, path builders, config, error/response utils, v8 console /
@@ -763,6 +763,120 @@ rather than real gaps:
 | `resolveAbsolutePaths`: 3-segment path sets `folder` (the `>= 3` boundary)      | `reconstruct-path.test.ts`    |
 | Custom-skills index emits no `## Disabled` section when all skills are enabled  | `custom-skills-store.test.ts` |
 
+## Baseline (2026-07-16, `shared` — `src/tools/shared/`)
+
+The largest tool domain and the last one triaged: 50 mutated files / ~9,400
+source LOC of cross-cutting infrastructure — the tool framework, validation,
+arrangement helpers, the device reader, and the specialized-device specs. Too
+big for one PR, so it was triaged in four independent test-only PRs by subarea,
+each iterating against a temporarily-narrowed `mutate` glob (uncommitted — a
+~2-minute inner loop vs ~5 for the whole domain). The gate comes from a final
+whole-domain pass — Stryker 9.6.1, Node 24, `coverageAnalysis: "perTest"`:
+
+| Metric   | Triaged (whole domain) | Gate (`break`) |
+| -------- | ---------------------- | -------------- |
+| `shared` | **95.25%**             | 94             |
+
+Per subarea, as measured in its own PR against the narrowed glob (there is no
+single pre-triage whole-domain number — each subarea was baselined separately):
+
+| Subarea (files)              | Baseline | Triaged    | Survivors (from) |
+| ---------------------------- | -------- | ---------- | ---------------- |
+| Utilities & framework (14)   | 87.28%   | **92.78%** | — (~52 killed)   |
+| Arrangement (8)              | 81.30%   | **95.98%** | 20 (from 97)     |
+| Device reader & helpers (12) | 87.10%   | **95.14%** | 80 (from 213)    |
+| Specialized devices (16)     | 90.19%   | **97.08%** | 33 (from 111)    |
+
+All test-only — no product code was touched in any of the four. The
+specialized-device subarea scored highest of the four (97.08%), as predicted:
+every device spec already had a colocated test, so the survivors were
+concentrated in declarative tables rather than untested logic.
+
+Three levers did most of the work in the specialized subarea:
+
+- **The discovery catalogs are data, and data needs a table test.** `actions`
+  (name / signature / description) and `paramOptions` are pure LLM-facing tables
+  the model reads to learn how to drive a device. The device tests asserted
+  behavior and at most `actions.map((a) => a.name)`, so every `signature` and
+  `description` string was unasserted. One `toStrictEqual` per catalog plus an
+  `it.each` over the display-name routing table killed ~25 string/array mutants
+  in one new file (`specialized-device-catalog.test.ts`).
+- **Warn text is the model's only error channel.** The `Options: …` /
+  `Available: …` / `must be one of …` lists are built with `join(", ")`, and
+  several tests asserted only a fragment (`stringContaining("Pre FX")`) — which
+  still matches when `join(", ")` decays to `join("")`. Asserting the whole
+  joined list (and the `paramName` the warning names) killed every one.
+- **Index 0 is a value, not a "not found".** `list.indexOf(...) < 0` guards
+  paired with tests that only ever selected a middle entry left the `< 0` →
+  `<= 0` mutants alive across Wavetable categories/wavetables, Hybrid Reverb IR
+  files, the mod-matrix source `"Amp"` (column 0) and target slot 0. Each needed
+  a test that selects the _first_ entry. The same shape appears in Hybrid
+  Reverb's `list.length === 1 && list[0] === <sentinel>` empty-category guard: a
+  category holding exactly one real IR must still be settable.
+
+Remaining survivors are bucket 2/3. Each of the 111 original specialized
+survivors was verified individually by applying the mutant and running the
+covering suite (see **Verifying a survivor** below); the 20 that survive that
+check are:
+
+- **Guards subsumed by a downstream check.** The action parser's
+  `if (quote) return null` (unterminated quote) is unreachable-by-effect: a
+  token whose quote never closed can never _end_ with its own quote character,
+  so `parseArgToken`'s `token.at(-1) !== first` rejects it anyway. Its
+  `token.length < 2` guard is likewise dead — a token starting with a quote that
+  reached `parseArgToken` at all has ≥2 characters (the split only happens once
+  the quote closes). Similarly `readIrFile`'s `value == null` returns
+  `undefined` either way, and `coerceInt`'s
+  `typeof value === "number" ? value : Number(value)` is `Number(number)`
+  identity.
+- **Discriminated-union shadows.** Simpler's `probe.kind === "single"` operands
+  can't be distinguished because `probe.path` / `probe.gain` only _exist_ on the
+  `single` variant — relaxing the check reads `undefined` and yields the same
+  result. `resolveSourceIndex`'s `n >= 0` is shadowed too: a negative index
+  falls through and returns a negative, which the caller already treats as
+  invalid.
+- **Defensive caps and type guards.** `MAX_TARGETS` (512) bounds a loop that
+  really terminates on the LOM's numeric sentinel; `typeof name === "string"` at
+  a point where the sentinel was already handled; `typeof v === "number"` on a
+  value Live always returns as a number. Killing these would mean forging LOM
+  responses Live cannot produce.
+- **A vestigial parameter.** `readParamEntries`'s `predicate` has exactly one
+  caller, which passes `() => true` — so its `if (!predicate(param)) continue`
+  is dead (and the domain's only `NoCoverage` mutant). Worth deleting, but that
+  is product code, out of scope for a test-only pass.
+- **Ambiguity we deliberately resolve one way.** Compressor's
+  `routingType.display_name === NO_INPUT_LABEL` only differs if a user names a
+  track literally `"No Input"`; the sentinel wins by design, and asserting that
+  would over-fit an ambiguity Live itself doesn't disambiguate.
+
+Note the gap between the harness verdict (20 uncatchable) and Stryker's 33
+survivors: the other ~13 are **`perTest` false survivors** — a killing test
+exists and passes, but Stryker never attributes it because the killing input
+short-circuits the mutated guard during the coverage dry-run. Almost all are
+`ObjectLiteral → {}` mutants on the spec objects themselves. This rate (13/111)
+is far higher than the arrangement and device subareas (0 and 2), which is why
+the whole-domain score lands below what the triage alone would suggest.
+
+### Gaps closed (`shared`, specialized subarea)
+
+| Gap (now killed)                                                                    | Test strengthened / added                    |
+| ----------------------------------------------------------------------------------- | -------------------------------------------- |
+| Simpler + Wavetable action catalogs (every `signature` / `description`)             | `specialized-device-catalog.test.ts` (new)   |
+| `class_display_name` → spec routing for all 12 specialized devices                  | `specialized-device-catalog.test.ts` (new)   |
+| Modulation-rate effects expose no params and no `paramOptions` key                  | `specialized-device-catalog.test.ts` (new)   |
+| Action grammar: `$` anchor, `""` arg, whitespace-only args, double-quoted commas    | `specialized-device-action-parser.test.ts`   |
+| Numeric args: multi-digit floats (`12.5`, `.25`) and digit-led words (`4x`)         | `specialized-device-action-parser.test.ts`   |
+| Mod matrix: source `"Amp"` (index 0), slot-0 target no re-add, ±1 amount boundary   | `wavetable-modulation-helpers.test.ts` (new) |
+| Mod matrix: name trimming, zero-cell exclusion, exactly-13-source scan              | `wavetable-modulation-helpers.test.ts` (new) |
+| Wavetable/Drift `inactiveWhen` rules (LFO sync, Cyc Env time mode)                  | `specialized-device-registry.test.ts`        |
+| First category / wavetable selectable (index 0) + `Available:` lists                | `wavetable.test.ts`                          |
+| Hybrid Reverb single-file category settable; first IR selectable; `Available:` list | `hybrid-reverb.test.ts`                      |
+| Compressor whitespace-only sidechain id clears; channel `Available:` list           | `compressor.test.ts`                         |
+| Simpler multi-sample / gain-less / non-number `voices` reads omit their params      | `simpler.test.ts`                            |
+| `coerceBool` trims; enum + int-set warnings name the param and list valid values    | `specialized-device-param-helpers.test.ts`   |
+| Boolean pseudo-param warnings name their param (`oversample`, `envListen`, …)       | `eq-eight` / `roar` / `hybrid-reverb` tests  |
+| `readSpecializedParams` search term is trimmed                                      | `specialized-device-registry.test.ts`        |
+
 ## Interpreting survivors
 
 Each survivor falls into one of three buckets — triage before acting:
@@ -779,33 +893,50 @@ Each survivor falls into one of three buckets — triage before acting:
 `# no coverage` mutants are lines no test exercises at all — usually the easiest
 wins, and a cross-check against the line-coverage gate.
 
+### Verifying a survivor
+
+Bucket 1 and bucket 2 look identical in the report, and guessing wrong wastes a
+lot of time — either writing tests for an equivalent mutant, or dismissing a
+real gap as "probably equivalent". Decide it empirically instead:
+
+1. Read the mutant's exact node out of
+   `reports/mutation/<scope>-incremental.json` — `location` (1-based
+   line/column, inclusive start, exclusive end) plus `replacement`. Use the
+   embedded `source` to print `line.slice(startCol - 1, endCol - 1)` and confirm
+   what you're replacing. Stryker mutates _sub-expressions_: a
+   `ConditionalExpression` on `if (a && b)` usually targets just `a`, and
+   hand-mutating the whole condition will mislead you.
+2. Apply it to the file, run the covering test suite, restore the file. A
+   non-zero exit means a killing test already exists (a `perTest` attribution
+   artifact — unkillable via more tests, so document it). Exit zero means it is
+   genuinely uncaught: a real gap _or_ an equivalent, which you then reason
+   about normally.
+
+Scripting this over every Survived/NoCoverage mutant in a scope takes a couple
+of minutes and turns triage into a worklist. Re-running it per-file after each
+edit is also a much faster confirm loop than a full Stryker pass. Two cautions:
+the verdict is binary (an uncaught equivalent still reads "uncaught"), and a
+test can kill a mutant for the wrong reason — so read the surviving code, don't
+just chase green.
+
 ## Status & next steps
 
-The `notation` scope is **ratcheted** (`thresholds.break = 86`), as is
-`sharedRuntime` (`src/shared/`, `break: 94`), `mcpServer` (`src/mcp-server/`,
-`break: 87`), and all nine triaged tool domains: the write-op tier `track`
-(`break: 85`), `session` (`break: 89`), `actions` (`break: 90`), `device`
-(`break: 90`), `clip` (`break: 96`), and the read-op / small tier `advanced`
-(`break: 97`), `core` (`break: 99`), `scene` (`break: 96`), `live-set`
-(`break: 98`). Only `shared` (`src/tools/shared`) remains in **baseline mode**
-(`break: null`, measure-only). The per-domain scope mechanism
-(`config/mutation-scopes.mjs` + the runner) is in place, so each area can be
-mutated on its own. Mutation testing stays off the per-PR hot path (a full pass
-is minutes). Remaining work (later releases):
+**Every `src/tools/` domain is now triaged and ratcheted**, as are `notation`
+(`thresholds.break = 86`), `sharedRuntime` (`src/shared/`, `break: 94`) and
+`mcpServer` (`src/mcp-server/`, `break: 87`). The ten tool domains: the write-op
+tier `track` (`break: 85`), `session` (`break: 89`), `actions` (`break: 90`),
+`device` (`break: 90`), `clip` (`break: 96`); the read-op / small tier
+`advanced` (`break: 97`), `core` (`break: 99`), `scene` (`break: 96`),
+`live-set` (`break: 98`); and `shared` (`break: 94`). No scope is left in
+baseline mode. The per-domain scope mechanism (`config/mutation-scopes.mjs` +
+the runner) is in place, so each area can be mutated on its own. Mutation
+testing stays off the per-PR hot path (a full pass is minutes). Remaining work
+(later releases):
 
 - Keep triaging the ~588 notation survivors, but expect diminishing returns: the
   dense clusters left are epsilon-boundary / warning-string / equivalent mutants
   (bucket 2/3), so genuine bucket-1 gaps are now sparse.
 - Raise each scope's `break` as its score climbs.
-- Only one `src/tools/` domain is left: `shared` (`src/tools/shared`, the
-  biggest single domain — split by subarea rather than triaging in one PR). The
-  write-op tier (`track`, `session`, `actions`, `device`, `clip`), the read-op /
-  small tier (`advanced`, `core`, `scene`, `live-set`), and `sharedRuntime` are
-  done. Per domain: run `npm run mutation -- <domain>`, close real gaps, flip
-  that domain's `break` from `null` to ~1 point below its triaged score (add it
-  to `TOOL_DOMAIN_BREAKS`). The big clean wins tend to be untested lookup/enum
-  tables (as in notation's chord table) and warn-and-skip guards whose tests
-  assert only the result, never the warning or the skipped write.
 - One non-`src/tools/` tree remains unmutated and would need a fresh glob set
   (not `toolDomain()`): the V8 adapter code (`src/live-api-adapter/`). Model it
   on `SHARED_RUNTIME_GLOBS` / `MCP_SERVER_GLOBS` and give it a non-colliding

--- a/src/tools/shared/device/specialized/tests/devices/compressor-test-helpers.ts
+++ b/src/tools/shared/device/specialized/tests/devices/compressor-test-helpers.ts
@@ -1,0 +1,191 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import "#src/live-api-adapter/live-api-extensions.ts";
+
+import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
+
+// Shared mock data + builders for the Compressor spec tests (compressor.test.ts
+// and compressor-sidechain-input.test.ts). Compressor's sidechain source/channel
+// are Live routing dicts, so the mocks must round-trip them as JSON strings.
+
+/**
+ * Encode a routing dict value for the mock get() call.
+ * The live-api-extensions getProperty() logic calls JSON.parse(rawValue[0])
+ * then reads the named key from the resulting object.
+ * @param property - Live API property name (used as the JSON wrapper key)
+ * @param value - The dict value to return (object or array)
+ * @returns Single-element array wrapping the JSON string
+ */
+export function routingProp(property: string, value: unknown): unknown[] {
+  return [JSON.stringify({ [property]: value })];
+}
+
+export interface RoutingEntry {
+  display_name: string;
+  identifier: number;
+}
+
+// Routing-type entries used across tests.
+export const NO_INPUT_ENTRY: RoutingEntry = {
+  display_name: "No Input",
+  identifier: 0,
+};
+export const DRIFT_ENTRY: RoutingEntry = {
+  display_name: "Drift",
+  identifier: 3,
+};
+export const AUDIO_FX_ENTRY: RoutingEntry = {
+  display_name: "AudioFX",
+  identifier: 16,
+};
+export const EXT_IN_ENTRY: RoutingEntry = {
+  display_name: "Ext. In",
+  identifier: 1,
+};
+export const RETURN_ENTRY: RoutingEntry = {
+  display_name: "A-Reverb",
+  identifier: 30,
+};
+export const MASTER_ENTRY: RoutingEntry = {
+  display_name: "Main",
+  identifier: 40,
+};
+
+// Channel entries used across tests.
+export const PRE_FX_ENTRY: RoutingEntry = {
+  display_name: "Pre FX",
+  identifier: 20,
+};
+export const POST_FX_ENTRY: RoutingEntry = {
+  display_name: "Post FX",
+  identifier: 21,
+};
+export const POST_MIXER_ENTRY: RoutingEntry = {
+  display_name: "Post Mixer",
+  identifier: 22,
+};
+
+export const DEFAULT_AVAILABLE_TYPES: RoutingEntry[] = [
+  NO_INPUT_ENTRY,
+  EXT_IN_ENTRY,
+  DRIFT_ENTRY,
+  AUDIO_FX_ENTRY,
+];
+
+export const DEFAULT_AVAILABLE_CHANNELS: RoutingEntry[] = [
+  PRE_FX_ENTRY,
+  POST_FX_ENTRY,
+  POST_MIXER_ENTRY,
+];
+
+export interface CompressorOverrides {
+  inputRoutingType?: RoutingEntry | null;
+  availableTypes?: RoutingEntry[];
+  inputRoutingChannel?: RoutingEntry | null;
+  availableChannels?: RoutingEntry[];
+}
+
+/**
+ * Register a mock Compressor device and return its LiveAPI.
+ * @param overrides - Optional property overrides
+ * @returns The Compressor LiveAPI object
+ */
+export function registerCompressor(
+  overrides: CompressorOverrides = {},
+): LiveAPI {
+  const availableTypes = overrides.availableTypes ?? DEFAULT_AVAILABLE_TYPES;
+  const availableChannels =
+    overrides.availableChannels ?? DEFAULT_AVAILABLE_CHANNELS;
+  const inputRoutingType =
+    overrides.inputRoutingType !== undefined
+      ? overrides.inputRoutingType
+      : null;
+  const inputRoutingChannel =
+    overrides.inputRoutingChannel !== undefined
+      ? overrides.inputRoutingChannel
+      : null;
+
+  const properties: Record<string, unknown> = {
+    class_display_name: "Compressor",
+    available_input_routing_types: routingProp(
+      "available_input_routing_types",
+      availableTypes,
+    ),
+    available_input_routing_channels: routingProp(
+      "available_input_routing_channels",
+      availableChannels,
+    ),
+  };
+
+  if (inputRoutingType != null) {
+    properties.input_routing_type = routingProp(
+      "input_routing_type",
+      inputRoutingType,
+    );
+  }
+
+  if (inputRoutingChannel != null) {
+    properties.input_routing_channel = routingProp(
+      "input_routing_channel",
+      inputRoutingChannel,
+    );
+  }
+
+  registerMockObject("comp-1", { type: "Device", properties });
+
+  return LiveAPI.from("id comp-1");
+}
+
+/**
+ * Register the live_set with two tracks: Drift (t1) and AudioFX (t2).
+ */
+export function registerLiveSetTracks(): void {
+  registerMockObject("live_set", {
+    path: "live_set",
+    type: "Device",
+    properties: {
+      tracks: ["id", "t1", "id", "t2"],
+    },
+  });
+
+  registerMockObject("t1", {
+    type: "Device",
+    properties: { name: "Drift" },
+  });
+
+  registerMockObject("t2", {
+    type: "Device",
+    properties: { name: "AudioFX" },
+  });
+}
+
+/**
+ * Register a live_set that also exposes a return track ("A-Reverb", id "r1") and
+ * the master track ("Main", id "master-1"), so sidechain reads can resolve
+ * return/master sources to track ids.
+ */
+export function registerLiveSetWithReturnsAndMaster(): void {
+  registerMockObject("live_set", {
+    path: "live_set",
+    type: "Device",
+    properties: {
+      tracks: ["id", "t1", "id", "t2"],
+      return_tracks: ["id", "r1"],
+    },
+  });
+
+  registerMockObject("t1", { type: "Device", properties: { name: "Drift" } });
+  registerMockObject("t2", { type: "Device", properties: { name: "AudioFX" } });
+  registerMockObject("r1", {
+    type: "Device",
+    properties: { name: "A-Reverb" },
+  });
+  registerMockObject("master-1", {
+    path: "live_set master_track",
+    type: "Device",
+    properties: { name: "Main" },
+  });
+}

--- a/src/tools/shared/device/specialized/tests/devices/compressor.test.ts
+++ b/src/tools/shared/device/specialized/tests/devices/compressor.test.ts
@@ -16,173 +16,24 @@ import {
   applySpecializedParamWrite,
   readSpecializedOptions,
   readSpecializedParams,
-} from "../specialized-device-registry.ts";
-
-// ---------------------------------------------------------------------------
-// Mock helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Encode a routing dict value for the mock get() call.
- * The live-api-extensions getProperty() logic calls JSON.parse(rawValue[0])
- * then reads the named key from the resulting object.
- * @param property - Live API property name (used as the JSON wrapper key)
- * @param value - The dict value to return (object or array)
- * @returns Single-element array wrapping the JSON string
- */
-function routingProp(property: string, value: unknown): unknown[] {
-  return [JSON.stringify({ [property]: value })];
-}
-
-interface RoutingEntry {
-  display_name: string;
-  identifier: number;
-}
-
-// Routing-type entries used across tests.
-const NO_INPUT_ENTRY: RoutingEntry = {
-  display_name: "No Input",
-  identifier: 0,
-};
-const DRIFT_ENTRY: RoutingEntry = { display_name: "Drift", identifier: 3 };
-const AUDIO_FX_ENTRY: RoutingEntry = {
-  display_name: "AudioFX",
-  identifier: 16,
-};
-const EXT_IN_ENTRY: RoutingEntry = { display_name: "Ext. In", identifier: 1 };
-const RETURN_ENTRY: RoutingEntry = { display_name: "A-Reverb", identifier: 30 };
-const MASTER_ENTRY: RoutingEntry = { display_name: "Main", identifier: 40 };
-
-// Channel entries used across tests.
-const PRE_FX_ENTRY: RoutingEntry = { display_name: "Pre FX", identifier: 20 };
-const POST_FX_ENTRY: RoutingEntry = {
-  display_name: "Post FX",
-  identifier: 21,
-};
-const POST_MIXER_ENTRY: RoutingEntry = {
-  display_name: "Post Mixer",
-  identifier: 22,
-};
-
-const DEFAULT_AVAILABLE_TYPES: RoutingEntry[] = [
-  NO_INPUT_ENTRY,
-  EXT_IN_ENTRY,
-  DRIFT_ENTRY,
+} from "../../specialized-device-registry.ts";
+import {
   AUDIO_FX_ENTRY,
-];
-
-const DEFAULT_AVAILABLE_CHANNELS: RoutingEntry[] = [
-  PRE_FX_ENTRY,
+  type CompressorOverrides,
+  DEFAULT_AVAILABLE_CHANNELS,
+  DEFAULT_AVAILABLE_TYPES,
+  DRIFT_ENTRY,
+  EXT_IN_ENTRY,
+  MASTER_ENTRY,
+  NO_INPUT_ENTRY,
   POST_FX_ENTRY,
-  POST_MIXER_ENTRY,
-];
-
-interface CompressorOverrides {
-  inputRoutingType?: RoutingEntry | null;
-  availableTypes?: RoutingEntry[];
-  inputRoutingChannel?: RoutingEntry | null;
-  availableChannels?: RoutingEntry[];
-}
-
-/**
- * Register a mock Compressor device and return its LiveAPI.
- * @param overrides - Optional property overrides
- * @returns The Compressor LiveAPI object
- */
-function registerCompressor(overrides: CompressorOverrides = {}): LiveAPI {
-  const availableTypes = overrides.availableTypes ?? DEFAULT_AVAILABLE_TYPES;
-  const availableChannels =
-    overrides.availableChannels ?? DEFAULT_AVAILABLE_CHANNELS;
-  const inputRoutingType =
-    overrides.inputRoutingType !== undefined
-      ? overrides.inputRoutingType
-      : null;
-  const inputRoutingChannel =
-    overrides.inputRoutingChannel !== undefined
-      ? overrides.inputRoutingChannel
-      : null;
-
-  const properties: Record<string, unknown> = {
-    class_display_name: "Compressor",
-    available_input_routing_types: routingProp(
-      "available_input_routing_types",
-      availableTypes,
-    ),
-    available_input_routing_channels: routingProp(
-      "available_input_routing_channels",
-      availableChannels,
-    ),
-  };
-
-  if (inputRoutingType != null) {
-    properties.input_routing_type = routingProp(
-      "input_routing_type",
-      inputRoutingType,
-    );
-  }
-
-  if (inputRoutingChannel != null) {
-    properties.input_routing_channel = routingProp(
-      "input_routing_channel",
-      inputRoutingChannel,
-    );
-  }
-
-  registerMockObject("comp-1", { type: "Device", properties });
-
-  return LiveAPI.from("id comp-1");
-}
-
-/**
- * Register the live_set with two tracks: Drift (t1) and AudioFX (t2).
- */
-function registerLiveSetTracks(): void {
-  registerMockObject("live_set", {
-    path: "live_set",
-    type: "Device",
-    properties: {
-      tracks: ["id", "t1", "id", "t2"],
-    },
-  });
-
-  registerMockObject("t1", {
-    type: "Device",
-    properties: { name: "Drift" },
-  });
-
-  registerMockObject("t2", {
-    type: "Device",
-    properties: { name: "AudioFX" },
-  });
-}
-
-/**
- * Register a live_set that also exposes a return track ("A-Reverb", id "r1") and
- * the master track ("Main", id "master-1"), so sidechain reads can resolve
- * return/master sources to track ids.
- */
-function registerLiveSetWithReturnsAndMaster(): void {
-  registerMockObject("live_set", {
-    path: "live_set",
-    type: "Device",
-    properties: {
-      tracks: ["id", "t1", "id", "t2"],
-      return_tracks: ["id", "r1"],
-    },
-  });
-
-  registerMockObject("t1", { type: "Device", properties: { name: "Drift" } });
-  registerMockObject("t2", { type: "Device", properties: { name: "AudioFX" } });
-  registerMockObject("r1", {
-    type: "Device",
-    properties: { name: "A-Reverb" },
-  });
-  registerMockObject("master-1", {
-    path: "live_set master_track",
-    type: "Device",
-    properties: { name: "Main" },
-  });
-}
+  PRE_FX_ENTRY,
+  registerCompressor,
+  registerLiveSetTracks,
+  registerLiveSetWithReturnsAndMaster,
+  RETURN_ENTRY,
+  routingProp,
+} from "./compressor-test-helpers.ts";
 
 // ---------------------------------------------------------------------------
 // sidechainSourceTrackId — read
@@ -357,6 +208,25 @@ describe("Compressor sidechainSourceTrackId write", () => {
       device,
       "sidechainSourceTrackId",
       "",
+      "updateDevice",
+    );
+
+    expect(device.set).toHaveBeenCalledWith(
+      "input_routing_type",
+      JSON.stringify({ input_routing_type: { identifier: 0 } }),
+    );
+  });
+
+  it("clears to No Input when value is whitespace only", () => {
+    // Trimmed before the clear check, so a blank-looking value clears the
+    // source rather than being looked up as a track id.
+    registerLiveSetTracks();
+    const device = registerCompressor();
+
+    applySpecializedParamWrite(
+      device,
+      "sidechainSourceTrackId",
+      "   ",
       "updateDevice",
     );
 
@@ -548,7 +418,13 @@ describe("Compressor sidechainChannel write", () => {
       "updateDevice",
     );
 
-    expect(outlet).toHaveBeenCalledWith(1, expect.stringContaining("Pre FX"));
+    // The full channel catalog, comma-separated.
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining(
+        `Available: ${DEFAULT_AVAILABLE_CHANNELS.map((c) => c.display_name).join(", ")}`,
+      ),
+    );
   });
 
   it("warns and skips (no throw) when channels are unavailable", () => {

--- a/src/tools/shared/device/specialized/tests/devices/drift.test.ts
+++ b/src/tools/shared/device/specialized/tests/devices/drift.test.ts
@@ -12,7 +12,7 @@ import { readDevice } from "#src/tools/device/read/read-device.ts";
 import {
   applySpecializedParamWrite,
   readSpecializedParams,
-} from "../specialized-device-registry.ts";
+} from "../../specialized-device-registry.ts";
 
 // Default property values for a Drift device at factory defaults.
 const DRIFT_DEFAULTS = {

--- a/src/tools/shared/device/specialized/tests/devices/eq-eight.test.ts
+++ b/src/tools/shared/device/specialized/tests/devices/eq-eight.test.ts
@@ -12,7 +12,7 @@ import { readDevice } from "#src/tools/device/read/read-device.ts";
 import {
   applySpecializedParamWrite,
   readSpecializedParams,
-} from "../specialized-device-registry.ts";
+} from "../../specialized-device-registry.ts";
 
 /**
  * Register a mock EQ Eight device and return its LiveAPI.
@@ -161,6 +161,20 @@ describe("EQ Eight pseudo-params", () => {
       applySpecializedParamWrite(device, "oversample", "false", "updateDevice");
 
       expect(device.set).toHaveBeenCalledWith("oversample", 0);
+    });
+
+    it("warns naming oversample and skips uninterpretable input", () => {
+      const device = registerEqEight();
+
+      applySpecializedParamWrite(device, "oversample", "maybe", "updateDevice");
+
+      expect(device.set).not.toHaveBeenCalled();
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining(
+          '"maybe" is not a valid oversample (expected true/false)',
+        ),
+      );
     });
   });
 });

--- a/src/tools/shared/device/specialized/tests/devices/hybrid-reverb.test.ts
+++ b/src/tools/shared/device/specialized/tests/devices/hybrid-reverb.test.ts
@@ -13,7 +13,7 @@ import {
   applySpecializedParamWrite,
   readSpecializedOptions,
   readSpecializedParams,
-} from "../specialized-device-registry.ts";
+} from "../../specialized-device-registry.ts";
 
 // Category list for testing: underscore-separated internal names.
 const MOCK_CATEGORY_LIST = [
@@ -143,9 +143,13 @@ describe("Hybrid Reverb pseudo-params", () => {
         "updateDevice",
       );
 
+      // The whole catalog, comma-separated and de-underscored — this warning is
+      // the model's only listing of the valid category names.
       expect(outlet).toHaveBeenCalledWith(
         1,
-        expect.stringContaining("Early Reflections"),
+        expect.stringContaining(
+          "Available: Early Reflections, Halls, Real Places",
+        ),
       );
     });
   });
@@ -218,6 +222,31 @@ describe("Hybrid Reverb pseudo-params", () => {
         1,
         expect.stringContaining("no files"),
       );
+    });
+
+    it("sets the only file in a single-file category", () => {
+      // A one-entry list is "empty" only when that entry is the sentinel — a
+      // category holding exactly one real IR must still be settable.
+      const device = registerHybridReverb({
+        ir_file_list: ["Solo Hall"],
+      });
+
+      applySpecializedParamWrite(device, "irFile", "Solo Hall", "updateDevice");
+
+      expect(device.set).toHaveBeenCalledWith("ir_file_index", 0);
+    });
+
+    it("sets the first file in the list (index 0)", () => {
+      const device = registerHybridReverb();
+
+      applySpecializedParamWrite(
+        device,
+        "irFile",
+        "Berliner Hall LR",
+        "updateDevice",
+      );
+
+      expect(device.set).toHaveBeenCalledWith("ir_file_index", 0);
     });
   });
 
@@ -365,6 +394,25 @@ describe("Hybrid Reverb pseudo-params", () => {
       );
 
       expect(device.set).toHaveBeenCalledWith("ir_time_shaping_on", 0);
+    });
+
+    it("warns naming irTimeShapingOn and skips uninterpretable input", () => {
+      const device = registerHybridReverb();
+
+      applySpecializedParamWrite(
+        device,
+        "irTimeShapingOn",
+        "maybe",
+        "updateDevice",
+      );
+
+      expect(device.set).not.toHaveBeenCalled();
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining(
+          '"maybe" is not a valid irTimeShapingOn (expected true/false)',
+        ),
+      );
     });
   });
 

--- a/src/tools/shared/device/specialized/tests/devices/meld.test.ts
+++ b/src/tools/shared/device/specialized/tests/devices/meld.test.ts
@@ -12,7 +12,7 @@ import { readDevice } from "#src/tools/device/read/read-device.ts";
 import {
   applySpecializedParamWrite,
   readSpecializedParams,
-} from "../specialized-device-registry.ts";
+} from "../../specialized-device-registry.ts";
 
 /**
  * Register a mock Meld device and return its LiveAPI.

--- a/src/tools/shared/device/specialized/tests/devices/roar.test.ts
+++ b/src/tools/shared/device/specialized/tests/devices/roar.test.ts
@@ -12,7 +12,7 @@ import { readDevice } from "#src/tools/device/read/read-device.ts";
 import {
   applySpecializedParamWrite,
   readSpecializedParams,
-} from "../specialized-device-registry.ts";
+} from "../../specialized-device-registry.ts";
 
 /**
  * Register a mock Roar device and return its LiveAPI.
@@ -114,6 +114,20 @@ describe("Roar pseudo-params", () => {
       applySpecializedParamWrite(device, "envListen", "off", "updateDevice");
 
       expect(device.set).toHaveBeenCalledWith("env_listen", 0);
+    });
+
+    it("warns naming envListen and skips uninterpretable input", () => {
+      const device = registerRoar();
+
+      applySpecializedParamWrite(device, "envListen", "maybe", "updateDevice");
+
+      expect(device.set).not.toHaveBeenCalled();
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining(
+          '"maybe" is not a valid envListen (expected true/false)',
+        ),
+      );
     });
   });
 });

--- a/src/tools/shared/device/specialized/tests/devices/simpler.test.ts
+++ b/src/tools/shared/device/specialized/tests/devices/simpler.test.ts
@@ -12,15 +12,18 @@ import {
   applySpecializedActions,
   applySpecializedParamWrite,
   readSpecializedParams,
-} from "../specialized-device-registry.ts";
+} from "../../specialized-device-registry.ts";
 
 interface SimplerProps {
   multiSampleMode?: number;
   playbackMode?: number;
   slicingPlaybackMode?: number;
   retrigger?: number;
-  voices?: number;
+  // `unknown` so a test can feed a non-number and exercise the read guard.
+  voices?: unknown;
   samplePath?: string;
+  // When true, the sample child exposes no `gain` property at all.
+  omitSampleGain?: boolean;
 }
 
 /**
@@ -33,7 +36,9 @@ function registerSimpler(props: SimplerProps = {}): LiveAPI {
   if (props.samplePath != null) {
     registerMockObject("sample-1", {
       type: "Sample",
-      properties: { file_path: props.samplePath, gain: 1 },
+      properties: props.omitSampleGain
+        ? { file_path: props.samplePath }
+        : { file_path: props.samplePath, gain: 1 },
     });
   }
 
@@ -104,6 +109,35 @@ describe("Simpler pseudo-params", () => {
         value: true,
       });
     });
+
+    it("omits sample and gainDb in multi-sample mode", () => {
+      // The probe reports `multisample` (no path/gain), so neither
+      // single-sample param may be emitted — not even as undefined/NaN.
+      const device = registerSimpler({ multiSampleMode: 1 });
+      const names = readSpecializedParams(device).map((p) => p.name);
+
+      expect(names).not.toContain("sample");
+      expect(names).not.toContain("gainDb");
+    });
+
+    it("omits gainDb when the loaded sample exposes no gain", () => {
+      const device = registerSimpler({
+        samplePath: "/tmp/kick.wav",
+        omitSampleGain: true,
+      });
+      const params = readSpecializedParams(device);
+
+      expect(params).toContainEqual({ name: "sample", value: "/tmp/kick.wav" });
+      expect(params.map((p) => p.name)).not.toContain("gainDb");
+    });
+
+    it("omits voices when the device reports a non-number", () => {
+      const device = registerSimpler({ voices: "eight" });
+
+      expect(readSpecializedParams(device).map((p) => p.name)).not.toContain(
+        "voices",
+      );
+    });
   });
 
   describe("write", () => {
@@ -141,6 +175,20 @@ describe("Simpler pseudo-params", () => {
       applySpecializedParamWrite(device, "retrigger", "true", "t");
 
       expect(device.set).toHaveBeenCalledWith("retrigger", 1);
+    });
+
+    it("warns naming retrigger and skips uninterpretable input", () => {
+      const device = registerSimpler();
+
+      applySpecializedParamWrite(device, "retrigger", "sometimes", "t");
+
+      expect(device.set).not.toHaveBeenCalled();
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining(
+          '"sometimes" is not a valid retrigger (expected true/false)',
+        ),
+      );
     });
 
     it("sets gainDb on the loaded sample, converting dB to linear", () => {

--- a/src/tools/shared/device/specialized/tests/devices/spectral-resonator.test.ts
+++ b/src/tools/shared/device/specialized/tests/devices/spectral-resonator.test.ts
@@ -12,7 +12,7 @@ import { readDevice } from "#src/tools/device/read/read-device.ts";
 import {
   applySpecializedParamWrite,
   readSpecializedParams,
-} from "../specialized-device-registry.ts";
+} from "../../specialized-device-registry.ts";
 
 /**
  * Register a mock Spectral Resonator device and return its LiveAPI.

--- a/src/tools/shared/device/specialized/tests/devices/wavetable-modulation-helpers.test.ts
+++ b/src/tools/shared/device/specialized/tests/devices/wavetable-modulation-helpers.test.ts
@@ -1,0 +1,267 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import "#src/live-api-adapter/live-api-extensions.ts";
+
+import { describe, expect, it } from "vitest";
+import {
+  MOD_SOURCES,
+  readModulations,
+} from "../../devices/wavetable-modulation-helpers.ts";
+import { applySpecializedActions } from "../../specialized-device-registry.ts";
+import {
+  buildModMethods,
+  registerWavetable,
+} from "./wavetable-test-helpers.ts";
+
+// Edge cases of the Wavetable mod-matrix helpers: the index-0 boundaries (source
+// "Amp" and target slot 0 are both real values, not "not found"), the ±1 amount
+// contract, whitespace tolerance on LLM-supplied names, and the warning text
+// that tells the model what it should have passed. The happy paths live in
+// wavetable.test.ts.
+
+describe("modulation source resolution", () => {
+  it("accepts the first source in the matrix (index 0)", () => {
+    // "Amp" is column 0 — a `> 0` found-check would reject it and fall through
+    // to the numeric branch, making the source unusable.
+    const device = registerWavetable({}, buildModMethods(["Osc 1 Pos"]));
+
+    applySpecializedActions(
+      device,
+      ["setModulation('Osc 1 Pos', 'Amp', 0.5)"],
+      "updateDevice",
+    );
+
+    expect(device.call).toHaveBeenCalledWith("set_modulation_value", 0, 0, 0.5);
+  });
+
+  it("accepts a bare source index and trims whitespace off a source name", () => {
+    const device = registerWavetable({}, buildModMethods(["Osc 1 Pos"]));
+
+    applySpecializedActions(
+      device,
+      [
+        "setModulation('Osc 1 Pos', 4, 0.25)",
+        "setModulation('Osc 1 Pos', '  LFO 1  ', 0.75)",
+      ],
+      "updateDevice",
+    );
+
+    expect(device.call).toHaveBeenCalledWith(
+      "set_modulation_value",
+      0,
+      4,
+      0.25,
+    );
+    expect(device.call).toHaveBeenCalledWith(
+      "set_modulation_value",
+      0,
+      3,
+      0.75,
+    );
+  });
+
+  it.each([-1, 13, 99])("rejects out-of-range source index %s", (index) => {
+    const device = registerWavetable({}, buildModMethods(["Osc 1 Pos"]));
+
+    applySpecializedActions(
+      device,
+      [`setModulation('Osc 1 Pos', ${index}, 0.5)`],
+      "updateDevice",
+    );
+
+    expect(device.call).not.toHaveBeenCalledWith(
+      "set_modulation_value",
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("names every valid source when the source is invalid", () => {
+    const device = registerWavetable({}, buildModMethods(["Osc 1 Pos"]));
+
+    applySpecializedActions(
+      device,
+      [
+        "setModulation('Osc 1 Pos', 'Nope', 0.5)",
+        "clearModulation('Osc 1 Pos', 'Nope')",
+      ],
+      "updateDevice",
+    );
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining(
+        `setModulation source "Nope" is invalid. Valid: ${MOD_SOURCES.join(", ")}`,
+      ),
+    );
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining(
+        `clearModulation source "Nope" is invalid. Valid: ${MOD_SOURCES.join(", ")}`,
+      ),
+    );
+  });
+});
+
+describe("modulation target resolution", () => {
+  it("trims whitespace off a target name", () => {
+    const device = registerWavetable({}, buildModMethods(["Osc 1 Pos"]));
+
+    applySpecializedActions(
+      device,
+      ["setModulation('  Osc 1 Pos  ', 'LFO 1', 0.5)"],
+      "updateDevice",
+    );
+
+    expect(device.call).toHaveBeenCalledWith("set_modulation_value", 0, 3, 0.5);
+  });
+
+  it("trims whitespace when looking up a parameter to add", () => {
+    // findParamChild is only reached for a target that is NOT yet in the
+    // matrix, so the empty-matrix mock is what exercises its trim.
+    const device = registerWavetable({}, buildModMethods([]));
+
+    applySpecializedActions(
+      device,
+      ["addModulationTarget('  Osc 1 Pos  ')"],
+      "updateDevice",
+    );
+
+    expect(device.call).toHaveBeenCalledWith(
+      "add_parameter_to_modulation_matrix",
+      "id p1",
+    );
+  });
+
+  it("does not re-add a target already in slot 0", () => {
+    // Slot 0 is a valid existing target: a `> 0` check would treat it as
+    // missing and re-add it to the matrix.
+    const device = registerWavetable({}, buildModMethods(["Osc 1 Pos"]));
+
+    applySpecializedActions(
+      device,
+      ["setModulation('Osc 1 Pos', 'LFO 1', 0.5)"],
+      "updateDevice",
+    );
+
+    expect(device.call).not.toHaveBeenCalledWith(
+      "add_parameter_to_modulation_matrix",
+      expect.anything(),
+    );
+    expect(device.call).toHaveBeenCalledWith("set_modulation_value", 0, 3, 0.5);
+  });
+
+  it("does not warn when an auto-added target lands in slot 0", () => {
+    // The matrix starts empty, so the added target resolves to index 0 — the
+    // post-add check must accept it rather than report "could not add".
+    const targets: string[] = [];
+    const device = registerWavetable(
+      {},
+      {
+        ...buildModMethods(targets),
+        add_parameter_to_modulation_matrix: () => {
+          targets.push("Osc 1 Pos");
+
+          return null;
+        },
+      },
+    );
+
+    applySpecializedActions(
+      device,
+      ["setModulation('Osc 1 Pos', 'LFO 1', 0.5)"],
+      "updateDevice",
+    );
+
+    expect(device.call).toHaveBeenCalledWith("set_modulation_value", 0, 3, 0.5);
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("could not add to matrix"),
+    );
+  });
+
+  it("returns -1 for an unknown target in a non-empty matrix", () => {
+    // Exercises the resolve loop's non-matching path: the scan must run past a
+    // real target and still report "not in the modulation matrix".
+    const device = registerWavetable({}, buildModMethods(["Osc 1 Pos"]));
+
+    applySpecializedActions(
+      device,
+      ["clearModulation('Filter Freq', 'LFO 1')"],
+      "updateDevice",
+    );
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining(
+        'clearModulation target "Filter Freq" is not in the modulation matrix',
+      ),
+    );
+  });
+});
+
+describe("setModulation amount contract", () => {
+  it.each([1, -1])("accepts the boundary amount %s", (amount) => {
+    const device = registerWavetable({}, buildModMethods(["Osc 1 Pos"]));
+
+    applySpecializedActions(
+      device,
+      [`setModulation('Osc 1 Pos', 'LFO 1', ${amount})`],
+      "updateDevice",
+    );
+
+    expect(device.call).toHaveBeenCalledWith(
+      "set_modulation_value",
+      0,
+      3,
+      amount,
+    );
+  });
+
+  it.each([1.5, -1.5])("rejects the out-of-range amount %s", (amount) => {
+    const device = registerWavetable({}, buildModMethods(["Osc 1 Pos"]));
+
+    applySpecializedActions(
+      device,
+      [`setModulation('Osc 1 Pos', 'LFO 1', ${amount})`],
+      "updateDevice",
+    );
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining(`amount must be in -1..1 (got ${amount})`),
+    );
+  });
+});
+
+describe("readModulations", () => {
+  it("omits zero-amount cells", () => {
+    const device = registerWavetable(
+      {},
+      buildModMethods(["Osc 1 Pos"], { "0,3": 0.5, "0,4": 0 }),
+    );
+
+    expect(readModulations(device)).toStrictEqual([
+      { target: "Osc 1 Pos", source: "LFO 1", amount: 0.5 },
+    ]);
+  });
+
+  it("reads exactly the 13 known sources per target", () => {
+    // Every cell is nonzero, so the scan's source bound is what limits the
+    // result: one entry per MOD_SOURCES column, none past the last.
+    const cells: Record<string, number> = {};
+
+    for (let s = 0; s < 20; s++) {
+      cells[`0,${s}`] = 0.5;
+    }
+
+    const device = registerWavetable({}, buildModMethods(["Osc 1 Pos"], cells));
+    const result = readModulations(device) as { source: string }[];
+
+    expect(result.map((r) => r.source)).toStrictEqual([...MOD_SOURCES]);
+  });
+});

--- a/src/tools/shared/device/specialized/tests/devices/wavetable-test-helpers.ts
+++ b/src/tools/shared/device/specialized/tests/devices/wavetable-test-helpers.ts
@@ -1,0 +1,114 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import "#src/live-api-adapter/live-api-extensions.ts";
+
+import { expect } from "vitest";
+import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
+
+// Shared mock data + builders for the Wavetable specs (wavetable.test.ts and
+// wavetable-modulation-helpers.test.ts).
+
+export const OSC_CATEGORIES = ["Basic Shapes", "Bass", "Pads"];
+export const OSC1_WAVETABLES = ["Saw Dual 1", "Saw Dual 2", "Pulse"];
+export const OSC2_WAVETABLES = ["Square", "Triangle", "Sine"];
+
+// Parameter IDs — pairs for getChildIds: ["id", "p1", "id", "p2", ...]
+export const PARAM_IDS = ["id", "p1", "id", "p2", "id", "p3"];
+
+/**
+ * Register the three standard param mocks referenced by PARAM_IDS.
+ */
+export function registerStandardParamMocks(): void {
+  registerMockObject("p1", { properties: { name: "Osc 1 Pos" } });
+  registerMockObject("p2", { properties: { name: "Filter Freq" } });
+  registerMockObject("p3", { properties: { name: "Volume" } });
+}
+
+/**
+ * Build mock methods for modulation matrix operations.
+ * get_modulation_target_parameter_name returns the name for i < targets.length,
+ * numeric sentinel 1 otherwise. get_modulation_value reads from sparse cells map.
+ * @param targets - Target parameter names in index order
+ * @param cells - Sparse non-zero cell map "targetIdx,sourceIdx" → amount
+ * @param modulatable - Whether is_parameter_modulatable returns 1
+ * @returns methods object for registerMockObject
+ */
+export function buildModMethods(
+  targets: string[],
+  cells: Record<string, number> = {},
+  modulatable = 1,
+): Record<string, (...args: unknown[]) => unknown> {
+  return {
+    get_modulation_target_parameter_name: (i: unknown) =>
+      (i as number) < targets.length ? targets[i as number] : 1,
+    get_modulation_value: (t: unknown, s: unknown) =>
+      cells[`${String(t)},${String(s)}`] ?? 0,
+    set_modulation_value: () => null,
+    add_parameter_to_modulation_matrix: () => null,
+    is_parameter_modulatable: () => modulatable,
+  };
+}
+
+/**
+ * Register a mock Wavetable device and return its LiveAPI.
+ * List props register flat ([a,b]) so getPropertyList() returns [a,b].
+ * @param properties - Property overrides merged onto Wavetable defaults
+ * @param methods - Method overrides for device.call()
+ * @returns The Wavetable LiveAPI object
+ */
+export function registerWavetable(
+  properties: Record<string, unknown> = {},
+  methods: Record<string, (...args: unknown[]) => unknown> = {},
+): LiveAPI {
+  registerMockObject("wt-1", {
+    type: "Device",
+    properties: {
+      class_display_name: "Wavetable",
+      filter_routing: 0,
+      mono_poly: 0,
+      poly_voices: 4,
+      unison_mode: 0,
+      unison_voice_count: 2,
+      oscillator_1_effect_mode: 0,
+      oscillator_2_effect_mode: 0,
+      oscillator_1_wavetable_category: 0,
+      oscillator_2_wavetable_category: 0,
+      oscillator_1_wavetable_index: 0,
+      oscillator_2_wavetable_index: 0,
+      oscillator_wavetable_categories: OSC_CATEGORIES,
+      oscillator_1_wavetables: OSC1_WAVETABLES,
+      oscillator_2_wavetables: OSC2_WAVETABLES,
+      parameters: PARAM_IDS,
+      ...properties,
+    },
+    methods: { ...buildModMethods([], {}, 0), ...methods },
+  });
+
+  registerStandardParamMocks();
+
+  return LiveAPI.from("id wt-1");
+}
+
+/**
+ * Assert that no modulation value was written and a warning was emitted.
+ * @param device - The mock device to inspect (the returned LiveAPI from registerWavetable)
+ * @param warningSubstring - Substring expected in the warning message
+ */
+export function expectModulationNotSet(
+  device: LiveAPI,
+  warningSubstring: string,
+): void {
+  expect(device.call).not.toHaveBeenCalledWith(
+    "set_modulation_value",
+    expect.anything(),
+    expect.anything(),
+    expect.anything(),
+  );
+  expect(outlet).toHaveBeenCalledWith(
+    1,
+    expect.stringContaining(warningSubstring),
+  );
+}

--- a/src/tools/shared/device/specialized/tests/devices/wavetable.test.ts
+++ b/src/tools/shared/device/specialized/tests/devices/wavetable.test.ts
@@ -15,110 +15,17 @@ import {
   readSpecializedModulations,
   readSpecializedOptions,
   readSpecializedParams,
-} from "../specialized-device-registry.ts";
-
-// Shared mock data
-const OSC_CATEGORIES = ["Basic Shapes", "Bass", "Pads"];
-const OSC1_WAVETABLES = ["Saw Dual 1", "Saw Dual 2", "Pulse"];
-const OSC2_WAVETABLES = ["Square", "Triangle", "Sine"];
-
-// Parameter IDs — pairs for getChildIds: ["id", "p1", "id", "p2", ...]
-const PARAM_IDS = ["id", "p1", "id", "p2", "id", "p3"];
-
-/**
- * Register the three standard param mocks referenced by PARAM_IDS.
- */
-function registerStandardParamMocks(): void {
-  registerMockObject("p1", { properties: { name: "Osc 1 Pos" } });
-  registerMockObject("p2", { properties: { name: "Filter Freq" } });
-  registerMockObject("p3", { properties: { name: "Volume" } });
-}
-
-/**
- * Assert that no modulation value was written and a warning was emitted.
- * @param device - The mock device to inspect (the returned LiveAPI from registerWavetable)
- * @param warningSubstring - Substring expected in the warning message
- */
-function expectModulationNotSet(
-  device: LiveAPI,
-  warningSubstring: string,
-): void {
-  expect(device.call).not.toHaveBeenCalledWith(
-    "set_modulation_value",
-    expect.anything(),
-    expect.anything(),
-    expect.anything(),
-  );
-  expect(outlet).toHaveBeenCalledWith(
-    1,
-    expect.stringContaining(warningSubstring),
-  );
-}
-
-/**
- * Build mock methods for modulation matrix operations.
- * get_modulation_target_parameter_name returns the name for i < targets.length,
- * numeric sentinel 1 otherwise. get_modulation_value reads from sparse cells map.
- * @param targets - Target parameter names in index order
- * @param cells - Sparse non-zero cell map "targetIdx,sourceIdx" → amount
- * @param modulatable - Whether is_parameter_modulatable returns 1
- * @returns methods object for registerMockObject
- */
-function buildModMethods(
-  targets: string[],
-  cells: Record<string, number> = {},
-  modulatable = 1,
-): Record<string, (...args: unknown[]) => unknown> {
-  return {
-    get_modulation_target_parameter_name: (i: unknown) =>
-      (i as number) < targets.length ? targets[i as number] : 1,
-    get_modulation_value: (t: unknown, s: unknown) =>
-      cells[`${String(t)},${String(s)}`] ?? 0,
-    set_modulation_value: () => null,
-    add_parameter_to_modulation_matrix: () => null,
-    is_parameter_modulatable: () => modulatable,
-  };
-}
-
-/**
- * Register a mock Wavetable device and return its LiveAPI.
- * List props register flat ([a,b]) so getPropertyList() returns [a,b].
- * @param properties - Property overrides merged onto Wavetable defaults
- * @param methods - Method overrides for device.call()
- * @returns The Wavetable LiveAPI object
- */
-function registerWavetable(
-  properties: Record<string, unknown> = {},
-  methods: Record<string, (...args: unknown[]) => unknown> = {},
-): LiveAPI {
-  registerMockObject("wt-1", {
-    type: "Device",
-    properties: {
-      class_display_name: "Wavetable",
-      filter_routing: 0,
-      mono_poly: 0,
-      poly_voices: 4,
-      unison_mode: 0,
-      unison_voice_count: 2,
-      oscillator_1_effect_mode: 0,
-      oscillator_2_effect_mode: 0,
-      oscillator_1_wavetable_category: 0,
-      oscillator_2_wavetable_category: 0,
-      oscillator_1_wavetable_index: 0,
-      oscillator_2_wavetable_index: 0,
-      oscillator_wavetable_categories: OSC_CATEGORIES,
-      oscillator_1_wavetables: OSC1_WAVETABLES,
-      oscillator_2_wavetables: OSC2_WAVETABLES,
-      parameters: PARAM_IDS,
-      ...properties,
-    },
-    methods: { ...buildModMethods([], {}, 0), ...methods },
-  });
-
-  registerStandardParamMocks();
-
-  return LiveAPI.from("id wt-1");
-}
+} from "../../specialized-device-registry.ts";
+import {
+  buildModMethods,
+  expectModulationNotSet,
+  OSC1_WAVETABLES,
+  OSC2_WAVETABLES,
+  OSC_CATEGORIES,
+  PARAM_IDS,
+  registerStandardParamMocks,
+  registerWavetable,
+} from "./wavetable-test-helpers.ts";
 
 describe("Wavetable pseudo-params — read", () => {
   it("reads all three filterRouting values by index", () => {
@@ -455,6 +362,58 @@ describe("Wavetable pseudo-params — write", () => {
     expect(outlet).toHaveBeenCalledWith(
       1,
       expect.stringContaining("osc2Wavetable"),
+    );
+  });
+
+  // The first entry in each list is a real choice, so the not-found guard must
+  // reject only index < 0 — treating index 0 as "not found" would make the
+  // first category / wavetable unselectable.
+  it("writes the first category in the list (index 0)", () => {
+    const device = registerWavetable();
+
+    applySpecializedParamWrite(
+      device,
+      "osc1Category",
+      "Basic Shapes",
+      "updateDevice",
+    );
+
+    expect(device.set).toHaveBeenCalledWith(
+      "oscillator_1_wavetable_category",
+      0,
+    );
+  });
+
+  it("writes the first wavetable in the list (index 0)", () => {
+    const device = registerWavetable();
+
+    applySpecializedParamWrite(
+      device,
+      "osc1Wavetable",
+      "Saw Dual 1",
+      "updateDevice",
+    );
+
+    expect(device.set).toHaveBeenCalledWith("oscillator_1_wavetable_index", 0);
+  });
+
+  it("lists the available categories and wavetables when a name is unknown", () => {
+    const device = registerWavetable();
+
+    applySpecializedParamWrite(device, "osc1Category", "Nope", "updateDevice");
+    applySpecializedParamWrite(device, "osc1Wavetable", "Nope", "updateDevice");
+
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining(
+        `not a valid osc1Category. Available: ${OSC_CATEGORIES.join(", ")}`,
+      ),
+    );
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining(
+        `not a valid osc1Wavetable. Available: ${OSC1_WAVETABLES.join(", ")}`,
+      ),
     );
   });
 });

--- a/src/tools/shared/device/specialized/tests/specialized-device-action-parser.test.ts
+++ b/src/tools/shared/device/specialized/tests/specialized-device-action-parser.test.ts
@@ -50,6 +50,27 @@ describe("parseAction", () => {
     });
   });
 
+  it("parses multi-digit floats on both sides of the decimal point", () => {
+    // Guards the numeric pattern's repetition: a single-digit case like `4.5`
+    // still matches if `\d+` decays to `\d`, but `12.5` / `.25` do not.
+    expect(parseAction("warpAs(12.5)")).toStrictEqual({
+      name: "warpAs",
+      args: [12.5],
+    });
+    expect(parseAction("setAmount(.25)")).toStrictEqual({
+      name: "setAmount",
+      args: [0.25],
+    });
+  });
+
+  it("treats a digit-led word as a string, not a truncated number", () => {
+    // The numeric pattern is fully anchored: `4x` must not parse as 4/NaN.
+    expect(parseAction("setMode(4x)")).toStrictEqual({
+      name: "setMode",
+      args: ["4x"],
+    });
+  });
+
   it("parses single-quoted string args", () => {
     expect(parseAction("addModulationTarget('Filter 1 Freq')")).toStrictEqual({
       name: "addModulationTarget",
@@ -64,6 +85,20 @@ describe("parseAction", () => {
     });
   });
 
+  it("parses an empty quoted string as an empty-string arg", () => {
+    expect(parseAction("setName('')")).toStrictEqual({
+      name: "setName",
+      args: [""],
+    });
+  });
+
+  it("parses whitespace-only parentheses as no args", () => {
+    expect(parseAction("reverse(   )")).toStrictEqual({
+      name: "reverse",
+      args: [],
+    });
+  });
+
   it("parses mixed string and number args", () => {
     expect(
       parseAction("setModulation('Osc 1 Pos', 'Env 2', 0.5)"),
@@ -75,6 +110,15 @@ describe("parseAction", () => {
 
   it("respects commas inside quoted strings", () => {
     expect(parseAction("setLabel('a, b, c')")).toStrictEqual({
+      name: "setLabel",
+      args: ["a, b, c"],
+    });
+  });
+
+  it("respects commas inside double-quoted strings", () => {
+    // Double quotes must open a quoted span too, not just single quotes —
+    // otherwise the comma splits the token and the arg is lost.
+    expect(parseAction('setLabel("a, b, c")')).toStrictEqual({
       name: "setLabel",
       args: ["a, b, c"],
     });
@@ -100,6 +144,12 @@ describe("parseAction", () => {
 
   it("returns null when the name starts with a digit", () => {
     expect(parseAction("1bad()")).toBeNull();
+  });
+
+  it("returns null for trailing content after the closing paren", () => {
+    // The action pattern is anchored at both ends: a complete-looking call
+    // followed by junk is malformed, not a bare `reverse()`.
+    expect(parseAction("reverse() junk")).toBeNull();
   });
 
   it("returns null for an unterminated quote", () => {

--- a/src/tools/shared/device/specialized/tests/specialized-device-catalog.test.ts
+++ b/src/tools/shared/device/specialized/tests/specialized-device-catalog.test.ts
@@ -1,0 +1,178 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import "#src/live-api-adapter/live-api-extensions.ts";
+
+import { describe, expect, it } from "vitest";
+import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
+import { compressorSpec } from "../devices/compressor.ts";
+import { driftSpec } from "../devices/drift.ts";
+import { eqEightSpec } from "../devices/eq-eight.ts";
+import { hybridReverbSpec } from "../devices/hybrid-reverb.ts";
+import { meldSpec } from "../devices/meld.ts";
+import {
+  autoFilterSpec,
+  autoPanTremoloSpec,
+  phaserFlangerSpec,
+} from "../devices/modulation-rate-effects.ts";
+import { roarSpec } from "../devices/roar.ts";
+import { simplerSpec } from "../devices/simpler.ts";
+import { spectralResonatorSpec } from "../devices/spectral-resonator.ts";
+import { wavetableSpec } from "../devices/wavetable.ts";
+import {
+  getSpecForDevice,
+  readSpecializedActions,
+  readSpecializedOptions,
+  readSpecializedParams,
+} from "../specialized-device-registry.ts";
+import { type SpecializedDeviceSpec } from "../specialized-device-types.ts";
+
+// The declarative half of the specialized-device layer: the class_display_name →
+// spec routing table and the LLM-facing discovery catalogs (`actions`,
+// `paramOptions`). These are pure data the model relies on to call a device
+// correctly, so the tables themselves are the contract worth asserting — the
+// behavioral wiring around them lives in specialized-device-registry.test.ts.
+
+/**
+ * Register a mock device with a given class_display_name.
+ * @param displayName - The device's class_display_name
+ * @returns The device LiveAPI
+ */
+function registerDevice(displayName: string): LiveAPI {
+  registerMockObject("dev-1", {
+    type: "Device",
+    properties: { class_display_name: displayName },
+  });
+
+  return LiveAPI.from("id dev-1");
+}
+
+describe("display-name routing table", () => {
+  const ROUTES: [string, SpecializedDeviceSpec][] = [
+    ["Drift", driftSpec],
+    ["Meld", meldSpec],
+    ["Simpler", simplerSpec],
+    ["Wavetable", wavetableSpec],
+    ["Auto Filter", autoFilterSpec],
+    ["Auto Pan-Tremolo", autoPanTremoloSpec],
+    ["Compressor", compressorSpec],
+    ["EQ Eight", eqEightSpec],
+    ["Hybrid Reverb", hybridReverbSpec],
+    ["Phaser-Flanger", phaserFlangerSpec],
+    ["Roar", roarSpec],
+    ["Spectral Resonator", spectralResonatorSpec],
+  ];
+
+  it.each(ROUTES)("routes %s to its spec", (displayName, spec) => {
+    expect(getSpecForDevice(registerDevice(displayName))).toBe(spec);
+  });
+});
+
+describe("action catalogs", () => {
+  it("exposes Simpler's full action catalog", () => {
+    expect(readSpecializedActions(registerDevice("Simpler"))).toStrictEqual([
+      {
+        name: "reverse",
+        signature: "reverse",
+        description: "Reverse the active sample region",
+      },
+      {
+        name: "crop",
+        signature: "crop",
+        description: "Crop the sample to the active region",
+      },
+      {
+        name: "warpDouble",
+        signature: "warpDouble",
+        description: "Double the warp tempo (Sample tab ✻2)",
+      },
+      {
+        name: "warpHalf",
+        signature: "warpHalf",
+        description: "Halve the warp tempo (Sample tab ÷2)",
+      },
+      {
+        name: "warpAs",
+        signature: "warpAs(beats)",
+        description: "Warp the active region to span the given number of beats",
+      },
+    ]);
+  });
+
+  it("exposes Wavetable's full action catalog", () => {
+    expect(readSpecializedActions(registerDevice("Wavetable"))).toStrictEqual([
+      {
+        name: "setModulation",
+        signature:
+          "setModulation('<targetParamName>', '<source>', <amount -1..1>)",
+        description:
+          "Set a mod-matrix amount routing a source to a target parameter",
+      },
+      {
+        name: "clearModulation",
+        signature: "clearModulation('<targetParamName>', '<source>')",
+        description: "Clear a mod-matrix routing from a source to a target",
+      },
+      {
+        name: "addModulationTarget",
+        signature: "addModulationTarget('<paramName>')",
+        description:
+          "Add a parameter as a modulation target so it can be routed",
+      },
+    ]);
+  });
+});
+
+describe("modulation-rate effect specs", () => {
+  // Auto Filter / Auto Pan-Tremolo / Phaser-Flanger carry no pseudo-params at
+  // all — only `inactiveWhen` rules — so both discovery catalogs stay empty.
+  const RATE_EFFECTS = ["Auto Filter", "Auto Pan-Tremolo", "Phaser-Flanger"];
+
+  it.each(RATE_EFFECTS)("%s exposes no pseudo-params", (displayName) => {
+    expect(readSpecializedParams(registerDevice(displayName))).toStrictEqual(
+      [],
+    );
+  });
+
+  it.each(RATE_EFFECTS)("%s contributes no options catalog", (displayName) => {
+    // No params carry `options` and there are no dynamic catalogs, so the
+    // result must be a bare {} — not an empty `paramOptions` key.
+    expect(readSpecializedOptions(registerDevice(displayName))).toStrictEqual(
+      {},
+    );
+  });
+});
+
+describe("paramOptions catalogs", () => {
+  it("lists Simpler's discrete voice counts", () => {
+    const { paramOptions } = readSpecializedOptions(
+      registerDevice("Simpler"),
+    ) as { paramOptions: Record<string, unknown> };
+
+    expect(paramOptions.voices).toStrictEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16, 20, 24, 32,
+    ]);
+    expect(paramOptions.playbackMode).toStrictEqual([
+      "classic",
+      "one-shot",
+      "slicing",
+    ]);
+    expect(paramOptions.slicingPlaybackMode).toStrictEqual([
+      "mono",
+      "poly",
+      "thru",
+    ]);
+  });
+
+  it("states Wavetable's unison-voice range as a constraint string", () => {
+    // `options` is a range string here rather than a value list — the model
+    // needs the bounds, not eight enumerated counts.
+    const unison = wavetableSpec.params.find(
+      (p) => p.name === "unisonVoiceCount",
+    );
+
+    expect(unison?.options).toBe("2-8");
+  });
+});

--- a/src/tools/shared/device/specialized/tests/specialized-device-param-helpers.test.ts
+++ b/src/tools/shared/device/specialized/tests/specialized-device-param-helpers.test.ts
@@ -94,9 +94,13 @@ describe("writeEnumByIndex", () => {
     );
 
     expect(device.set).not.toHaveBeenCalled();
+    // The warning must list the valid labels, comma-separated — it is the only
+    // place the model learns what it should have passed.
     expect(outlet).toHaveBeenCalledWith(
       1,
-      expect.stringContaining("not a valid mode"),
+      expect.stringContaining(
+        '"delta" is not a valid mode. Options: alpha, beta, gamma',
+      ),
     );
   });
 });
@@ -136,6 +140,11 @@ describe("coerceBool", () => {
 
   it("returns null for uninterpretable strings", () => {
     expect(coerceBool("maybe")).toBeNull();
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    expect(coerceBool("  true  ")).toBe(true);
+    expect(coerceBool("\toff\n")).toBe(false);
   });
 });
 
@@ -291,9 +300,12 @@ describe("writeIntFromSet", () => {
     );
 
     expect(device.set).not.toHaveBeenCalled();
+    // The warning must enumerate the allowed values, comma-separated.
     expect(outlet).toHaveBeenCalledWith(
       1,
-      expect.stringContaining("voices must be one of"),
+      expect.stringContaining(
+        `voices must be one of ${ALLOWED.join(", ")} (got "5")`,
+      ),
     );
   });
 });

--- a/src/tools/shared/device/specialized/tests/specialized-device-registry.test.ts
+++ b/src/tools/shared/device/specialized/tests/specialized-device-registry.test.ts
@@ -119,6 +119,17 @@ describe("readSpecializedParams", () => {
       { name: "envListen", value: true },
     ]);
   });
+
+  it("trims surrounding whitespace off the search term", () => {
+    const device = registerDevice("Roar", {
+      routing_mode_index: 1,
+      env_listen: 1,
+    });
+
+    expect(readSpecializedParams(device, "  env  ")).toStrictEqual([
+      { name: "envListen", value: true },
+    ]);
+  });
 });
 
 describe("applySpecializedActions", () => {
@@ -591,6 +602,76 @@ describe("modulation-rate-effects specs (real rule data)", () => {
         expectOnlyActive(rules, params, SECTION_2, active2);
       },
     );
+  });
+
+  describe("wavetableSpec", () => {
+    /**
+     * Build one LFO's sync mode plus its free-running and synced rate params.
+     * @param lfo - LFO number (1 or 2)
+     * @param mode - Sync mode value (Free or Tempo)
+     * @returns Parameter entries
+     */
+    function build(lfo: number, mode: string): Record<string, unknown>[] {
+      return [
+        { name: `LFO ${lfo} Sync`, value: mode },
+        { name: `LFO ${lfo} Rate`, value: 1.49 },
+        { name: `LFO ${lfo} S. Rate`, value: "1/8" },
+      ];
+    }
+
+    // Both LFOs carry an independent rule; each mode leaves exactly one of the
+    // two rate params active.
+    it.each([
+      [1, "Free", "LFO 1 Rate"],
+      [1, "Tempo", "LFO 1 S. Rate"],
+      [2, "Free", "LFO 2 Rate"],
+      [2, "Tempo", "LFO 2 S. Rate"],
+    ])("LFO %s Sync %s → only %s active", (lfo, mode, active) => {
+      expectOnlyActive(
+        wavetableSpec.inactiveWhen as InactiveWhenRule[],
+        build(lfo, mode),
+        [`LFO ${lfo} Rate`, `LFO ${lfo} S. Rate`],
+        active,
+      );
+    });
+  });
+
+  describe("driftSpec", () => {
+    const GROUP = [
+      "Cyc Env Rate",
+      "Cyc Env Time",
+      "Cyc Env Ratio",
+      "Cyc Env Synced",
+    ];
+
+    /**
+     * Build Drift's cycling-envelope mode plus its four rate params.
+     * @param mode - Cyc Env Time Mode value
+     * @returns Parameter entries
+     */
+    function build(mode: string): Record<string, unknown>[] {
+      return [
+        { name: "Cyc Env Time Mode", value: mode },
+        { name: "Cyc Env Rate", value: 1 },
+        { name: "Cyc Env Time", value: 1000 },
+        { name: "Cyc Env Ratio", value: 2 },
+        { name: "Cyc Env Synced", value: "1/4" },
+      ];
+    }
+
+    it.each([
+      ["Freq", "Cyc Env Rate"],
+      ["Time", "Cyc Env Time"],
+      ["Ratio", "Cyc Env Ratio"],
+      ["Sync", "Cyc Env Synced"],
+    ])("Cyc Env Time Mode %s → only %s active", (mode, active) => {
+      expectOnlyActive(
+        driftSpec.inactiveWhen as InactiveWhenRule[],
+        build(mode),
+        GROUP,
+        active,
+      );
+    });
   });
 });
 


### PR DESCRIPTION
Final subarea of the `src/tools/shared` mutation triage, plus the one-time gate flip and doc baseline that completes the domain.

## Result

| Scope | Baseline | Triaged | Gate |
| --- | --- | --- | --- |
| Specialized devices (16 files) | 90.19% | **97.08%** | — |
| **`shared` (whole domain, 50 files)** | — | **95.25%** | **94** |

With `shared` ratcheted, **every `src/tools/` domain is now triaged** and no scope is left in baseline mode. The whole-domain score reproduced at 95.25% across three runs, so the floor has real headroom.

Test-only — no product code touched.

## Levers

Specialized was predicted to be mostly bucket 2/3 (every device already had a colocated test), and that held: the survivors were concentrated in declarative tables rather than untested logic.

- **The discovery catalogs are data, and data needs a table test.** `actions` (name/signature/description) and `paramOptions` are pure LLM-facing tables the model reads to learn how to drive a device. Tests asserted behavior and at most `actions.map(a => a.name)`, so every `signature`/`description` string was unasserted. One `toStrictEqual` per catalog plus an `it.each` over the display-name routing table killed ~25 mutants in one new file.
- **Warn text is the model's only error channel.** The `Options:` / `Available:` / `must be one of` lists are built with `join(", ")`, and several tests asserted only a fragment (`stringContaining("Pre FX")`) — which still matches when `join(", ")` decays to `join("")`. Asserting the whole joined list killed every one.
- **Index 0 is a value, not a "not found".** `indexOf(...) < 0` guards paired with tests that only ever selected a middle entry left `< 0` → `<= 0` alive across Wavetable categories/wavetables, Hybrid Reverb IR files, mod source `"Amp"` (column 0) and target slot 0. Same shape in Hybrid Reverb's `list.length === 1 && list[0] === <sentinel>` guard — a category holding exactly one real IR must still be settable.

## Residual survivors

Every one of the 111 original survivors was verified individually by applying the mutant and running the covering suite. The 20 that survive that check are documented as equivalent:

- **Guards subsumed downstream** — the action parser's unterminated-quote `return null` is unreachable-by-effect (a token whose quote never closed can't *end* with its quote char, so `parseArgToken` rejects it anyway); its `token.length < 2` guard is likewise dead.
- **Discriminated-union shadows** — Simpler's `probe.kind === "single"` operands can't be distinguished because `probe.path`/`probe.gain` only exist on that variant.
- **Defensive LOM caps** — `MAX_TARGETS`, sentinel type guards. Killing these means forging responses Live cannot produce.
- **One vestigial parameter** — `readParamEntries`'s `predicate` has one caller passing `() => true`, so its guard is dead code (and the domain's only `NoCoverage` mutant). Worth deleting, but that's product code and out of scope here.

Stryker reports 33 rather than 20: the other ~13 are **perTest attribution artifacts** (a killing test exists and passes, but the killing input short-circuits the mutated guard during the coverage dry-run). That rate is much higher here than in the arrangement/device subareas (0 and 2), which is why the whole-domain score lands below what the triage alone suggests.

`dev/Mutation-Testing.md` now documents that verification loop under **Verifying a survivor** — it's the tool that made this triage tractable and is reusable for any future scope.

## Housekeeping

`wavetable.test.ts` and `compressor.test.ts` were both at the 650-line cap, so their mock builders moved to `*-test-helpers.ts` (also removing the need to duplicate them in the new files), and the per-device specs moved into `tests/devices/` to stay under the 12-item folder cap.

`npm run check` and `npm run check:build` green (9934 tests, functions 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)