### PR TITLE
test(mutation): triage V8 adapter, add scope + ratchet break

### DIFF
--- a/config/mutation-scopes.mjs
+++ b/config/mutation-scopes.mjs
@@ -101,6 +101,31 @@ const MCP_SERVER_GLOBS = [
   "!src/mcp-server/mcp-server.ts",
 ];
 
+// src/live-api-adapter is the Max V8 runtime side: the LiveAPI wrapper
+// interface, path helpers, and the V8 half of the RPC protocols to Node. It is
+// the counterpart to mcpServer (the Node-for-Max side) and, like it, is NOT
+// under src/tools/ so toolDomain() can't build its globs; its scope key is
+// `v8Adapter` (camelCase, non-colliding with any tool domain). Same exclusions
+// as sharedRuntime minus `.def.ts`/`*-disabled.ts` (no tool defs or
+// feature-flag stubs live here). code-exec-v8-protocol.ts IS included: it is
+// coverage-THRESHOLD-excluded (covering its async Node round-trip isn't worth
+// it) but its pure paths are unit-tested, so it carries real mutable behavior.
+const V8_ADAPTER_GLOBS = [
+  "src/live-api-adapter/**/*.ts",
+  "!src/live-api-adapter/**/*.test.ts",
+  "!src/live-api-adapter/**/tests/**",
+  "!src/live-api-adapter/**/*-test-helpers.ts",
+  "!src/live-api-adapter/**/*-mock-helpers.ts",
+  "!src/live-api-adapter/**/types.ts",
+  // live-api-adapter.ts is the V8 bundle entry point: importing it runs
+  // module-load side effects (emits `outlet(0, "started")`, registers Max
+  // message handlers), so it's exercised by the e2e suites, not unit tests, and
+  // is already coverage-excluded in vitest.config.ts. Exclude it here too (same
+  // rationale as mcp-server.ts in MCP_SERVER_GLOBS) — its mutants are all
+  // NoCoverage bootstrap wiring, not assertable behavior.
+  "!src/live-api-adapter/live-api-adapter.ts",
+];
+
 // Tool domains: one subdirectory each under src/tools/ (src/tools/constants.ts
 // is a plain root-level constants module, intentionally left unscoped).
 const TOOL_DOMAINS = [
@@ -150,10 +175,24 @@ const SHARED_RUNTIME_BREAK = 94;
 // the perTest guard-attribution quirk (see dev/Mutation-Testing.md).
 const MCP_SERVER_BREAK = 87;
 
+// The v8Adapter (src/live-api-adapter) break gate. Triaged 2026-07-16 at 97.97%
+// (the bundle entry point live-api-adapter.ts is excluded); the floor sits ~1
+// point below, matching notation's ratchet. This scope is unusually
+// timeout-classification-noisy: live-api-extensions.ts patches the global
+// LiveAPI at test-SETUP time, so most of its mutants are static — Stryker runs
+// the whole suite for each, and a mutant that breaks the patch breaks setup for
+// every test file, blowing the time budget and landing as Timeout (counted as
+// killed) rather than Killed. Which mutants tip over varies per run: two
+// observed runs scored 98.22% and 97.97%, so the floor is set from the lower.
+// Remaining survivors are all equivalent / log-string / thin-orchestration
+// mutants (see dev/Mutation-Testing.md).
+const V8_ADAPTER_BREAK = 97;
+
 export const SCOPES = {
   notation: { mutate: NOTATION_GLOBS, break: 86 },
   sharedRuntime: { mutate: SHARED_RUNTIME_GLOBS, break: SHARED_RUNTIME_BREAK },
   mcpServer: { mutate: MCP_SERVER_GLOBS, break: MCP_SERVER_BREAK },
+  v8Adapter: { mutate: V8_ADAPTER_GLOBS, break: V8_ADAPTER_BREAK },
   ...Object.fromEntries(
     TOOL_DOMAINS.map((name) => [
       name,
@@ -165,5 +204,5 @@ export const SCOPES = {
 // Named groups the runner expands into multiple scopes.
 export const SCOPE_GROUPS = {
   tools: [...TOOL_DOMAINS],
-  all: ["notation", "sharedRuntime", "mcpServer", ...TOOL_DOMAINS],
+  all: ["notation", "sharedRuntime", "mcpServer", "v8Adapter", ...TOOL_DOMAINS],
 };

--- a/dev/Mutation-Testing.md
+++ b/dev/Mutation-Testing.md
@@ -877,6 +877,123 @@ the whole-domain score lands below what the triage alone would suggest.
 | Boolean pseudo-param warnings name their param (`oversample`, `envListen`, …)       | `eq-eight` / `roar` / `hybrid-reverb` tests  |
 | `readSpecializedParams` search term is trimmed                                      | `specialized-device-registry.test.ts`        |
 
+## Baseline (2026-07-16, `v8Adapter` — `src/live-api-adapter/`)
+
+The Max V8 runtime side — the `LiveAPI` wrapper interface, the path helpers, and
+the V8 half of the two RPC protocols to Node. The counterpart to `mcpServer`
+(the Node-for-Max side) and the last tree to be mutated. Small: 4 mutated files
+/ ~750 source LOC. Stryker 9.6.1, Node 24, `coverageAnalysis: "perTest"`:
+
+| Metric      | Baseline | Triaged    | Gate (`break`) |
+| ----------- | -------- | ---------- | -------------- |
+| `v8Adapter` | 78.17%   | **97.97%** | 97             |
+
+Per file:
+
+| File (mutants)                     | Baseline | Triaged    | Survivors (from)  |
+| ---------------------------------- | -------- | ---------- | ----------------- |
+| `live-api-extensions.ts` (279)     | 81.72%   | **98.92%** | 3 (from 51)       |
+| `code-exec-v8-protocol.ts` (43)    | 23.26%   | **95.35%** | 2 (from 33)       |
+| `node-request-v8-protocol.ts` (35) | 97.14%   | **100%**   | 0 (from 1)        |
+| `live-api-path-utils.ts` (37)      | 97.30%   | **91.89%** | 3 (all one cause) |
+
+All test-only — no product code was touched. `live-api-adapter.ts` is excluded
+as the V8 bundle entry point (it emits `outlet(0, "started")` and registers Max
+message handlers at import), the same rationale `mcpServer` uses for
+`mcp-server.ts`.
+
+`live-api-path-utils.ts` _drops_ against its baseline without a single test
+being removed: two of its three survivors were classified `Timeout` (which
+counts as killed) in the first run and `Survived` in the second. The second
+reading is the honest one — see the noise note below.
+
+### Why this scope is timeout-noisy
+
+`live-api-extensions.ts` patches the global `LiveAPI` prototype, and
+`src/test/test-setup.ts` imports it at **setup** time, so the module body runs
+once per test file, outside any test. Nearly all of its mutants are therefore
+**static**: Stryker can't attribute them per-test and runs the whole suite for
+each ("Ran all tests for this mutant"). A mutant that breaks the patch breaks
+setup for _every_ test file, so the full run blows the time budget and lands as
+`Timeout` rather than `Killed` — both count as killed, but which mutants tip
+over shifts with machine load. Three runs of identical code:
+
+| Run | Score  | Timeouts | Wall clock |
+| --- | ------ | -------- | ---------- |
+| 1   | 98.22% | 21       | 19m        |
+| 2   | 97.97% | 10       | 14m        |
+| 3   | 97.97% | 1        | 1m35s      |
+
+The gate is set from the low end. Note the runtime swing has the same cause —
+each timeout burns a full budget, so an unloaded machine finishes the smallest
+tree in ~90 seconds while a busy one takes twenty minutes. Don't read a slow run
+as a hang.
+
+A `Timeout` here is not a weak kill. Spot-checking one (the `clipSlotIndex`
+guard) by hand: the adapter suite fails it in **1.5 seconds** — it can't flip to
+`Survived`, only between `Timeout` and `Killed`.
+
+Three levers did most of the work:
+
+- **Test how a module installs itself, not just what it installs.** The eight
+  index getters are defined behind
+  `if (!Object.prototype.hasOwnProperty.call(LiveAPI.prototype, "…"))` guards.
+  On the single load a test run performs, the guard is _always_ false, so
+  `if (true)` is indistinguishable — ~15 guard mutants survived as a block. They
+  die to one new file (`live-api-extensions-install.test.ts`) asserting the two
+  contracts the guards exist for: re-importing after `vi.resetModules()` must
+  not throw (`Object.defineProperty` defaults to `configurable: false`, so an
+  unguarded redefine throws `Cannot redefine property`), and importing with
+  `LiveAPI` absent must be inert (the module is pulled into Node-side bundles
+  where the Max global doesn't exist).
+- **A mock that reimplements the thing under test hides it.** `readTrack` and
+  `readClip` consume `returnTrackIndex` / `takeLaneIndex`, but every caller's
+  test registers a mock object carrying those as _properties_ — which
+  `MockLiveAPI`'s constructor copies onto the instance, shadowing the prototype
+  getter. Both getters had **zero** real coverage despite looking well-covered;
+  the path regexes are only reachable from an unregistered `LiveAPI.from(path)`.
+- **Reach for the round-trip harness that already exists.** `code-exec` sat at
+  23.26% because its Node round-trip was untested — but the sibling
+  `node-request` protocol tests it at 97.14% with ~50 lines of Task stand-ins.
+  Extracting those into `v8-protocol-test-helpers.ts` (shared by both, so no
+  jscpd clone) and mirroring the suite took `code-exec` to 95.35%.
+
+### Documented equivalents (`v8Adapter`)
+
+Six of the eight residuals are equivalent — each verified by applying the mutant
+and running the suite, then confirming the root cause in isolation:
+
+| Mutant                                               | Why it can't be killed                                                                                                                                                                                                |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `live-api-path-utils.ts:33` (×3)                     | Emptying/skipping the `typeof idOrPath === "number"` branch falls through to `/^\d+$/.test(idOrPath)`, which coerces the number and returns the identical `id N`. Only unreachable inputs (negatives, floats) differ. |
+| `live-api-extensions.ts:132` `startsWith`→`endsWith` | The branch only runs when `/^\d+$/.test(val)`, and an all-digit string can contain neither `"id "` prefix nor suffix — both sides are always false.                                                                   |
+| `live-api-extensions.ts:159` `<`→`<=`                | `getChildIds` steps `i += 2` and reads `idArray[i] === "id"`; the extra iteration reads index `length`, which is `undefined` and never `"id"`.                                                                        |
+| `live-api-extensions.ts:330` `matches.length === 0`  | `path.match(/devices (\d+)/g)` returns `null`, never `[]`, so the length arm is unreachable behind `!matches`.                                                                                                        |
+
+The other two are bucket 3, both in the coverage-threshold-excluded
+`code-exec-v8-protocol.ts`: the `console.error` text for a result with no
+pending request (a diagnostic log — `error` is not relayed to the LLM, unlike
+`warn`), and `executeNoteCode`'s body (`NoCoverage`) — a three-line delegation
+to `extractNotesFromClip` + `buildCodeExecutionContext` +
+`executeNoteCodeWithData`, each independently tested, whose only untested part
+is the clip-mock scaffolding the vitest exclusion already calls out as not worth
+reconstructing.
+
+### Gaps closed (`v8Adapter`)
+
+| Gap (now killed)                                                            | Test strengthened / added                   |
+| --------------------------------------------------------------------------- | ------------------------------------------- |
+| The 8 `hasOwnProperty` install guards + the `typeof LiveAPI` module guard   | `live-api-extensions-install.test.ts` (new) |
+| `returnTrackIndex` / `takeLaneIndex` getters (regex, index 0, multi-digit)  | `live-api-extensions-path-indices.test.ts`  |
+| `sceneIndex` clip_slots fallback on a double-digit track index              | `live-api-extensions-path-indices.test.ts`  |
+| `exists()` for the `"id 0"` and numeric `0` id shapes                       | `live-api-extensions-basic.test.ts`         |
+| Routing `getProperty`: warns on parse failure, stays silent when unset      | `live-api-extensions.test.ts`               |
+| `setColor` format vs hex error messages; per-channel NaN rejection          | `live-api-extensions-color.test.ts`         |
+| `setProperty` passes a numeric value through without formatting             | `live-api-extensions-setters.test.ts`       |
+| Request IDs count **up** from their prefix (not merely unique)              | both `*-v8-protocol.test.ts`                |
+| code-exec round trip: resolve, parse error, timeout, cancel, late/dup reply | `code-exec-v8-protocol.test.ts`             |
+| `executeNoteCodeWithData` wraps code, passes globals, validates notes       | `code-exec-v8-protocol.test.ts`             |
+
 ## Interpreting survivors
 
 Each survivor falls into one of three buckets — triage before acting:
@@ -921,29 +1038,23 @@ just chase green.
 
 ## Status & next steps
 
-**Every `src/tools/` domain is now triaged and ratcheted**, as are `notation`
-(`thresholds.break = 86`), `sharedRuntime` (`src/shared/`, `break: 94`) and
-`mcpServer` (`src/mcp-server/`, `break: 87`). The ten tool domains: the write-op
+**The whole source tree is now triaged and ratcheted — no scope is left in
+baseline mode, and none remains unmutated.** The ten tool domains: the write-op
 tier `track` (`break: 85`), `session` (`break: 89`), `actions` (`break: 90`),
 `device` (`break: 90`), `clip` (`break: 96`); the read-op / small tier
 `advanced` (`break: 97`), `core` (`break: 99`), `scene` (`break: 96`),
-`live-set` (`break: 98`); and `shared` (`break: 94`). No scope is left in
-baseline mode. The per-domain scope mechanism (`config/mutation-scopes.mjs` +
-the runner) is in place, so each area can be mutated on its own. Mutation
-testing stays off the per-PR hot path (a full pass is minutes). Remaining work
-(later releases):
+`live-set` (`break: 98`); and `shared` (`break: 94`). Plus the four
+non-`src/tools/` scopes: `notation` (`break: 86`), `sharedRuntime`
+(`src/shared/`, `break: 94`), `mcpServer` (`src/mcp-server/`, `break: 87`) and
+`v8Adapter` (`src/live-api-adapter/`, `break: 97`). The per-domain scope
+mechanism (`config/mutation-scopes.mjs` + the runner) is in place, so each area
+can be mutated on its own. Mutation testing stays off the per-PR hot path (a
+full pass is minutes). Remaining work (later releases):
 
 - Keep triaging the ~588 notation survivors, but expect diminishing returns: the
   dense clusters left are epsilon-boundary / warning-string / equivalent mutants
   (bucket 2/3), so genuine bucket-1 gaps are now sparse.
 - Raise each scope's `break` as its score climbs.
-- One non-`src/tools/` tree remains unmutated and would need a fresh glob set
-  (not `toolDomain()`): the V8 adapter code (`src/live-api-adapter/`). Model it
-  on `SHARED_RUNTIME_GLOBS` / `MCP_SERVER_GLOBS` and give it a non-colliding
-  scope key. Expect a low ceiling and a heavy entry-point exclusion —
-  `live-api-adapter.ts` runs `outlet(0, "started")` + registers handlers at
-  import and is already coverage-excluded (exclude it as `mcpServer` does its
-  entry point).
 - Optionally wire a scheduled (nightly/weekly) non-blocking CI job once several
   domains have floors — full-tree runtime is hours, not minutes.
 

--- a/src/live-api-adapter/tests/code-exec-v8-protocol.test.ts
+++ b/src/live-api-adapter/tests/code-exec-v8-protocol.test.ts
@@ -8,11 +8,30 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { MAX_CHUNK_SIZE } from "#src/shared/mcp-response-utils.ts";
 import { projectRoot } from "#src/test/helpers/meta-test-helpers.ts";
-import { requestCodeExecution } from "../code-exec-v8-protocol.ts";
+import {
+  executeNoteCodeWithData,
+  handleCodeExecResult,
+  requestCodeExecution,
+} from "../code-exec-v8-protocol.ts";
+import {
+  installCapturingTask,
+  installTrackingTask,
+  latestOutletPayload,
+  latestOutletRequestId,
+} from "./v8-protocol-test-helpers.ts";
 
 // No v8-max-console mock needed: importing it is side-effect-free and the
 // request-size guard path never logs. (Avoiding the standard mock block also
 // keeps this file from adding an irreducible vi.mock-boilerplate test clone.)
+
+/**
+ * Get the requestId from the most recent code_exec_request outlet call.
+ *
+ * @returns The requestId argument
+ */
+function latestRequestId(): string {
+  return latestOutletRequestId("code_exec_request");
+}
 
 describe("code-exec-v8-protocol requestCodeExecution", () => {
   it("resolves a loud error without sending a request too large for one IPC message", async () => {
@@ -60,6 +79,253 @@ describe("code-exec-v8-protocol requestCodeExecution", () => {
       expect.any(String),
       expect.any(String),
     );
+  });
+
+  it("emits the code and globals as the request payload", () => {
+    void requestCodeExecution("return notes", { notes: [{ pitch: 60 }] });
+
+    expect(latestOutletPayload("code_exec_request")).toStrictEqual({
+      code: "return notes",
+      globals: { notes: [{ pitch: 60 }] },
+    });
+  });
+
+  it("defaults globals to an empty object", () => {
+    void requestCodeExecution("return 1");
+
+    expect(
+      latestOutletPayload<{ globals: unknown }>("code_exec_request").globals,
+    ).toStrictEqual({});
+  });
+
+  // Uniqueness alone is also satisfied by a counter running the wrong way, so
+  // pin the prefix and the direction. The counter is module state shared with
+  // every other test here, hence the relative assertion.
+  it("generates request IDs that count up from the code-exec- prefix", () => {
+    void requestCodeExecution("a");
+    const id1 = latestRequestId();
+
+    void requestCodeExecution("b");
+    const id2 = latestRequestId();
+
+    expect(id1).toMatch(/^code-exec-\d+$/);
+    expect(Number(id2.slice("code-exec-".length))).toBe(
+      Number(id1.slice("code-exec-".length)) + 1,
+    );
+  });
+
+  it("names the oversized request in the error it resolves", async () => {
+    const result = await requestCodeExecution("return notes", {
+      notes: "x".repeat(MAX_CHUNK_SIZE),
+    });
+
+    expect((result as { error: string }).error).toContain("code-exec request");
+  });
+
+  it("arms a timeout task for the pending request", () => {
+    const scheduleCalls: number[] = [];
+    const restore = installTrackingTask(scheduleCalls);
+
+    try {
+      void requestCodeExecution("return notes");
+
+      expect(scheduleCalls).toStrictEqual([10_000]);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("code-exec-v8-protocol handleCodeExecResult", () => {
+  it("resolves the pending request with the parsed Node result", async () => {
+    const promise = requestCodeExecution("return notes");
+
+    handleCodeExecResult(
+      latestRequestId(),
+      JSON.stringify({ success: true, result: [{ pitch: 62 }] }),
+    );
+
+    await expect(promise).resolves.toStrictEqual({
+      success: true,
+      result: [{ pitch: 62 }],
+    });
+  });
+
+  it("resolves with a parse error when Node sends malformed JSON", async () => {
+    const promise = requestCodeExecution("return notes");
+
+    handleCodeExecResult(latestRequestId(), "not json {");
+
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect((result as { error: string }).error).toContain(
+      "Failed to parse code_exec_result:",
+    );
+  });
+
+  it("cancels the timeout task once the result arrives", () => {
+    const scheduleCalls: number[] = [];
+    const restore = installTrackingTask(scheduleCalls);
+
+    try {
+      void requestCodeExecution("return notes");
+      handleCodeExecResult(
+        latestRequestId(),
+        JSON.stringify({ success: true, result: [] }),
+      );
+
+      // -1 is how a Max Task is cancelled.
+      expect(scheduleCalls).toStrictEqual([10_000, -1]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("ignores a result for an unknown request", () => {
+    expect(() =>
+      handleCodeExecResult("code-exec-does-not-exist", "{}"),
+    ).not.toThrow();
+  });
+
+  it("ignores a second result for the same request", async () => {
+    const promise = requestCodeExecution("return notes");
+    const requestId = latestRequestId();
+
+    handleCodeExecResult(
+      requestId,
+      JSON.stringify({ success: true, result: [{ pitch: 60 }] }),
+    );
+    // A late duplicate must not throw on the already-deleted pending entry.
+    expect(() =>
+      handleCodeExecResult(
+        requestId,
+        JSON.stringify({ success: true, result: [{ pitch: 99 }] }),
+      ),
+    ).not.toThrow();
+
+    await expect(promise).resolves.toStrictEqual({
+      success: true,
+      result: [{ pitch: 60 }],
+    });
+  });
+});
+
+describe("code-exec-v8-protocol timeout", () => {
+  it("resolves with a timeout error when Node never replies", async () => {
+    const captured: Array<() => void> = [];
+    const restore = installCapturingTask(captured);
+
+    try {
+      const promise = requestCodeExecution("return notes");
+
+      captured.at(-1)?.();
+
+      await expect(promise).resolves.toStrictEqual({
+        success: false,
+        error: "Code execution timed out after 10000ms",
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it("does not resolve twice when a result arrives before the timeout fires", async () => {
+    const captured: Array<() => void> = [];
+    const restore = installCapturingTask(captured);
+
+    try {
+      const promise = requestCodeExecution("return notes");
+      const requestId = latestRequestId();
+
+      handleCodeExecResult(
+        requestId,
+        JSON.stringify({ success: true, result: [] }),
+      );
+      // The task callback still fires if cancellation was a no-op; the pending
+      // entry is gone, so it must leave the settled result alone.
+      captured.at(-1)?.();
+
+      await expect(promise).resolves.toStrictEqual({
+        success: true,
+        result: [],
+      });
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe("code-exec-v8-protocol executeNoteCodeWithData", () => {
+  const CONTEXT = {
+    view: "session",
+    trackIndex: 0,
+    clipIndex: 0,
+    clipCount: 1,
+  } as unknown as Parameters<typeof executeNoteCodeWithData>[2];
+
+  it("wraps the user code in a function receiving notes and context", () => {
+    void executeNoteCodeWithData(
+      "return notes;",
+      [{ pitch: 60 } as never],
+      CONTEXT,
+    );
+
+    expect(
+      latestOutletPayload<{ code: string }>("code_exec_request").code,
+    ).toBe("(function(notes, context) { return notes; })(notes, context)");
+  });
+
+  it("passes the notes and context through as globals", () => {
+    void executeNoteCodeWithData(
+      "return notes;",
+      [{ pitch: 60 } as never],
+      CONTEXT,
+    );
+
+    expect(
+      latestOutletPayload<{ globals: unknown }>("code_exec_request").globals,
+    ).toStrictEqual({ notes: [{ pitch: 60 }], context: CONTEXT });
+  });
+
+  it("returns a sandbox failure unchanged, without validating notes", async () => {
+    const promise = executeNoteCodeWithData("boom", [], CONTEXT);
+
+    handleCodeExecResult(
+      latestRequestId(),
+      JSON.stringify({ success: false, error: "ReferenceError: boom" }),
+    );
+
+    await expect(promise).resolves.toStrictEqual({
+      success: false,
+      error: "ReferenceError: boom",
+    });
+  });
+
+  it("validates the notes the sandbox returned on success", async () => {
+    const promise = executeNoteCodeWithData("return notes;", [], CONTEXT);
+
+    handleCodeExecResult(
+      latestRequestId(),
+      // Deliberately under-specified notes: only the validator fills in the
+      // defaults below, so asserting them proves the raw sandbox result was
+      // not passed straight through.
+      JSON.stringify({ success: true, result: [{ pitch: 62, start: 0 }] }),
+    );
+
+    await expect(promise).resolves.toStrictEqual({
+      success: true,
+      notes: [
+        {
+          pitch: 62,
+          start: 0,
+          duration: 1,
+          velocity: 100,
+          probability: 1,
+          velocityDeviation: 0,
+        },
+      ],
+    });
   });
 });
 

--- a/src/live-api-adapter/tests/live-api-extensions-basic.test.ts
+++ b/src/live-api-adapter/tests/live-api-extensions-basic.test.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -52,6 +53,24 @@ describe("LiveAPI extensions - basic methods", () => {
       const nonExistentApi = LiveAPI.from("0");
 
       expect(nonExistentApi.exists()).toBe(false);
+    });
+
+    // Live reports a missing object's id in three shapes and exists() checks
+    // each separately. The mock always surfaces a string id, so the "id 0" and
+    // numeric forms are only reachable by invoking the extension directly.
+    it.each([["id 0"], ["0"], [0]])(
+      "returns false for the non-existent id %o",
+      (id) => {
+        expect(
+          LiveAPI.prototype.exists.call({ id } as unknown as LiveAPI),
+        ).toBe(false);
+      },
+    );
+
+    it("returns true for a numeric id other than 0", () => {
+      expect(
+        LiveAPI.prototype.exists.call({ id: 7 } as unknown as LiveAPI),
+      ).toBe(true);
     });
   });
 

--- a/src/live-api-adapter/tests/live-api-extensions-color.test.ts
+++ b/src/live-api-adapter/tests/live-api-extensions-color.test.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -81,19 +82,43 @@ describe("LiveAPI extensions - color methods", () => {
       expect(api.set).toHaveBeenCalledWith("color", 255);
     });
 
+    // Assert the specific message: a bare toThrow() can't tell the format guard
+    // from the NaN guard, and a "#"-less 7-char string reaches the NaN guard
+    // when the format check is broken.
+    const FORMAT_ERROR = 'Invalid color format: must be "#RRGGBB"';
+
     it("throws error for invalid format without #", () => {
-      expect(() => api.setColor("red")).toThrow();
-      expect(() => api.setColor("rgb(255, 0, 0)")).toThrow();
+      expect(() => api.setColor("red")).toThrow(FORMAT_ERROR);
+      expect(() => api.setColor("rgb(255, 0, 0)")).toThrow(FORMAT_ERROR);
+    });
+
+    it("throws the format error for a 7-character string with no leading #", () => {
+      expect(() => api.setColor("1234567")).toThrow(FORMAT_ERROR);
     });
 
     it("throws error for wrong length", () => {
-      expect(() => api.setColor("#F00")).toThrow();
-      expect(() => api.setColor("#12345")).toThrow();
-      expect(() => api.setColor("#1234567")).toThrow();
+      expect(() => api.setColor("#F00")).toThrow(FORMAT_ERROR);
+      expect(() => api.setColor("#12345")).toThrow(FORMAT_ERROR);
+      expect(() => api.setColor("#1234567")).toThrow(FORMAT_ERROR);
     });
 
     it("throws error for invalid hex characters", () => {
-      expect(() => api.setColor("#GGGGGG")).toThrow();
+      expect(() => api.setColor("#GGGGGG")).toThrow(
+        "Invalid hex values in color: #GGGGGG",
+      );
+    });
+
+    // Each channel is parsed and NaN-checked independently, so a color that is
+    // bad in only one channel must still be rejected.
+    it.each([
+      ["#GG0000", "red"],
+      ["#00GG00", "green"],
+      ["#0000GG", "blue"],
+    ])("throws when only the %s channel is invalid (%s)", (cssColor) => {
+      expect(() => api.setColor(cssColor)).toThrow(
+        `Invalid hex values in color: ${cssColor}`,
+      );
+      expect(api.set).not.toHaveBeenCalled();
     });
 
     it("forms a bidirectional conversion with getColor", () => {

--- a/src/live-api-adapter/tests/live-api-extensions-install.test.ts
+++ b/src/live-api-adapter/tests/live-api-extensions-install.test.ts
@@ -1,0 +1,52 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LiveAPI } from "#src/test/mocks/mock-live-api.ts";
+import "../live-api-extensions.ts";
+
+// How the extensions module INSTALLS itself onto the global LiveAPI, as opposed
+// to what the installed members do (covered by the sibling files). Two contracts
+// live here, and both are invisible to a normal single-import test run:
+//
+//   1. It is inert when LiveAPI is absent. The module is pulled into Node-side
+//      bundles and unit tests where the Max V8 global doesn't exist; importing
+//      it there must not throw.
+//   2. Installing twice is a no-op. The index getters are defined with
+//      `Object.defineProperty` and default to configurable: false, so a second
+//      unguarded define would throw TypeError — hence the hasOwnProperty guards.
+
+const g = globalThis as Record<string, unknown>;
+
+describe("LiveAPI extensions - installation", () => {
+  afterEach(() => {
+    // The suite-wide global must survive whatever this file does to it: the
+    // shared test setup installed the extensions onto this exact class object.
+    g.LiveAPI = LiveAPI;
+    vi.resetModules();
+  });
+
+  it("installs nothing when LiveAPI is undefined", async () => {
+    delete g.LiveAPI;
+    vi.resetModules();
+
+    await expect(import("../live-api-extensions.ts")).resolves.toBeDefined();
+  });
+
+  it("re-importing does not redefine the index getters", async () => {
+    // Guards absent → Object.defineProperty throws on the non-configurable
+    // property the first install already created.
+    vi.resetModules();
+
+    await expect(import("../live-api-extensions.ts")).resolves.toBeDefined();
+  });
+
+  it("keeps the index getters working after a re-import", async () => {
+    vi.resetModules();
+    await import("../live-api-extensions.ts");
+
+    expect(LiveAPI.from("live_set tracks 3").trackIndex).toBe(3);
+  });
+});

--- a/src/live-api-adapter/tests/live-api-extensions-path-indices.test.ts
+++ b/src/live-api-adapter/tests/live-api-extensions-path-indices.test.ts
@@ -55,6 +55,69 @@ describe("LiveAPI extensions - path index extensions", () => {
     });
   });
 
+  // Every consumer of this getter (readTrack) registers a mock object carrying
+  // a returnTrackIndex property, which the mock copies onto the instance and
+  // shadows the prototype getter — so the path parsing itself is only reachable
+  // from tests that build an unregistered LiveAPI, like these.
+  describe("returnTrackIndex", () => {
+    it("should return returnTrackIndex from a return track path", () => {
+      const returnTrack = LiveAPI.from(livePath.returnTrack(1));
+
+      expect(returnTrack.returnTrackIndex).toBe(1);
+    });
+
+    it("should handle return track index 0", () => {
+      const returnTrack = LiveAPI.from(livePath.returnTrack(0));
+
+      expect(returnTrack.returnTrackIndex).toBe(0);
+    });
+
+    it("should handle double-digit return track indices", () => {
+      const returnTrack = LiveAPI.from(livePath.returnTrack(11));
+
+      expect(returnTrack.returnTrackIndex).toBe(11);
+    });
+
+    it("should return null for a regular track path", () => {
+      // "live_set tracks 3" must not satisfy the return_tracks pattern.
+      const track = LiveAPI.from(livePath.track(3));
+
+      expect(track.returnTrackIndex).toBe(null);
+    });
+
+    it("should return null for a non-track path", () => {
+      const scene = LiveAPI.from(livePath.scene(2));
+
+      expect(scene.returnTrackIndex).toBe(null);
+    });
+  });
+
+  describe("takeLaneIndex", () => {
+    it("should return takeLaneIndex from a take lane path", () => {
+      const takeLane = LiveAPI.from(livePath.track(0).takeLane(2));
+
+      expect(takeLane.takeLaneIndex).toBe(2);
+    });
+
+    it("should handle take lane index 0", () => {
+      const takeLane = LiveAPI.from(livePath.track(0).takeLane(0));
+
+      expect(takeLane.takeLaneIndex).toBe(0);
+    });
+
+    it("should handle double-digit take lane indices", () => {
+      const takeLane = LiveAPI.from(livePath.track(0).takeLane(10));
+
+      expect(takeLane.takeLaneIndex).toBe(10);
+    });
+
+    it("should return null for a path without take lanes", () => {
+      const track = LiveAPI.from(livePath.track(0));
+
+      expect(track.takeLaneIndex).toBe(null);
+    });
+  });
+
   describe("category", () => {
     it("should return 'regular' for a track path", () => {
       const track = LiveAPI.from(livePath.track(3));
@@ -99,6 +162,14 @@ describe("LiveAPI extensions - path index extensions", () => {
       const scene = LiveAPI.from(livePath.scene(10));
 
       expect(scene.sceneIndex).toBe(10);
+    });
+
+    it("should return sceneIndex from a clip_slots path on a double-digit track", () => {
+      // The track index in the clip_slots fallback is skipped over, not
+      // captured — it must still match when it is more than one digit wide.
+      const clipSlot = LiveAPI.from(livePath.track(12).clipSlot(6));
+
+      expect(clipSlot.sceneIndex).toBe(6);
     });
 
     it("should return null for non-scene/clip_slots paths", () => {

--- a/src/live-api-adapter/tests/live-api-extensions-setters.test.ts
+++ b/src/live-api-adapter/tests/live-api-extensions-setters.test.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -150,6 +151,13 @@ describe("LiveAPI extensions - setter methods", () => {
     it("should auto-format numeric ID for highlighted_clip_slot", () => {
       api.setProperty("highlighted_clip_slot", "101");
       expect(api.set).toHaveBeenCalledWith("highlighted_clip_slot", "id 101");
+    });
+
+    // The string check guards the startsWith call that follows it: a raw number
+    // is a legitimate value here and must reach set() untouched.
+    it("should pass a numeric value through without formatting", () => {
+      api.setProperty("selected_track", 123);
+      expect(api.set).toHaveBeenCalledWith("selected_track", 123);
     });
 
     it("should not double-format already prefixed IDs", () => {

--- a/src/live-api-adapter/tests/live-api-extensions.test.ts
+++ b/src/live-api-adapter/tests/live-api-extensions.test.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -177,6 +178,41 @@ describe("LiveAPI extensions", () => {
       const channel = track.getProperty("input_routing_channel");
 
       expect(channel).toBeNull();
+    });
+
+    // A malformed and an absent routing value both yield null, so the relayed
+    // warning is the only thing separating "Live sent us garbage" from "Live
+    // sent us nothing" — assert it on both sides.
+    it("should warn when a routing property fails to parse", () => {
+      const mockTrack = registerMockObject("track4", {
+        path: livePath.track(0),
+        type: "Track",
+      });
+
+      mockTrack.get.mockReturnValue(["invalid json {"]);
+
+      LiveAPI.from("track4").getProperty("input_routing_type");
+
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining(
+          `LiveAPI getProperty: failed to parse "input_routing_type" response:`,
+        ),
+      );
+    });
+
+    it("should not warn when a routing property has no value to parse", () => {
+      const mockTrack = registerMockObject("track5", {
+        path: livePath.track(0),
+        type: "Track",
+      });
+
+      mockTrack.get.mockReturnValue([]);
+
+      expect(
+        LiveAPI.from("track5").getProperty("input_routing_type"),
+      ).toBeNull();
+      expect(outlet).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/live-api-adapter/tests/node-request-v8-protocol.test.ts
+++ b/src/live-api-adapter/tests/node-request-v8-protocol.test.ts
@@ -13,6 +13,12 @@ import {
   handleNodeResponse,
   requestNode,
 } from "../node-request-v8-protocol.ts";
+import {
+  installCapturingTask,
+  installTrackingTask,
+  latestOutletPayload,
+  latestOutletRequestId,
+} from "./v8-protocol-test-helpers.ts";
 
 vi.mock(import("#src/shared/v8-max-console.ts"), () => ({
   log: vi.fn(),
@@ -27,13 +33,7 @@ vi.mock(import("#src/shared/v8-max-console.ts"), () => ({
  * @returns The requestId from the latest node_request outlet call
  */
 function latestRequestId(): string {
-  const outletMock = vi.mocked(globalThis.outlet);
-  const call = outletMock.mock.calls.at(-1);
-
-  expect(call?.[0]).toBe(0);
-  expect(call?.[1]).toBe("node_request");
-
-  return call?.[2] as string;
+  return latestOutletRequestId("node_request");
 }
 
 /**
@@ -42,64 +42,7 @@ function latestRequestId(): string {
  * @returns Parsed request payload
  */
 function latestRequestPayload(): { route: string; args: unknown } {
-  const outletMock = vi.mocked(globalThis.outlet);
-  const call = outletMock.mock.calls.at(-1);
-  const json = call?.[3] as string;
-
-  return JSON.parse(json) as { route: string; args: unknown };
-}
-
-/**
- * Install a non-auto-firing Task on globalThis that records each
- * schedule(ms) call into the supplied array. Returns a restore function
- * the caller should invoke in a finally block.
- *
- * @param scheduleCalls - Array that captures every schedule() ms value
- * @returns Restore function that puts the original globalThis.Task back
- */
-function installTrackingTask(scheduleCalls: number[]): () => void {
-  class TrackingTask {
-    schedule = (ms: number): void => {
-      scheduleCalls.push(ms);
-    };
-
-    constructor(_callback: () => void) {}
-  }
-
-  const g = globalThis as Record<string, unknown>;
-  const originalTask = g.Task;
-
-  g.Task = TrackingTask;
-
-  return () => {
-    g.Task = originalTask;
-  };
-}
-
-/**
- * Install a Task on globalThis that captures the callback so the test can
- * invoke it manually to simulate a fired timeout.
- *
- * @param captured - Single-element array that receives the latest callback
- * @returns Restore function that puts the original globalThis.Task back
- */
-function installCapturingTask(captured: Array<() => void>): () => void {
-  class CapturingTask {
-    schedule = (_ms: number): void => {};
-
-    constructor(callback: () => void) {
-      captured.push(callback);
-    }
-  }
-
-  const g = globalThis as Record<string, unknown>;
-  const originalTask = g.Task;
-
-  g.Task = CapturingTask;
-
-  return () => {
-    g.Task = originalTask;
-  };
+  return latestOutletPayload<{ route: string; args: unknown }>("node_request");
 }
 
 describe("node-request-v8-protocol", () => {
@@ -132,6 +75,22 @@ describe("node-request-v8-protocol", () => {
     const id2 = latestRequestId();
 
     expect(id1).not.toBe(id2);
+  });
+
+  // Uniqueness alone is also satisfied by a counter running the wrong way, so
+  // pin the shape and the direction. The counter is module state shared with
+  // every other test here, hence the relative assertion.
+  it("generates request IDs that count up from the node-req- prefix", () => {
+    void requestNode("a");
+    const id1 = latestRequestId();
+
+    void requestNode("b");
+    const id2 = latestRequestId();
+
+    expect(id1).toMatch(/^node-req-\d+$/);
+    expect(Number(id2.slice("node-req-".length))).toBe(
+      Number(id1.slice("node-req-".length)) + 1,
+    );
   });
 
   it("resolves the promise when handleNodeResponse is called", async () => {

--- a/src/live-api-adapter/tests/v8-protocol-test-helpers.ts
+++ b/src/live-api-adapter/tests/v8-protocol-test-helpers.ts
@@ -1,0 +1,104 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { expect, vi } from "vitest";
+
+// Shared harness for the two V8↔Node request protocols (node-request and
+// code-exec). Both send `outlet(0, <message>, requestId, json)`, arm a Max Task
+// as a timeout, and resolve a pending Promise when the reply arrives — so the
+// Task stand-ins and outlet readers below are written once for both.
+
+/**
+ * Read the argument list of the most recent outlet call, asserting it is the
+ * expected protocol message.
+ *
+ * @param message - Expected outlet message name (e.g. "node_request")
+ * @returns The full outlet call arguments
+ */
+export function latestOutletCall(message: string): unknown[] {
+  const outletMock = vi.mocked(globalThis.outlet);
+  const call = outletMock.mock.calls.at(-1);
+
+  expect(call?.[0]).toBe(0);
+  expect(call?.[1]).toBe(message);
+
+  return call as unknown[];
+}
+
+/**
+ * Get the requestId from the most recent outlet call.
+ *
+ * @param message - Expected outlet message name
+ * @returns The requestId argument
+ */
+export function latestOutletRequestId(message: string): string {
+  return latestOutletCall(message)[2] as string;
+}
+
+/**
+ * Parse the JSON payload from the most recent outlet call.
+ *
+ * @param message - Expected outlet message name
+ * @returns The parsed payload
+ */
+export function latestOutletPayload<T>(message: string): T {
+  return JSON.parse(latestOutletCall(message)[3] as string) as T;
+}
+
+/**
+ * Install a non-auto-firing Task on globalThis that records each schedule(ms)
+ * call into the supplied array. Returns a restore function the caller should
+ * invoke in a finally block.
+ *
+ * @param scheduleCalls - Array that captures every schedule() ms value
+ * @returns Restore function that puts the original globalThis.Task back
+ */
+export function installTrackingTask(scheduleCalls: number[]): () => void {
+  class TrackingTask {
+    schedule = (ms: number): void => {
+      scheduleCalls.push(ms);
+    };
+
+    constructor(_callback: () => void) {}
+  }
+
+  return installTask(TrackingTask);
+}
+
+/**
+ * Install a Task on globalThis that captures the callback so the test can
+ * invoke it manually to simulate a fired timeout.
+ *
+ * @param captured - Array that receives each constructed Task's callback
+ * @returns Restore function that puts the original globalThis.Task back
+ */
+export function installCapturingTask(captured: Array<() => void>): () => void {
+  class CapturingTask {
+    schedule = (_ms: number): void => {};
+
+    constructor(callback: () => void) {
+      captured.push(callback);
+    }
+  }
+
+  return installTask(CapturingTask);
+}
+
+/**
+ * Swap globalThis.Task for a stand-in class.
+ *
+ * @param TaskClass - Replacement Task constructor
+ * @returns Restore function that puts the original globalThis.Task back
+ */
+function installTask(TaskClass: unknown): () => void {
+  const g = globalThis as Record<string, unknown>;
+  const originalTask = g.Task;
+
+  g.Task = TaskClass;
+
+  return () => {
+    g.Task = originalTask;
+  };
+}


### PR DESCRIPTION
Adds the `v8Adapter` scope (`src/live-api-adapter/`) — the Max V8 runtime side, and the **last unmutated tree** — then triages it. Test-only: no product code changed.

| Metric      | Baseline | Triaged    | Gate |
| ----------- | -------- | ---------- | ---- |
| `v8Adapter` | 78.17%   | **97.97%** | 97   |

| File | Baseline | Triaged |
| ---- | -------- | ------- |
| `live-api-extensions.ts` | 81.72% | **98.92%** |
| `code-exec-v8-protocol.ts` | 23.26% | **95.35%** |
| `node-request-v8-protocol.ts` | 97.14% | **100%** |
| `live-api-path-utils.ts` | 97.30% | 91.89% (see below) |

**With this, every scope is triaged and ratcheted — none left in baseline mode, and no tree unmutated.**

## Scope setup

Needs its own glob const rather than `toolDomain()` (which hardcodes `src/tools/`), modeled on `MCP_SERVER_GLOBS`. Excludes `live-api-adapter.ts` as the V8 bundle entry point — it emits `outlet(0, "started")` and registers Max handlers at import, so it's e2e-exercised and already coverage-excluded. Same rationale `mcpServer` uses for `mcp-server.ts`.

## Three levers

- **Test how a module installs itself, not just what it installs.** The 8 index getters sit behind `hasOwnProperty` guards. On the single load a test run performs the guard is *always* false, so `if (true)` is indistinguishable — ~15 guard mutants survived as a block. One new file asserts the two contracts they exist for: re-importing must not throw (`defineProperty` defaults to `configurable: false`), and importing with `LiveAPI` absent must be inert (the module is pulled into Node-side bundles).
- **A mock that reimplements the thing under test hides it.** `returnTrackIndex` / `takeLaneIndex` had **zero** real coverage despite consumers in `readTrack`/`readClip`: every caller's test registers a mock object carrying them as properties, which `MockLiveAPI`'s constructor copies onto the instance, shadowing the prototype getter entirely.
- **Reach for the round-trip harness that already exists.** `code-exec` was at 23.26% with its Node round-trip untested — but the sibling `node-request` protocol tests the same shape at 97.14%. Extracted its Task stand-ins into a shared `v8-protocol-test-helpers.ts` (used by both, so no jscpd clone) and mirrored the suite.

## On `live-api-path-utils.ts` dropping

Nothing was removed. Two of its three survivors were classified `Timeout` (which counts as *killed*) in the first run and `Survived` in later ones. The later reading is honest: all three are the same equivalent — emptying the `typeof idOrPath === "number"` branch falls through to `/^\d+$/.test(...)`, which coerces the number and returns the identical `id N`.

## Timeout noise (documented)

`live-api-extensions.ts` patches the global `LiveAPI` at test-**setup** time, so most of its mutants are *static* — Stryker runs the whole suite for each, and a mutant that breaks the patch breaks setup for every test file, blowing the time budget and landing as `Timeout` rather than `Killed`. Which mutants tip over shifts with machine load:

| Run | Score | Timeouts | Wall clock |
| --- | ----- | -------- | ---------- |
| 1 | 98.22% | 21 | 19m |
| 2 | 97.97% | 10 | 14m |
| 3 | 97.97% | 1 | 1m35s |

The gate is set from the low end. A `Timeout` here isn't a weak kill — spot-checking one by hand, the adapter suite fails it in **1.5s**; it can't flip to `Survived`.

## Residuals

Six of eight are equivalent, each verified by applying the mutant and running the suite: the path-utils cluster above; `startsWith`→`endsWith` (an all-digit string can contain neither); `<`→`<=` in `getChildIds` (the extra read is `undefined`, never `"id"`); `matches.length === 0` (`.match(/g)` returns `null`, never `[]`). The other two are bucket 3 in the coverage-threshold-excluded `code-exec` module: a `console.error` diagnostic string, and `executeNoteCode`'s body — a 3-line delegation whose parts are each independently tested.

## Verification

`npm run check` green (Functions 100%, Statements 99.71%, Branches 97.81%), `npm run check:build` green, duplication green. Gate confirmed: *"Final mutation score of 97.97 is greater than or equal to break threshold 97"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)