### PR TITLE
Robust project context storage: on-disk backup beside the .als

### DIFF
--- a/dev/Memory-System.md
+++ b/dev/Memory-System.md
@@ -115,19 +115,24 @@ the next load. Residual gap: clearing as the literal first action on a
 freshly-upgraded set before any other tool call — negligible, since
 `ppal-connect` (which triggers the first sync) is the entry point.
 
-Because the trigger is per-tool-call, anything that changes the context
-_without_ a tool call is only backed up on the next tool call:
+The tool-call sync is the primary trigger, but a **manual edit** (device-UI
+textedit or webui `POST /config`) changes the context without invoking a tool,
+so a second trigger covers it: V8's `projectContext()` param setter. Both manual
+paths propagate to the device param and thus through this setter, which
+fire-and-forgets `backupProjectContextOnEdit` (sharing the sync memo). That
+function only **backs up** a non-empty blob or **clears** the sidecar for an
+emptied one — it **never restores** (restore stays the first tool-call sync's
+job). An empty param seen _before_ the first sync is left untouched: it may be
+an upgrade-wiped device, and deleting the sidecar would destroy the very backup
+a restore needs; a non-empty edit is always safe (it can only write). The shared
+memo dedupes the tool-call sync's own outlet round-trip, so the restore echo
+can't loop.
 
-- A **save-then-close-then-upgrade** with zero Producer Pal activity in between
-  — accepted rather than run a background poller.
-- A **manual edit** (device-UI textedit or webui `POST /config`, neither of
-  which invokes a tool) — **KNOWN GAP, not yet closed.** A user who sets context
-  manually and upgrades without ever chatting loses it, which is the exact flow
-  the backup exists to protect. Planned fix: hook a fire-and-forget backup into
-  V8's `projectContext()` setter — the choke point both manual paths route
-  through — gated on `memo.syncedOnce` so load-time param population and the
-  restore echo don't trip it (and it only ever backs up / clears, never
-  restores).
+Residual gap (accepted, not closed — a background poller was rejected): setting
+context while the Set is _unsaved_ (no `file_path` to write beside), then saving
+and upgrading with no further tool call or context edit. The `null → path`
+transition on first save fires neither the setter nor a tool call, so no backup
+is written. Any later tool call or context edit closes it.
 
 The sidecar is NOT under `~/.producer-pal`, so it deliberately does not go
 through the config-markdown store — it writes into the user's Live project

--- a/dev/Memory-System.md
+++ b/dev/Memory-System.md
@@ -62,11 +62,76 @@ with no `name` returns the whole index (there is no separate `list` action).
 throws before touching any state, because `context.ts` switches on scope first,
 then validates the action within it.
 
-`project` and `global` are unchanged from the pre-memory tool: `project` is a
-device-held blob (V8 has no filesystem, so nothing here round-trips to Node);
+`project` and `global` are unchanged from the pre-memory tool: `project`
+read/write hit a device-held blob (V8 has no filesystem, so those two actions
+don't round-trip to Node — the on-disk backup below is a separate mechanism);
 `global` round-trips to Node over the RPC bridge (`globalContext.read` /
 `globalContext.write` in `helpers/global-context/global-context-node-routes.ts`)
 to reach `context.md`.
+
+### Project context on-disk backup
+
+The `project` blob lives in a Max device parameter, so it's serialized into the
+`.als` and survives save/reload — but **not a device upgrade**: dropping in a
+newer `.amxd` gives a fresh device whose param is empty, losing the context. The
+backup mirrors the blob to a `Producer Pal Project Context.md` file sibling to
+the Live Set's `.als`, so an upgraded device can recover it. Two alternatives
+were rejected: copying from a sibling device already in the set (fragile
+load-time coordination), and a central `~/.producer-pal` store keyed by set path
+(doesn't travel with the project; keying breaks on rename/move).
+
+`Song.file_path` is **not observable** (no notification on save), so instead of
+reacting to a save we pull it on every MCP tool call and only act on change. The
+flow, split across the runtime boundary (V8 has the Live API; Node has the
+filesystem):
+
+- **V8** (`live-api-adapter/project-context-sync.ts`, called from `mcp_request`
+  before the tool runs): reads `live_set file_path` (a cheap `getProperty`) and,
+  when a first sync / changed path / changed blob warrants it, calls the
+  `projectContext.sync` RPC with `{ filePath, content }`. A cross-request memo
+  skips the Node hop on the vast majority of calls. On a `restore` response it
+  writes the blob back into the device param via the existing
+  `update_project_context` outlet (so it re-persists into the `.als`).
+- **Node** (`helpers/project-context-backup/`): the `projectContext.sync` route
+  owns the `fs`. Sidecar path = `<dir of .als>/Producer Pal Project Context.md`
+  — one per project _folder_, shared by every `.als` in it, so saving a new
+  `.als` into the same folder is a no-op and only Save-As to a new folder writes
+  a fresh backup. A non-empty param with a missing or stale sidecar ⇒
+  **backup**. An empty param is ambiguous, disambiguated by an `allowRestore`
+  flag V8 sends (see below): with a non-empty sidecar ⇒ **restore** (also
+  updates Node's `config.projectContext` mirror directly, so a restore during
+  `ppal-connect` shows in that response's injected block — the Max round-trip
+  that re-persists the param can't be relied on to land in time); otherwise ⇒
+  **clear** (delete the sidecar). Otherwise a no-op.
+
+**Restore vs. clear.** An empty param means either "device was upgraded, param
+wiped" (restore) or "the user cleared the context"
+(`ppal-context write content:""`, an explicit supported clear). Only a device
+(re)load wipes the param, and that resets V8's module-level memo, so restore is
+gated on `allowRestore = !memo.syncedOnce` — allowed only on the session's first
+sync. After that first sync, an empty param is a deliberate clear, and the route
+_deletes_ the sidecar so the clear sticks and isn't resurrected by a restore on
+the next load. Residual gap: clearing as the literal first action on a
+freshly-upgraded set before any other tool call — negligible, since
+`ppal-connect` (which triggers the first sync) is the entry point.
+
+Because the trigger is per-tool-call, anything that changes the context
+_without_ a tool call is only backed up on the next tool call:
+
+- A **save-then-close-then-upgrade** with zero Producer Pal activity in between
+  — accepted rather than run a background poller.
+- A **manual edit** (device-UI textedit or webui `POST /config`, neither of
+  which invokes a tool) — **KNOWN GAP, not yet closed.** A user who sets context
+  manually and upgrades without ever chatting loses it, which is the exact flow
+  the backup exists to protect. Planned fix: hook a fire-and-forget backup into
+  V8's `projectContext()` setter — the choke point both manual paths route
+  through — gated on `memo.syncedOnce` so load-time param population and the
+  restore echo don't trip it (and it only ever backs up / clears, never
+  restores).
+
+The sidecar is NOT under `~/.producer-pal`, so it deliberately does not go
+through the config-markdown store — it writes into the user's Live project
+folder using a path the Live API supplied.
 
 `memory` also round-trips to Node, via sibling RPC ops (`memory.read` /
 `memory.remember` / `memory.forget` / `memory.list` in

--- a/docs/guide/context.md
+++ b/docs/guide/context.md
@@ -62,6 +62,14 @@ with the Live Set and is gone if you delete the device. This is the same text as
 the device's [Context tab](/guide/device#context-tab) — the device shows it in a
 small box, the editor gives it room.
 
+Because a device upgrade starts you on a fresh, empty device, Producer Pal also
+mirrors this context to a `Producer Pal Project Context.md` file saved next to
+your Set's `.als`, and restores it the first time you use Producer Pal after
+upgrading. It's a backup, not the source of truth — you normally never touch it,
+and it's safe to delete. (Unlike the two layers below, this is the one context
+file that lives with your project rather than under `~/.producer-pal`.) See
+[a rare case where the newest context isn't captured](/support/known-issues#recent-project-context-can-be-lost-on-a-device-upgrade-rare).
+
 Keep it about the project, not about you. "Kick stays four-on-the-floor" belongs
 here; "I always work in A minor" belongs in Global.
 

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -25,6 +25,15 @@ drag the new `.amxd` into Live to replace the old version.
 Check the version number in the device UI to confirm you're running the latest
 version.
 
+::: tip Your project context carries over
+
+Project context is backed up next to each Set's `.als` and restored
+automatically on the new device — see
+[the rare exception](/support/known-issues#recent-project-context-can-be-lost-on-a-device-upgrade-rare)
+if you changed it right before a first save.
+
+:::
+
 ## 3. Update Platform-Specific Files
 
 ### For Claude Desktop Users

--- a/docs/support/known-issues.md
+++ b/docs/support/known-issues.md
@@ -28,6 +28,37 @@ Producer Pal cannot read, create, or edit arrangement automation or clip
 envelopes (parameter values that change over time). See
 [Limitations](/features#limitations) on the Features page for details.
 
+## Recent Project Context Can Be Lost on a Device Upgrade (Rare)
+
+Your **project context** lives inside the Producer Pal device, so it travels
+with your Live Set. To survive a device upgrade — a newer `.amxd` starts as a
+fresh, empty device — Producer Pal also keeps a backup:
+`Producer Pal Project Context.md`, saved next to your Set's `.als`. It restores
+this automatically the first time you use Producer Pal after upgrading.
+
+The backup is (re)written whenever the context changes through a Producer Pal
+tool call, a chat, or an edit in the device or Chat UI. One narrow sequence can
+leave the newest context un-backed-up:
+
+1. Change the project context,
+2. save the Set for the **first time**, or **Save As** to a new project folder,
+   then
+3. later replace the device with a newer version — with no Producer Pal activity
+   in between.
+
+The backup lives in the project's folder, and it's that first save which
+establishes the folder. A Max for Live device has no reliable way to know when
+the Live Set is saved, so Producer Pal can only write the backup while it's
+already doing something — a tool call, chat, or context edit. If nothing touches
+the context after that first save, no backup has been written there yet.
+
+**To be safe:** after saving and before upgrading, use Producer Pal once — any
+chat, tool call, or context edit writes the backup.
+
+**If context does go missing after an upgrade:** copy it out of the old device
+before removing it, or open one of Live's automatic project backups (Live keeps
+several).
+
 ## Claude Desktop Caches Tool Definitions
 
 If you change a setting that rewrites the tool definitions — **small model

--- a/src/live-api-adapter/live-api-adapter.ts
+++ b/src/live-api-adapter/live-api-adapter.ts
@@ -47,7 +47,10 @@ import { readTrack } from "#src/tools/track/read/read-track.ts";
 import { updateTrack } from "#src/tools/track/update/update-track.ts";
 import { handleCodeExecResult } from "./code-exec-v8-protocol.ts";
 import { handleNodeResponse } from "./node-request-v8-protocol.ts";
-import { syncProjectContextBackup } from "./project-context-sync.ts";
+import {
+  backupProjectContextOnEdit,
+  syncProjectContextBackup,
+} from "./project-context-sync.ts";
 
 // Configure 2 outlets: MCP responses (0) and warnings (1)
 outlets = 2;
@@ -221,6 +224,13 @@ export function projectContext(content: unknown): void {
   const value = content === "bang" ? "" : String(content ?? "");
 
   sessionState.projectContext.content = value;
+
+  // Device-UI and webui edits reach us only through this setter (never an MCP
+  // tool call), so kick off a best-effort on-disk backup here too. Fire-and-
+  // forget: the write is Node-side and must not block the param update. The
+  // shared memo dedupes the tool-call sync's own outlet round-trip, so the
+  // restore echo can't loop, and requestNode never rejects so this can't throw.
+  void backupProjectContextOnEdit(value);
 }
 
 /**

--- a/src/live-api-adapter/live-api-adapter.ts
+++ b/src/live-api-adapter/live-api-adapter.ts
@@ -47,6 +47,7 @@ import { readTrack } from "#src/tools/track/read/read-track.ts";
 import { updateTrack } from "#src/tools/track/update/update-track.ts";
 import { handleCodeExecResult } from "./code-exec-v8-protocol.ts";
 import { handleNodeResponse } from "./node-request-v8-protocol.ts";
+import { syncProjectContextBackup } from "./project-context-sync.ts";
 
 // Configure 2 outlets: MCP responses (0) and warnings (1)
 outlets = 2;
@@ -223,6 +224,20 @@ export function projectContext(content: unknown): void {
 }
 
 /**
+ * Apply a project-context blob restored from the on-disk backup: update the
+ * session state and re-persist it into the Max device param via the same outlet
+ * ppal-context uses. A null (no restore happened) is a no-op.
+ *
+ * @param restored - The restored blob, or null when nothing was restored
+ */
+function applyRestoredProjectContext(restored: string | null): void {
+  if (restored == null) return;
+
+  sessionState.projectContext.content = restored;
+  outlet(0, "update_project_context", restored);
+}
+
+/**
  * Set the sample folder path
  *
  * @param path - Sample folder path
@@ -338,6 +353,16 @@ export async function mcp_request(
     }
 
     const requestContext = buildRequestContext(incomingContext);
+
+    // Best-effort: keep the on-disk project-context backup in sync with the
+    // current Live Set, and restore it into an empty param after a device
+    // upgrade. Runs before the tool so a restored blob is visible to it — and,
+    // for ppal-connect, to the Node-side injected project-context block. The
+    // post-await write to sessionState lives in a helper so concurrent requests
+    // don't trip require-atomic-updates.
+    applyRestoredProjectContext(
+      await syncProjectContextBackup(sessionState.projectContext.content),
+    );
 
     try {
       // NOTE: toCompactJSLiteral() basically formats things as JS literal syntax with unquoted keys

--- a/src/live-api-adapter/project-context-sync.ts
+++ b/src/live-api-adapter/project-context-sync.ts
@@ -1,0 +1,180 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// V8-side driver for the on-disk project-context backup. The Live Set's
+// file_path isn't observable, so instead of reacting to a save we pull it on
+// every tool call (cheap: one getProperty) and only round-trip to Node when
+// something might have changed — a first sync this session, a file_path change
+// (first save / Save-As to a new folder), or an edited blob. Node owns the
+// filesystem side (project-context-backup-node-routes.ts); this decides when to
+// ask and applies a restore back into the device param. See dev/Memory-System.md.
+
+import * as console from "#src/shared/v8-max-console.ts";
+import { requestNode } from "./node-request-v8-protocol.ts";
+
+/** Subset of the Node route's result this side acts on. */
+interface ProjectContextSyncResult {
+  action: "restore" | "backup" | "clear" | "none";
+  content?: string;
+}
+
+/**
+ * Cross-request memo so the vast majority of tool calls skip the Node hop. Only
+ * a first sync, a changed file_path, or a changed blob warrants a round-trip.
+ */
+interface SyncMemo {
+  syncedOnce: boolean;
+  lastFilePath: string | null;
+  lastContent: string | null;
+}
+
+const memo: SyncMemo = {
+  syncedOnce: false,
+  lastFilePath: null,
+  lastContent: null,
+};
+
+/**
+ * Back up or restore the project context for the current Live Set, if warranted.
+ * Best-effort: any failure is logged and swallowed so it can't break the tool
+ * call that triggered it.
+ *
+ * @param content - The device param's current project-context blob
+ * @returns The restored blob when a restore happened (so the caller re-persists
+ *   it into the device param), else null
+ */
+export async function syncProjectContextBackup(
+  content: string,
+): Promise<string | null> {
+  const filePath = readLiveSetFilePath();
+
+  // An unsaved set has no sidecar location. Forget the memo'd path so the next
+  // save (file_path null -> a path) reads as a change and triggers a sync.
+  if (filePath == null) {
+    forgetMemoPath();
+
+    return null;
+  }
+
+  if (!needsSync(filePath, content)) return null;
+
+  // Restore is only valid on the first sync of a session: a device (re)load is
+  // the one thing that wipes the param (e.g. an upgrade). After that, an empty
+  // param is a deliberate user clear — Node propagates it instead of restoring.
+  const { ok, restored } = await requestSync(
+    filePath,
+    content,
+    !hasSyncedThisSession(),
+  );
+
+  // Only memoize a completed sync, so a transient failure retries next call
+  // rather than being remembered as done (important for the restore case).
+  // The memo reads/writes live in synchronous helpers (not this async body) so
+  // concurrent tool calls don't trip require-atomic-updates over shared state.
+  if (ok) rememberSync(filePath, restored ?? content);
+
+  return restored;
+}
+
+/** Reset the cross-request memo. Test-only. */
+export function resetProjectContextSyncMemo(): void {
+  memo.syncedOnce = false;
+  memo.lastFilePath = null;
+  memo.lastContent = null;
+}
+
+// --- Helpers below main export ---
+
+/**
+ * Whether the current Live Set + blob differ from the last completed sync.
+ *
+ * @param filePath - The current Live Set file path
+ * @param content - The current project-context blob
+ * @returns true when a sync round-trip is warranted
+ */
+function needsSync(filePath: string, content: string): boolean {
+  return (
+    !memo.syncedOnce ||
+    filePath !== memo.lastFilePath ||
+    content !== memo.lastContent
+  );
+}
+
+/**
+ * Whether at least one sync has completed since this V8 instance loaded. False
+ * on a freshly (re)loaded device — the only state in which an empty param may be
+ * an upgrade wipe rather than a user clear.
+ *
+ * @returns true once a sync has completed this session
+ */
+function hasSyncedThisSession(): boolean {
+  return memo.syncedOnce;
+}
+
+/**
+ * Record a completed sync so identical follow-up calls skip the Node hop.
+ *
+ * @param filePath - The synced Live Set file path
+ * @param content - The blob now on disk (the restored value after a restore)
+ */
+function rememberSync(filePath: string, content: string): void {
+  memo.syncedOnce = true;
+  memo.lastFilePath = filePath;
+  memo.lastContent = content;
+}
+
+/** Forget the memo'd path so the next non-null file_path reads as a change. */
+function forgetMemoPath(): void {
+  memo.lastFilePath = null;
+}
+
+/**
+ * The current Live Set's absolute .als path, or null when unsaved (or the Live
+ * API isn't ready). Live reports an empty string for an unsaved set.
+ *
+ * @returns Absolute path to the .als, or null
+ */
+function readLiveSetFilePath(): string | null {
+  try {
+    const raw = LiveAPI.from("live_set").getProperty("file_path");
+
+    return typeof raw === "string" && raw.length > 0 ? raw : null;
+  } catch {
+    // Live API not ready yet — treat as "no path" and try again next call.
+    return null;
+  }
+}
+
+/**
+ * Ask Node to reconcile param and sidecar.
+ *
+ * @param filePath - Absolute path to the Live Set (.als) file
+ * @param content - The device param's current project-context blob
+ * @param allowRestore - Whether an empty param may be restored (first sync only)
+ * @returns `ok` false when the round-trip failed (so the caller can retry
+ *   later); `restored` carries the blob on a restore, else null
+ */
+async function requestSync(
+  filePath: string,
+  content: string,
+  allowRestore: boolean,
+): Promise<{ ok: boolean; restored: string | null }> {
+  const response = await requestNode<ProjectContextSyncResult>(
+    "projectContext.sync",
+    { filePath, content, allowRestore },
+  );
+
+  if (!response.success) {
+    console.warn(`Project context backup sync failed: ${response.error}`);
+
+    return { ok: false, restored: null };
+  }
+
+  if (response.result?.action === "restore") {
+    return { ok: true, restored: response.result.content ?? "" };
+  }
+
+  return { ok: true, restored: null };
+}

--- a/src/live-api-adapter/project-context-sync.ts
+++ b/src/live-api-adapter/project-context-sync.ts
@@ -78,6 +78,46 @@ export async function syncProjectContextBackup(
   return restored;
 }
 
+/**
+ * Back up a manual project-context edit (device UI or webui) that never passed
+ * through an MCP tool call. Both manual paths funnel through the V8 param setter,
+ * which fire-and-forgets this. It only backs up a non-empty blob or clears the
+ * sidecar for an emptied one — it NEVER restores; treating an empty param as an
+ * upgrade wipe is the first tool-call sync's job alone. The filesystem write
+ * still happens Node-side (this only supplies the Live Set path and the blob),
+ * and the shared memo dedupes the tool-call sync's own outlet round-trip so a
+ * restore echo through the setter can't loop.
+ *
+ * @param content - The project-context blob the setter just received
+ */
+export async function backupProjectContextOnEdit(
+  content: string,
+): Promise<void> {
+  // Leave an empty param alone until a tool-call sync has run: before that the
+  // emptiness may be an upgrade-wiped device, and clearing would delete the very
+  // sidecar the first sync would restore from. A non-empty edit is always safe
+  // to back up (it can only write, never delete).
+  if (content.trim() === "" && !hasSyncedThisSession()) return;
+
+  const filePath = readLiveSetFilePath();
+
+  // An unsaved set has no sidecar location. Forget the memo'd path so the next
+  // save reads as a change and triggers a sync (mirrors syncProjectContextBackup).
+  if (filePath == null) {
+    forgetMemoPath();
+
+    return;
+  }
+
+  if (!needsSync(filePath, content)) return;
+
+  // Manual edits never restore, so allowRestore is always false. Only memoize a
+  // completed sync so a transient failure retries next edit.
+  const { ok } = await requestSync(filePath, content, false);
+
+  if (ok) rememberSync(filePath, content);
+}
+
 /** Reset the cross-request memo. Test-only. */
 export function resetProjectContextSyncMemo(): void {
   memo.syncedOnce = false;

--- a/src/live-api-adapter/tests/project-context-sync.test.ts
+++ b/src/live-api-adapter/tests/project-context-sync.test.ts
@@ -1,0 +1,214 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
+import {
+  resetProjectContextSyncMemo,
+  syncProjectContextBackup,
+} from "../project-context-sync.ts";
+
+vi.mock(import("#src/live-api-adapter/node-request-v8-protocol.ts"), () => ({
+  requestNode: vi.fn(),
+}));
+
+vi.mock(import("#src/shared/v8-max-console.ts"), () => ({
+  log: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+const { requestNode } =
+  await import("#src/live-api-adapter/node-request-v8-protocol.ts");
+const mockRequestNode = vi.mocked(requestNode);
+
+const SAVED_PATH = "/Users/x/MySong Project/MySong.als";
+
+/**
+ * Register the mock live_set with a given file_path (null = unsaved).
+ * @param filePath - The file_path the mock live_set should report (null = unsaved)
+ */
+function setFilePath(filePath: string | null): void {
+  registerMockObject("live_set", {
+    path: "live_set",
+    properties: { file_path: filePath ?? "" },
+  });
+}
+
+/**
+ * Make the next projectContext.sync resolve as a given route action.
+ * @param action - The action the mocked route should report
+ * @param content - Restored content to include (for the restore action)
+ */
+function mockSyncResult(
+  action: "restore" | "backup" | "clear" | "none",
+  content?: string,
+): void {
+  mockRequestNode.mockResolvedValueOnce({
+    success: true,
+    result: content == null ? { action } : { action, content },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetProjectContextSyncMemo();
+});
+
+afterEach(() => {
+  resetProjectContextSyncMemo();
+});
+
+describe("syncProjectContextBackup — unsaved set", () => {
+  it("skips the Node round-trip entirely when the set is unsaved", async () => {
+    setFilePath(null);
+
+    const restored = await syncProjectContextBackup("some context");
+
+    expect(restored).toBeNull();
+    expect(mockRequestNode).not.toHaveBeenCalled();
+  });
+});
+
+describe("syncProjectContextBackup — backup", () => {
+  it("syncs on the first call and passes filePath + content", async () => {
+    setFilePath(SAVED_PATH);
+    mockSyncResult("backup");
+
+    const restored = await syncProjectContextBackup("Genre: jungle");
+
+    expect(restored).toBeNull();
+    // First sync of the session ⇒ allowRestore true.
+    expect(mockRequestNode).toHaveBeenCalledWith("projectContext.sync", {
+      filePath: SAVED_PATH,
+      content: "Genre: jungle",
+      allowRestore: true,
+    });
+  });
+
+  it("does not round-trip again when nothing changed", async () => {
+    setFilePath(SAVED_PATH);
+    mockSyncResult("backup");
+    await syncProjectContextBackup("Genre: jungle");
+
+    await syncProjectContextBackup("Genre: jungle");
+
+    expect(mockRequestNode).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-syncs when the content changes", async () => {
+    setFilePath(SAVED_PATH);
+    mockSyncResult("backup");
+    await syncProjectContextBackup("Genre: jungle");
+    mockSyncResult("backup");
+
+    await syncProjectContextBackup("Genre: techno");
+
+    expect(mockRequestNode).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-syncs when the file_path changes (Save-As to a new folder)", async () => {
+    setFilePath(SAVED_PATH);
+    mockSyncResult("backup");
+    await syncProjectContextBackup("Genre: jungle");
+    setFilePath("/Users/x/Copy Project/Copy.als");
+    mockSyncResult("backup");
+
+    await syncProjectContextBackup("Genre: jungle");
+
+    expect(mockRequestNode).toHaveBeenCalledTimes(2);
+    // Second sync of the session ⇒ allowRestore false.
+    expect(mockRequestNode).toHaveBeenLastCalledWith("projectContext.sync", {
+      filePath: "/Users/x/Copy Project/Copy.als",
+      content: "Genre: jungle",
+      allowRestore: false,
+    });
+  });
+});
+
+describe("syncProjectContextBackup — restore", () => {
+  it("returns the restored blob so the caller re-persists it", async () => {
+    setFilePath(SAVED_PATH);
+    mockSyncResult("restore", "Restored from disk");
+
+    const restored = await syncProjectContextBackup("");
+
+    expect(restored).toBe("Restored from disk");
+  });
+
+  it("memoizes the restored content so it does not re-sync immediately", async () => {
+    setFilePath(SAVED_PATH);
+    mockSyncResult("restore", "Restored from disk");
+    await syncProjectContextBackup("");
+
+    // Caller applied the restore to the param; next call sees that content.
+    await syncProjectContextBackup("Restored from disk");
+
+    expect(mockRequestNode).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a restore action with no content as an empty restore", async () => {
+    setFilePath(SAVED_PATH);
+    mockSyncResult("restore");
+
+    const restored = await syncProjectContextBackup("");
+
+    expect(restored).toBe("");
+  });
+});
+
+describe("syncProjectContextBackup — allowRestore gating", () => {
+  it("sends allowRestore:false once a sync has completed (an in-session clear)", async () => {
+    setFilePath(SAVED_PATH);
+    mockSyncResult("backup");
+    await syncProjectContextBackup("Genre: jungle");
+
+    // User clears the project context; the next sync must not restore.
+    mockSyncResult("clear");
+    const restored = await syncProjectContextBackup("");
+
+    expect(restored).toBeNull();
+    expect(mockRequestNode).toHaveBeenLastCalledWith("projectContext.sync", {
+      filePath: SAVED_PATH,
+      content: "",
+      allowRestore: false,
+    });
+  });
+});
+
+describe("syncProjectContextBackup — Live API not ready", () => {
+  it("returns null without a round-trip when reading file_path throws", async () => {
+    const spy = vi.spyOn(LiveAPI, "from").mockImplementation(() => {
+      throw new Error("Live API not ready");
+    });
+
+    try {
+      const restored = await syncProjectContextBackup("anything");
+
+      expect(restored).toBeNull();
+      expect(mockRequestNode).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("syncProjectContextBackup — failure", () => {
+  it("returns null and does not memoize a failed sync (so it retries)", async () => {
+    setFilePath(SAVED_PATH);
+    mockRequestNode.mockResolvedValueOnce({ success: false, error: "boom" });
+
+    const first = await syncProjectContextBackup("Genre: jungle");
+
+    expect(first).toBeNull();
+
+    // Same inputs: because the failure wasn't memoized, it retries.
+    mockSyncResult("backup");
+    await syncProjectContextBackup("Genre: jungle");
+
+    expect(mockRequestNode).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/live-api-adapter/tests/project-context-sync.test.ts
+++ b/src/live-api-adapter/tests/project-context-sync.test.ts
@@ -6,6 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
 import {
+  backupProjectContextOnEdit,
   resetProjectContextSyncMemo,
   syncProjectContextBackup,
 } from "../project-context-sync.ts";
@@ -210,5 +211,85 @@ describe("syncProjectContextBackup — failure", () => {
     await syncProjectContextBackup("Genre: jungle");
 
     expect(mockRequestNode).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("backupProjectContextOnEdit — manual edits", () => {
+  it("backs up a non-empty edit made before any tool-call sync (never restores)", async () => {
+    setFilePath(SAVED_PATH);
+    mockSyncResult("backup");
+
+    await backupProjectContextOnEdit("Genre: jungle");
+
+    // A manual edit must never restore, even as the session's first sync.
+    expect(mockRequestNode).toHaveBeenCalledWith("projectContext.sync", {
+      filePath: SAVED_PATH,
+      content: "Genre: jungle",
+      allowRestore: false,
+    });
+  });
+
+  it("leaves an emptied param alone before any sync (may be an upgrade wipe)", async () => {
+    setFilePath(SAVED_PATH);
+
+    await backupProjectContextOnEdit("   ");
+
+    // Deleting the sidecar here would destroy a backup the first sync restores.
+    expect(mockRequestNode).not.toHaveBeenCalled();
+  });
+
+  it("clears the sidecar for an empty edit once a sync has established state", async () => {
+    setFilePath(SAVED_PATH);
+    mockSyncResult("backup");
+    await backupProjectContextOnEdit("Genre: jungle");
+
+    mockSyncResult("clear");
+    await backupProjectContextOnEdit("");
+
+    expect(mockRequestNode).toHaveBeenLastCalledWith("projectContext.sync", {
+      filePath: SAVED_PATH,
+      content: "",
+      allowRestore: false,
+    });
+  });
+
+  it("does not round-trip when the edited blob matches the last sync", async () => {
+    setFilePath(SAVED_PATH);
+    mockSyncResult("backup");
+    await backupProjectContextOnEdit("Genre: jungle");
+
+    await backupProjectContextOnEdit("Genre: jungle");
+
+    expect(mockRequestNode).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the round-trip and forgets the memo path when the set is unsaved", async () => {
+    setFilePath(null);
+
+    await backupProjectContextOnEdit("Genre: jungle");
+
+    expect(mockRequestNode).not.toHaveBeenCalled();
+  });
+
+  it("does not memoize a failed edit backup (so the next edit retries)", async () => {
+    setFilePath(SAVED_PATH);
+    mockRequestNode.mockResolvedValueOnce({ success: false, error: "boom" });
+    await backupProjectContextOnEdit("Genre: jungle");
+
+    mockSyncResult("backup");
+    await backupProjectContextOnEdit("Genre: jungle");
+
+    expect(mockRequestNode).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares the memo with the tool-call sync so a restore echo can't loop", async () => {
+    setFilePath(SAVED_PATH);
+    mockSyncResult("restore", "Restored from disk");
+    await syncProjectContextBackup("");
+
+    // The restore re-persists into the param, echoing back through the setter.
+    await backupProjectContextOnEdit("Restored from disk");
+
+    expect(mockRequestNode).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/mcp-server/create-express-app.ts
+++ b/src/mcp-server/create-express-app.ts
@@ -20,13 +20,18 @@ import {
   type Notation,
 } from "#src/shared/notation.ts";
 import { toolDefLiveApi } from "#src/tools/advanced/live-api.def.ts";
-import { TOOL_NAMES, createMcpServer } from "./create-mcp-server.ts";
+import {
+  TOOL_NAMES,
+  createMcpServer,
+  validateTools,
+} from "./create-mcp-server.ts";
 import { enrichConnect } from "./helpers/connect/enrich-connect.ts";
 import { requestBody } from "./helpers/http/request-body.ts";
 import {
   isLocalOrigin,
   rejectCrossOriginWrite,
 } from "./helpers/http/request-origin.ts";
+import { registerProjectContextBackupNodeRoutes } from "./helpers/project-context-backup/project-context-backup-node-routes.ts";
 import { callLiveApi } from "./max-api-adapter.ts";
 import * as console from "./node-for-max-logger.ts";
 import { registerCustomSkillsCollectionRoutes } from "./routes/custom-skills-collection-route.ts";
@@ -93,6 +98,17 @@ Max.addHandler("projectContext", (content: unknown) => {
   const value = content === "bang" ? "" : String(content ?? "");
 
   config.projectContext = value;
+});
+
+// The V8 side calls projectContext.sync on tool calls to back the project
+// context up to a sidecar beside the Live Set (surviving device upgrades). A
+// restore updates our mirror directly so a restore during ppal-connect shows up
+// in that response's injected project-context block — the Max round-trip that
+// re-persists the param can't be relied on to land in time.
+registerProjectContextBackupNodeRoutes({
+  setProjectContext: (value: string) => {
+    config.projectContext = value;
+  },
 });
 
 Max.addHandler("compactOutput", (enabled: unknown) => {
@@ -346,30 +362,6 @@ export function createExpressApp(): Express {
   return app;
 }
 
-const VALID_TOOL_SET = new Set<string>(TOOL_NAMES);
-
-/**
- * Build the set of valid tool names, including ppal-live-api when enabled.
- * @param liveApiEnabled - Current value of config.liveApiEnabled
- * @returns Set of valid tool names
- */
-function getValidToolSet(liveApiEnabled: boolean): Set<string> {
-  if (!liveApiEnabled) return VALID_TOOL_SET;
-
-  return new Set<string>([...VALID_TOOL_SET, LIVE_API_TOOL_NAME]);
-}
-
-/**
- * Build the list of valid tool names for error responses.
- * @param liveApiEnabled - Current value of config.liveApiEnabled
- * @returns Sorted list of valid tool names
- */
-function getValidToolNames(liveApiEnabled: boolean): string[] {
-  if (!liveApiEnabled) return [...TOOL_NAMES];
-
-  return [...TOOL_NAMES, LIVE_API_TOOL_NAME];
-}
-
 /**
  * Handle POST /config requests to update device UI settings
  *
@@ -475,47 +467,4 @@ async function handleConfigUpdate(req: Request, res: Response): Promise<void> {
   }
 
   res.json(config);
-}
-
-/**
- * Validate the tools array from a config update request.
- * Returns an error object if invalid, or null if valid.
- *
- * @param tools - The tools value from the request body
- * @param liveApiEnabled - Whether ppal-live-api is an accepted tool name
- * @returns Error response body or null
- */
-function validateTools(
-  tools: unknown,
-  liveApiEnabled: boolean,
-): { error: string; validToolNames: string[] } | null {
-  const validToolNames = getValidToolNames(liveApiEnabled);
-  const validToolSet = getValidToolSet(liveApiEnabled);
-
-  if (!Array.isArray(tools)) {
-    return {
-      error: "tools must be an array of tool names",
-      validToolNames,
-    };
-  }
-
-  const list = tools.map(String);
-  const invalid = list.filter((name) => !validToolSet.has(name));
-
-  if (invalid.length > 0) {
-    return {
-      error: `Invalid tool name(s): ${invalid.join(", ")}`,
-      validToolNames,
-    };
-  }
-
-  if (!list.includes("ppal-connect")) {
-    return {
-      error:
-        "ppal-connect must be included in tools (it is the required entry point)",
-      validToolNames,
-    };
-  }
-
-  return null;
 }

--- a/src/mcp-server/create-mcp-server.ts
+++ b/src/mcp-server/create-mcp-server.ts
@@ -141,3 +141,57 @@ export function createMcpServer(
 
   return server;
 }
+
+/**
+ * Validate the `tools` whitelist from a POST /config request: every name must
+ * be a known tool (ppal-live-api only when the Live API tool is enabled) and
+ * ppal-connect must be present (it is the required entry point). Lives here,
+ * with the tool registry that owns TOOL_NAMES, rather than in the route handler.
+ *
+ * @param tools - The tools value from the request body
+ * @param liveApiEnabled - Whether ppal-live-api is an accepted tool name
+ * @returns An error response body when invalid, or null when valid
+ */
+export function validateTools(
+  tools: unknown,
+  liveApiEnabled: boolean,
+): { error: string; validToolNames: string[] } | null {
+  const validToolNames = getValidToolNames(liveApiEnabled);
+  const validToolSet = new Set<string>(validToolNames);
+
+  if (!Array.isArray(tools)) {
+    return { error: "tools must be an array of tool names", validToolNames };
+  }
+
+  const list = tools.map(String);
+  const invalid = list.filter((name) => !validToolSet.has(name));
+
+  if (invalid.length > 0) {
+    return {
+      error: `Invalid tool name(s): ${invalid.join(", ")}`,
+      validToolNames,
+    };
+  }
+
+  if (!list.includes("ppal-connect")) {
+    return {
+      error:
+        "ppal-connect must be included in tools (it is the required entry point)",
+      validToolNames,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * The list of valid tool names, including ppal-live-api when enabled.
+ *
+ * @param liveApiEnabled - Whether ppal-live-api is an accepted tool name
+ * @returns The valid tool names
+ */
+function getValidToolNames(liveApiEnabled: boolean): string[] {
+  if (!liveApiEnabled) return [...TOOL_NAMES];
+
+  return [...TOOL_NAMES, toolDefLiveApi.toolName];
+}

--- a/src/mcp-server/helpers/project-context-backup/project-context-backup-node-routes.ts
+++ b/src/mcp-server/helpers/project-context-backup/project-context-backup-node-routes.ts
@@ -1,0 +1,156 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// The `projectContext.sync` V8 → Node RPC route. V8 checks the current Live Set
+// on every tool call (file_path isn't observable, so we pull rather than get
+// notified) and calls this route when something might have changed. The route
+// owns the filesystem side of the on-disk backup: restore the sidecar into an
+// empty param after a device upgrade, or back the param up when it changed or
+// the sidecar is missing. See dev/Memory-System.md for the design.
+
+import { registerNodeRoute } from "../../rpc/node-request-protocol.ts";
+import {
+  deleteProjectContextSidecar,
+  readProjectContextSidecar,
+  writeProjectContextSidecar,
+} from "./project-context-backup-store.ts";
+
+/** What V8 sends: where the Live Set is, and the device's current blob. */
+export interface ProjectContextSyncArgs {
+  /** Absolute path to the Live Set (.als), or null when the set is unsaved. */
+  filePath: string | null;
+  /** The device param's current project-context blob ("" when empty). */
+  content: string;
+  /**
+   * Whether an empty param may be restored from the sidecar. Only true on the
+   * first sync of a session (a device (re)load — the one way an upgrade wipes
+   * the param). After that, an empty param is a deliberate user clear, so we
+   * propagate the clear instead of resurrecting the backup.
+   */
+  allowRestore: boolean;
+}
+
+/** What the route did, echoed back so V8 can apply a restore to the param. */
+export interface ProjectContextSyncResult {
+  action: "restore" | "backup" | "clear" | "none";
+  /** The restored blob — present only when action === "restore". */
+  content?: string;
+}
+
+/** Node-side collaborators the route needs beyond the filesystem. */
+export interface ProjectContextBackupDeps {
+  /**
+   * Update Node's mirror of the project-context blob on a restore, so a restore
+   * during ppal-connect is reflected in the connect response's injected context
+   * block (which reads the mirror). The V8 side separately re-persists the blob
+   * into the device param via the update_project_context outlet.
+   */
+  setProjectContext: (content: string) => void;
+}
+
+/**
+ * Register the `projectContext.sync` route. Call once at startup.
+ *
+ * @param deps - Node-side collaborators (the project-context mirror setter)
+ */
+export function registerProjectContextBackupNodeRoutes(
+  deps: ProjectContextBackupDeps,
+): void {
+  registerNodeRoute("projectContext.sync", (args) => syncRoute(args, deps));
+}
+
+// --- Helpers below main export ---
+
+/**
+ * Reconcile the device param against the on-disk sidecar for one Live Set.
+ *
+ * @param args - The sync args from V8 ({ filePath, content })
+ * @param deps - Node-side collaborators (the project-context mirror setter)
+ * @returns What happened, with the restored blob when action is "restore"
+ */
+function syncRoute(
+  args: unknown,
+  deps: ProjectContextBackupDeps,
+): ProjectContextSyncResult {
+  const { filePath, content, allowRestore } = (args ??
+    {}) as Partial<ProjectContextSyncArgs>;
+
+  // An unsaved set has no sidecar location — nothing to do until it's saved.
+  if (typeof filePath !== "string" || filePath.length === 0) {
+    return { action: "none" };
+  }
+
+  const currentContent = typeof content === "string" ? content : "";
+
+  if (currentContent.trim() !== "") {
+    return backupIfStale(filePath, currentContent);
+  }
+
+  // Empty param. On the first sync of a session it may be an upgrade-wiped
+  // device (restore); otherwise it's a deliberate clear (propagate to disk).
+  return allowRestore
+    ? restoreIfBackupExists(filePath, deps)
+    : clearBackupIfPresent(filePath);
+}
+
+/**
+ * Param is empty (e.g. a freshly upgraded device): restore from the sidecar if
+ * one holds real content. An empty/whitespace sidecar is treated as no backup.
+ *
+ * @param filePath - Absolute path to the Live Set (.als) file
+ * @param deps - Node-side collaborators (the project-context mirror setter)
+ * @returns A "restore" result carrying the blob, or "none"
+ */
+function restoreIfBackupExists(
+  filePath: string,
+  deps: ProjectContextBackupDeps,
+): ProjectContextSyncResult {
+  const sidecar = readProjectContextSidecar(filePath);
+
+  if (sidecar == null || sidecar.trim() === "") {
+    return { action: "none" };
+  }
+
+  deps.setProjectContext(sidecar);
+
+  return { action: "restore", content: sidecar };
+}
+
+/**
+ * Param was cleared by the user (empty, and not the session's first sync):
+ * delete the sidecar so the clear sticks and isn't restored on the next load.
+ *
+ * @param filePath - Absolute path to the Live Set (.als) file
+ * @returns A "clear" result when a sidecar was deleted, else "none"
+ */
+function clearBackupIfPresent(filePath: string): ProjectContextSyncResult {
+  return deleteProjectContextSidecar(filePath)
+    ? { action: "clear" }
+    : { action: "none" };
+}
+
+/**
+ * Param has content: write the sidecar when it's missing or differs (covers
+ * both an ordinary edit and a first-save / Save-As to a folder with no backup
+ * yet). A byte-identical sidecar is left untouched.
+ *
+ * @param filePath - Absolute path to the Live Set (.als) file
+ * @param content - The device param's current project-context blob
+ * @returns A "backup" result when written, else "none"
+ */
+function backupIfStale(
+  filePath: string,
+  content: string,
+): ProjectContextSyncResult {
+  const existing = readProjectContextSidecar(filePath);
+
+  if (existing === content) {
+    return { action: "none" };
+  }
+
+  writeProjectContextSidecar(filePath, content);
+
+  return { action: "backup" };
+}

--- a/src/mcp-server/helpers/project-context-backup/project-context-backup-store.ts
+++ b/src/mcp-server/helpers/project-context-backup/project-context-backup-store.ts
@@ -1,0 +1,104 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Reads and writes the on-disk backup of a Live Set's project context: a
+// "Producer Pal Project Context.md" file sibling to the Live Set's .als, so it
+// survives a device upgrade (which wipes the device's own param blob). One
+// sidecar per project *folder*, shared by every .als in it — saving a new .als
+// into the same folder finds the sidecar already there, and Save-As to a new
+// folder is the case that needs a fresh write. See dev/Memory-System.md.
+//
+// This writes into the user's Live project folder (a path from the Live API's
+// song file_path), NOT ~/.producer-pal, so it deliberately does NOT go through
+// the config-markdown store — there is no configurable dir and no Vitest-inert
+// guard here; tests point file_path at a temp dir instead.
+
+import {
+  existsSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { errorMessage } from "#src/shared/error-utils.ts";
+import * as console from "../../node-for-max-logger.ts";
+
+/** Filename of the project-context backup, dropped beside the Live Set. */
+const SIDECAR_FILENAME = "Producer Pal Project Context.md";
+
+/**
+ * Absolute path of the backup sidecar for a given Live Set file. The sidecar is
+ * a sibling of the .als (one per project folder), so the path is derived from
+ * the .als's directory, not its basename.
+ *
+ * @param liveSetPath - Absolute path to the Live Set (.als) file
+ * @returns Absolute path to the sidecar markdown file
+ */
+export function projectContextSidecarPath(liveSetPath: string): string {
+  return join(dirname(liveSetPath), SIDECAR_FILENAME);
+}
+
+/**
+ * Read the backup sidecar beside the given Live Set, verbatim. A missing or
+ * unreadable file yields null so the caller can distinguish "no backup" from an
+ * empty backup.
+ *
+ * @param liveSetPath - Absolute path to the Live Set (.als) file
+ * @returns Sidecar contents verbatim, or null when absent/unreadable
+ */
+export function readProjectContextSidecar(liveSetPath: string): string | null {
+  const path = projectContextSidecarPath(liveSetPath);
+
+  if (!existsSync(path)) return null;
+
+  try {
+    return readFileSync(path, "utf8");
+  } catch (error) {
+    console.error(
+      `Failed to read project context backup: ${errorMessage(error)}`,
+    );
+
+    return null;
+  }
+}
+
+/**
+ * Overwrite the backup sidecar beside the given Live Set (atomic temp+rename,
+ * matching the config-markdown store). The content is the raw project-context
+ * blob so the file round-trips byte-for-byte and stays hand-editable.
+ *
+ * @param liveSetPath - Absolute path to the Live Set (.als) file
+ * @param content - Project-context blob to persist
+ */
+export function writeProjectContextSidecar(
+  liveSetPath: string,
+  content: string,
+): void {
+  const path = projectContextSidecarPath(liveSetPath);
+  const tmpPath = `${path}.tmp`;
+
+  writeFileSync(tmpPath, content, "utf8");
+  renameSync(tmpPath, path);
+}
+
+/**
+ * Delete the backup sidecar beside the given Live Set, if present. Used when the
+ * user clears the project context in-session so the clear propagates to disk and
+ * isn't resurrected by a restore on the next device load. A missing file is a
+ * no-op.
+ *
+ * @param liveSetPath - Absolute path to the Live Set (.als) file
+ * @returns true when a sidecar was deleted, false when there was none
+ */
+export function deleteProjectContextSidecar(liveSetPath: string): boolean {
+  const path = projectContextSidecarPath(liveSetPath);
+
+  if (!existsSync(path)) return false;
+
+  rmSync(path, { force: true });
+
+  return true;
+}

--- a/src/mcp-server/helpers/project-context-backup/tests/project-context-backup-node-routes.test.ts
+++ b/src/mcp-server/helpers/project-context-backup/tests/project-context-backup-node-routes.test.ts
@@ -1,0 +1,193 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearNodeRoutes } from "#src/mcp-server/rpc/node-request-protocol.ts";
+import { dispatchNodeRoute } from "#src/mcp-server/tests/config-dir-test-helpers.ts";
+import { registerProjectContextBackupNodeRoutes } from "../project-context-backup-node-routes.ts";
+import {
+  projectContextSidecarPath,
+  readProjectContextSidecar,
+} from "../project-context-backup-store.ts";
+
+vi.mock(import("#src/mcp-server/node-for-max-logger.ts"), () => ({
+  log: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+let projectDir = "";
+let liveSetPath = "";
+const setProjectContext = vi.fn<(content: string) => void>();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  projectDir = mkdtempSync(join(tmpdir(), "ppal-proj-"));
+  liveSetPath = join(projectDir, "MySong.als");
+  registerProjectContextBackupNodeRoutes({ setProjectContext });
+});
+
+afterEach(() => {
+  clearNodeRoutes();
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+/**
+ * Seed a sidecar file beside the test Live Set.
+ * @param content - Content to write to the sidecar
+ */
+function seedSidecar(content: string): void {
+  writeFileSync(projectContextSidecarPath(liveSetPath), content, "utf8");
+}
+
+describe("projectContext.sync — unsaved set", () => {
+  it("does nothing when filePath is null", async () => {
+    const res = await dispatchNodeRoute("projectContext.sync", {
+      filePath: null,
+      content: "anything",
+      allowRestore: true,
+    });
+
+    expect(res.result).toStrictEqual({ action: "none" });
+    expect(setProjectContext).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when filePath is an empty string", async () => {
+    const res = await dispatchNodeRoute("projectContext.sync", {
+      filePath: "",
+      content: "anything",
+      allowRestore: true,
+    });
+
+    expect(res.result).toStrictEqual({ action: "none" });
+  });
+
+  it("does nothing when args are missing entirely", async () => {
+    const res = await dispatchNodeRoute("projectContext.sync", null);
+
+    expect(res.result).toStrictEqual({ action: "none" });
+  });
+});
+
+describe("projectContext.sync — restore (empty param, first sync)", () => {
+  it("restores from a sidecar with real content", async () => {
+    seedSidecar("Genre: jungle");
+
+    const res = await dispatchNodeRoute("projectContext.sync", {
+      filePath: liveSetPath,
+      content: "",
+      allowRestore: true,
+    });
+
+    expect(res.result).toStrictEqual({
+      action: "restore",
+      content: "Genre: jungle",
+    });
+    expect(setProjectContext).toHaveBeenCalledWith("Genre: jungle");
+  });
+
+  it("does not restore when there is no sidecar", async () => {
+    const res = await dispatchNodeRoute("projectContext.sync", {
+      filePath: liveSetPath,
+      content: "",
+      allowRestore: true,
+    });
+
+    expect(res.result).toStrictEqual({ action: "none" });
+    expect(setProjectContext).not.toHaveBeenCalled();
+  });
+
+  it("treats a whitespace-only sidecar as no backup", async () => {
+    seedSidecar("   \n  ");
+
+    const res = await dispatchNodeRoute("projectContext.sync", {
+      filePath: liveSetPath,
+      content: "",
+      allowRestore: true,
+    });
+
+    expect(res.result).toStrictEqual({ action: "none" });
+    expect(setProjectContext).not.toHaveBeenCalled();
+  });
+
+  it("treats non-string content as empty", async () => {
+    // content omitted → typeof !== "string" → "" → empty-param path.
+    const res = await dispatchNodeRoute("projectContext.sync", {
+      filePath: liveSetPath,
+      allowRestore: true,
+    });
+
+    expect(res.result).toStrictEqual({ action: "none" });
+  });
+});
+
+describe("projectContext.sync — clear (empty param, later sync)", () => {
+  it("deletes the sidecar when the user clears (not first sync)", async () => {
+    seedSidecar("Genre: jungle");
+
+    const res = await dispatchNodeRoute("projectContext.sync", {
+      filePath: liveSetPath,
+      content: "",
+      allowRestore: false,
+    });
+
+    expect(res.result).toStrictEqual({ action: "clear" });
+    expect(existsSync(projectContextSidecarPath(liveSetPath))).toBe(false);
+    // A clear must NOT restore the old content back into the param.
+    expect(setProjectContext).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when there is no sidecar to clear", async () => {
+    const res = await dispatchNodeRoute("projectContext.sync", {
+      filePath: liveSetPath,
+      content: "",
+      allowRestore: false,
+    });
+
+    expect(res.result).toStrictEqual({ action: "none" });
+  });
+});
+
+describe("projectContext.sync — backup (non-empty param)", () => {
+  it("writes a sidecar when none exists (first save / Save-As to new folder)", async () => {
+    const res = await dispatchNodeRoute("projectContext.sync", {
+      filePath: liveSetPath,
+      content: "Genre: jungle",
+      allowRestore: false,
+    });
+
+    expect(res.result).toStrictEqual({ action: "backup" });
+    expect(readProjectContextSidecar(liveSetPath)).toBe("Genre: jungle");
+  });
+
+  it("overwrites a stale sidecar", async () => {
+    seedSidecar("old");
+
+    const res = await dispatchNodeRoute("projectContext.sync", {
+      filePath: liveSetPath,
+      content: "new",
+      allowRestore: false,
+    });
+
+    expect(res.result).toStrictEqual({ action: "backup" });
+    expect(readProjectContextSidecar(liveSetPath)).toBe("new");
+  });
+
+  it("leaves a byte-identical sidecar untouched", async () => {
+    seedSidecar("same");
+
+    const res = await dispatchNodeRoute("projectContext.sync", {
+      filePath: liveSetPath,
+      content: "same",
+      allowRestore: false,
+    });
+
+    expect(res.result).toStrictEqual({ action: "none" });
+  });
+});

--- a/src/mcp-server/helpers/project-context-backup/tests/project-context-backup-store.test.ts
+++ b/src/mcp-server/helpers/project-context-backup/tests/project-context-backup-store.test.ts
@@ -1,0 +1,101 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  deleteProjectContextSidecar,
+  projectContextSidecarPath,
+  readProjectContextSidecar,
+  writeProjectContextSidecar,
+} from "../project-context-backup-store.ts";
+
+vi.mock(import("#src/mcp-server/node-for-max-logger.ts"), () => ({
+  log: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+let projectDir = "";
+let liveSetPath = "";
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "ppal-proj-"));
+  liveSetPath = join(projectDir, "MySong.als");
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe("projectContextSidecarPath", () => {
+  it("puts the sidecar beside the .als, keyed on the folder not the basename", () => {
+    expect(projectContextSidecarPath(liveSetPath)).toBe(
+      join(projectDir, "Producer Pal Project Context.md"),
+    );
+    // A different .als in the same folder resolves to the SAME sidecar.
+    expect(projectContextSidecarPath(join(projectDir, "Other.als"))).toBe(
+      projectContextSidecarPath(liveSetPath),
+    );
+  });
+});
+
+describe("readProjectContextSidecar", () => {
+  it("returns null when no sidecar exists", () => {
+    expect(readProjectContextSidecar(liveSetPath)).toBeNull();
+  });
+
+  it("returns the sidecar contents verbatim when present", () => {
+    writeFileSync(
+      projectContextSidecarPath(liveSetPath),
+      "  Keep this exactly.\n\n",
+      "utf8",
+    );
+
+    expect(readProjectContextSidecar(liveSetPath)).toBe(
+      "  Keep this exactly.\n\n",
+    );
+  });
+
+  it("returns null (not throw) when the sidecar path is unreadable", () => {
+    // A directory at the sidecar path exists but can't be read as a file.
+    mkdirSync(projectContextSidecarPath(liveSetPath));
+
+    expect(readProjectContextSidecar(liveSetPath)).toBeNull();
+  });
+});
+
+describe("writeProjectContextSidecar", () => {
+  it("writes the blob and round-trips byte-for-byte", () => {
+    writeProjectContextSidecar(liveSetPath, "Genre: jungle\nBPM: 170");
+
+    expect(readProjectContextSidecar(liveSetPath)).toBe(
+      "Genre: jungle\nBPM: 170",
+    );
+  });
+
+  it("overwrites an existing sidecar", () => {
+    writeProjectContextSidecar(liveSetPath, "first");
+    writeProjectContextSidecar(liveSetPath, "second");
+
+    expect(readProjectContextSidecar(liveSetPath)).toBe("second");
+  });
+});
+
+describe("deleteProjectContextSidecar", () => {
+  it("deletes an existing sidecar and reports true", () => {
+    writeProjectContextSidecar(liveSetPath, "gone soon");
+
+    expect(deleteProjectContextSidecar(liveSetPath)).toBe(true);
+    expect(readProjectContextSidecar(liveSetPath)).toBeNull();
+  });
+
+  it("reports false when there is no sidecar", () => {
+    expect(deleteProjectContextSidecar(liveSetPath)).toBe(false);
+  });
+});

--- a/src/mcp-server/tests/express-app/create-express-app-config.test.ts
+++ b/src/mcp-server/tests/express-app/create-express-app-config.test.ts
@@ -3,10 +3,16 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { beforeAll, describe, expect, it } from "vitest";
+import Max from "max-api";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { projectContextSidecarPath } from "../../helpers/project-context-backup/project-context-backup-store.ts";
 import { TOOL_NAMES } from "../../create-mcp-server.ts";
+import { dispatchNodeRoute } from "../config-dir-test-helpers.ts";
 import { setupExpressAppServer } from "../express-app-test-helpers.ts";
 
 describe("MCP Express App - Config", () => {
@@ -151,6 +157,54 @@ describe("MCP Express App - Config", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ projectContext: "" }),
       });
+    });
+
+    it("restores the on-disk backup into config on projectContext.sync (device upgrade)", async () => {
+      const projectDir = mkdtempSync(join(tmpdir(), "ppal-proj-"));
+      const liveSetPath = join(projectDir, "MySong.als");
+
+      try {
+        // Upgraded device: the param is empty but a sidecar holds the backup.
+        writeFileSync(
+          projectContextSidecarPath(liveSetPath),
+          "Restored from disk",
+          "utf8",
+        );
+        await fetch(configUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ projectContext: "" }),
+        });
+
+        // The V8 side calls this route on its first tool call after the upgrade.
+        // dispatchNodeRoute reads Max.outlet's first recorded call, so clear the
+        // server-startup calls first.
+        vi.mocked(Max.outlet).mockClear();
+        const res = await dispatchNodeRoute("projectContext.sync", {
+          filePath: liveSetPath,
+          content: "",
+          allowRestore: true,
+        });
+
+        expect(res.result).toStrictEqual({
+          action: "restore",
+          content: "Restored from disk",
+        });
+
+        // The route updated config directly so a restore during ppal-connect is
+        // reflected in that response's injected project-context block.
+        const configResponse = await fetch(configUrl);
+        const config = await configResponse.json();
+
+        expect(config.projectContext).toBe("Restored from disk");
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true });
+        await fetch(configUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ projectContext: "" }),
+        });
+      }
     });
 
     it("should update sampleFolder", async () => {


### PR DESCRIPTION
## Why

Project context lives in a Max device parameter, so it's serialized into the `.als` and survives save/reload — but **not a device upgrade**. Dropping in a newer `.amxd` gives a fresh device with an empty param, silently losing the context. Devices ship every few weeks, so this bites real users.

## What

Mirror the project-context blob to a `Producer Pal Project Context.md` sidecar saved **next to the Set's `.als`** (one per project folder), and restore it automatically the first time Producer Pal is used after an upgrade.

The device param stays the source of truth; the sidecar is a backup. Split across the runtime boundary — V8 has the Live API, Node has the filesystem:

- **V8** (`project-context-sync.ts`) reads `live_set file_path` (not observable, so we pull it) and, on a first sync / changed path / changed blob, calls the `projectContext.sync` RPC. A cross-request memo skips the hop on the vast majority of calls.
- **Node** (`helpers/project-context-backup/`) owns the `fs`: non-empty param with a missing/stale sidecar ⇒ **backup**; empty param ⇒ **restore** (first sync only, gated by `allowRestore`) or **clear** (delete the sidecar so a deliberate clear sticks).

### Triggers
- **Every MCP tool call** (the primary path).
- **Manual edits** — device-UI textedit and webui `POST /config` both funnel through V8's `projectContext()` param setter, which now fire-and-forgets a backup (never restores; empty-before-first-sync is left alone so an upgrade-wiped device can't delete its own backup).

### Residual gap (accepted, documented)
Setting context while the Set is **unsaved**, then saving and upgrading with no further tool call or edit. The `null → path` first-save fires neither trigger — and a Max for Live device has no reliable way to detect a save. Any later tool call or edit closes it. Documented in Known Issues + the upgrade guide.

## Docs
- `guide/context.md` — explains the sidecar where the context layers are documented.
- `support/known-issues.md` — the rare edge case, its root cause, how to avoid/recover.
- `installation/upgrading.md` — a reassuring cross-linked tip.
- `dev/Memory-System.md` — as-built design.

## Testing
`npm run check` green (10030 tests, functions 100%, branches 97.82%), `npm run check:build` green, `npm run docs:test` green. New source files at 100% coverage.

**Still to do before marking ready:** manual verification in Ableton (LLM flow writes the `.md`; a manual edit writes it; a device upgrade restores it; an in-session clear deletes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)