### PR TITLE
test: reduce test duplication and tighten jscpd threshold to 1.2

### DIFF
--- a/config/.jscpd-tests.json
+++ b/config/.jscpd-tests.json
@@ -1,5 +1,5 @@
 {
-  "threshold": 1.4,
+  "threshold": 1.2,
   "reporters": ["console"],
   "ignorePattern": [
     "// Producer Pal",

--- a/src/mcp-server/live-library/tests/fixtures/plugins-fixture.ts
+++ b/src/mcp-server/live-library/tests/fixtures/plugins-fixture.ts
@@ -32,7 +32,7 @@ export interface PluginsFixture {
 /** Whether to include the v2-only ARA columns in the plugins table. */
 export type PluginsSchema = "v1" | "v2";
 
-interface PluginSeed {
+export interface PluginSeed {
   name: string;
   vendor: string | null;
   version: string | null;

--- a/src/mcp-server/live-library/tests/list-plugins.test.ts
+++ b/src/mcp-server/live-library/tests/list-plugins.test.ts
@@ -12,11 +12,13 @@ import {
   it,
   vi,
 } from "vitest";
+import { type PluginItem } from "../library-types.ts";
 import { listPlugins } from "../list-plugins.ts";
 import {
   createFilesDbWithoutPluginsFixture,
   createFilesDbWithPluginsFixture,
   createPluginsDbFixture,
+  type PluginSeed,
   type PluginsFixture,
 } from "./fixtures/plugins-fixture.ts";
 
@@ -169,10 +171,7 @@ describe("listPlugins — filtering and derivation", () => {
   });
 
   it("derives format and category from dev_identifier", async () => {
-    usePluginsDb(fixture.dbPath);
-
-    const result = await listPlugins();
-    const byName = new Map(result.plugins.map((p) => [p.name, p]));
+    const byName = await pluginsByName(fixture.dbPath);
 
     expect(byName.get("Massive")?.format).toBe("VST3");
     expect(byName.get("Massive")?.category).toBe("instrument");
@@ -195,10 +194,7 @@ describe("listPlugins — filtering and derivation", () => {
   });
 
   it("carries through vendor and version, with nulls preserved", async () => {
-    usePluginsDb(fixture.dbPath);
-
-    const result = await listPlugins();
-    const byName = new Map(result.plugins.map((p) => [p.name, p]));
+    const byName = await pluginsByName(fixture.dbPath);
 
     expect(byName.get("Serum")?.vendor).toBe("Xfer Records");
     expect(byName.get("Serum")?.version).toBe("1.3.6");
@@ -280,13 +276,31 @@ describe("listPlugins — filtering and derivation", () => {
 describe("listPlugins — subcategories parsing", () => {
   it("splits on |, drops the redundant category prefix, handles empty/null", async () => {
     const fixture = createPluginsDbFixture("v2", [
-      pluginSeed("Multi", "device:vst3:instr:Multi", "Instrument|Synth|Bass"),
-      pluginSeed("Single", "device:vst3:audiofx:Single", "Fx|EQ"),
-      pluginSeed("CategoryOnly", "device:vst3:audiofx:CatOnly", "Fx"),
-      pluginSeed("Empty", "device:vst:instr:Empty", ""),
-      pluginSeed("NullSubs", "device:vst3:instr:NullSubs", null),
+      pluginSeed("Multi", {
+        dev_identifier: "device:vst3:instr:Multi",
+        subcategories: "Instrument|Synth|Bass",
+      }),
+      pluginSeed("Single", {
+        dev_identifier: "device:vst3:audiofx:Single",
+        subcategories: "Fx|EQ",
+      }),
+      pluginSeed("CategoryOnly", {
+        dev_identifier: "device:vst3:audiofx:CatOnly",
+        subcategories: "Fx",
+      }),
+      pluginSeed("Empty", {
+        dev_identifier: "device:vst:instr:Empty",
+        subcategories: "",
+      }),
+      pluginSeed("NullSubs", {
+        dev_identifier: "device:vst3:instr:NullSubs",
+        subcategories: null,
+      }),
       // No recognized category prefix → keep every segment.
-      pluginSeed("NoPrefix", "device:vst3:audiofx:NoPrefix", "Reverb|Delay"),
+      pluginSeed("NoPrefix", {
+        dev_identifier: "device:vst3:audiofx:NoPrefix",
+        subcategories: "Reverb|Delay",
+      }),
     ]);
 
     try {
@@ -336,10 +350,13 @@ describe("listPlugins — dev_identifier / vendor branch coverage", () => {
   // scheme-only identifier ("device"), and a null-vendor row for the vendor
   // filter's `?? ""` fallback.
   const branchSeeds = [
-    row("SchemeNoCat", "Acme", "device:vst3:weird:Thing"),
-    row("NullDevId", null, null),
-    row("EmptyScheme", null, "device:"),
-    row("SchemeOnly", null, "device"),
+    pluginSeed("SchemeNoCat", {
+      vendor: "Acme",
+      dev_identifier: "device:vst3:weird:Thing",
+    }),
+    pluginSeed("NullDevId"),
+    pluginSeed("EmptyScheme", { dev_identifier: "device:" }),
+    pluginSeed("SchemeOnly", { dev_identifier: "device" }),
   ];
   let fixture: PluginsFixture;
 
@@ -362,10 +379,7 @@ describe("listPlugins — dev_identifier / vendor branch coverage", () => {
   });
 
   it("returns null format/category for null or malformed dev_identifiers", async () => {
-    usePluginsDb(fixture.dbPath);
-
-    const result = await listPlugins();
-    const byName = new Map(result.plugins.map((p) => [p.name, p]));
+    const byName = await pluginsByName(fixture.dbPath);
 
     for (const name of ["NullDevId", "EmptyScheme", "SchemeOnly"]) {
       expect(byName.get(name)?.format).toBeNull();
@@ -392,65 +406,39 @@ describe("listPlugins — dev_identifier / vendor branch coverage", () => {
 });
 
 /**
- * Build a minimal enabled plugin row with an arbitrary vendor/dev_identifier.
+ * Run listPlugins against a fixture DB and index the results by plugin name.
  *
- * @param name - Plugin display name
- * @param vendor - Vendor name (or null)
- * @param devIdentifier - dev_identifier URI (or null)
- * @returns A plugin row for createPluginsDbFixture
+ * @param dbPath - Path of the separate plugins DB to read from
+ * @returns The returned plugins keyed by name
  */
-function row(
-  name: string,
-  vendor: string | null,
-  devIdentifier: string | null,
-): {
-  name: string;
-  vendor: string | null;
-  version: string | null;
-  scanstate: number | null;
-  enabled: number;
-  subcategories: string | null;
-  dev_identifier: string | null;
-} {
-  return {
-    name,
-    vendor,
-    version: null,
-    scanstate: 1,
-    enabled: 1,
-    subcategories: null,
-    dev_identifier: devIdentifier,
-  };
+async function pluginsByName(dbPath: string): Promise<Map<string, PluginItem>> {
+  usePluginsDb(dbPath);
+
+  const result = await listPlugins();
+
+  return new Map(result.plugins.map((p) => [p.name, p]));
 }
 
 /**
- * Build a minimal enabled PluginSeed for subcategory-parsing tests.
+ * Build a minimal enabled PluginSeed, overriding only the columns a test cares
+ * about. Defaults: no vendor/version/subcategories/dev_identifier, scanstate 1.
  *
  * @param name - Plugin display name
- * @param devIdentifier - dev_identifier URI
- * @param subcategories - Raw pipe-delimited subcategories column value (or null)
- * @returns A PluginSeed-shaped object for createPluginsDbFixture
+ * @param overrides - Columns to set on top of the minimal enabled row
+ * @returns A PluginSeed for createPluginsDbFixture
  */
 function pluginSeed(
   name: string,
-  devIdentifier: string,
-  subcategories: string | null,
-): {
-  name: string;
-  vendor: string | null;
-  version: string | null;
-  scanstate: number | null;
-  enabled: number;
-  subcategories: string | null;
-  dev_identifier: string | null;
-} {
+  overrides: Partial<PluginSeed> = {},
+): PluginSeed {
   return {
     name,
     vendor: null,
     version: null,
     scanstate: 1,
     enabled: 1,
-    subcategories,
-    dev_identifier: devIdentifier,
+    subcategories: null,
+    dev_identifier: null,
+    ...overrides,
   };
 }

--- a/src/mcp-server/tests/rest-api/rest-api-routes.test.ts
+++ b/src/mcp-server/tests/rest-api/rest-api-routes.test.ts
@@ -16,6 +16,16 @@ type MockMax = typeof Max & {
 };
 const mockMax = Max as MockMax;
 
+// Parsed body of a REST tool-call response. Every field is optional because
+// which ones appear depends on the route outcome and the ?format mode.
+type ToolCallBody = {
+  result?: unknown;
+  isError?: boolean;
+  errorCode?: string;
+  warnings?: string[];
+  appended?: string[];
+};
+
 /**
  * Stub Max.outlet to resolve MCP requests with a given response payload.
  * Returns a holder whose `.lastContext` field is populated with the parsed
@@ -124,6 +134,26 @@ describe("REST API Routes", () => {
       headers: { "Content-Type": "application/json" },
       body: "{}",
     });
+  }
+
+  /**
+   * Stub ppal-connect to report a tool error carrying the given text, call it,
+   * and return the HTTP response alongside its parsed body.
+   * @param text - Error text the stubbed tool returns in its isError response
+   * @returns The HTTP response and its parsed JSON body
+   */
+  async function callConnectReportingToolError(text: string): Promise<{
+    response: Response;
+    body: ToolCallBody;
+  }> {
+    stubMaxOutlet({
+      content: [{ type: "text", text }],
+      isError: true,
+    });
+
+    const response = await callTool("ppal-connect");
+
+    return { response, body: (await response.json()) as ToolCallBody };
   }
 
   describe("GET /api/tools", () => {
@@ -293,17 +323,11 @@ describe("REST API Routes", () => {
     });
 
     it("should return isError true when tool reports error", async () => {
-      stubMaxOutlet({
-        content: [{ type: "text", text: "something went wrong" }],
-        isError: true,
-      });
-
-      const response = await callTool("ppal-connect");
+      const { response, body } = await callConnectReportingToolError(
+        "something went wrong",
+      );
 
       expect(response.status).toBe(200);
-
-      const body = await response.json();
-
       expect(body.result).toBe("something went wrong");
       expect(body.isError).toBe(true);
     });
@@ -322,6 +346,29 @@ describe("REST API Routes", () => {
           body: "{}",
         },
       );
+    }
+
+    /**
+     * Stub a `{"ok":true}` JSON result followed by the given extra content
+     * blocks, then call the tool in json mode and return the parsed body. Uses
+     * a non-connect tool so the real skills block isn't also appended by the
+     * wrapper and mistaken for one of the extra blocks under test.
+     * @param extraTexts - Text of each content block appended after the result
+     * @returns The parsed JSON response body
+     */
+    async function readTrackJsonWithExtraBlocks(
+      extraTexts: string[],
+    ): Promise<ToolCallBody> {
+      stubMaxOutlet({
+        content: [
+          { type: "text", text: '{"ok":true}' },
+          ...extraTexts.map((text) => ({ type: "text", text })),
+        ],
+      });
+
+      const response = await callToolWithFormat("ppal-read-track", "json");
+
+      return (await response.json()) as ToolCallBody;
     }
 
     it("should default to compactOutput: false (json) when format is omitted", async () => {
@@ -426,17 +473,11 @@ describe("REST API Routes", () => {
       // extra content blocks with no WARNING: prefix (see connect-append.ts).
       // JSON mode must preserve them, not silently drop them. Use a non-connect
       // tool so the real skills block isn't also appended by the wrapper.
-      stubMaxOutlet({
-        content: [
-          { type: "text", text: '{"ok":true}' },
-          { type: "text", text: "WARNING: real warning" },
-          { type: "text", text: "# Producer Pal Skills\n..." },
-          { type: "text", text: "# Global context\n..." },
-        ],
-      });
-
-      const response = await callToolWithFormat("ppal-read-track", "json");
-      const body = await response.json();
+      const body = await readTrackJsonWithExtraBlocks([
+        "WARNING: real warning",
+        "# Producer Pal Skills\n...",
+        "# Global context\n...",
+      ]);
 
       expect(body.result).toStrictEqual({ ok: true });
       expect(body.warnings).toStrictEqual(["real warning"]);
@@ -463,15 +504,7 @@ describe("REST API Routes", () => {
     });
 
     it("omits `appended` when there are no non-WARNING extra blocks (format=json)", async () => {
-      stubMaxOutlet({
-        content: [
-          { type: "text", text: '{"ok":true}' },
-          { type: "text", text: "WARNING: heads up" },
-        ],
-      });
-
-      const response = await callToolWithFormat("ppal-read-track", "json");
-      const body = await response.json();
+      const body = await readTrackJsonWithExtraBlocks(["WARNING: heads up"]);
 
       expect(body.result).toStrictEqual({ ok: true });
       expect(body.warnings).toStrictEqual(["heads up"]);
@@ -623,17 +656,11 @@ describe("REST API Routes", () => {
     it("should keep returning HTTP 200 for an ordinary (non-timeout) tool error", async () => {
       // An ordinary error carries isError but no timeout discriminator, so the
       // legacy 200 + isError contract is preserved.
-      stubMaxOutlet({
-        content: [{ type: "text", text: "something went wrong" }],
-        isError: true,
-      });
-
-      const response = await callTool("ppal-connect");
+      const { response, body } = await callConnectReportingToolError(
+        "something went wrong",
+      );
 
       expect(response.status).toBe(200);
-
-      const body = await response.json();
-
       expect(body.isError).toBe(true);
       expect(body.result).toBe("something went wrong");
       expect(body.errorCode).toBeUndefined();

--- a/src/tools/actions/duplicate/tests/duplicate-arrangement-length.test.ts
+++ b/src/tools/actions/duplicate/tests/duplicate-arrangement-length.test.ts
@@ -10,41 +10,24 @@ import { duplicate } from "#src/tools/actions/duplicate/duplicate.ts";
 import {
   children,
   registerArrangementClip,
+  type RegisteredMockObject,
   registerMockObject,
   registerTrackWithArrangementDup,
 } from "#src/tools/actions/duplicate/helpers/duplicate-test-helpers.ts";
 import { createShortenedClipInHoldingMock, updateClipMock } from "./setup.ts";
 
-interface LengthMocks {
-  track0: ReturnType<typeof registerMockObject>;
-}
-
-function setupLengthMocks(): LengthMocks {
-  const track0 = registerTrackWithArrangementDup(0, {
-    arrangement_clips: children(livePath.track(0).arrangementClip(0)),
-  });
-
-  registerArrangementClip(0, 0, 16);
-  registerMockObject("live_set", { path: livePath.liveSet });
-
-  return { track0 };
-}
-
 describe("duplicate - arrangementLength functionality", () => {
   it("should duplicate a clip to arrangement with shorter length", async () => {
-    registerMockObject("clip1", {
-      path: livePath.track(0).clipSlot(0).clip(),
-      properties: {
-        length: 8,
-        looping: 0,
-        name: "Test Clip",
-        color: 4047616,
-        signature_numerator: 4,
-        signature_denominator: 4,
-        loop_start: 0,
-        loop_end: 8,
-        is_midi_clip: 1,
-      },
+    registerSourceClip({
+      length: 8,
+      looping: 0,
+      name: "Test Clip",
+      color: 4047616,
+      signature_numerator: 4,
+      signature_denominator: 4,
+      loop_start: 0,
+      loop_end: 8,
+      is_midi_clip: 1,
     });
 
     registerMockObject("live_set/tracks/0", {
@@ -72,56 +55,30 @@ describe("duplicate - arrangementLength functionality", () => {
   });
 
   it("should duplicate a looping clip with lengthening via updateClip", async () => {
-    registerMockObject("clip1", {
-      path: livePath.track(0).clipSlot(0).clip(),
-      properties: {
-        length: 4,
-        looping: 1,
-        name: "Test Clip",
-        color: 4047616,
-        signature_numerator: 4,
-        signature_denominator: 4,
-        loop_start: 0,
-        loop_end: 4,
-        is_midi_clip: 1,
-      },
+    registerSourceClip({
+      length: 4,
+      looping: 1,
+      name: "Test Clip",
+      color: 4047616,
+      signature_numerator: 4,
+      signature_denominator: 4,
+      loop_start: 0,
+      loop_end: 4,
+      is_midi_clip: 1,
     });
 
     const { track0 } = setupLengthMocks();
 
-    const result = await duplicate({
-      type: "clip",
-      id: "clip1",
-
-      arrangementStart: "5|1",
-      arrangementLength: "1bar+n/2", // 6 beats - longer than original 4 beats
-    });
-
-    // New implementation first duplicates the clip
-    expect(track0.call).toHaveBeenCalledWith(
-      "duplicate_clip_to_arrangement",
-      "id clip1",
-      16,
-    );
-
-    // Then delegates to updateClip for lengthening/tiling
-    // The mocked updateClip handles the complexity - its behavior is tested in update-clip.test.js
-    // Just verify the result structure is valid
-    // When updateClip returns a single clip, the result is the clip object directly
-    expect(result).toHaveProperty("arrangementStart", "5|1");
-    expect(result).toHaveProperty("id", livePath.track(0).arrangementClip(0));
+    await expectDuplicateDelegatesLengthening(track0, "1bar+n/2"); // 6 beats - longer than original 4 beats
   });
 
   it("returns the lengthened clip even when updateClip resolves asynchronously (regression for missing await)", async () => {
-    registerMockObject("clip1", {
-      path: livePath.track(0).clipSlot(0).clip(),
-      properties: {
-        length: 4,
-        looping: 1,
-        signature_numerator: 4,
-        signature_denominator: 4,
-        is_midi_clip: 1,
-      },
+    registerSourceClip({
+      length: 4,
+      looping: 1,
+      signature_numerator: 4,
+      signature_denominator: 4,
+      is_midi_clip: 1,
     });
 
     setupLengthMocks();
@@ -148,39 +105,18 @@ describe("duplicate - arrangementLength functionality", () => {
   });
 
   it("should duplicate a non-looping clip at original length when requested length is longer", async () => {
-    registerMockObject("clip1", {
-      path: livePath.track(0).clipSlot(0).clip(),
-      properties: {
-        length: 4,
-        looping: 0,
-        signature_numerator: 4,
-        signature_denominator: 4,
-        is_midi_clip: 1,
-      },
+    registerSourceClip({
+      length: 4,
+      looping: 0,
+      signature_numerator: 4,
+      signature_denominator: 4,
+      is_midi_clip: 1,
     });
 
     const { track0 } = setupLengthMocks();
 
-    const result = await duplicate({
-      type: "clip",
-      id: "clip1",
-
-      arrangementStart: "5|1",
-      arrangementLength: "2bar", // 8 beats - longer than original 4 beats
-    });
-
-    // New implementation duplicates then uses updateClip for lengthening
     // For non-looping clips, updateClip exposes hidden content or extends loop_end
-    // Just verify the result has the correct structure
-    expect(track0.call).toHaveBeenCalledWith(
-      "duplicate_clip_to_arrangement",
-      "id clip1",
-      16,
-    );
-
-    // When updateClip returns a single clip, the result is the clip object directly
-    expect(result).toHaveProperty("arrangementStart", "5|1");
-    expect(result).toHaveProperty("id", livePath.track(0).arrangementClip(0));
+    await expectDuplicateDelegatesLengthening(track0, "2bar"); // 8 beats - longer than original 4 beats
   });
 
   // arrangementLength resolves against the SONG time signature, consistent with
@@ -193,19 +129,16 @@ describe("duplicate - arrangementLength functionality", () => {
   ] as const)(
     "resolves arrangementLength bars against the song meter, not the %s clip meter (shortening)",
     async (label, numerator, denominator) => {
-      registerMockObject("clip1", {
-        path: livePath.track(0).clipSlot(0).clip(),
-        properties: {
-          length: 16, // longer than the 8-beat target → shortening path
-          looping: 0,
-          name: `Test Clip ${label}`,
-          color: 4047616,
-          signature_numerator: numerator,
-          signature_denominator: denominator,
-          loop_start: 0,
-          loop_end: 16,
-          is_midi_clip: 1,
-        },
+      registerSourceClip({
+        length: 16, // longer than the 8-beat target → shortening path
+        looping: 0,
+        name: `Test Clip ${label}`,
+        color: 4047616,
+        signature_numerator: numerator,
+        signature_denominator: denominator,
+        loop_start: 0,
+        loop_end: 16,
+        is_midi_clip: 1,
       });
 
       registerMockObject("live_set/tracks/0", { path: livePath.track(0) });
@@ -231,17 +164,14 @@ describe("duplicate - arrangementLength functionality", () => {
   );
 
   it("re-encodes the lengthen target in the song meter so a bar-aligned length round-trips through updateClip (3/4 clip, 4/4 song)", async () => {
-    registerMockObject("clip1", {
-      path: livePath.track(0).clipSlot(0).clip(),
-      properties: {
-        length: 3, // shorter than the 12-beat target → lengthening path
-        looping: 1,
-        signature_numerator: 3,
-        signature_denominator: 4,
-        loop_start: 0,
-        loop_end: 3,
-        is_midi_clip: 1,
-      },
+    registerSourceClip({
+      length: 3, // shorter than the 12-beat target → lengthening path
+      looping: 1,
+      signature_numerator: 3,
+      signature_denominator: 4,
+      loop_start: 0,
+      loop_end: 3,
+      is_midi_clip: 1,
     });
 
     setupLengthMocks(); // registers track0 (arrangement dup) + a 4/4 song meter
@@ -264,10 +194,7 @@ describe("duplicate - arrangementLength functionality", () => {
   });
 
   it("should error when arrangementLength is zero or negative", async () => {
-    registerMockObject("clip1", {
-      path: livePath.track(0).clipSlot(0).clip(),
-      properties: { length: 4, looping: 1 },
-    });
+    registerSourceClip({ length: 4, looping: 1 });
 
     registerMockObject("live_set", { path: livePath.liveSet });
 
@@ -285,10 +212,7 @@ describe("duplicate - arrangementLength functionality", () => {
   });
 
   it("should work normally without arrangementLength (backward compatibility)", async () => {
-    registerMockObject("clip1", {
-      path: livePath.track(0).clipSlot(0).clip(),
-      properties: { length: 8, looping: 0 },
-    });
+    registerSourceClip({ length: 8, looping: 0 });
 
     const track0 = registerTrackWithArrangementDup(0);
     const arrClip = registerArrangementClip(0, 0, 16);
@@ -322,3 +246,69 @@ describe("duplicate - arrangementLength functionality", () => {
     });
   });
 });
+
+// Register the source clip under test ("clip1") in the session slot every test
+// in this file duplicates from: track 0, scene 0.
+// Returns the registered mock object handle.
+function registerSourceClip(
+  properties: Record<string, unknown>,
+): RegisteredMockObject {
+  return registerMockObject("clip1", {
+    path: livePath.track(0).clipSlot(0).clip(),
+    properties,
+  });
+}
+
+interface LengthMocks {
+  track0: RegisteredMockObject;
+}
+
+// Register the mocks the lengthening path needs: a track 0 that can
+// duplicate_clip_to_arrangement (and reports one arrangement clip), the
+// resulting arrangement clip at beat 16, and a live_set with the default 4/4
+// song meter.
+// Returns the registered track 0 mock object handle.
+function setupLengthMocks(): LengthMocks {
+  const track0 = registerTrackWithArrangementDup(0, {
+    arrangement_clips: children(livePath.track(0).arrangementClip(0)),
+  });
+
+  registerArrangementClip(0, 0, 16);
+  registerMockObject("live_set", { path: livePath.liveSet });
+
+  return { track0 };
+}
+
+// Duplicate "clip1" to bar 5 with an arrangementLength longer than the clip,
+// then assert the shared lengthening contract: the implementation first
+// duplicates the clip into the arrangement at beat 16, then delegates to
+// updateClip for lengthening/tiling. The mocked updateClip handles the
+// complexity — its behavior is tested in update-clip.test.js — so we only check
+// that the single clip it returns is passed back as the result object directly.
+// Takes the track 0 mock handle and the arrangementLength to request; returns
+// the duplicate() result.
+async function expectDuplicateDelegatesLengthening(
+  track0: RegisteredMockObject,
+  arrangementLength: string,
+): Promise<unknown> {
+  const result = await duplicate({
+    type: "clip",
+    id: "clip1",
+
+    arrangementStart: "5|1",
+    arrangementLength,
+  });
+
+  expect(track0.call).toHaveBeenCalledWith(
+    "duplicate_clip_to_arrangement",
+    "id clip1",
+    16,
+  );
+
+  expect(result).toStrictEqual({
+    id: livePath.track(0).arrangementClip(0),
+    arrangementStart: "5|1",
+  });
+
+  return result;
+}

--- a/src/tools/device/read/tests/read-device-drum-pad-path.test.ts
+++ b/src/tools/device/read/tests/read-device-drum-pad-path.test.ts
@@ -52,6 +52,29 @@ function setupKickPadMocks(
   });
 }
 
+/**
+ * Setup the C1/Kick pad holding one chain ("Layer 1") that contains one Simpler
+ * device, reachable at "t1/d0/pC1/c0/d0" (or "t1/d0/pC1/d0" via implicit chain).
+ */
+function setupKickPadWithChainDevice() {
+  setupKickPadMocks({
+    padExtra: { chainIds: ["chain-1"] },
+    chainProperties: {
+      "chain-1": { name: "Layer 1", deviceIds: ["device-1"] },
+    },
+    deviceProperties: { "device-1": simplerDevice },
+  });
+}
+
+/**
+ * Assert a read result is the "device-1" Simpler instrument.
+ * @param result - The readDevice result to check
+ */
+function expectSimplerDeviceResult(result: Record<string, unknown>) {
+  expect(result.id).toBe("device-1");
+  expect(result.type).toBe("instrument: Simpler");
+}
+
 describe("readDevice with drum pad path", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -231,35 +254,21 @@ describe("readDevice with drum pad path", () => {
   });
 
   it("should read device inside drum pad chain", () => {
-    setupKickPadMocks({
-      padExtra: { chainIds: ["chain-1"] },
-      chainProperties: {
-        "chain-1": { name: "Layer 1", deviceIds: ["device-1"] },
-      },
-      deviceProperties: { "device-1": simplerDevice },
-    });
+    setupKickPadWithChainDevice();
 
     const result = readDevice({ path: "t1/d0/pC1/c0/d0" });
 
-    expect(result.id).toBe("device-1");
-    expect(result.type).toBe("instrument: Simpler");
+    expectSimplerDeviceResult(result);
   });
 
   it("should read device inside drum pad with implicit chain (pC1/d0)", () => {
-    setupKickPadMocks({
-      padExtra: { chainIds: ["chain-1"] },
-      chainProperties: {
-        "chain-1": { name: "Layer 1", deviceIds: ["device-1"] },
-      },
-      deviceProperties: { "device-1": simplerDevice },
-    });
+    setupKickPadWithChainDevice();
 
     // "pC1/d0" omits the chain segment; chain 0 is implied (== "pC1/c0/d0"),
     // matching the write-side pad-property shortcut.
     const result = readDevice({ path: "t1/d0/pC1/d0" });
 
-    expect(result.id).toBe("device-1");
-    expect(result.type).toBe("instrument: Simpler");
+    expectSimplerDeviceResult(result);
   });
 
   it("should throw error for invalid device index in drum pad chain", () => {
@@ -275,13 +284,7 @@ describe("readDevice with drum pad path", () => {
 
   it("should throw for a device index equal to the device count (boundary)", () => {
     // One device (index 0); "d1" is one past the end (pins the `>=` bound).
-    setupKickPadMocks({
-      padExtra: { chainIds: ["chain-1"] },
-      chainProperties: {
-        "chain-1": { name: "Layer 1", deviceIds: ["device-1"] },
-      },
-      deviceProperties: { "device-1": simplerDevice },
-    });
+    setupKickPadWithChainDevice();
 
     expect(() => readDevice({ path: "t1/d0/pC1/c0/d1" })).toThrow(
       "Invalid device index in path: t1/d0/pC1/c0/d1",
@@ -290,13 +293,7 @@ describe("readDevice with drum pad path", () => {
 
   it("should throw for a non-numeric device segment", () => {
     // "dX" parses to NaN; the NaN guard must reject it with the index error.
-    setupKickPadMocks({
-      padExtra: { chainIds: ["chain-1"] },
-      chainProperties: {
-        "chain-1": { name: "Layer 1", deviceIds: ["device-1"] },
-      },
-      deviceProperties: { "device-1": simplerDevice },
-    });
+    setupKickPadWithChainDevice();
 
     expect(() => readDevice({ path: "t1/d0/pC1/c0/dX" })).toThrow(
       "Invalid device index in path: t1/d0/pC1/c0/dX",

--- a/src/tools/device/read/tests/read-device-params.test.ts
+++ b/src/tools/device/read/tests/read-device-params.test.ts
@@ -14,19 +14,9 @@ describe("readDevice param-values include option", () => {
   });
 
   it("should include full parameters when param-values is requested", () => {
-    setupDeviceParamMocks({
-      strForValue: (value) => {
-        if (value === 0) return "-inf dB";
-        if (value === 1) return "0 dB";
+    setupDeviceParamMocks({ strForValue: dbStrForValue });
 
-        return "-6 dB";
-      },
-    });
-
-    const result = readDevice({
-      deviceId: "device-123",
-      include: ["param-values"],
-    });
+    const { result } = readDeviceParamValues();
 
     expect(result).toStrictEqual({
       id: "device-123",
@@ -55,14 +45,9 @@ describe("readDevice param-values include option", () => {
       },
     });
 
-    const result = readDevice({
-      deviceId: "device-123",
-      include: ["param-values"],
-    });
+    const { params } = readDeviceParamValues();
 
     // Quantized params now have value as string and options array
-    const params = result.parameters as Record<string, unknown>[];
-
     expect(params[0]).toStrictEqual({
       id: "param-1",
       name: "Device On",
@@ -77,12 +62,7 @@ describe("readDevice param-values include option", () => {
       strForValue: () => "50",
     });
 
-    const result = readDevice({
-      deviceId: "device-123",
-      include: ["param-values"],
-    });
-
-    const params = result.parameters as Record<string, unknown>[];
+    const { params } = readDeviceParamValues();
 
     expect(params[0]!.state).toBe("inactive");
   });
@@ -101,14 +81,9 @@ describe("readDevice param-values include option", () => {
       strForValue: (value) => String(value),
     });
 
-    const result = readDevice({
-      deviceId: "device-123",
-      include: ["param-values"],
-    });
+    const { params } = readDeviceParamValues();
 
     // min and max should always be included for numeric params
-    const params = result.parameters as Record<string, unknown>[];
-
     expect(params[0]).toHaveProperty("min", 0);
     expect(params[0]).toHaveProperty("max", 48);
     expect(params[0]!.value).toBe(12);
@@ -127,14 +102,9 @@ describe("readDevice param-values include option", () => {
       },
     });
 
-    const result = readDevice({
-      deviceId: "device-123",
-      include: ["param-values"],
-    });
+    const { params } = readDeviceParamValues();
 
     // Quantized params should have options, not min/max
-    const params = result.parameters as Record<string, unknown>[];
-
     expect(params[0]).not.toHaveProperty("min");
     expect(params[0]).not.toHaveProperty("max");
     expect(params[0]).toHaveProperty("options");
@@ -161,12 +131,7 @@ describe("readDevice param-values include option", () => {
       },
     });
 
-    const result = readDevice({
-      deviceId: "device-123",
-      include: ["param-values"],
-    });
-
-    const params = result.parameters as Record<string, unknown>[];
+    const { params } = readDeviceParamValues();
 
     expect(params[0]).toStrictEqual({
       id: "param-1",
@@ -178,42 +143,18 @@ describe("readDevice param-values include option", () => {
     });
   });
 
-  /**
-   * Setup mocks for automation tests
-   * @param automationState - Automation state value
-   */
-  function setupAutomationMocks(automationState: number) {
-    setupDeviceParamMocks({
-      param: { automation_state: automationState },
-      strForValue: (value) => {
-        if (value === 0) return "-inf dB";
-        if (value === 1) return "0 dB";
-
-        return "-6 dB";
-      },
-    });
-  }
-
   it("should include automation when not 'none'", () => {
     setupAutomationMocks(1);
-    const result = readDevice({
-      deviceId: "device-123",
-      include: ["param-values"],
-    });
 
-    const params = result.parameters as Record<string, unknown>[];
+    const { params } = readDeviceParamValues();
 
     expect(params[0]!.automation).toBe("active");
   });
 
   it("should omit automation when 'none'", () => {
     setupAutomationMocks(0);
-    const result = readDevice({
-      deviceId: "device-123",
-      include: ["param-values"],
-    });
 
-    const params = result.parameters as Record<string, unknown>[];
+    const { params } = readDeviceParamValues();
 
     expect(params[0]).not.toHaveProperty("automation");
   });
@@ -241,3 +182,45 @@ describe("readDevice params include option (lightweight)", () => {
     ]);
   });
 });
+
+/**
+ * Reads the mocked device with the "param-values" include.
+ * @returns The whole read result plus its parameter list, cast for property assertions
+ */
+function readDeviceParamValues(): {
+  result: ReturnType<typeof readDevice>;
+  params: Record<string, unknown>[];
+} {
+  const result = readDevice({
+    deviceId: "device-123",
+    include: ["param-values"],
+  });
+
+  return {
+    result,
+    params: result.parameters as Record<string, unknown>[],
+  };
+}
+
+/**
+ * Stubs Live's str_for_value for a dB-scaled parameter.
+ * @param value - The normalized parameter value Live is asking about
+ * @returns The dB label Live would display for that value
+ */
+function dbStrForValue(value: unknown): string {
+  if (value === 0) return "-inf dB";
+  if (value === 1) return "0 dB";
+
+  return "-6 dB";
+}
+
+/**
+ * Setup mocks for automation tests
+ * @param automationState - Automation state value
+ */
+function setupAutomationMocks(automationState: number): void {
+  setupDeviceParamMocks({
+    param: { automation_state: automationState },
+    strForValue: dbStrForValue,
+  });
+}

--- a/src/tools/shared/arrangement/tests/arrangement-splitting.test.ts
+++ b/src/tools/shared/arrangement/tests/arrangement-splitting.test.ts
@@ -82,6 +82,17 @@ function expectCreateMidiClipCount(
   expect(createMidiCalls).toHaveLength(count);
 }
 
+// Assert a split ran (segments were duplicated) and produced exactly `count`
+// create_midi_clip trims — the signature of which EPSILON-boundary trim steps
+// were skipped.
+function expectSplitTrimCount(
+  trackMock: RegisteredMockObject,
+  count: number,
+): void {
+  expectDuplicateCalled(trackMock);
+  expectCreateMidiClipCount(trackMock, count);
+}
+
 describe("prepareSplitParams", () => {
   function setupPrepareTest(): {
     mockClip: LiveAPI;
@@ -440,14 +451,7 @@ describe("performSplitting", () => {
   });
 
   it("should split into 3 segments exercising middle segment extraction", () => {
-    const clipId = "clip_1";
-
-    const { callState } = setupClipSplittingMocks(clipId, {
-      looping: true,
-      endTime: 12.0, // 12-beat clip
-      loopEnd: 4.0,
-    });
-    const { mockClip, clips } = createPerformContext(clipId);
+    const { callState, mockClip, clips } = setupSplitTest(TWELVE_BEAT_LOOPED);
 
     // Split a 12-beat clip at 4 and 8 beats → 3 segments
     performSplitting([mockClip], [4, 8], clips, HOLDING_AREA);
@@ -619,59 +623,34 @@ describe("performSplitting", () => {
   });
 
   it("should skip right-trim when split point is within EPSILON of clip end", () => {
-    const clipId = "clip_1";
-
     // Clip of 8 beats, split at ~8 beats (within EPSILON of clip end)
     // This means rightTrimLen <= EPSILON, skipping the right-trim step
-    const { callState } = setupClipSplittingMocks(clipId, {
-      looping: true,
-      endTime: 8.0,
-      loopEnd: 4.0,
-    });
-    const { mockClip, clips } = createPerformContext(clipId);
+    const { callState, mockClip, clips } = setupSplitTest(EIGHT_BEAT_LOOPED);
 
     // Split at 7.9999 (almost the full clip length of 8)
     // rightTrimLen = 8 - 7.9999 = 0.0001 which is <= EPSILON (0.001)
     performSplitting([mockClip], [7.9999], clips, HOLDING_AREA);
 
-    expectDuplicateCalled(callState.trackMock);
-
     // Normal 2-segment split needs 2 create_midi_clip (right-trim + left-trim).
     // Right-trim skipped (0.0001 <= EPSILON), only left-trim remains.
-    expectCreateMidiClipCount(callState.trackMock, 1);
+    expectSplitTrimCount(callState.trackMock, 1);
   });
 
   it("should skip left-trim when last segment starts within EPSILON of clip start", () => {
-    const clipId = "clip_1";
-
     // Clip of 8 beats, split very close to the start
-    const { callState } = setupClipSplittingMocks(clipId, {
-      looping: true,
-      endTime: 8.0,
-      loopEnd: 4.0,
-    });
-    const { mockClip, clips } = createPerformContext(clipId);
+    const { callState, mockClip, clips } = setupSplitTest(EIGHT_BEAT_LOOPED);
 
     // Split at 0.0005 beats (within EPSILON of 0)
     // lastSegStart = 0.0005 which is <= EPSILON, skipping left-trim for last segment
     performSplitting([mockClip], [0.0005], clips, HOLDING_AREA);
 
-    expectDuplicateCalled(callState.trackMock);
-
     // Normal 2-segment split needs 2 create_midi_clip (right-trim + left-trim).
     // Left-trim skipped (0.0005 <= EPSILON), only right-trim remains.
-    expectCreateMidiClipCount(callState.trackMock, 1);
+    expectSplitTrimCount(callState.trackMock, 1);
   });
 
   it("should skip both trims for middle segment at EPSILON boundaries", () => {
-    const clipId = "clip_1";
-
-    const { callState } = setupClipSplittingMocks(clipId, {
-      looping: true,
-      endTime: 12.0,
-      loopEnd: 4.0,
-    });
-    const { mockClip, clips } = createPerformContext(clipId);
+    const { callState, mockClip, clips } = setupSplitTest(TWELVE_BEAT_LOOPED);
 
     // 3-segment split at boundaries very close to 0 and clip end.
     // Middle segment: segStart=0.0005 (<=EPSILON), segEnd=11.9995
@@ -680,14 +659,12 @@ describe("performSplitting", () => {
     // for the middle segment extraction.
     performSplitting([mockClip], [0.0005, 11.9995], clips, HOLDING_AREA);
 
-    expectDuplicateCalled(callState.trackMock);
-
     // Step 2: seg0 right-trim (11.9995 > EPSILON) → happens
     // Step 3: middle segment left-trim (0.0005 <= EPSILON) → skipped
     //         middle segment right-trim (0.0005 <= EPSILON) → skipped
     // Step 4: last segment left-trim (11.9995 > EPSILON) → happens
     // Normal 3-segment split would have 4 create_midi_clip calls;
     // skipping both middle trims leaves 2.
-    expectCreateMidiClipCount(callState.trackMock, 2);
+    expectSplitTrimCount(callState.trackMock, 2);
   });
 });

--- a/src/tools/shared/device/tests/simpler-sample.test.ts
+++ b/src/tools/shared/device/tests/simpler-sample.test.ts
@@ -35,14 +35,19 @@ function registerSimpler(opts: { multiSampleMode?: number } = {}) {
  * Register a Simpler with a loaded sample child and return the sample mock.
  * @param opts - Options
  * @param opts.gain - Current linear gain on the sample (default 1)
+ * @param opts.filePath - Sample file path (default "/tmp/kick.wav"; "" models a
+ *   sample child with nothing loaded)
  * @returns The Sample mock object
  */
 function registerSimplerWithSample(
-  opts: { gain?: number } = {},
+  opts: { gain?: number; filePath?: string } = {},
 ): RegisteredMockObject {
   const sample = registerMockObject("sample-1", {
     type: "Sample",
-    properties: { file_path: "/tmp/kick.wav", gain: opts.gain ?? 1 },
+    properties: {
+      file_path: opts.filePath ?? "/tmp/kick.wav",
+      gain: opts.gain ?? 1,
+    },
   });
 
   registerMockObject("simpler-1", {
@@ -57,6 +62,21 @@ function registerSimplerWithSample(
   });
 
   return sample;
+}
+
+/**
+ * Register a non-Simpler device (an Operator) at the first track's first slot.
+ * @returns The device mock object
+ */
+function registerOperator(): RegisteredMockObject {
+  return registerMockObject("op-1", {
+    path: livePath.track(0).device(0),
+    type: "Device",
+    properties: {
+      class_display_name: "Operator",
+      parameters: children(),
+    },
+  });
 }
 
 describe("setSimplerSample", () => {
@@ -88,14 +108,7 @@ describe("setSimplerSample", () => {
   });
 
   it("warns and skips on non-Simpler devices, naming the device class", () => {
-    const device = registerMockObject("op-1", {
-      path: livePath.track(0).device(0),
-      type: "Device",
-      properties: {
-        class_display_name: "Operator",
-        parameters: children(),
-      },
-    });
+    const device = registerOperator();
 
     setSimplerSample(LiveAPI.from("id op-1"), "/tmp/kick.wav", "updateDevice");
 
@@ -213,14 +226,7 @@ describe("setSimplerSample", () => {
   });
 
   it("uses the toolName parameter as warning prefix", () => {
-    registerMockObject("op-1", {
-      path: livePath.track(0).device(0),
-      type: "Device",
-      properties: {
-        class_display_name: "Operator",
-        parameters: children(),
-      },
-    });
+    registerOperator();
 
     setSimplerSample(LiveAPI.from("id op-1"), "/tmp/kick.wav", "createDevice");
 
@@ -263,20 +269,7 @@ describe("probeSimplerSample", () => {
   });
 
   it("reports empty when the loaded sample has no file path", () => {
-    registerMockObject("sample-1", {
-      type: "Sample",
-      properties: { file_path: "" },
-    });
-    registerMockObject("simpler-1", {
-      path: livePath.track(0).device(0),
-      type: "SimplerDevice",
-      properties: {
-        class_display_name: "Simpler",
-        multi_sample_mode: 0,
-        parameters: children(),
-        sample: ["id", "sample-1"],
-      },
-    });
+    registerSimplerWithSample({ filePath: "" });
 
     expect(
       probeSimplerSample(LiveAPI.from("id simpler-1"), "Simpler"),
@@ -318,14 +311,7 @@ describe("setSimplerGain", () => {
   });
 
   it("warns and skips on non-Simpler devices", () => {
-    const device = registerMockObject("op-1", {
-      path: livePath.track(0).device(0),
-      type: "Device",
-      properties: {
-        class_display_name: "Operator",
-        parameters: children(),
-      },
-    });
+    const device = registerOperator();
 
     setSimplerGain(LiveAPI.from("id op-1"), 0, "updateDevice");
 

--- a/src/tools/track/update/tests/update-track-send.test.ts
+++ b/src/tools/track/update/tests/update-track-send.test.ts
@@ -108,12 +108,7 @@ describe("updateTrack - send properties", () => {
       sendGainDb: -12,
     });
 
-    expect(send1.set).not.toHaveBeenCalled();
-    expect(outlet).toHaveBeenCalledWith(
-      1,
-      expect.stringContaining("must both be specified"),
-    );
-    expect(result).toStrictEqual({ id: "123" });
+    expectSendUpdateSkipped(result, [send1, send2], "must both be specified");
   });
 
   it("should warn and skip when only sendReturn is provided", () => {
@@ -123,12 +118,7 @@ describe("updateTrack - send properties", () => {
       sendReturn: "A",
     });
 
-    expect(send1.set).not.toHaveBeenCalled();
-    expect(outlet).toHaveBeenCalledWith(
-      1,
-      expect.stringContaining("must both be specified"),
-    );
-    expect(result).toStrictEqual({ id: "123" });
+    expectSendUpdateSkipped(result, [send1, send2], "must both be specified");
   });
 
   it("should warn and skip when return track not found", () => {
@@ -141,13 +131,11 @@ describe("updateTrack - send properties", () => {
       sendReturn: "C",
     });
 
-    expect(send1.set).not.toHaveBeenCalled();
-    expect(send2.set).not.toHaveBeenCalled();
-    expect(outlet).toHaveBeenCalledWith(
-      1,
-      expect.stringContaining('no return track found matching "C"'),
+    expectSendUpdateSkipped(
+      result,
+      [send1, send2],
+      'no return track found matching "C"',
     );
-    expect(result).toStrictEqual({ id: "123" });
   });
 
   it("should not over-match a return whose name merely starts with the letter", () => {
@@ -165,12 +153,11 @@ describe("updateTrack - send properties", () => {
       sendReturn: "A",
     });
 
-    expect(send1.set).not.toHaveBeenCalled();
-    expect(outlet).toHaveBeenCalledWith(
-      1,
-      expect.stringContaining('no return track found matching "A"'),
+    expectSendUpdateSkipped(
+      result,
+      [send1, send2],
+      'no return track found matching "A"',
     );
-    expect(result).toStrictEqual({ id: "123" });
   });
 
   it("should warn and skip when track has no sends", () => {
@@ -187,11 +174,7 @@ describe("updateTrack - send properties", () => {
       sendReturn: "A",
     });
 
-    expect(outlet).toHaveBeenCalledWith(
-      1,
-      expect.stringContaining("has no sends"),
-    );
-    expect(result).toStrictEqual({ id: "123" });
+    expectSendUpdateSkipped(result, [send1, send2], "has no sends");
   });
 
   it("should set sends on multiple tracks", () => {
@@ -241,11 +224,7 @@ describe("updateTrack - send properties", () => {
       sendReturn: "A",
     });
 
-    expect(outlet).toHaveBeenCalledWith(
-      1,
-      expect.stringContaining("has no mixer device"),
-    );
-    expect(result).toStrictEqual({ id: "123" });
+    expectSendUpdateSkipped(result, [send1, send2], "has no mixer device");
   });
 
   it("should warn and skip when send index exceeds available sends", () => {
@@ -268,12 +247,26 @@ describe("updateTrack - send properties", () => {
       sendReturn: "C", // Matches return track at index 2
     });
 
-    expect(send1.set).not.toHaveBeenCalled();
-    expect(send2.set).not.toHaveBeenCalled();
-    expect(outlet).toHaveBeenCalledWith(
-      1,
-      expect.stringContaining("doesn't exist on track"),
-    );
-    expect(result).toStrictEqual({ id: "123" });
+    expectSendUpdateSkipped(result, [send1, send2], "doesn't exist on track");
   });
 });
+
+// Asserts that updateTrack declined to apply a send update: none of the given
+// sends were written, the warning was relayed to the LLM on outlet 1, and the
+// track itself still reported a plain success result (warn-and-skip must never
+// throw, so partial successes can continue across tracks).
+function expectSendUpdateSkipped(
+  result: ReturnType<typeof updateTrack>,
+  sends: RegisteredMockObject[],
+  expectedWarning: string,
+): void {
+  for (const send of sends) {
+    expect(send.set).not.toHaveBeenCalled();
+  }
+
+  expect(outlet).toHaveBeenCalledWith(
+    1,
+    expect.stringContaining(expectedWarning),
+  );
+  expect(result).toStrictEqual({ id: "123" });
+}

--- a/webui/src/hooks/chat/tests/conversations/use-conversations-branching.test.ts
+++ b/webui/src/hooks/chat/tests/conversations/use-conversations-branching.test.ts
@@ -21,6 +21,9 @@ import {
   waitForEffects,
 } from "./use-conversations-test-helpers";
 
+/** The injectable pending-fork signal the hook consumes on save. */
+type PendingForkRef = { current: PendingFork | null };
+
 /**
  * Render useConversations with an injectable pending-fork signal.
  * @returns Hook result, the mutable chat-history state, and the fork ref
@@ -54,6 +57,43 @@ async function save(
   await act(() => result.current.saveCurrentConversation());
 }
 
+/**
+ * Render the hook and persist ORIGINAL as the trunk conversation.
+ * @returns Hook result, chat-history state, the fork ref, and the trunk's id
+ */
+async function setupWithSavedOriginal() {
+  const { result, state, pendingForkRef } = await setupForkHook();
+
+  await save(result, state, ORIGINAL);
+  const originalId = result.current.activeConversationId!;
+
+  return { result, state, pendingForkRef, originalId };
+}
+
+/**
+ * Raise the pending-fork signal, then save history as the forked sibling.
+ * @param result - Hook result ref
+ * @param state - Mutable chat-history state
+ * @param pendingForkRef - Injected pending-fork signal ref
+ * @param history - Chat history to persist as the fork
+ * @param anchorIndex - Message index the fork branches from
+ * @returns The active conversation id after the save
+ */
+async function saveAsFork(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- loose test typing
+  result: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- loose test typing
+  state: any,
+  pendingForkRef: PendingForkRef,
+  history: { role: string; content: string }[],
+  anchorIndex = 0,
+): Promise<string> {
+  pendingForkRef.current = { anchorIndex };
+  await save(result, state, history);
+
+  return result.current.activeConversationId!;
+}
+
 const ORIGINAL = [
   { role: "user", content: "original question" },
   { role: "assistant", content: "original answer" },
@@ -67,14 +107,10 @@ describe("useConversations branching", () => {
   beforeEach(resetConversationsTestState);
 
   it("forks into a new record and leaves the original intact", async () => {
-    const { result, state, pendingForkRef } = await setupForkHook();
+    const { result, state, pendingForkRef, originalId } =
+      await setupWithSavedOriginal();
 
-    await save(result, state, ORIGINAL);
-    const originalId = result.current.activeConversationId!;
-
-    pendingForkRef.current = { anchorIndex: 0 };
-    await save(result, state, FORKED);
-    const forkId = result.current.activeConversationId!;
+    const forkId = await saveAsFork(result, state, pendingForkRef, FORKED);
 
     expect(forkId).not.toBe(originalId);
     expect(pendingForkRef.current).toBeNull(); // signal consumed
@@ -90,14 +126,10 @@ describe("useConversations branching", () => {
   });
 
   it("keeps branch linkage on a later (post-response) save", async () => {
-    const { result, state, pendingForkRef } = await setupForkHook();
+    const { result, state, pendingForkRef, originalId } =
+      await setupWithSavedOriginal();
 
-    await save(result, state, ORIGINAL);
-    const originalId = result.current.activeConversationId!;
-
-    pendingForkRef.current = { anchorIndex: 0 };
-    await save(result, state, FORKED);
-    const forkId = result.current.activeConversationId!;
+    const forkId = await saveAsFork(result, state, pendingForkRef, FORKED);
 
     // A normal save follows with no fork pending (e.g. the autosave after the
     // assistant finishes responding). It must not strip the branch fields.
@@ -116,10 +148,8 @@ describe("useConversations branching", () => {
   });
 
   it("preserves branch linkage when a follow-up save is fired before the fork save resolves", async () => {
-    const { result, state, pendingForkRef } = await setupForkHook();
-
-    await save(result, state, ORIGINAL);
-    const originalId = result.current.activeConversationId!;
+    const { result, state, pendingForkRef, originalId } =
+      await setupWithSavedOriginal();
 
     // Fire the fork save and an immediate follow-up without awaiting the fork
     // save first. Serialized saves keep the read-after-write ordering, so the
@@ -153,11 +183,9 @@ describe("useConversations branching", () => {
   });
 
   it("collapses the branch family to one list entry, represented by the active sibling", async () => {
-    const { result, state, pendingForkRef } = await setupForkHook();
+    const { result, state, pendingForkRef } = await setupWithSavedOriginal();
 
-    await save(result, state, ORIGINAL);
-    pendingForkRef.current = { anchorIndex: 0 };
-    await save(result, state, FORKED);
+    await saveAsFork(result, state, pendingForkRef, FORKED);
 
     // Pass the active id (as the hook's refreshList does) so the family is
     // represented by the sibling being viewed. This is also deterministic when
@@ -170,21 +198,21 @@ describe("useConversations branching", () => {
   });
 
   it("attaches a re-fork at the same point to the original trunk", async () => {
-    const { result, state, pendingForkRef } = await setupForkHook();
-
-    await save(result, state, ORIGINAL);
-    const trunkId = result.current.activeConversationId!;
+    const {
+      result,
+      state,
+      pendingForkRef,
+      originalId: trunkId,
+    } = await setupWithSavedOriginal();
 
     // First fork.
-    pendingForkRef.current = { anchorIndex: 0 };
-    await save(result, state, FORKED);
-    const firstForkId = result.current.activeConversationId!;
+    const firstForkId = await saveAsFork(result, state, pendingForkRef, FORKED);
 
     // Re-fork the first fork at the same point: should share the trunk, not
     // chain off the first fork.
-    pendingForkRef.current = { anchorIndex: 0 };
-    await save(result, state, [{ role: "user", content: "third take" }]);
-    const secondForkId = result.current.activeConversationId!;
+    const secondForkId = await saveAsFork(result, state, pendingForkRef, [
+      { role: "user", content: "third take" },
+    ]);
 
     const secondFork = await loadConversation(secondForkId);
 
@@ -197,10 +225,9 @@ describe("useConversations branching", () => {
     const { result, state, pendingForkRef } = await setupForkHook();
 
     // Fork signal set with no active conversation (nothing saved yet).
-    pendingForkRef.current = { anchorIndex: 0 };
-    await save(result, state, ORIGINAL);
+    const savedId = await saveAsFork(result, state, pendingForkRef, ORIGINAL);
 
-    const saved = await loadConversation(result.current.activeConversationId!);
+    const saved = await loadConversation(savedId);
 
     expect(saved?.forkParentId).toBeUndefined();
     expect(saved?.forkedAtIndex).toBeUndefined();
@@ -208,16 +235,13 @@ describe("useConversations branching", () => {
   });
 
   it("consumes a leaked fork signal on an empty-history save so a later save isn't mis-branched", async () => {
-    const { result, state, pendingForkRef } = await setupForkHook();
-
-    await save(result, state, ORIGINAL);
-    const originalId = result.current.activeConversationId!;
+    const { result, state, pendingForkRef, originalId } =
+      await setupWithSavedOriginal();
 
     // A fork aborted before streaming any content (e.g. edit the first message,
     // then Stop) reaches the save with empty history. The signal must be
     // consumed here even though there's nothing to persist...
-    pendingForkRef.current = { anchorIndex: 0 };
-    await save(result, state, []);
+    await saveAsFork(result, state, pendingForkRef, []);
 
     expect(pendingForkRef.current).toBeNull(); // consumed despite empty history
     expect(result.current.activeConversationId).toBe(originalId); // no new record

--- a/webui/src/hooks/chat/tests/conversations/use-conversations-delete-race.test.ts
+++ b/webui/src/hooks/chat/tests/conversations/use-conversations-delete-race.test.ts
@@ -82,6 +82,56 @@ async function expectLateAutosaveDropped(
   restore();
 }
 
+/**
+ * Drive the bulk-delete race for an already-saved active conversation: save one
+ * conversation, fire `bulkDelete` concurrently with a late autosave, and assert
+ * the row is gone both when the delete settles and after the gated late write
+ * lands (releasing it must not resurrect the cleared conversation).
+ * @param bulkDelete - the bulk delete under test, read off the live hook result
+ */
+async function expectBulkDeleteDropsSavedLateAutosave(
+  bulkDelete: (result: HookHandle["result"]) => Promise<void>,
+): Promise<void> {
+  const handle = await setupHook();
+  const { state, result } = handle;
+
+  await saveWithMessage(state, result);
+  const savedId = result.current.activeConversationId!;
+
+  await expectLateAutosaveDropped(
+    handle,
+    () => bulkDelete(result),
+    async () => {
+      expect(result.current.conversations).toHaveLength(0);
+      expect(await loadConversation(savedId)).toBeUndefined();
+    },
+    async () => expect(await loadConversation(savedId)).toBeUndefined(),
+  );
+}
+
+/**
+ * Drive the bulk-delete race for a never-saved conversation (activeConversationId
+ * === null, its id minted lazily inside the teardown autosave): fire `bulkDelete`
+ * concurrently with that late autosave and assert no zombie row survives, either
+ * when the delete settles or after the gated late write lands.
+ * @param bulkDelete - the bulk delete under test, read off the live hook result
+ */
+async function expectBulkDeleteDropsNeverSavedLateAutosave(
+  bulkDelete: (result: HookHandle["result"]) => Promise<void>,
+): Promise<void> {
+  const handle = await setupHook();
+  const { result } = handle;
+
+  expect(result.current.activeConversationId).toBeNull();
+
+  await expectLateAutosaveDropped(
+    handle,
+    () => bulkDelete(result),
+    () => expect(result.current.conversations).toHaveLength(0),
+    () => expect(result.current.conversations).toHaveLength(0),
+  );
+}
+
 describe("useConversations delete/save races", () => {
   beforeEach(resetConversationsTestState);
 
@@ -113,20 +163,8 @@ describe("useConversations delete/save races", () => {
   it("deleteAll drops a late autosave for the just-cleared conversation", async () => {
     // F2: bulk deletes had no drain and no guard. The active conversation's
     // teardown autosave must not survive the clear.
-    const handle = await setupHook();
-    const { state, result } = handle;
-
-    await saveWithMessage(state, result);
-    const savedId = result.current.activeConversationId!;
-
-    await expectLateAutosaveDropped(
-      handle,
-      () => result.current.deleteAllConversations(),
-      async () => {
-        expect(result.current.conversations).toHaveLength(0);
-        expect(await loadConversation(savedId)).toBeUndefined();
-      },
-      async () => expect(await loadConversation(savedId)).toBeUndefined(),
+    await expectBulkDeleteDropsSavedLateAutosave((result) =>
+      result.current.deleteAllConversations(),
     );
   });
 
@@ -152,20 +190,8 @@ describe("useConversations delete/save races", () => {
   });
 
   it("deleteUnbookmarked drops a late autosave for the deleted active conversation", async () => {
-    const handle = await setupHook();
-    const { state, result } = handle;
-
-    await saveWithMessage(state, result);
-    const savedId = result.current.activeConversationId!;
-
-    await expectLateAutosaveDropped(
-      handle,
-      () => result.current.deleteUnbookmarkedConversations(),
-      async () => {
-        expect(result.current.conversations).toHaveLength(0);
-        expect(await loadConversation(savedId)).toBeUndefined();
-      },
-      async () => expect(await loadConversation(savedId)).toBeUndefined(),
+    await expectBulkDeleteDropsSavedLateAutosave((result) =>
+      result.current.deleteUnbookmarkedConversations(),
     );
   });
 
@@ -196,34 +222,19 @@ describe("useConversations delete/save races", () => {
     // null; its id is minted lazily inside the teardown autosave. Without
     // reserving that id the bulk delete can't cancel it, so the late save writes
     // a surviving zombie row after the store was cleared.
-    const handle = await setupHook();
-    const { result } = handle;
-
-    expect(result.current.activeConversationId).toBeNull();
-
-    // The stream-teardown autosave for the never-saved conversation, enqueued
-    // after the bulk delete reserved its pending-new id.
-    await expectLateAutosaveDropped(
-      handle,
-      () => result.current.deleteAllConversations(),
-      () => expect(result.current.conversations).toHaveLength(0),
-      () => expect(result.current.conversations).toHaveLength(0),
+    //
+    // The gated late save is the stream-teardown autosave for the never-saved
+    // conversation, enqueued after the bulk delete reserved its pending-new id.
+    await expectBulkDeleteDropsNeverSavedLateAutosave((result) =>
+      result.current.deleteAllConversations(),
     );
   });
 
   it("deleteUnbookmarked drops a late autosave for a never-saved conversation (activeId null)", async () => {
     // G2 sibling: a never-saved conversation is implicitly unbookmarked, so the
     // unbookmarked bulk delete sweeps it too and must cancel its lazily-minted id.
-    const handle = await setupHook();
-    const { result } = handle;
-
-    expect(result.current.activeConversationId).toBeNull();
-
-    await expectLateAutosaveDropped(
-      handle,
-      () => result.current.deleteUnbookmarkedConversations(),
-      () => expect(result.current.conversations).toHaveLength(0),
-      () => expect(result.current.conversations).toHaveLength(0),
+    await expectBulkDeleteDropsNeverSavedLateAutosave((result) =>
+      result.current.deleteUnbookmarkedConversations(),
     );
   });
 

--- a/webui/src/hooks/chat/tests/use-compaction.test.ts
+++ b/webui/src/hooks/chat/tests/use-compaction.test.ts
@@ -7,7 +7,7 @@
  * @vitest-environment happy-dom
  */
 import { act, renderHook } from "@testing-library/preact";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, type Mock, vi } from "vitest";
 import { useCompaction } from "#webui/hooks/chat/use-compaction";
 import {
   createMockAdapter,
@@ -25,6 +25,36 @@ function ui(role: "user" | "model", rawHistoryIndex: number): UIMessage {
   };
 }
 
+/**
+ * Builds `turnCount` user/assistant exchanges of client history, numbered from
+ * 1 (u1/a1, u2/a2, …). Used both to seed MockChatClient.chatHistory and to
+ * assert what was handed to summarize(), so the two always line up.
+ * @param turnCount - Number of user/assistant exchanges to build
+ * @returns The flat history, two messages per turn
+ */
+function turns(turnCount: number): TestMessage[] {
+  const history: TestMessage[] = [];
+
+  for (let turn = 1; turn <= turnCount; turn++) {
+    history.push({ role: "user", content: `u${turn}` });
+    history.push({ role: "assistant", content: `a${turn}` });
+  }
+
+  return history;
+}
+
+/**
+ * The UI-message view of `turns(turnCount)`: one user/model pair per turn, with
+ * rawHistoryIndex tracking the flat history positions.
+ * @param turnCount - Number of user/assistant exchanges to build
+ * @returns The UI messages, two per turn
+ */
+function uiTurns(turnCount: number): UIMessage[] {
+  return turns(turnCount).map((message, index) =>
+    ui(message.role === "user" ? "user" : "model", index),
+  );
+}
+
 interface SetupOptions {
   chatHistory?: TestMessage[];
   messages?: UIMessage[];
@@ -36,16 +66,13 @@ interface SetupOptions {
 function setup(opts: SetupOptions = {}) {
   const client = new MockChatClient();
 
-  client.chatHistory = opts.chatHistory ?? [
-    { role: "user", content: "u1" },
-    { role: "assistant", content: "a1" },
-  ];
+  client.chatHistory = opts.chatHistory ?? turns(1);
 
   const clientRef = { current: opts.noClient ? null : client };
   const adapter = createMockAdapter();
   const setMessages = vi.fn();
   const autoSave = vi.fn();
-  const messages = opts.messages ?? [ui("user", 0), ui("model", 1)];
+  const messages = opts.messages ?? uiTurns(1);
 
   const { result } = renderHook(() =>
     useCompaction({
@@ -62,22 +89,44 @@ function setup(opts: SetupOptions = {}) {
   return { result, client, clientRef, adapter, setMessages, autoSave };
 }
 
+type CompactionHook = ReturnType<typeof setup>["result"];
+
+/**
+ * Runs the hook's compact() for a targeted message index inside act(), so the
+ * resulting state updates are flushed before the test asserts.
+ * @param result - The rendered useCompaction result from setup()
+ * @param mergedMessageIndex - Index of the UI message the compact button targets
+ */
+async function compactAt(
+  result: CompactionHook,
+  mergedMessageIndex: number,
+): Promise<void> {
+  await act(async () => {
+    await result.current.compact(mergedMessageIndex);
+  });
+}
+
+/**
+ * Asserts compact() bailed out entirely: it never summarized and never touched
+ * the UI messages.
+ * @param client - The mock chat client from setup()
+ * @param setMessages - The setMessages spy from setup()
+ */
+function expectNoCompaction(client: MockChatClient, setMessages: Mock): void {
+  expect(client.summarize).not.toHaveBeenCalled();
+  expect(setMessages).not.toHaveBeenCalled();
+}
+
 describe("useCompaction", () => {
   it("compacts the whole conversation when the last message is targeted", async () => {
     const { result, client, setMessages, autoSave } = setup();
 
-    await act(async () => {
-      await result.current.compact(1);
-    });
+    await compactAt(result, 1);
 
-    expect(client.summarize).toHaveBeenCalledWith([
-      { role: "user", content: "u1" },
-      { role: "assistant", content: "a1" },
-    ]);
+    expect(client.summarize).toHaveBeenCalledWith(turns(1));
     // Non-destructive: prior turns are kept and the summary marker is appended.
     expect(client.chatHistory).toStrictEqual([
-      { role: "user", content: "u1" },
-      { role: "assistant", content: "a1" },
+      ...turns(1),
       { role: "user", content: "Summary of 2 messages" },
     ]);
     expect(setMessages).toHaveBeenCalled();
@@ -89,30 +138,15 @@ describe("useCompaction", () => {
     // The compact button is gated to the last assistant message, so there is no
     // tail to drop — compaction always summarizes the entire visible history.
     const { result, client } = setup({
-      chatHistory: [
-        { role: "user", content: "u1" },
-        { role: "assistant", content: "a1" },
-        { role: "user", content: "u2" },
-        { role: "assistant", content: "a2" },
-      ],
-      messages: [ui("user", 0), ui("model", 1), ui("user", 2), ui("model", 3)],
+      chatHistory: turns(2),
+      messages: uiTurns(2),
     });
 
-    await act(async () => {
-      await result.current.compact(1);
-    });
+    await compactAt(result, 1);
 
-    expect(client.summarize).toHaveBeenCalledWith([
-      { role: "user", content: "u1" },
-      { role: "assistant", content: "a1" },
-      { role: "user", content: "u2" },
-      { role: "assistant", content: "a2" },
-    ]);
+    expect(client.summarize).toHaveBeenCalledWith(turns(2));
     expect(client.chatHistory).toStrictEqual([
-      { role: "user", content: "u1" },
-      { role: "assistant", content: "a1" },
-      { role: "user", content: "u2" },
-      { role: "assistant", content: "a2" },
+      ...turns(2),
       { role: "user", content: "Summary of 4 messages" },
     ]);
   });
@@ -122,20 +156,15 @@ describe("useCompaction", () => {
       isAssistantResponding: true,
     });
 
-    await act(async () => {
-      await result.current.compact(1);
-    });
+    await compactAt(result, 1);
 
-    expect(client.summarize).not.toHaveBeenCalled();
-    expect(setMessages).not.toHaveBeenCalled();
+    expectNoCompaction(client, setMessages);
   });
 
   it("does nothing when there is no active client", async () => {
     const { result, setMessages } = setup({ noClient: true });
 
-    await act(async () => {
-      await result.current.compact(0);
-    });
+    await compactAt(result, 0);
 
     expect(setMessages).not.toHaveBeenCalled();
     expect(result.current.canUndoCompaction).toBe(false);
@@ -146,9 +175,7 @@ describe("useCompaction", () => {
 
     client.summarize.mockRejectedValueOnce(new Error("boom"));
 
-    await act(async () => {
-      await result.current.compact(1);
-    });
+    await compactAt(result, 1);
 
     expect(adapter.createErrorMessage).toHaveBeenCalled();
     expect(setMessages).toHaveBeenCalled();
@@ -190,9 +217,7 @@ describe("useCompaction", () => {
     const { result, client } = setup();
     const original = [...client.chatHistory];
 
-    await act(async () => {
-      await result.current.compact(1);
-    });
+    await compactAt(result, 1);
     await act(async () => {
       result.current.undoCompaction();
     });
@@ -216,23 +241,17 @@ describe("useCompaction", () => {
   it("does nothing when the targeted message index has no message", async () => {
     const { result, client, setMessages } = setup({ messages: [] });
 
-    await act(async () => {
-      await result.current.compact(0);
-    });
+    await compactAt(result, 0);
 
-    expect(client.summarize).not.toHaveBeenCalled();
-    expect(setMessages).not.toHaveBeenCalled();
+    expectNoCompaction(client, setMessages);
   });
 
   it("does nothing when the client history is empty", async () => {
     const { result, client, setMessages } = setup({ chatHistory: [] });
 
-    await act(async () => {
-      await result.current.compact(1);
-    });
+    await compactAt(result, 1);
 
-    expect(client.summarize).not.toHaveBeenCalled();
-    expect(setMessages).not.toHaveBeenCalled();
+    expectNoCompaction(client, setMessages);
   });
 
   it("ignores a rejected summary after the conversation was switched away", async () => {
@@ -268,9 +287,7 @@ describe("useCompaction", () => {
       bootstrapClientRef: { current: bootstrap },
     });
 
-    await act(async () => {
-      await result.current.compact(1);
-    });
+    await compactAt(result, 1);
 
     expect(bootstrap).toHaveBeenCalled();
     // The mock createErrorMessage mutates the array it receives, so assert the
@@ -286,9 +303,7 @@ describe("useCompaction", () => {
   it("invalidateCompactionUndo clears the undo availability", async () => {
     const { result } = setup();
 
-    await act(async () => {
-      await result.current.compact(1);
-    });
+    await compactAt(result, 1);
     expect(result.current.canUndoCompaction).toBe(true);
 
     await act(async () => {

--- a/webui/src/hooks/voice/tests/persistence/use-voice-persistence.test.ts
+++ b/webui/src/hooks/voice/tests/persistence/use-voice-persistence.test.ts
@@ -13,6 +13,8 @@ import { GEMINI_REALTIME_MODEL } from "#webui/lib/constants/models";
 import { loadConversation, saveConversation } from "#webui/lib/conversation-db";
 import { createTestRecord } from "#webui/test-utils/conversation-test-helpers";
 import {
+  bulkDeleteDuringPendingNewSave,
+  continueSavedVoiceSession,
   fireHashChange,
   renderVoicePersistence,
   renderVoicePersistenceWithHistory,
@@ -93,20 +95,12 @@ describe("useVoicePersistence", () => {
       voiceHistory: [userTextItem("first turn")],
     });
 
-    window.location.hash = record.id;
-
-    const { result, rerender } = renderVoicePersistenceWithHistory({
-      model: "gpt-realtime-current",
-    });
-
-    await waitForEffects();
-    rerender([userTextItem("first turn"), userTextItem("second turn")]);
-    await waitForEffects(800);
+    const { result, loaded } = await continueSavedVoiceSession(
+      record,
+      "gpt-realtime-current",
+    );
 
     expect(result.current.activeConversationId).toBe(record.id);
-
-    const loaded = await loadConversation(record.id);
-
     expect(loaded?.model).toBe("gpt-realtime-original");
     expect(loaded?.modelLabel).toBe("gpt-realtime-original");
   });
@@ -135,20 +129,12 @@ describe("useVoicePersistence", () => {
       voiceHistory: [userTextItem("first turn")],
     });
 
-    window.location.hash = record.id;
-
-    const { result, rerender } = renderVoicePersistenceWithHistory({
-      model: GEMINI_REALTIME_MODEL,
-    });
-
-    await waitForEffects();
-    rerender([userTextItem("first turn"), userTextItem("second turn")]);
-    await waitForEffects(800);
+    const { result, loaded } = await continueSavedVoiceSession(
+      record,
+      GEMINI_REALTIME_MODEL,
+    );
 
     expect(result.current.activeConversationId).toBe(record.id);
-
-    const loaded = await loadConversation(record.id);
-
     expect(loaded?.provider).toBe("openai");
   });
 
@@ -448,34 +434,22 @@ describe("useVoicePersistence", () => {
   });
 
   it("does not resurrect a pending new conversation deleted via deleteAllConversations", async () => {
-    const { result, rerender } = renderVoicePersistenceWithHistory();
-
-    await waitForEffects();
-    // A brand-new session produces transcript: the autosave reserves an id but
-    // hasn't resolved yet, so no active id has been adopted.
-    rerender([userTextItem("brand new")]);
-    expect(result.current.activeConversationId).toBeNull();
-
-    // Delete-all lands during that pre-adoption window. It doesn't stop the
-    // session, so the reserved-id autosave is still scheduled.
-    await act(() => result.current.deleteAllConversations());
-    // Let the debounce fire; the reserved-id save must bail, not create a record.
-    await waitForEffects(800);
+    // Delete-all lands during the pre-adoption window. It doesn't stop the
+    // session, so the reserved-id autosave is still scheduled — and must bail
+    // rather than create a record.
+    const result = await bulkDeleteDuringPendingNewSave((hook) =>
+      hook.deleteAllConversations(),
+    );
 
     expect(result.current.conversations).toHaveLength(0);
     expect(result.current.activeConversationId).toBeNull();
   });
 
   it("does not resurrect a pending new conversation deleted via deleteUnbookmarkedConversations", async () => {
-    const { result, rerender } = renderVoicePersistenceWithHistory();
-
-    await waitForEffects();
-    rerender([userTextItem("brand new")]);
-    expect(result.current.activeConversationId).toBeNull();
-
     // A pending-new conversation is unbookmarked, so the bulk delete targets it.
-    await act(() => result.current.deleteUnbookmarkedConversations());
-    await waitForEffects(800);
+    const result = await bulkDeleteDuringPendingNewSave((hook) =>
+      hook.deleteUnbookmarkedConversations(),
+    );
 
     expect(result.current.conversations).toHaveLength(0);
     expect(result.current.activeConversationId).toBeNull();

--- a/webui/src/hooks/voice/tests/persistence/voice-persistence-test-helpers.ts
+++ b/webui/src/hooks/voice/tests/persistence/voice-persistence-test-helpers.ts
@@ -5,7 +5,7 @@
 
 import { type RealtimeItem } from "@openai/agents/realtime";
 import { act, renderHook } from "@testing-library/preact";
-import { vi } from "vitest";
+import { expect, vi } from "vitest";
 import {
   type UseVoicePersistenceReturn,
   useVoicePersistence,
@@ -13,6 +13,7 @@ import {
 import {
   type ConversationRecord,
   getConversationDb,
+  loadConversation,
   resetDbCache,
   saveConversation,
 } from "#webui/lib/conversation-db";
@@ -153,6 +154,58 @@ export async function setupForeignTextRecord(
   await waitForEffects();
 
   return { textRecord, onForeignRecord, result };
+}
+
+/**
+ * Continue a previously saved voice record (hash load → Stop → Talk) while
+ * current settings point at `model`: adds one more transcript turn, lets the
+ * autosave debounce fire, and reads the record back so the caller can check
+ * which fields the merge preserved vs re-stamped.
+ * @param record - The saved voice record to continue
+ * @param model - The realtime model the current settings select
+ * @returns The rendered hook result and the reloaded record
+ */
+export async function continueSavedVoiceSession(
+  record: ConversationRecord,
+  model: string,
+): Promise<{
+  result: VoicePersistenceHistoryView["result"];
+  loaded: ConversationRecord | undefined;
+}> {
+  window.location.hash = record.id;
+
+  const { result, rerender } = renderVoicePersistenceWithHistory({ model });
+
+  await waitForEffects();
+  rerender([userTextItem("first turn"), userTextItem("second turn")]);
+  await waitForEffects(800);
+
+  return { result, loaded: await loadConversation(record.id) };
+}
+
+/**
+ * Run a bulk delete inside the autosave's pre-adoption window: a brand-new
+ * session produces transcript, so the autosave reserves an id but hasn't
+ * resolved yet and no active id has been adopted (asserted here as the
+ * scenario's precondition). The bulk delete lands in that window without
+ * stopping the session, so the reserved-id autosave is still scheduled — then
+ * the debounce is allowed to fire so the caller can check it bailed.
+ * @param bulkDelete - The bulk delete to invoke during the window
+ * @returns The rendered hook result
+ */
+export async function bulkDeleteDuringPendingNewSave(
+  bulkDelete: (hook: UseVoicePersistenceReturn) => Promise<void>,
+): Promise<VoicePersistenceHistoryView["result"]> {
+  const { result, rerender } = renderVoicePersistenceWithHistory();
+
+  await waitForEffects();
+  rerender([userTextItem("brand new")]);
+  expect(result.current.activeConversationId).toBeNull();
+
+  await act(() => bulkDelete(result.current));
+  await waitForEffects(800);
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
Second dedup round. Extracts cohesive setup and assertion helpers across the 12 test files carrying the largest within-file clones.

| | Before | After |
|---|---|---|
| Tests duplication | 1.269% | **1.114%** |
| Clones | 213 | 189 |
| Duplicated lines | 2029 | 1780 |
| Threshold (`config/.jscpd-tests.json`) | 1.4 | **1.2** |

## Approach

One agent per file, each given its exact jscpd clone ranges plus hard extract-don't-compress rules. Several files turned out to be hand-rolling setup that a helper in the same file or a sibling `*-test-helpers.ts` already provided — those collapse to existing abstractions rather than new ones (`arrangement-splitting` was mostly deletion in favor of the existing `setupSplitTest()` and its fixture constants).

## Verification

- **Test count unchanged: 562 files / 9975 tests**, identical to the baseline on `dev`. Every case keeps its own named `it()`; nothing was merged into a table-driven loop.
- Comment lines went **up** (37 added vs 20 removed) and total line count went **up** by 18 — extraction, not compression.
- Coverage unchanged, Functions still 100%.
- `npm run check` green: Source 0.26%, Tests 1.11%, Scripts 0.15%, Evals 0.39%, E2E 0.83%.
- `npm run ui:test` 14/14 (webui touched).

## Assertions deliberately strengthened

- `update-track-send`: three "nothing should be touched" tests now check both sends instead of one. Verified passing, not assumed.
- `duplicate-arrangement-length`: `toStrictEqual` on the whole result replaces two loose `toHaveProperty` checks, so extra properties are now caught.

## Worth a reviewer's eye

`use-compaction` now uses one `turns(n)` builder for both seeding client history and asserting what `summarize()` received. The behavior under test stays pinned; what's no longer independently spelled out is the arbitrary `u1`/`a1` fixture text.

## Headroom

1.11% against a 1.2 threshold is ~0.09. Second-order clones can appear as tests shrink, so an unrelated test change could nudge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)