### PR TITLE
feat(mcp): per-request smallModelMode via header (unblock small-model workers)

### DIFF
--- a/src/mcp-server/create-express-app.ts
+++ b/src/mcp-server/create-express-app.ts
@@ -13,6 +13,10 @@ import express, {
 } from "express";
 import Max from "max-api";
 import chatUiHtml from "virtual:chat-ui-html";
+import {
+  SMALL_MODEL_MODE_HEADER,
+  resolveSmallModelMode,
+} from "#src/shared/config.ts";
 import { errorMessage } from "#src/shared/error-utils.ts";
 import {
   DEFAULT_NOTATION,
@@ -25,6 +29,7 @@ import {
   createMcpServer,
   validateTools,
 } from "./create-mcp-server.ts";
+import { type WrappedCallLiveApi } from "./helpers/connect/connect-append.ts";
 import { enrichConnect } from "./helpers/connect/enrich-connect.ts";
 import { requestBody } from "./helpers/http/request-body.ts";
 import {
@@ -156,14 +161,29 @@ function applyLiveApiEnabled(next: boolean): void {
   }
 }
 
-// Enrich ppal-connect Node-side with the skills, context, memory, and next-step
-// blocks (see enrich-connect.ts for the block order and why it matters).
-// config.projectContext is the per-Live Set context blob.
-const callLiveApiEnriched = enrichConnect(callLiveApi, () => ({
-  notation: config.notation,
-  smallModelMode: config.smallModelMode,
-  projectContext: config.projectContext,
-}));
+/**
+ * Enrich ppal-connect Node-side with the skills, context, memory, and next-step
+ * blocks (see enrich-connect.ts for the block order and why it matters).
+ * config.projectContext is the per-Live Set context blob. smallModelMode arrives
+ * through a getter (not config directly) so a POST /mcp request can supply its
+ * own per-request value for the skills variant — the same value that shrinks its
+ * tool schemas — while REST routes keep reading the live global.
+ *
+ * @param getSmallModelMode - Reads the small-model mode for this wrapper's calls
+ * @returns A callLiveApi whose ppal-connect results carry every block
+ */
+function buildEnrichedCall(
+  getSmallModelMode: () => boolean,
+): WrappedCallLiveApi {
+  return enrichConnect(callLiveApi, () => ({
+    notation: config.notation,
+    smallModelMode: getSmallModelMode(),
+    projectContext: config.projectContext,
+  }));
+}
+
+// REST routes read the live global; POST /mcp builds its own per-request wrapper.
+const callLiveApiEnriched = buildEnrichedCall(() => config.smallModelMode);
 
 interface JsonRpcError {
   jsonrpc: string;
@@ -275,12 +295,25 @@ export function createExpressApp(): Express {
 
       console.info(`MCP request: ${method}`);
 
-      const server = createMcpServer(callLiveApiEnriched, {
-        smallModelMode: config.smallModelMode,
-        notation: config.notation,
-        liveApiEnabled: config.liveApiEnabled,
-        tools: config.tools,
-      });
+      // Per-request small-model mode: the built-in chat and each subagent worker
+      // send their own value via this header, so one caller's mode never leaks
+      // to the concurrently-running main session (a POST /config would). Absent
+      // ⇒ the global default, so external MCP clients are unaffected. Drives both
+      // the tool-schema shrink (below) and the skills variant (enriched wrapper).
+      const requestSmallModelMode = resolveSmallModelMode(
+        req.get(SMALL_MODEL_MODE_HEADER),
+        config.smallModelMode,
+      );
+
+      const server = createMcpServer(
+        buildEnrichedCall(() => requestSmallModelMode),
+        {
+          smallModelMode: requestSmallModelMode,
+          notation: config.notation,
+          liveApiEnabled: config.liveApiEnabled,
+          tools: config.tools,
+        },
+      );
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined, // Stateless mode
       });

--- a/src/mcp-server/tests/express-app/create-express-app-small-model-header.test.ts
+++ b/src/mcp-server/tests/express-app/create-express-app-small-model-header.test.ts
@@ -1,0 +1,161 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import Max from "max-api";
+import { describe, expect, it, vi } from "vitest";
+import { SMALL_MODEL_MODE_HEADER } from "#src/shared/config.ts";
+import { MAX_ERROR_DELIMITER } from "#src/shared/mcp-response-utils.ts";
+import { setupExpressAppServer } from "../express-app-test-helpers.ts";
+
+type MockMax = typeof Max & {
+  defaultMcpResponseHandler:
+    ((requestId: string, ...chunks: string[]) => void) | null;
+};
+const mockMax = Max as MockMax;
+
+/**
+ * Connect an MCP client to the server with (or without) the small-model-mode
+ * header. The transport carries the header on every request the client makes.
+ *
+ * @param serverUrl - The running server's /mcp URL
+ * @param header - Value for the small-model-mode header, or undefined to omit it
+ * @returns A connected client and its transport (close the transport when done)
+ */
+async function connectWithHeader(
+  serverUrl: string,
+  header: string | undefined,
+): Promise<{ client: Client; transport: StreamableHTTPClientTransport }> {
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  const transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
+    requestInit:
+      header == null
+        ? undefined
+        : { headers: { [SMALL_MODEL_MODE_HEADER]: header } },
+  });
+
+  await client.connect(transport);
+
+  return { client, transport };
+}
+
+/**
+ * Whether ppal-create-track's schema still exposes the `count` param — present
+ * in full mode, dropped under small-model mode. A clean, stable discriminator
+ * for the per-request schema shrink (the first of the two consumers the header
+ * drives).
+ *
+ * @param serverUrl - The running server's /mcp URL
+ * @param header - Value for the small-model-mode header, or undefined to omit it
+ * @returns True when `count` is present in ppal-create-track's input schema
+ */
+async function createTrackHasCount(
+  serverUrl: string,
+  header: string | undefined,
+): Promise<boolean> {
+  const { client, transport } = await connectWithHeader(serverUrl, header);
+
+  try {
+    const { tools } = await client.listTools();
+    const createTrack = tools.find((t) => t.name === "ppal-create-track");
+
+    return createTrack?.inputSchema.properties?.count != null;
+  } finally {
+    await transport.close();
+  }
+}
+
+/**
+ * Call ppal-connect with a header and return the injected skills block — the
+ * text block starting with the skills heading, which enrich-connect appends
+ * Node-side and which varies (basic vs standard) by small-model mode. This is
+ * the second consumer the header drives. Max is mocked to return a bare success
+ * so the connect handler resolves and enrichment runs.
+ *
+ * @param serverUrl - The running server's /mcp URL
+ * @param header - Value for the small-model-mode header, or undefined to omit it
+ * @returns The injected skills block text, or "" when none was found
+ */
+async function connectSkillsBlock(
+  serverUrl: string,
+  header: string | undefined,
+): Promise<string> {
+  Max.outlet = vi.fn((message: string, requestId: string) => {
+    if (message === "mcp_request") {
+      setTimeout(() => {
+        mockMax.defaultMcpResponseHandler!(
+          requestId,
+          JSON.stringify({ content: [{ type: "text", text: "{}" }] }),
+          MAX_ERROR_DELIMITER,
+        );
+      }, 1);
+    }
+
+    return Promise.resolve();
+  }) as typeof Max.outlet;
+
+  const { client, transport } = await connectWithHeader(serverUrl, header);
+
+  try {
+    const result = await client.callTool({
+      name: "ppal-connect",
+      arguments: {},
+    });
+    const content = result.content as Array<{ type: string; text?: string }>;
+
+    return (
+      content.find((c) => c.text?.startsWith("# Producer Pal Skills"))?.text ??
+      ""
+    );
+  } finally {
+    await transport.close();
+  }
+}
+
+// The harness leaves the global config.smallModelMode at its default (false).
+describe("POST /mcp per-request small-model-mode header", () => {
+  const appState = setupExpressAppServer();
+
+  describe("tool-schema shrink", () => {
+    it("shrinks tool schemas for this request when the header is true", async () => {
+      expect(await createTrackHasCount(appState.serverUrl, "true")).toBe(false);
+    });
+
+    it("keeps full schemas when the header is explicitly false", async () => {
+      expect(await createTrackHasCount(appState.serverUrl, "false")).toBe(true);
+    });
+
+    it("falls back to the global default (full schemas) when absent", async () => {
+      // Proves an external MCP client that sends no header is unaffected.
+      expect(await createTrackHasCount(appState.serverUrl, undefined)).toBe(
+        true,
+      );
+    });
+
+    it("does not leak one request's mode onto the next", async () => {
+      // A shrunk request must not mutate the global for a later headerless one.
+      await createTrackHasCount(appState.serverUrl, "true");
+
+      expect(await createTrackHasCount(appState.serverUrl, undefined)).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("skills variant", () => {
+    it("serves a different skills variant per-request driven by the header", async () => {
+      const basic = await connectSkillsBlock(appState.serverUrl, "true");
+      const standard = await connectSkillsBlock(appState.serverUrl, "false");
+
+      // Both connect requests inject a skills block...
+      expect(basic.startsWith("# Producer Pal Skills")).toBe(true);
+      expect(standard.startsWith("# Producer Pal Skills")).toBe(true);
+      // ...but the small-model (basic) variant differs from the standard one,
+      // proving the per-request header — not just the global — selects it.
+      expect(basic).not.toBe(standard);
+    });
+  });
+});

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -68,3 +68,43 @@ Be creative and focus on the user's musical goals.`;
 export function resolveSystemInstruction(override?: string | null): string {
   return override?.trim() ? override : SYSTEM_INSTRUCTION;
 }
+
+// --- Per-request small-model mode (MCP transport) ---
+
+/**
+ * HTTP header that carries a per-request small-model-mode override on POST /mcp.
+ *
+ * Small-model mode drives BOTH tool-schema shrinking (create-mcp-server.ts) and
+ * the skills variant (basic vs standard, enrich-connect.ts). It is otherwise a
+ * single server-side global (`config.smallModelMode`), which means every caller
+ * shares one value. This header lets an individual caller — the built-in chat,
+ * or a spawned subagent worker — drive its own value for its own requests, so a
+ * full-strength orchestrator can delegate to cheap small-model workers without
+ * clobbering the global (which a POST /config would).
+ *
+ * Absent ⇒ the server falls back to `config.smallModelMode`. External MCP
+ * clients (Claude Desktop, MCP Inspector) and the device toggle never send it
+ * and keep using the global default. Sent lowercase; HTTP header names are
+ * case-insensitive and Express's `req.get` matches accordingly.
+ */
+export const SMALL_MODEL_MODE_HEADER = "x-producer-pal-small-model-mode";
+
+/**
+ * Resolve the effective small-model mode for one request from its header value,
+ * falling back to the global default when the header is absent or unrecognized.
+ * The client sends the string "true" or "false"; anything else is treated as
+ * absent so a stray value can't force a mode.
+ *
+ * @param headerValue - The request's header value, or undefined when absent
+ * @param fallback - The global `config.smallModelMode` to use when no header
+ * @returns The small-model mode to apply for this request
+ */
+export function resolveSmallModelMode(
+  headerValue: string | undefined,
+  fallback: boolean,
+): boolean {
+  if (headerValue === "true") return true;
+  if (headerValue === "false") return false;
+
+  return fallback;
+}

--- a/src/shared/tests/config.test.ts
+++ b/src/shared/tests/config.test.ts
@@ -7,7 +7,9 @@ import { describe, expect, it } from "vitest";
 import {
   MIN_LIVE_VERSION,
   SAME_TIME_EPSILON,
+  SMALL_MODEL_MODE_HEADER,
   VERSION,
+  resolveSmallModelMode,
 } from "#src/shared/config.ts";
 
 describe("config constants", () => {
@@ -24,5 +26,34 @@ describe("config constants", () => {
   it("SAME_TIME_EPSILON is a small positive position tolerance", () => {
     expect(SAME_TIME_EPSILON).toBeGreaterThan(0);
     expect(SAME_TIME_EPSILON).toBeLessThan(0.01);
+  });
+});
+
+describe("SMALL_MODEL_MODE_HEADER", () => {
+  it("is a lowercase custom header name", () => {
+    expect(SMALL_MODEL_MODE_HEADER).toBe("x-producer-pal-small-model-mode");
+  });
+});
+
+describe("resolveSmallModelMode", () => {
+  it('returns true for "true" regardless of fallback', () => {
+    expect(resolveSmallModelMode("true", false)).toBe(true);
+    expect(resolveSmallModelMode("true", true)).toBe(true);
+  });
+
+  it('returns false for "false" regardless of fallback', () => {
+    expect(resolveSmallModelMode("false", true)).toBe(false);
+    expect(resolveSmallModelMode("false", false)).toBe(false);
+  });
+
+  it("falls back to the global default when the header is absent", () => {
+    expect(resolveSmallModelMode(undefined, true)).toBe(true);
+    expect(resolveSmallModelMode(undefined, false)).toBe(false);
+  });
+
+  it("falls back for an unrecognized value so a stray header can't force a mode", () => {
+    expect(resolveSmallModelMode("1", true)).toBe(true);
+    expect(resolveSmallModelMode("yes", false)).toBe(false);
+    expect(resolveSmallModelMode("", true)).toBe(true);
   });
 });

--- a/webui/src/chat/helpers/mcp-client-helpers.ts
+++ b/webui/src/chat/helpers/mcp-client-helpers.ts
@@ -7,6 +7,7 @@
  */
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { SMALL_MODEL_MODE_HEADER } from "#src/shared/config";
 
 const MCP_CLIENT_NAME = "producer-pal-chat-ui";
 const MCP_CLIENT_VERSION = "1.0.0";
@@ -20,13 +21,31 @@ export interface McpToolDefinition {
 
 /**
  * Creates and connects an MCP client to the specified URL.
+ *
+ * When `smallModelMode` is provided, every request this client makes carries the
+ * per-request small-model-mode header, so the server shrinks tool schemas and
+ * serves the basic skills variant for THIS caller (the built-in chat, or a
+ * subagent worker) independent of the global default. Omit it — as the voice
+ * paths do — to send no header and let the server fall back to the global.
+ *
  * @param mcpUrl - URL of the MCP server
+ * @param smallModelMode - Per-request small-model mode; omit to use the global
  * @returns Connected MCP client
  */
 export async function createConnectedMcpClient(
   mcpUrl: string,
+  smallModelMode?: boolean,
 ): Promise<Client> {
-  const transport = new StreamableHTTPClientTransport(new URL(mcpUrl));
+  const transport = new StreamableHTTPClientTransport(
+    new URL(mcpUrl),
+    smallModelMode == null
+      ? undefined
+      : {
+          requestInit: {
+            headers: { [SMALL_MODEL_MODE_HEADER]: String(smallModelMode) },
+          },
+        },
+  );
   const client = new Client({
     name: MCP_CLIENT_NAME,
     version: MCP_CLIENT_VERSION,

--- a/webui/src/chat/helpers/tests/mcp-client-helpers.test.ts
+++ b/webui/src/chat/helpers/tests/mcp-client-helpers.test.ts
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { SMALL_MODEL_MODE_HEADER } from "#src/shared/config";
 import {
   createConnectedMcpClient,
   filterEnabledTools,
@@ -22,6 +24,8 @@ vi.mock(import("@modelcontextprotocol/sdk/client/index.js"), () => ({
 vi.mock(import("@modelcontextprotocol/sdk/client/streamableHttp.js"), () => ({
   StreamableHTTPClientTransport: vi.fn(),
 }));
+
+const mockTransport = vi.mocked(StreamableHTTPClientTransport);
 
 const tools: McpToolDefinition[] = [
   { name: "tool-a", inputSchema: {} },
@@ -70,5 +74,29 @@ describe("createConnectedMcpClient", () => {
 
     expect(client).toBeDefined();
     expect(mockConnect).toHaveBeenCalledOnce();
+  });
+
+  it("sends no per-request header when smallModelMode is omitted", async () => {
+    await createConnectedMcpClient("http://localhost:3000/mcp");
+
+    // Voice paths omit the flag and must fall back to the global config value.
+    expect(mockTransport.mock.calls[0]?.[1]).toBeUndefined();
+  });
+
+  it("sends the small-model-mode header true when enabled", async () => {
+    await createConnectedMcpClient("http://localhost:3000/mcp", true);
+
+    expect(
+      mockTransport.mock.calls[0]?.[1]?.requestInit?.headers,
+    ).toStrictEqual({ [SMALL_MODEL_MODE_HEADER]: "true" });
+  });
+
+  it("sends the small-model-mode header false when explicitly disabled", async () => {
+    // Explicit false is authoritative for this caller, overriding the global.
+    await createConnectedMcpClient("http://localhost:3000/mcp", false);
+
+    expect(
+      mockTransport.mock.calls[0]?.[1]?.requestInit?.headers,
+    ).toStrictEqual({ [SMALL_MODEL_MODE_HEADER]: "false" });
   });
 });

--- a/webui/src/chat/sdk/client.ts
+++ b/webui/src/chat/sdk/client.ts
@@ -85,6 +85,7 @@ export class ChatSdkClient {
     const { tools, mcpClient } = await createMcpTools(
       mcpUrl,
       this.config.enabledTools,
+      this.config.smallModelMode,
     );
 
     this.mcpClient = mcpClient;

--- a/webui/src/chat/sdk/mcp-tools.ts
+++ b/webui/src/chat/sdk/mcp-tools.ts
@@ -22,13 +22,17 @@ export interface McpTools {
  * Each tool's execute function delegates to mcpClient.callTool().
  * @param mcpUrl - URL of the MCP server
  * @param enabledTools - Map of tool names to enabled state
+ * @param smallModelMode - Per-request small-model mode carried on every MCP
+ *   request (shrinks tool schemas + selects the basic skills variant); omit for
+ *   the global default
  * @returns AI SDK tools and the underlying MCP client
  */
 export async function createMcpTools(
   mcpUrl: string,
   enabledTools?: Record<string, boolean>,
+  smallModelMode?: boolean,
 ): Promise<McpTools> {
-  const mcpClient = await createConnectedMcpClient(mcpUrl);
+  const mcpClient = await createConnectedMcpClient(mcpUrl, smallModelMode);
   const toolsResult = await mcpClient.listTools();
   const filtered = filterEnabledTools(toolsResult.tools, enabledTools);
 

--- a/webui/src/chat/sdk/tests/client/client.test.ts
+++ b/webui/src/chat/sdk/tests/client/client.test.ts
@@ -250,6 +250,7 @@ describe("ChatSdkClient", () => {
       expect(createMcpTools).toHaveBeenCalledWith(
         "http://localhost:3000/mcp",
         undefined,
+        undefined,
       );
     });
 
@@ -265,6 +266,23 @@ describe("ChatSdkClient", () => {
       expect(createMcpTools).toHaveBeenCalledWith(
         "http://custom:9000/mcp",
         undefined,
+        undefined,
+      );
+    });
+
+    it("forwards config.smallModelMode so the MCP transport sends the header", async () => {
+      const { createMcpTools } = await import("#webui/chat/sdk/mcp-tools");
+      const client = new ChatSdkClient(
+        "key",
+        createConfig({ smallModelMode: true }),
+      );
+
+      await client.initialize();
+
+      expect(createMcpTools).toHaveBeenCalledWith(
+        "http://localhost:3000/mcp",
+        undefined,
+        true,
       );
     });
   });

--- a/webui/src/chat/sdk/tests/mcp-tools.test.ts
+++ b/webui/src/chat/sdk/tests/mcp-tools.test.ts
@@ -60,6 +60,16 @@ describe("createMcpTools", () => {
 
     expect(createConnectedMcpClient).toHaveBeenCalledWith(
       "http://custom:9000/mcp",
+      undefined,
+    );
+  });
+
+  it("forwards smallModelMode to the MCP client (per-request header)", async () => {
+    await createMcpTools("http://localhost:3000/mcp", undefined, true);
+
+    expect(createConnectedMcpClient).toHaveBeenCalledWith(
+      "http://localhost:3000/mcp",
+      true,
     );
   });
 

--- a/webui/src/chat/sdk/tests/spawn-subagent-tool.test.ts
+++ b/webui/src/chat/sdk/tests/spawn-subagent-tool.test.ts
@@ -66,6 +66,12 @@ describe("buildWorkerConfig", () => {
     expect(worker.temperature).toBe(0.7);
     expect(worker.systemInstruction).toBe("custom prompt");
   });
+
+  it("inherits smallModelMode so the worker sends its own per-request header", () => {
+    const worker = buildWorkerConfig(createConfig({ smallModelMode: true }));
+
+    expect(worker.smallModelMode).toBe(true);
+  });
 });
 
 describe("extractWorkerResult", () => {

--- a/webui/src/chat/sdk/types.ts
+++ b/webui/src/chat/sdk/types.ts
@@ -99,6 +99,14 @@ export interface ChatClientConfig {
   systemInstruction?: string;
   mcpUrl?: string;
   enabledTools?: Record<string, boolean>;
+  /**
+   * Small-model mode for THIS client's MCP requests, sent as a per-request
+   * header so the server shrinks tool schemas and serves the basic skills
+   * variant for this caller alone. A subagent worker inherits it from the
+   * orchestrator config (buildWorkerConfig), so a small-model worker gets the
+   * reduced context even while the orchestrator runs full-strength.
+   */
+  smallModelMode?: boolean;
   showThoughts: boolean;
   providerOptions?: ProviderOptions;
   /** Recompute provider options for a given thinking level (used for mid-conversation overrides) */

--- a/webui/src/hooks/chat/adapter.ts
+++ b/webui/src/hooks/chat/adapter.ts
@@ -208,6 +208,9 @@ export const chatAdapter: ChatAdapter<
     // The stored showThoughts setting is preserved for when the UI toggle is re-introduced.
     const showThoughts =
       thinking !== "Off" && Boolean(extraParams?.showThoughts);
+    // Carried onto the config so client.initialize sends it as the per-request
+    // MCP header (schema shrink + basic skills variant for this caller).
+    const smallModelMode = Boolean(extraParams?.smallModelMode);
 
     const languageModel = createProviderModel(provider, model, apiKey, baseUrl);
     const providerOptions = buildProviderOptions(
@@ -235,6 +238,7 @@ export const chatAdapter: ChatAdapter<
       temperature: suppressTemperature ? undefined : temperature,
       systemInstruction,
       enabledTools,
+      smallModelMode,
       showThoughts,
       providerOptions,
       buildProviderOptions: (overrideThinking: string) =>

--- a/webui/src/hooks/chat/tests/adapter.test.ts
+++ b/webui/src/hooks/chat/tests/adapter.test.ts
@@ -74,6 +74,34 @@ describe("chatAdapter", () => {
       expect(config.enabledTools).toStrictEqual({});
     });
 
+    it("carries smallModelMode from extraParams onto the config", () => {
+      const on = chatAdapter.buildConfig(
+        "gpt-4o",
+        1.0,
+        "default",
+        {},
+        undefined,
+        {
+          ...extraParams,
+          smallModelMode: true,
+        },
+      );
+
+      expect(on.smallModelMode).toBe(true);
+
+      // Absent in extraParams coerces to false so the header is always explicit.
+      const off = chatAdapter.buildConfig(
+        "gpt-4o",
+        1.0,
+        "default",
+        {},
+        undefined,
+        extraParams,
+      );
+
+      expect(off.smallModelMode).toBe(false);
+    });
+
     it("passes enabled tools to config", () => {
       const enabledTools = { "ppal-connect": true, "ppal-read": false };
       const config = chatAdapter.buildConfig(

--- a/webui/src/hooks/chat/use-chat-mode-state.ts
+++ b/webui/src/hooks/chat/use-chat-mode-state.ts
@@ -142,6 +142,7 @@ export function useChatModeState(params: UseChatModeStateParams) {
     extraParams: {
       baseUrl,
       showThoughts: settings.showThoughts,
+      smallModelMode: settings.smallModelMode,
       provider: settings.provider,
       apiKey: resolvedApiKey,
       systemInstructionOverride,


### PR DESCRIPTION
## What

Makes `smallModelMode` **per-request** on `POST /mcp` so a spawned subagent worker (or the built-in chat) can drive its own value, independent of the single server-side global. This unblocks the subagents value prop: a full-strength orchestrator delegating to cheap small-model workers with shrunk tool schemas + basic skills.

## The problem

`smallModelMode` was a single global (`config.smallModelMode`) — set via `POST /config` or the device toggle, read fresh per `POST /mcp` to drive **both** tool-schema shrinking (`create-mcp-server.ts`) and the skills variant (basic vs standard, `enrich-connect.ts`). One value for every caller, so a worker's `ppal-*` calls read whatever the main session set. Heterogeneous small-model workers were blocked. (Model/provider/thinking already apply per-worker — they're client-side model-call params — `smallModelMode` was the odd one out.)

## The fix

- New header `x-producer-pal-small-model-mode`. The `POST /mcp` handler resolves it (falling back to the global when absent) and threads that one value into **both** consumers: `createMcpServer` (schema shrink) and a per-request enriched `callLiveApi` (skills variant).
- Deliberately a **header, not a worker `POST /config`** — that's global and would clobber the concurrently-running main session.
- The **global stays as the fallback**: external MCP clients (Claude Desktop, MCP Inspector) and the device toggle send no header and are unaffected. Voice paths pass no value, so `createConnectedMcpClient` omits the header and they keep using the global.
- **Client**: `ChatClientConfig` carries `smallModelMode` (settings → `extraParams` → `buildConfig`); `client.initialize` forwards it to the MCP transport as a header. A worker inherits it via `buildWorkerConfig`.
- Shared header name + resolver live in `src/shared/config.ts` next to the parallel `resolveSystemInstruction` (both cross-cut server + webui).

## Tests

- `resolveSmallModelMode` unit tests (all branches).
- E2E through the real Express app + MCP client: the header shrinks `ppal-create-track`'s schema for that request only, keeps full schemas when `false`/absent, and doesn't leak onto the next request; a `ppal-connect` call proves the header selects a different **skills variant** per-request.
- Client: transport sends the header only when a value is provided (voice omits it); `createMcpTools`/`client.initialize` forward it; `buildConfig` carries it; `buildWorkerConfig` inherits it.

`npm run check` (10109 tests, 100% functions), `npm run ui:test` (14/14), and `npm run check:build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)