### PR TITLE
Default CORS to localhost origins (ENABLE_DEV_CORS → ENABLE_REMOTE_CORS)

### DIFF
--- a/.github/workflows/run-checks-and-tests.yml
+++ b/.github/workflows/run-checks-and-tests.yml
@@ -38,16 +38,16 @@ jobs:
         run: npm ci
 
       - name: Guard against dev-only env vars in CI
-        # These flags enable Live API access and arbitrary code execution.
-        # They must never be baked into release artifacts.
+        # These flags enable Live API access, arbitrary code execution, and
+        # wildcard CORS. They must never be baked into release artifacts.
         run: |
           if [ "${ENABLE_LIVE_API:-}" = "true" ] || \
              [ "${ENABLE_CODE_EXEC:-}" = "true" ] || \
-             [ "${ENABLE_DEV_CORS:-}" = "true" ]; then
+             [ "${ENABLE_REMOTE_CORS:-}" = "true" ]; then
             echo "::error::Dev-only env vars must not be set in CI builds:"
             echo "  ENABLE_LIVE_API=${ENABLE_LIVE_API:-}"
             echo "  ENABLE_CODE_EXEC=${ENABLE_CODE_EXEC:-}"
-            echo "  ENABLE_DEV_CORS=${ENABLE_DEV_CORS:-}"
+            echo "  ENABLE_REMOTE_CORS=${ENABLE_REMOTE_CORS:-}"
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,10 +92,9 @@ architecture.
 
 - **Testing builds**: Always use `npm run build:debug` for development. It sets
   `ENABLE_LIVE_API=true` (forces `liveApiEnabled` on so the Direct Live API tool
-  is always available — the Setup-tab toggle can't disable it in this build),
-  `ENABLE_CODE_EXEC=true`, and `ENABLE_DEV_CORS=true`.
-  `POST /config { liveApiEnabled }` still works either direction (used by e2e to
-  test the disabled state).
+  is always available — the Setup-tab toggle can't disable it in this build) and
+  `ENABLE_CODE_EXEC=true`. `POST /config { liveApiEnabled }` still works either
+  direction (used by e2e to test the disabled state).
 
 - **Exact dependency versions**: All package.json versions must be exact (no
   `^`/`~`/ranges). `.npmrc` enforces it for `npm install`;

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -166,12 +166,15 @@ which require v24+.
    → Settings → Extension
 
 **Note**: For development and testing, use `npm run build:debug` to enable
-debug-only flags (`ENABLE_LIVE_API`, `ENABLE_CODE_EXEC`, `ENABLE_DEV_CORS`).
-`ENABLE_LIVE_API=true` forces the runtime `liveApiEnabled` flag on so the Direct
-Live API tool (`ppal-live-api`) is always available — the Setup-tab toggle
-cannot disable it in this build. `POST /config { liveApiEnabled }` still works
-in either direction so e2e tests can exercise both states. Use
-`npm run build:dev` for a normal build with CORS enabled (for `npm run ui:dev`).
+debug-only flags (`ENABLE_LIVE_API`, `ENABLE_CODE_EXEC`). `ENABLE_LIVE_API=true`
+forces the runtime `liveApiEnabled` flag on so the Direct Live API tool
+(`ppal-live-api`) is always available — the Setup-tab toggle cannot disable it
+in this build. `POST /config { liveApiEnabled }` still works in either direction
+so e2e tests can exercise both states. Chat UI development (`npm run ui:dev`)
+works against any build: the MCP server reflects CORS for localhost origins by
+default, so a browser page on another local port can reach it. Set
+`ENABLE_REMOTE_CORS=true` before a build only if you need to reach the server
+from a non-localhost browser origin (a remote inspector, or over the LAN).
 
 ## Core Development Scripts
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,8 +36,11 @@ released builds rather than merely switched off:
   present in the codebase behind a build flag. It is stripped out of shipped
   builds — the code and the tool parameters that expose it are not in the
   released bundle at all.
-- **Permissive CORS.** Development builds relax cross-origin rules so the chat
-  UI can be served from a dev server. Shipped builds send no such headers.
+- **Wildcard CORS.** By default the server accepts browser requests only from
+  localhost origins — enough for a local page you build to reach it, while pages
+  from the internet are blocked. A build flag widens this to any origin, for dev
+  tooling served from a non-localhost origin; that wildcard is never set in a
+  released build.
 
 Continuous integration fails the build if any of these development flags are set
 when producing a release, so they can't be enabled by accident.

--- a/config/rollup.config.mjs
+++ b/config/rollup.config.mjs
@@ -41,7 +41,9 @@ const envVarReplacements = {
   "process.env.ENABLE_WARP_MARKERS": JSON.stringify(
     process.env.ENABLE_WARP_MARKERS,
   ),
-  "process.env.ENABLE_DEV_CORS": JSON.stringify(process.env.ENABLE_DEV_CORS),
+  "process.env.ENABLE_REMOTE_CORS": JSON.stringify(
+    process.env.ENABLE_REMOTE_CORS,
+  ),
 };
 
 // When code execution is disabled, substitute the real code-exec modules with

--- a/dev/Chat-UI.md
+++ b/dev/Chat-UI.md
@@ -393,7 +393,7 @@ npm run build     # Includes UI build
 **Development workflow:**
 
 - UI only: `npm run ui:dev` for hot reload at localhost:5173
-- Full-stack: Run `npm run dev` (or `npm run build:dev`) + `npm run ui:dev` in
+- Full-stack: Run `npm run dev` (or `npm run build`) + `npm run ui:dev` in
   separate terminals
 - Tests colocated with source (`.test.ts` / `.test.tsx`), run with `npm test`
 - See `DEVELOPERS.md` for detailed workflow scenarios

--- a/dev/Development-Tools.md
+++ b/dev/Development-Tools.md
@@ -158,14 +158,15 @@ Provides:
 ### CORS and the streamable-http transport
 
 The streamable-http URL above is a browser-origin fetch from the inspector UI to
-the device's MCP server, so it requires CORS headers on `localhost:3350`. Dev
-builds (`npm run build:dev`, `npm run build:debug`, and `npm run dev`) already
-set `ENABLE_DEV_CORS=true`, so this just works during normal development.
+the device's MCP server, so it needs CORS headers on `localhost:3350`. The
+server reflects CORS for any localhost origin by default, in every build, so the
+inspector (served from a localhost origin) just works — dev or release. Pages
+from a non-localhost origin get no CORS headers and are blocked; set
+`ENABLE_REMOTE_CORS=true` before a build only if you need to reach the server
+from one (a remote inspector, or over the LAN).
 
-Release builds (`npm run build`) intentionally omit CORS headers — production
-users run the chat UI same-origin and shouldn't expose `localhost:3350` to
-arbitrary browser tabs. To debug a release build with the inspector, point it at
-the stdio portal instead:
+The stdio portal is another way in (and it pushes config-override flags to the
+device on connect, below):
 
 ```bash
 npx @modelcontextprotocol/inspector node /absolute/path/to/producer-pal/npm/producer-pal-portal.js

--- a/package.json
+++ b/package.json
@@ -32,10 +32,9 @@
   ],
   "scripts": {
     "build": "npm run parser:build && npm run ui:build && rollup -c config/rollup.config.mjs && npm run dxt:build",
-    "build:dev": "ENABLE_DEV_CORS=true npm run build",
-    "build:debug": "ENABLE_LIVE_API=true ENABLE_CODE_EXEC=true ENABLE_DEV_CORS=true npm run build",
+    "build:debug": "ENABLE_LIVE_API=true ENABLE_CODE_EXEC=true npm run build",
     "build:watch": "npm run build && rollup -c config/rollup.config.mjs -w",
-    "dev": "npm run parser:build && ENABLE_DEV_CORS=true rollup -c config/rollup.config.mjs -w",
+    "dev": "npm run parser:build && rollup -c config/rollup.config.mjs -w",
     "dev:debug": "ENABLE_LIVE_API=true ENABLE_CODE_EXEC=true npm run dev",
     "test": "npm run test:setup && vitest run --reporter=./config/vitest-minimal-reporter.mjs --silent=true",
     "test:watch": "npm run test:setup && vitest --reporter=dot --silent=true",

--- a/src/mcp-server/create-express-app.ts
+++ b/src/mcp-server/create-express-app.ts
@@ -23,7 +23,10 @@ import { toolDefLiveApi } from "#src/tools/advanced/live-api.def.ts";
 import { TOOL_NAMES, createMcpServer } from "./create-mcp-server.ts";
 import { enrichConnect } from "./helpers/connect/enrich-connect.ts";
 import { requestBody } from "./helpers/http/request-body.ts";
-import { rejectCrossOriginWrite } from "./helpers/http/request-origin.ts";
+import {
+  isLocalOrigin,
+  rejectCrossOriginWrite,
+} from "./helpers/http/request-origin.ts";
 import { callLiveApi } from "./max-api-adapter.ts";
 import * as console from "./node-for-max-logger.ts";
 import { registerCustomSkillsCollectionRoutes } from "./routes/custom-skills-collection-route.ts";
@@ -191,28 +194,50 @@ function setNoStore(res: Response): void {
 export function createExpressApp(): Express {
   const app = express();
 
-  // CORS middleware for MCP Inspector and Vite dev server support.
-  // Only enabled in dev builds (ENABLE_DEV_CORS=true). Production builds
-  // serve the chat UI from the same origin, so no CORS headers are needed.
-  if (process.env.ENABLE_DEV_CORS === "true") {
-    app.use((req: Request, res: Response, next: NextFunction): void => {
-      res.setHeader("Access-Control-Allow-Origin", "*");
+  // CORS: by default reflect only localhost origins, so a browser page you
+  // serve locally (a dev server, the MCP Inspector, your own tool on another
+  // port) can call the API, while pages from the internet stay blocked. The
+  // Origin header is browser-set and can't be forged by page JS, so an internet
+  // page always carries its real domain and gets no header. Non-browser clients
+  // (curl, scripts, Max) ignore CORS entirely and are unaffected either way.
+  // Set ENABLE_REMOTE_CORS to widen this to any origin ("*") — needed only for
+  // browser dev tooling served from a non-localhost origin (a remote Inspector,
+  // LAN). Specify it manually on the CLI before a build; it is never baked into
+  // an npm script.
+  app.use((req: Request, res: Response, next: NextFunction): void => {
+    const origin = req.get("Origin");
+    let allowOrigin: string | null = null;
+
+    if (process.env.ENABLE_REMOTE_CORS === "true") {
+      allowOrigin = "*";
+    } else if (origin != null && isLocalOrigin(origin)) {
+      allowOrigin = origin;
+    }
+
+    if (allowOrigin != null) {
+      res.setHeader("Access-Control-Allow-Origin", allowOrigin);
+
+      // Reflected origins vary per request, so caches must key on Origin.
+      if (allowOrigin !== "*") {
+        res.setHeader("Vary", "Origin");
+      }
+
       res.setHeader(
         "Access-Control-Allow-Methods",
         "GET, POST, OPTIONS, DELETE",
       );
       res.setHeader("Access-Control-Allow-Headers", "*");
 
-      // Handle preflight requests
+      // Answer the preflight for an allowed origin.
       if (req.method === "OPTIONS") {
         res.status(200).end();
 
         return;
       }
+    }
 
-      next();
-    });
-  }
+    next();
+  });
 
   // Tool arguments with large MIDI note arrays or bar|beat transforms can
   // exceed Express's 100 KB default.

--- a/src/mcp-server/mcp-server.ts
+++ b/src/mcp-server/mcp-server.ts
@@ -49,7 +49,7 @@ console.log(`Producer Pal ${VERSION} starting MCP server on port ${port}...`);
 const devFlags = [
   ["ENABLE_LIVE_API", process.env.ENABLE_LIVE_API],
   ["ENABLE_CODE_EXEC", process.env.ENABLE_CODE_EXEC],
-  ["ENABLE_DEV_CORS", process.env.ENABLE_DEV_CORS],
+  ["ENABLE_REMOTE_CORS", process.env.ENABLE_REMOTE_CORS],
 ].filter(([, value]) => value === "true");
 
 if (devFlags.length > 0) {

--- a/src/mcp-server/tests/express-app-test-helpers.ts
+++ b/src/mcp-server/tests/express-app-test-helpers.ts
@@ -49,7 +49,7 @@ interface ExpressAppTestState {
  *
  * @param options - Setup options
  * @param options.beforeStart - Optional callback to run before starting the server
- * @param options.enableDevFeatures - Set ENABLE_CODE_EXEC and ENABLE_DEV_CORS env vars before server start
+ * @param options.enableDevFeatures - Set ENABLE_CODE_EXEC env var before server start
  * @param options.enableLiveApi - POST /config { liveApiEnabled: true } after server start
  * @returns Test state with server and URL references
  */
@@ -75,9 +75,7 @@ export function setupExpressAppServer(
   beforeAll(async () => {
     if (options.enableDevFeatures) {
       prevEnv.ENABLE_CODE_EXEC = process.env.ENABLE_CODE_EXEC;
-      prevEnv.ENABLE_DEV_CORS = process.env.ENABLE_DEV_CORS;
       process.env.ENABLE_CODE_EXEC = "true";
-      process.env.ENABLE_DEV_CORS = "true";
     }
 
     options.beforeStart?.();
@@ -111,14 +109,13 @@ export function setupExpressAppServer(
     // Restore env so a thread-pool run can't leak these into another test file.
     if (options.enableDevFeatures) {
       restoreEnv("ENABLE_CODE_EXEC", prevEnv.ENABLE_CODE_EXEC);
-      restoreEnv("ENABLE_DEV_CORS", prevEnv.ENABLE_DEV_CORS);
     }
   });
 
   return state;
 }
 
-type DevFeatureEnvVar = "ENABLE_CODE_EXEC" | "ENABLE_DEV_CORS";
+type DevFeatureEnvVar = "ENABLE_CODE_EXEC";
 
 /**
  * Restore an env var to its prior value, deleting it if it was unset before.

--- a/src/mcp-server/tests/express-app/create-express-app-cors.test.ts
+++ b/src/mcp-server/tests/express-app/create-express-app-cors.test.ts
@@ -8,26 +8,41 @@ import { type AddressInfo } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
- * Sends an OPTIONS preflight to /mcp on a fresh Express app and returns the response.
+ * Sends a request to a freshly created Express app and returns the response.
+ * OPTIONS requests include the preflight headers a browser would send.
  *
- * @returns The preflight response
+ * @param options - Request options
+ * @param options.method - HTTP method (default "OPTIONS")
+ * @param options.origin - Origin header to send, if any
+ * @param options.path - Request path (default "/mcp")
+ * @returns The response
  */
-async function getPreflightResponse(): Promise<Response> {
+async function requestApp(options: {
+  method?: string;
+  origin?: string;
+  path?: string;
+}): Promise<Response> {
+  const method = options.method ?? "OPTIONS";
   const { createExpressApp } = await import("../../create-express-app.ts");
   const app = createExpressApp();
   const server = await new Promise<Server>((resolve) => {
     const s = app.listen(0, () => resolve(s));
   });
-  const url = `http://localhost:${(server.address() as AddressInfo).port}/mcp`;
+  const port = (server.address() as AddressInfo).port;
+  const url = `http://localhost:${port}${options.path ?? "/mcp"}`;
+  const headers: Record<string, string> = {};
+
+  if (options.origin != null) {
+    headers.Origin = options.origin;
+  }
+
+  if (method === "OPTIONS") {
+    headers["Access-Control-Request-Method"] = "POST";
+    headers["Access-Control-Request-Headers"] = "content-type";
+  }
 
   try {
-    return await fetch(url, {
-      method: "OPTIONS",
-      headers: {
-        "Access-Control-Request-Method": "POST",
-        "Access-Control-Request-Headers": "content-type",
-      },
-    });
+    return await fetch(url, { method, headers });
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }
@@ -38,40 +53,61 @@ describe("MCP Express App - CORS", () => {
     vi.resetModules();
   });
 
-  describe("when ENABLE_DEV_CORS is enabled", () => {
-    beforeEach(() => {
-      vi.stubEnv("ENABLE_DEV_CORS", "true");
-    });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
 
-    afterEach(() => {
-      vi.unstubAllEnvs();
-    });
+  describe("by default (localhost only)", () => {
+    it("reflects a localhost origin on the preflight", async () => {
+      const res = await requestApp({ origin: "http://localhost:5173" });
 
-    it("sets wildcard CORS headers on OPTIONS preflight", async () => {
-      const response = await getPreflightResponse();
-
-      expect(response.status).toBe(200);
-      expect(response.headers.get("access-control-allow-origin")).toBe("*");
-      expect(response.headers.get("access-control-allow-methods")).toContain(
-        "POST",
+      expect(res.status).toBe(200);
+      expect(res.headers.get("access-control-allow-origin")).toBe(
+        "http://localhost:5173",
       );
-      expect(response.headers.get("access-control-allow-headers")).toBe("*");
+      expect(res.headers.get("vary")).toBe("Origin");
+      expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+      expect(res.headers.get("access-control-allow-headers")).toBe("*");
+    });
+
+    it("reflects a localhost origin on a non-preflight request", async () => {
+      const res = await requestApp({
+        method: "GET",
+        origin: "http://127.0.0.1:8080",
+        path: "/config",
+      });
+
+      expect(res.headers.get("access-control-allow-origin")).toBe(
+        "http://127.0.0.1:8080",
+      );
+    });
+
+    it("sends no CORS header for a foreign origin", async () => {
+      const res = await requestApp({ origin: "https://evil.example" });
+
+      expect(res.headers.get("access-control-allow-origin")).toBeNull();
+    });
+
+    it("sends no CORS header when there is no Origin", async () => {
+      const res = await requestApp({});
+
+      expect(res.headers.get("access-control-allow-origin")).toBeNull();
     });
   });
 
-  describe("when ENABLE_DEV_CORS is disabled", () => {
+  describe("with ENABLE_REMOTE_CORS", () => {
     beforeEach(() => {
-      vi.stubEnv("ENABLE_DEV_CORS", "");
+      vi.stubEnv("ENABLE_REMOTE_CORS", "true");
     });
 
-    afterEach(() => {
-      vi.unstubAllEnvs();
-    });
+    it("allows any origin with a wildcard", async () => {
+      const res = await requestApp({ origin: "https://anywhere.example" });
 
-    it("does not set CORS headers on OPTIONS preflight", async () => {
-      const response = await getPreflightResponse();
-
-      expect(response.headers.get("access-control-allow-origin")).toBeNull();
+      expect(res.status).toBe(200);
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      expect(res.headers.get("vary")).toBeNull();
+      expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+      expect(res.headers.get("access-control-allow-headers")).toBe("*");
     });
   });
 });

--- a/src/mcp-server/tests/express-app/create-express-app.test.ts
+++ b/src/mcp-server/tests/express-app/create-express-app.test.ts
@@ -447,25 +447,6 @@ describe("MCP Express App", () => {
     });
   });
 
-  describe("CORS", () => {
-    it("should handle OPTIONS preflight requests", async () => {
-      const response = await fetch(appState.serverUrl, {
-        method: "OPTIONS",
-        headers: {
-          "Access-Control-Request-Method": "POST",
-          "Access-Control-Request-Headers": "content-type",
-        },
-      });
-
-      expect(response.status).toBe(200);
-      expect(response.headers.get("access-control-allow-origin")).toBe("*");
-      expect(response.headers.get("access-control-allow-methods")).toContain(
-        "POST",
-      );
-      expect(response.headers.get("access-control-allow-headers")).toBe("*");
-    });
-  });
-
   describe("Chat UI", () => {
     let chatUrl: string;
     let contextUrl: string;


### PR DESCRIPTION
Makes "build your own browser interface" against the REST API actually work, without opening the server to the whole internet.

## Problem

CORS headers were dev-only (`ENABLE_DEV_CORS=true`, set by the debug/dev builds). In a **production** build the server sent no CORS headers at all, so a browser page on a different origin — another local port, the MCP Inspector, your own web UI — couldn't call `/api/tools/*` or `/mcp`: a JSON `POST` failed its preflight, and even a cross-origin `GET` came back unreadable. Non-browser clients (curl, Node, Max, hardware) were never affected, so the docs' "build a web page that drives Live" claim was only true for non-browser clients.

## Change

The server now **reflects the request `Origin` when it's localhost** (`localhost` / `127.0.0.1` / `[::1]`, any port), in **every** build. A page you serve locally can drive Live; pages from the internet get no header and stay blocked.

Why this is a sound middle ground:
- `Origin` is a browser-set forbidden header — page JS can't forge it, so an internet page always carries its real domain and is blocked.
- Origin-based gating is **DNS-rebinding-resistant** (rebinding defeats `Host` checks, not `Origin`).
- It doesn't widen the existing no-auth / [LAN-reachable](src/mcp-server/create-express-app.ts) model: any local process could already reach the server directly. CORS only ever governed *browser cross-origin reads*.
- Reuses the existing [`isLocalOrigin()`](src/mcp-server/helpers/http/request-origin.ts) helper (already used to gate `/config` writes).

`ENABLE_DEV_CORS` → **`ENABLE_REMOTE_CORS`**, repurposed: widens the policy to any origin (`*`), needed only for browser dev tooling served from a *non-localhost* origin (a remote Inspector, or over the LAN). It's **no longer baked into any npm script** — set it manually before a build when you need it. Localhost reflection already covers Vite (:5173) and the Inspector (:6274), so `build:debug`/`dev` drop the flag and the now-redundant `build:dev` script is removed.

## Verification

- `npm run check` — green (9991 passed, functions 100%). The CORS tests drive a real Express server over `fetch`: localhost reflected (+ `Vary: Origin`, preflight 200), foreign origin blocked, no-Origin bare, `ENABLE_REMOTE_CORS` wildcard.
- `npm run check:build` — bundles + docs compile. Confirmed in the production bundle that the wildcard branch is dead-code-eliminated when the flag is unset, leaving localhost reflection as the default.

## Follow-up

Once this lands, the Extending page's "build your own interface — a web page" claim (in the docs PR #974) becomes accurate for locally-served pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)