### PR TITLE
Add Codex subscription eval transport

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,3 +1,10 @@
+<!--
+Producer Pal
+Copyright (C) 2026 Adam Murray, Taylor Haun
+AI assistance: Claude (Anthropic), Codex (OpenAI)
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
 # Evals
 
 Two CLI tools for testing LLM behavior with Producer Pal's MCP tools:
@@ -49,6 +56,9 @@ be inferred from the prefix:
 | `gpt-5-nano`                    | openai     |
 | `google/gemini-3-flash-preview` | google     |
 | `anthropic/claude-sonnet-4-5`   | anthropic  |
+| `codex-code/sol`                | codex-code |
+| `codex-code/terra`              | codex-code |
+| `codex-code/luna`               | codex-code |
 | `openrouter/some-model`         | openrouter |
 | `local/model-name`              | local      |
 
@@ -60,6 +70,10 @@ scripts/eval -a -m gemini-3-flash-preview
 
 # Compare two models on one scenario
 scripts/eval -t connect-to-ableton -m gemini-3-flash-preview -m claude-sonnet-4-5
+
+# Compare Codex subscription models (requires `codex login`)
+scripts/eval -t connect-to-ableton \
+  -m codex-code/sol -m codex-code/terra -m codex-code/luna
 
 # Skip Live Set reopening (reuse current MCP connection)
 scripts/eval -t connect-to-ableton -s

--- a/evals/chat/codex/codex-cli-protocol.test.ts
+++ b/evals/chat/codex/codex-cli-protocol.test.ts
@@ -27,6 +27,7 @@ describe("codexCliProtocol", () => {
     expect(args).toStrictEqual(
       expect.arrayContaining(["--model", "gpt-5.6-terra"]),
     );
+    expect(args).toContain('sandbox_mode="read-only"');
     expect(args).toContain("mcp_servers.producer-pal.required=true");
     expect(args).toContain(
       'mcp_servers.producer-pal.default_tools_approval_mode="approve"',
@@ -34,11 +35,12 @@ describe("codexCliProtocol", () => {
     expect(args.at(-1)).toBe("-");
   });
 
-  it("builds a resume turn without the unsupported sandbox flag", () => {
+  it("pins resumed turns to the read-only sandbox through config", () => {
     const args = codexCliProtocol({ ...input, resumeThreadId: "thread-123" });
 
     expect(args.slice(0, 2)).toStrictEqual(["exec", "resume"]);
     expect(args).not.toContain("--sandbox");
+    expect(args).toContain('sandbox_mode="read-only"');
     expect(args.slice(-2)).toStrictEqual(["thread-123", "-"]);
   });
 });

--- a/evals/chat/codex/codex-cli-protocol.test.ts
+++ b/evals/chat/codex/codex-cli-protocol.test.ts
@@ -1,0 +1,171 @@
+// Producer Pal
+// Copyright (C) 2026 Taylor Haun
+// AI assistance: Codex (OpenAI)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+
+import {
+  codexCliProtocol,
+  codexJudgeArgs,
+  parseCodexStream,
+  resolveCodexModel,
+  scrubOpenAiKeys,
+} from "./codex-cli-protocol.ts";
+
+describe("codexCliProtocol", () => {
+  const input = {
+    instructionsFile: "/tmp/instructions.md",
+    mcpUrl: "http://localhost:3350/mcp",
+    model: "terra",
+  };
+
+  it("builds a restricted initial MCP turn", () => {
+    const args = codexCliProtocol(input);
+
+    expect(args.slice(0, 3)).toStrictEqual(["exec", "--sandbox", "read-only"]);
+    expect(args).toStrictEqual(
+      expect.arrayContaining(["--model", "gpt-5.6-terra"]),
+    );
+    expect(args).toContain("mcp_servers.producer-pal.required=true");
+    expect(args).toContain(
+      'mcp_servers.producer-pal.default_tools_approval_mode="approve"',
+    );
+    expect(args.at(-1)).toBe("-");
+  });
+
+  it("builds a resume turn without the unsupported sandbox flag", () => {
+    const args = codexCliProtocol({ ...input, resumeThreadId: "thread-123" });
+
+    expect(args.slice(0, 2)).toStrictEqual(["exec", "resume"]);
+    expect(args).not.toContain("--sandbox");
+    expect(args.slice(-2)).toStrictEqual(["thread-123", "-"]);
+  });
+});
+
+describe("codexJudgeArgs", () => {
+  it("runs ephemerally without MCP configuration", () => {
+    const args = codexJudgeArgs("luna", "/tmp/judge.md");
+
+    expect(args).toContain("--ephemeral");
+    expect(args).toStrictEqual(
+      expect.arrayContaining(["--model", "gpt-5.6-luna"]),
+    );
+    expect(args.join(" ")).not.toContain("mcp_servers");
+  });
+});
+
+describe("resolveCodexModel", () => {
+  it("resolves friendly aliases and preserves explicit model ids", () => {
+    expect(resolveCodexModel("sol")).toBe("gpt-5.6-sol");
+    expect(resolveCodexModel("terra")).toBe("gpt-5.6-terra");
+    expect(resolveCodexModel("luna")).toBe("gpt-5.6-luna");
+    expect(resolveCodexModel("gpt-5.6-terra")).toBe("gpt-5.6-terra");
+  });
+});
+
+describe("scrubOpenAiKeys", () => {
+  it("forces Codex subscription auth while preserving other variables", () => {
+    const env = scrubOpenAiKeys({
+      CODEX_API_KEY: "codex-secret",
+      OPENAI_API_KEY: "api-secret",
+      OPENAI_KEY: "eval-secret",
+      PATH: "/usr/bin",
+      EMPTY: undefined,
+    });
+
+    expect(env).toStrictEqual({ PATH: "/usr/bin" });
+  });
+});
+
+describe("parseCodexStream", () => {
+  it("collects text, MCP calls, results, thread id and usage", () => {
+    const stdout = [
+      { type: "thread.started", thread_id: "thread-abc" },
+      {
+        type: "item.started",
+        item: {
+          id: "call-1",
+          type: "mcp_tool_call",
+          server: "producer-pal",
+          tool: "ppal-connect",
+          arguments: "{}",
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "call-1",
+          type: "mcp_tool_call",
+          server: "producer-pal",
+          tool: "ppal-connect",
+          arguments: {},
+          status: "completed",
+          result: { content: [{ type: "text", text: "connected" }] },
+        },
+      },
+      {
+        type: "item.completed",
+        item: { id: "message-1", type: "agent_message", text: "Connected." },
+      },
+      {
+        type: "turn.completed",
+        usage: {
+          input_tokens: 100,
+          cached_input_tokens: 80,
+          output_tokens: 20,
+          reasoning_output_tokens: 5,
+        },
+      },
+    ]
+      .map((event) => JSON.stringify(event))
+      .join("\n");
+    const parsed = parseCodexStream(stdout);
+
+    expect(parsed.text).toBe("Connected.");
+    expect(parsed.threadId).toBe("thread-abc");
+    expect(parsed.toolCalls).toStrictEqual([
+      {
+        name: "ppal-connect",
+        args: {},
+        result: JSON.stringify({
+          content: [{ type: "text", text: "connected" }],
+        }),
+      },
+    ]);
+    expect(parsed.usage).toStrictEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 80,
+      reasoningTokens: 5,
+    });
+  });
+
+  it("records a failed MCP result without failing the whole turn", () => {
+    const stdout = JSON.stringify({
+      type: "item.completed",
+      item: {
+        id: "call-1",
+        type: "mcp_tool_call",
+        tool: "ppal-connect",
+        arguments: {},
+        status: "failed",
+        error: { message: "connection refused" },
+      },
+    });
+
+    expect(parseCodexStream(stdout).toolCalls[0]?.result).toBe(
+      "ERROR: connection refused",
+    );
+  });
+
+  it("throws on fatal turn errors and ignores stray output", () => {
+    const stdout = [
+      "warning line",
+      JSON.stringify({ type: "turn.failed", error: { message: "boom" } }),
+    ].join("\n");
+
+    expect(() => parseCodexStream(stdout)).toThrow(/boom/);
+  });
+});

--- a/evals/chat/codex/codex-cli-protocol.ts
+++ b/evals/chat/codex/codex-cli-protocol.ts
@@ -1,0 +1,354 @@
+// Producer Pal
+// Copyright (C) 2026 Taylor Haun
+// AI assistance: Codex (OpenAI)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type TokenUsage } from "#webui/chat/sdk/types.ts";
+import { type ToolCall } from "../shared/types.ts";
+
+export const CODEX_MODEL_ALIASES: Record<string, string> = {
+  luna: "gpt-5.6-luna",
+  sol: "gpt-5.6-sol",
+  terra: "gpt-5.6-terra",
+};
+
+export const DEFAULT_CODEX_SYSTEM_PROMPT =
+  "You are Producer Pal, an AI assistant for music production in Ableton Live. " +
+  "Use only the available Producer Pal MCP tools (ppal-*) to inspect or change " +
+  "the Live Set. Do not use shell commands, files, web search, or subagents.";
+
+export interface CodexSessionArgsInput {
+  instructionsFile: string;
+  mcpUrl: string;
+  model: string;
+  resumeThreadId?: string;
+}
+
+/**
+ * Build arguments for an initial or resumed Codex eval turn.
+ * @param input - Model, instructions, MCP URL, and optional thread ID
+ * @returns Codex CLI arguments
+ */
+export function codexCliProtocol(input: CodexSessionArgsInput): string[] {
+  const common = buildCommonArgs(input);
+
+  if (input.resumeThreadId != null) {
+    return ["exec", "resume", ...common, input.resumeThreadId, "-"];
+  }
+
+  return ["exec", "--sandbox", "read-only", ...common, "-"];
+}
+
+/**
+ * Build arguments for an isolated Codex judge call.
+ * @param model - Friendly alias or explicit model ID
+ * @param instructionsFile - Absolute path to judge instructions
+ * @returns Codex CLI arguments
+ */
+export function codexJudgeArgs(
+  model: string,
+  instructionsFile: string,
+): string[] {
+  return [
+    "exec",
+    "--sandbox",
+    "read-only",
+    "--ephemeral",
+    ...buildRestrictedArgs(model, instructionsFile),
+    "-",
+  ];
+}
+
+/**
+ * Resolve a friendly Sol, Terra, or Luna alias to its Codex model ID.
+ * @param model - Friendly alias or explicit model ID
+ * @returns Resolved model ID
+ */
+export function resolveCodexModel(model: string): string {
+  return CODEX_MODEL_ALIASES[model] ?? model;
+}
+
+/**
+ * Remove OpenAI API keys so Codex uses the logged-in subscription.
+ * @param env - Parent process environment
+ * @returns Environment without OpenAI API keys or undefined values
+ */
+export function scrubOpenAiKeys(
+  env: NodeJS.ProcessEnv,
+): Record<string, string> {
+  const stripped = new Set(["CODEX_API_KEY", "OPENAI_API_KEY", "OPENAI_KEY"]);
+  const result: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value === "string" && !stripped.has(key)) result[key] = value;
+  }
+
+  return result;
+}
+
+export interface ParsedCodexTurn {
+  text: string;
+  toolCalls: ToolCall[];
+  threadId?: string;
+  usage?: TokenUsage;
+}
+
+/**
+ * Parse one Codex JSONL turn into the shared eval result shape.
+ * @param stdout - Codex JSONL stdout
+ * @returns Parsed assistant text, MCP calls, thread ID, and token usage
+ */
+export function parseCodexStream(stdout: string): ParsedCodexTurn {
+  const state: CodexStreamState = {
+    text: "",
+    toolCalls: [],
+    callsById: new Map(),
+  };
+
+  for (const line of stdout.split("\n")) {
+    const event = parseLine(line);
+
+    if (event != null) handleEvent(event, state);
+  }
+
+  if (state.error != null) throw new Error(`codex CLI error: ${state.error}`);
+
+  return {
+    text: state.text,
+    toolCalls: state.toolCalls,
+    ...(state.threadId != null ? { threadId: state.threadId } : {}),
+    ...(state.usage != null ? { usage: state.usage } : {}),
+  };
+}
+
+interface CodexStreamState {
+  text: string;
+  toolCalls: ToolCall[];
+  callsById: Map<string, ToolCall>;
+  threadId?: string;
+  usage?: TokenUsage;
+  error?: string;
+}
+
+/**
+ * Build restrictions and the Producer Pal MCP configuration.
+ * @param input - Model, instructions, and MCP session options
+ * @returns CLI arguments shared by initial and resumed turns
+ */
+function buildCommonArgs(input: CodexSessionArgsInput): string[] {
+  return [
+    ...buildRestrictedArgs(input.model, input.instructionsFile),
+    "-c",
+    `mcp_servers.producer-pal.url=${JSON.stringify(input.mcpUrl)}`,
+    "-c",
+    "mcp_servers.producer-pal.required=true",
+    "-c",
+    'mcp_servers.producer-pal.default_tools_approval_mode="approve"',
+  ];
+}
+
+/**
+ * Build arguments shared by MCP turns and judge calls.
+ * @param model - Friendly alias or explicit model ID
+ * @param instructionsFile - Absolute path to base instructions
+ * @returns Restricted Codex CLI arguments
+ */
+function buildRestrictedArgs(
+  model: string,
+  instructionsFile: string,
+): string[] {
+  return [
+    "--json",
+    "--skip-git-repo-check",
+    "--ignore-user-config",
+    "--ignore-rules",
+    "--disable",
+    "shell_tool",
+    "--disable",
+    "unified_exec",
+    "--disable",
+    "multi_agent",
+    "--model",
+    resolveCodexModel(model),
+    "-c",
+    'approval_policy="never"',
+    "-c",
+    'web_search="disabled"',
+    "-c",
+    `model_instructions_file=${JSON.stringify(instructionsFile)}`,
+  ];
+}
+
+/**
+ * Parse a JSONL line, ignoring diagnostics written to stdout.
+ * @param line - One stdout line
+ * @returns Parsed event or undefined for non-JSON output
+ */
+function parseLine(line: string): Record<string, unknown> | undefined {
+  const trimmed = line.trim();
+
+  if (!trimmed) return undefined;
+
+  try {
+    return JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Apply a Codex stream event to the current turn accumulator.
+ * @param event - Parsed Codex event
+ * @param state - Mutable turn accumulator
+ */
+function handleEvent(
+  event: Record<string, unknown>,
+  state: CodexStreamState,
+): void {
+  if (event.type === "thread.started" && typeof event.thread_id === "string") {
+    state.threadId = event.thread_id;
+  } else if (event.type === "turn.completed") {
+    state.usage = mapCodexUsage(event.usage);
+  } else if (event.type === "turn.failed" || event.type === "error") {
+    state.error = getErrorMessage(event);
+  } else if (event.type === "item.started" || event.type === "item.completed") {
+    handleItem(event.item, state);
+  }
+}
+
+/**
+ * Collect agent messages and MCP tool items.
+ * @param itemValue - Event item payload
+ * @param state - Mutable turn accumulator
+ */
+function handleItem(itemValue: unknown, state: CodexStreamState): void {
+  if (itemValue == null || typeof itemValue !== "object") return;
+  const item = itemValue as Record<string, unknown>;
+
+  if (item.type === "agent_message" && typeof item.text === "string") {
+    state.text += item.text;
+  } else if (item.type === "mcp_tool_call") {
+    collectMcpCall(item, state);
+  }
+}
+
+/**
+ * Add or complete an MCP call while avoiding started/completed duplicates.
+ * @param item - MCP tool-call item
+ * @param state - Mutable turn accumulator
+ */
+function collectMcpCall(
+  item: Record<string, unknown>,
+  state: CodexStreamState,
+): void {
+  const id = typeof item.id === "string" ? item.id : undefined;
+  let call = id == null ? undefined : state.callsById.get(id);
+
+  if (call == null && typeof item.tool === "string") {
+    call = {
+      name: item.tool,
+      args: toArguments(item.arguments),
+    };
+    state.toolCalls.push(call);
+    if (id != null) state.callsById.set(id, call);
+  }
+
+  if (call == null) return;
+  if (item.result != null) call.result = stringifyResult(item.result);
+
+  if (item.status === "failed") {
+    const message = getErrorMessage(item);
+
+    call.result ??= `ERROR: ${message}`;
+  }
+}
+
+/**
+ * Normalize object or JSON-string tool arguments.
+ * @param value - Raw Codex arguments
+ * @returns Object arguments for the shared tool-call shape
+ */
+function toArguments(value: unknown): Record<string, unknown> {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+
+      if (
+        parsed != null &&
+        typeof parsed === "object" &&
+        !Array.isArray(parsed)
+      ) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return {};
+    }
+  }
+
+  return {};
+}
+
+/**
+ * Map Codex token counters to the shared usage shape.
+ * @param value - Raw turn usage
+ * @returns Shared token usage or undefined
+ */
+function mapCodexUsage(value: unknown): TokenUsage | undefined {
+  if (value == null || typeof value !== "object") return undefined;
+  const usage = value as Record<string, unknown>;
+  const inputTokens = numberValue(usage.input_tokens);
+  const outputTokens = numberValue(usage.output_tokens);
+  const result: TokenUsage = {
+    inputTokens,
+    outputTokens,
+  };
+  const cached = numberValue(usage.cached_input_tokens);
+  const reasoning = numberValue(usage.reasoning_output_tokens);
+
+  if (cached > 0) result.cacheReadTokens = cached;
+  if (reasoning > 0) result.reasoningTokens = reasoning;
+
+  return result;
+}
+
+/**
+ * Return a numeric counter or zero when absent.
+ * @param value - Raw counter
+ * @returns Numeric counter
+ */
+function numberValue(value: unknown): number {
+  return typeof value === "number" ? value : 0;
+}
+
+/**
+ * Serialize a Codex MCP result for eval reports.
+ * @param value - Raw MCP result
+ * @returns String result
+ */
+function stringifyResult(value: unknown): string {
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+/**
+ * Extract a useful message from the event's supported error shapes.
+ * @param value - Event or MCP item containing an error
+ * @returns Error message
+ */
+function getErrorMessage(value: Record<string, unknown>): string {
+  if (typeof value.message === "string") return value.message;
+  const error = value.error;
+
+  if (typeof error === "string") return error;
+
+  if (error != null && typeof error === "object") {
+    const message = (error as Record<string, unknown>).message;
+
+    if (typeof message === "string") return message;
+  }
+
+  return "unknown error";
+}

--- a/evals/chat/codex/codex-cli-protocol.ts
+++ b/evals/chat/codex/codex-cli-protocol.ts
@@ -175,6 +175,8 @@ function buildRestrictedArgs(
     "-c",
     'web_search="disabled"',
     "-c",
+    'sandbox_mode="read-only"',
+    "-c",
     `model_instructions_file=${JSON.stringify(instructionsFile)}`,
   ];
 }

--- a/evals/chat/codex/codex-cli-session.ts
+++ b/evals/chat/codex/codex-cli-session.ts
@@ -1,0 +1,98 @@
+// Producer Pal
+// Copyright (C) 2026 Taylor Haun
+// AI assistance: Codex (OpenAI)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type EvalSession } from "#evals/scenarios/eval-session.ts";
+import { logTurnStart } from "#evals/scenarios/helpers/eval-session-base.ts";
+import { connectMcp } from "../mcp.ts";
+import { type TurnResult } from "../shared/types.ts";
+import {
+  codexCliProtocol,
+  DEFAULT_CODEX_SYSTEM_PROMPT,
+  parseCodexStream,
+} from "./codex-cli-protocol.ts";
+import { spawnCodex } from "./codex-cli.ts";
+
+export const CODEX_CODE_DEFAULT_MODEL = "terra";
+const DEFAULT_MCP_URL = "http://localhost:3350/mcp";
+
+export interface CodexCliSessionOptions {
+  instructions?: string;
+  mcpUrl?: string;
+  model?: string;
+}
+
+/**
+ * Create a multi-turn Codex session backed by Producer Pal's MCP server.
+ * @param options - Model, instructions, and optional MCP URL
+ * @returns Eval session compatible with the scenario runner
+ */
+export async function createCodexCliSession(
+  options: CodexCliSessionOptions,
+): Promise<EvalSession> {
+  const model = options.model ?? CODEX_CODE_DEFAULT_MODEL;
+  const mcpUrl = options.mcpUrl ?? process.env.MCP_URL ?? DEFAULT_MCP_URL;
+  const sessionDir = await mkdtemp(join(tmpdir(), "producer-pal-codex-"));
+  const instructionsFile = join(sessionDir, "instructions.md");
+
+  try {
+    await writeFile(
+      instructionsFile,
+      options.instructions ?? DEFAULT_CODEX_SYSTEM_PROMPT,
+      "utf8",
+    );
+  } catch (error) {
+    await rm(sessionDir, { recursive: true, force: true });
+    throw error;
+  }
+
+  let mcpClient: Awaited<ReturnType<typeof connectMcp>>["client"];
+
+  try {
+    ({ client: mcpClient } = await connectMcp(mcpUrl));
+  } catch (error) {
+    await rm(sessionDir, { recursive: true, force: true });
+    throw error;
+  }
+
+  let threadId: string | undefined;
+
+  return {
+    mcpClient,
+    sendMessage: async (
+      message: string,
+      turnNumber: number,
+    ): Promise<TurnResult> => {
+      logTurnStart(turnNumber, message);
+      const args = codexCliProtocol({
+        instructionsFile,
+        mcpUrl,
+        model,
+        ...(threadId != null ? { resumeThreadId: threadId } : {}),
+      });
+      const parsed = parseCodexStream(
+        await spawnCodex(args, message, { cwd: sessionDir }),
+      );
+
+      // eslint-disable-next-line require-atomic-updates -- turns run sequentially
+      if (parsed.threadId != null) threadId = parsed.threadId;
+
+      return {
+        text: parsed.text,
+        toolCalls: parsed.toolCalls,
+        ...(parsed.usage != null ? { stepUsages: [parsed.usage] } : {}),
+      };
+    },
+    close: async () => {
+      try {
+        await mcpClient.close();
+      } finally {
+        await rm(sessionDir, { recursive: true, force: true });
+      }
+    },
+  };
+}

--- a/evals/chat/codex/codex-cli.ts
+++ b/evals/chat/codex/codex-cli.ts
@@ -1,0 +1,79 @@
+// Producer Pal
+// Copyright (C) 2026 Taylor Haun
+// AI assistance: Codex (OpenAI)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { scrubOpenAiKeys } from "./codex-cli-protocol.ts";
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+export interface SpawnCodexOptions {
+  cwd: string;
+  timeoutMs?: number;
+}
+
+/**
+ * Spawn a restricted Codex turn and return its JSONL stdout.
+ * @param args - Codex CLI arguments
+ * @param prompt - User prompt written to stdin
+ * @param options - Working directory and optional timeout
+ * @returns Codex JSONL stdout
+ */
+export function spawnCodex(
+  args: string[],
+  prompt: string,
+  options: SpawnCodexOptions,
+): Promise<string> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const executable = process.env.CODEX_BIN ?? "codex";
+  const env = scrubOpenAiKeys(process.env);
+
+  return new Promise<string>((resolve, reject) => {
+    const child: ChildProcessWithoutNullStreams = spawn(executable, args, {
+      cwd: options.cwd,
+      env: env,
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 2000);
+    }, timeoutMs);
+
+    child.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+    child.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+
+      if (timedOut) {
+        reject(new Error(`codex CLI timed out after ${timeoutMs / 1000}s`));
+      } else if (code !== 0) {
+        reject(
+          new Error(
+            `codex CLI exited ${code}. stderr: ${stderr.slice(0, 500)}\n` +
+              `stdout: ${stdout.slice(0, 500)}`,
+          ),
+        );
+      } else {
+        resolve(stdout);
+      }
+    });
+    child.stdin.on("error", (error) => {
+      clearTimeout(timer);
+      child.kill("SIGKILL");
+      reject(error);
+    });
+    child.stdin.end(prompt);
+  });
+}

--- a/evals/chat/codex/codex-cli.ts
+++ b/evals/chat/codex/codex-cli.ts
@@ -43,11 +43,13 @@ export function spawnCodex(
       setTimeout(() => child.kill("SIGKILL"), 2000);
     }, timeoutMs);
 
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
     child.stdout.on("data", (data) => {
-      stdout += data.toString();
+      stdout += data;
     });
     child.stderr.on("data", (data) => {
-      stderr += data.toString();
+      stderr += data;
     });
     child.on("error", (error) => {
       clearTimeout(timer);

--- a/evals/chat/provider.ts
+++ b/evals/chat/provider.ts
@@ -1,6 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
-// AI assistance: Claude (Anthropic)
+// AI assistance: Claude (Anthropic), Codex (OpenAI)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
@@ -78,6 +78,11 @@ export function createProviderModel(
         includeUsage: true,
       }).chatModel(model);
     }
+
+    case "codex-code":
+      throw new Error(
+        "codex-code uses the Codex CLI transport, not the AI SDK provider.",
+      );
 
     default: {
       const _exhaustiveCheck: never = provider;

--- a/evals/chat/thinking.ts
+++ b/evals/chat/thinking.ts
@@ -1,6 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
-// AI assistance: Claude (Anthropic)
+// AI assistance: Claude (Anthropic), Codex (OpenAI)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
@@ -71,6 +71,8 @@ export function buildProviderOptions(
     case "openrouter":
       return buildOpenRouterThinking(level);
     case "local":
+      return undefined;
+    case "codex-code":
       return undefined;
 
     default: {

--- a/evals/scenarios/eval-session.ts
+++ b/evals/scenarios/eval-session.ts
@@ -1,6 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
-// AI assistance: Claude (Anthropic)
+// AI assistance: Claude (Anthropic), Codex (OpenAI)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
@@ -9,6 +9,10 @@
 
 import { type Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { type ModelMessage, stepCountIs, streamText } from "ai";
+import {
+  CODEX_CODE_DEFAULT_MODEL,
+  createCodexCliSession,
+} from "#evals/chat/codex/codex-cli-session.ts";
 import { createMcpTools } from "#evals/chat/mcp.ts";
 import { createProviderModel } from "#evals/chat/provider.ts";
 import { printStepUsage } from "#evals/chat/shared/formatting.ts";
@@ -36,6 +40,8 @@ export function getDefaultModel(provider: EvalProvider): string {
   switch (provider) {
     case "anthropic":
       return ANTHROPIC_CONFIG.defaultModel;
+    case "codex-code":
+      return CODEX_CODE_DEFAULT_MODEL;
     case "google":
       return GEMINI_CONFIG.defaultModel;
     case "openai":
@@ -83,6 +89,15 @@ interface EvalSessionOptions {
 export async function createEvalSession(
   options: EvalSessionOptions,
 ): Promise<EvalSession> {
+  if (options.provider === "codex-code") {
+    return await createCodexCliSession({
+      ...(options.model != null ? { model: options.model } : {}),
+      ...(options.instructions != null
+        ? { instructions: options.instructions }
+        : {}),
+    });
+  }
+
   const model = createProviderModel(
     options.provider,
     options.model ?? getDefaultModel(options.provider),

--- a/evals/scenarios/helpers/judge/codex-cli-judge.ts
+++ b/evals/scenarios/helpers/judge/codex-cli-judge.ts
@@ -1,0 +1,58 @@
+// Producer Pal
+// Copyright (C) 2026 Taylor Haun
+// AI assistance: Codex (OpenAI)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  codexJudgeArgs,
+  parseCodexStream,
+} from "#evals/chat/codex/codex-cli-protocol.ts";
+import { spawnCodex } from "#evals/chat/codex/codex-cli.ts";
+import {
+  finishJudgeOutput,
+  printJudgeChunk,
+  printJudgeHeader,
+} from "./judge-output.ts";
+
+export const CODEX_CODE_JUDGE_MODEL = "luna";
+
+/**
+ * Run an isolated Codex subscription model as the LLM judge.
+ * @param prompt - Evaluation prompt
+ * @param systemPrompt - Judge instructions
+ * @param model - Optional model alias or ID
+ * @param criteria - Criteria shown in console output
+ * @returns Raw judge response
+ */
+export async function callCodexCliJudge(
+  prompt: string,
+  systemPrompt: string,
+  model: string | undefined,
+  criteria: string,
+): Promise<string> {
+  const judgeModel = model ?? CODEX_CODE_JUDGE_MODEL;
+  const workingDir = await mkdtemp(join(tmpdir(), "producer-pal-judge-"));
+  const instructionsFile = join(workingDir, "instructions.md");
+
+  printJudgeHeader("codex-code", judgeModel, criteria);
+
+  try {
+    await writeFile(instructionsFile, systemPrompt, "utf8");
+    const stdout = await spawnCodex(
+      codexJudgeArgs(judgeModel, instructionsFile),
+      prompt,
+      { cwd: workingDir },
+    );
+    const text = parseCodexStream(stdout).text.trim();
+
+    printJudgeChunk(text);
+    finishJudgeOutput();
+
+    return text;
+  } finally {
+    await rm(workingDir, { recursive: true, force: true });
+  }
+}

--- a/evals/scenarios/helpers/judge/judge.ts
+++ b/evals/scenarios/helpers/judge/judge.ts
@@ -1,6 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
-// AI assistance: Claude (Anthropic)
+// AI assistance: Claude (Anthropic), Codex (OpenAI)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
@@ -11,6 +11,7 @@ import { streamText } from "ai";
 import { createProviderModel } from "#evals/chat/provider.ts";
 import { getDefaultModel } from "#evals/scenarios/eval-session.ts";
 import { type EvalProvider } from "#evals/scenarios/types.ts";
+import { callCodexCliJudge } from "./codex-cli-judge.ts";
 import {
   finishJudgeOutput,
   printJudgeChunk,
@@ -36,6 +37,11 @@ export async function callJudge(
   criteria: string,
 ): Promise<string> {
   const judgeModel = model ?? getDefaultModel(provider);
+
+  if (provider === "codex-code") {
+    return await callCodexCliJudge(prompt, systemPrompt, judgeModel, criteria);
+  }
+
   const languageModel = createProviderModel(provider, judgeModel);
 
   printJudgeHeader(provider, judgeModel, criteria);

--- a/evals/scenarios/types.ts
+++ b/evals/scenarios/types.ts
@@ -1,6 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
-// AI assistance: Claude (Anthropic)
+// AI assistance: Claude (Anthropic), Codex (OpenAI)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
@@ -19,7 +19,7 @@ export type { TurnResult, ToolCall } from "#evals/chat/shared/types.ts";
 export type { ConfigOptions };
 
 export type EvalProvider =
-  "anthropic" | "google" | "local" | "openai" | "openrouter";
+  "anthropic" | "codex-code" | "google" | "local" | "openai" | "openrouter";
 
 /**
  * A test scenario that runs against Ableton Live

--- a/evals/shared/list-models.ts
+++ b/evals/shared/list-models.ts
@@ -1,6 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
-// AI assistance: Claude (Anthropic)
+// AI assistance: Claude (Anthropic), Codex (OpenAI)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
@@ -171,6 +171,9 @@ async function fetchModelsForProvider(
           "anthropic-version": "2023-06-01",
         },
       );
+
+    case "codex-code":
+      return ["luna", "sol", "terra"];
 
     case "google":
       return await fetchGoogleModels();

--- a/evals/shared/parse-model-arg.ts
+++ b/evals/shared/parse-model-arg.ts
@@ -1,6 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
-// AI assistance: Claude (Anthropic)
+// AI assistance: Claude (Anthropic), Codex (OpenAI)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**

--- a/evals/shared/provider-configs.ts
+++ b/evals/shared/provider-configs.ts
@@ -1,6 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
-// AI assistance: Claude (Anthropic)
+// AI assistance: Claude (Anthropic), Codex (OpenAI)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
@@ -26,6 +26,14 @@ export const ANTHROPIC_CONFIG: ProviderConfig = {
   apiKeyEnvVar: "ANTHROPIC_KEY",
   providerName: "Anthropic",
   defaultModel: "claude-sonnet-4-5-20250929",
+};
+
+/** Codex CLI subscription provider configuration */
+export const CODEX_CODE_CONFIG: ProviderConfig = {
+  apiKeyEnvVar: "",
+  providerName: "Codex CLI",
+  defaultModel: "terra",
+  apiKeyOptional: true,
 };
 
 /** Google Gemini provider configuration */
@@ -78,6 +86,7 @@ export function validateApiKey(config: ProviderConfig): string {
 /** All provider configs keyed by provider id (registry order) */
 export const PROVIDER_CONFIGS: Record<EvalProvider, ProviderConfig> = {
   anthropic: ANTHROPIC_CONFIG,
+  "codex-code": CODEX_CODE_CONFIG,
   google: GEMINI_CONFIG,
   local: LOCAL_CONFIG,
   openai: OPENAI_CONFIG,


### PR DESCRIPTION
## Summary

- adds a subscription-authenticated Codex CLI provider to the 2.0 eval framework
- supports friendly `sol`, `terra`, and `luna` aliases for `gpt-5.6-*`
- preserves multi-turn Codex threads and captures Producer Pal MCP calls, results, and token usage
- supports Codex as both the evaluated model and the isolated LLM judge
- restricts eval subprocesses to the Producer Pal MCP server with read-only sandboxing, no shell, no web search, and no subagents
- lists Codex models without requiring an OpenAI API key and documents the CLI syntax

## Verification

- authoritative 2.0 scenario inventory: 74 scenarios
- isolated `codex-code/luna` judge smoke test passed using Codex subscription auth
- real Ableton 12.4 + Producer Pal 2.0 matrix:
  - `connect-to-ableton`: Sol/Terra/Luna all 3/3 checks
  - `create-and-edit-clip`: Sol/Terra/Luna all 9/9 checks
  - `scene-and-playback`: Sol/Terra/Luna all 7/7 checks
- `npm run fix`
- `npm run check` — 563 files, 9,983 tests passed
- `npm run check:build`

The real evals used the checked-in reproducible eval Live Set. No MCP e2e test suite was run.
