### PR TITLE
refactor(webui): remove phased-out showThoughts setting

### DIFF
--- a/dev/Chat-UI.md
+++ b/dev/Chat-UI.md
@@ -230,7 +230,6 @@ interface ConversationRecord {
   modelLabel: string | null; // display name
   thinking: string | null; // thinking level (e.g., "High", "Off")
   temperature: number | null; // temperature setting
-  showThoughts: boolean | null; // whether thinking was displayed
   messages: ChatMessage[]; // full history including toolCalls, toolResults, reasoning, responseModel
 }
 ```
@@ -294,17 +293,16 @@ through this single code path via provider-specific model factories in
 
 **Locked Settings:**
 
-Provider, model, thinking level, temperature, and showThoughts are locked per
-conversation. When a conversation is saved, these settings are stored on the
+Provider, model, thinking level, and temperature are locked per conversation.
+When a conversation is saved, these settings are stored on the
 `ConversationRecord`. When restored, they're passed as
 `ConversationLockedSettings` to prevent settings changes from affecting the
 active conversation.
 
 Per-message overrides (`MessageOverrides`) can still override
-thinking/temperature/ showThoughts for individual messages. When used, the
-overridden values are stamped on the assistant `ChatMessage` as
-`thinkingOverride`, `temperatureOverride`, and `showThoughtsOverride` — only
-when they differ from the conversation defaults.
+thinking/temperature for individual messages. When used, the overridden values
+are stamped on the assistant `ChatMessage` as `thinkingOverride` and
+`temperatureOverride` — only when they differ from the conversation defaults.
 
 **Response Model Tracking:**
 

--- a/e2e/ui/ui-test-helpers.ts
+++ b/e2e/ui/ui-test-helpers.ts
@@ -148,7 +148,6 @@ export async function installStubs(page: Page): Promise<void> {
         model: "gemini-3.6-flash",
         thinking: "Default",
         temperature: 1.0,
-        showThoughts: true,
       }),
     );
   });

--- a/e2e/webui/quick-connect.spec.ts
+++ b/e2e/webui/quick-connect.spec.ts
@@ -90,7 +90,6 @@ for (const config of TEST_CONFIGS) {
               model: settings.model,
               thinking: "Default",
               temperature: 1.0,
-              showThoughts: true,
             }),
           );
         },

--- a/webui/src/chat/sdk/tests/client-test-helpers.ts
+++ b/webui/src/chat/sdk/tests/client-test-helpers.ts
@@ -22,7 +22,6 @@ export function createConfig(
       provider: "openai",
       specificationVersion: "v3",
     } as never,
-    showThoughts: false,
     ...overrides,
   };
 }

--- a/webui/src/chat/sdk/types.ts
+++ b/webui/src/chat/sdk/types.ts
@@ -99,7 +99,6 @@ export interface ChatClientConfig {
   systemInstruction?: string;
   mcpUrl?: string;
   enabledTools?: Record<string, boolean>;
-  showThoughts: boolean;
   providerOptions?: ProviderOptions;
   /** Recompute provider options for a given thinking level (used for mid-conversation overrides) */
   buildProviderOptions?: (thinking: string) => ProviderOptions | undefined;

--- a/webui/src/components/chat/tests/ChatStart.test.tsx
+++ b/webui/src/components/chat/tests/ChatStart.test.tsx
@@ -20,7 +20,6 @@ import {
 const defaultOverrides = {
   thinking: "Default",
   temperature: 1.0,
-  showThoughts: true,
 };
 
 type RenderProps = Partial<ChatStartProps> & {
@@ -66,7 +65,6 @@ describe("ChatStart", () => {
       const overrides = {
         thinking: "Max",
         temperature: 0.5,
-        showThoughts: false,
       };
       const { handleSend } = renderChatStart({ overrides });
 

--- a/webui/src/components/settings/tests/PresetControls.test.tsx
+++ b/webui/src/components/settings/tests/PresetControls.test.tsx
@@ -26,7 +26,6 @@ function makeSettings(over?: Partial<UseSettingsReturn>): UseSettingsReturn {
     model: "claude",
     thinking: "Default",
     temperature: 1,
-    showThoughts: true,
     smallModelMode: false,
     applyPreset: vi.fn(),
     ...over,

--- a/webui/src/components/settings/tests/SettingsScreen.test.tsx
+++ b/webui/src/components/settings/tests/SettingsScreen.test.tsx
@@ -129,8 +129,6 @@ describe("SettingsScreen", () => {
     savedThinking: "Default",
     temperature: 1,
     setTemperature: vi.fn(),
-    showThoughts: false,
-    setShowThoughts: vi.fn(),
     applyPreset: vi.fn(),
     saveSettings: vi.fn(),
     cancelSettings: vi.fn(),

--- a/webui/src/components/tests/App-test-helpers.ts
+++ b/webui/src/components/tests/App-test-helpers.ts
@@ -52,8 +52,6 @@ export const mockSettingsHook = {
   setThinking: vi.fn(),
   temperature: 1.0,
   setTemperature: vi.fn(),
-  showThoughts: false,
-  setShowThoughts: vi.fn(),
 
   enabledTools: {},
   setEnabledTools: vi.fn(),

--- a/webui/src/hooks/chat/adapter.ts
+++ b/webui/src/hooks/chat/adapter.ts
@@ -28,14 +28,12 @@ import { type ChatAdapter } from "./use-chat-types";
  * @param provider - Provider identifier
  * @param thinking - Thinking level from UI settings
  * @param model - Model identifier
- * @param showThoughts - Whether to include reasoning in response
  * @returns Provider options object for streamText
  */
 function buildProviderOptions(
   provider: Provider,
   thinking: string,
   model: string,
-  showThoughts: boolean,
 ): ProviderOptions | undefined {
   if (provider === "anthropic") {
     return buildAnthropicOptions(thinking, model);
@@ -59,7 +57,6 @@ function buildProviderOptions(
         openrouter: {
           reasoning: {
             effort,
-            ...(!showThoughts ? { exclude: true } : {}),
           },
         },
       };
@@ -69,7 +66,7 @@ function buildProviderOptions(
   }
 
   if (provider === "openai") {
-    return buildOpenAIOptions(thinking, model, showThoughts);
+    return buildOpenAIOptions(thinking, model);
   }
 
   if (provider === "gemini") {
@@ -80,7 +77,7 @@ function buildProviderOptions(
         google: {
           thinkingConfig: {
             thinkingBudget,
-            includeThoughts: showThoughts,
+            includeThoughts: true,
           },
         },
       };
@@ -143,17 +140,18 @@ function buildAnthropicOptions(
  * Build OpenAI-specific provider options for reasoning.
  * @param thinking - Thinking level from UI settings
  * @param model - Model identifier
- * @param showThoughts - Whether to include reasoning summaries
  * @returns OpenAI provider options or undefined
  */
 function buildOpenAIOptions(
   thinking: string,
   model: string,
-  showThoughts: boolean,
 ): ProviderOptions | undefined {
   const effort = mapThinkingToReasoningEffort(thinking, model);
+  // Off thinking suppresses reasoning summaries even for reasoning models that
+  // generate reasoning internally — matching the openrouter/gemini paths, which
+  // return no reasoning options when thinking is Off.
   const reasoningSummary =
-    showThoughts && isOpenAIReasoningModel(model) ? "auto" : undefined;
+    thinking !== "Off" && isOpenAIReasoningModel(model) ? "auto" : undefined;
 
   if (effort || reasoningSummary) {
     return {
@@ -204,18 +202,9 @@ export const chatAdapter: ChatAdapter<
     const systemInstruction =
       lockedSystemInstruction ??
       resolveSystemInstruction(systemInstructionOverride);
-    // When thinking is Off, always exclude reasoning tokens even if the model generates them.
-    // The stored showThoughts setting is preserved for when the UI toggle is re-introduced.
-    const showThoughts =
-      thinking !== "Off" && Boolean(extraParams?.showThoughts);
 
     const languageModel = createProviderModel(provider, model, apiKey, baseUrl);
-    const providerOptions = buildProviderOptions(
-      provider,
-      thinking,
-      model,
-      showThoughts,
-    );
+    const providerOptions = buildProviderOptions(provider, thinking, model);
 
     // Adaptive-family Anthropic models (Sonnet 5, Opus 4.6+, Fable) reject any
     // non-default sampling parameter with a 400 — suppress temperature for them
@@ -235,10 +224,9 @@ export const chatAdapter: ChatAdapter<
       temperature: suppressTemperature ? undefined : temperature,
       systemInstruction,
       enabledTools,
-      showThoughts,
       providerOptions,
       buildProviderOptions: (overrideThinking: string) =>
-        buildProviderOptions(provider, overrideThinking, model, showThoughts),
+        buildProviderOptions(provider, overrideThinking, model),
       chatHistory,
     };
   },

--- a/webui/src/hooks/chat/helpers/tests/use-conversations-helpers.test.ts
+++ b/webui/src/hooks/chat/helpers/tests/use-conversations-helpers.test.ts
@@ -34,7 +34,6 @@ function refs(over: Partial<ActiveRefs> = {}): ActiveRefs {
     provider: null,
     thinking: null,
     temperature: null,
-    showThoughts: null,
     smallModelMode: null,
     systemInstruction: null,
     ...over,

--- a/webui/src/hooks/chat/helpers/tests/use-sync-active-meta.test.ts
+++ b/webui/src/hooks/chat/helpers/tests/use-sync-active-meta.test.ts
@@ -22,7 +22,6 @@ const ALL_NULL: SyncActiveMetaParams = {
   activeProvider: null,
   activeThinking: null,
   activeTemperature: null,
-  activeShowThoughts: null,
   activeSmallModelMode: null,
   activeSystemInstruction: null,
 };
@@ -45,7 +44,6 @@ describe("useSyncActiveMeta", () => {
         activeProvider: "anthropic",
         activeThinking: "high",
         activeTemperature: 0.7,
-        activeShowThoughts: true,
         activeSmallModelMode: false,
         activeSystemInstruction: "Be brief.",
       }),
@@ -57,7 +55,6 @@ describe("useSyncActiveMeta", () => {
       provider: "anthropic",
       thinking: "high",
       temperature: 0.7,
-      showThoughts: true,
       smallModelMode: false,
       systemInstruction: "Be brief.",
     });

--- a/webui/src/hooks/chat/helpers/use-active-settings.ts
+++ b/webui/src/hooks/chat/helpers/use-active-settings.ts
@@ -13,7 +13,6 @@ export interface ActiveSettings {
   activeProvider: Provider | null;
   activeThinking: string | null;
   activeTemperature: number | null;
-  activeShowThoughts: boolean | null;
   activeSmallModelMode: boolean | null;
   activeSystemInstruction: string | null;
 }
@@ -25,7 +24,6 @@ interface ActiveSettingsActions {
     provider: Provider,
     thinking: string,
     temperature: number,
-    showThoughts: boolean | null,
     smallModelMode: boolean,
     systemInstruction: string,
   ) => void;
@@ -50,9 +48,6 @@ export function useActiveSettings(): UseActiveSettingsReturn {
   const [activeTemperature, setActiveTemperature] = useState<number | null>(
     null,
   );
-  const [activeShowThoughts, setActiveShowThoughts] = useState<boolean | null>(
-    null,
-  );
   const [activeSmallModelMode, setActiveSmallModelMode] = useState<
     boolean | null
   >(null);
@@ -66,7 +61,6 @@ export function useActiveSettings(): UseActiveSettingsReturn {
       provider: Provider,
       thinking: string,
       temperature: number,
-      showThoughts: boolean | null,
       smallModelMode: boolean,
       systemInstruction: string,
     ) => {
@@ -74,7 +68,6 @@ export function useActiveSettings(): UseActiveSettingsReturn {
       setActiveProvider(provider);
       setActiveThinking(thinking);
       setActiveTemperature(temperature);
-      setActiveShowThoughts(showThoughts);
       setActiveSmallModelMode(smallModelMode);
       setActiveSystemInstruction(systemInstruction);
     },
@@ -87,7 +80,6 @@ export function useActiveSettings(): UseActiveSettingsReturn {
       setActiveProvider(lockedSettings?.provider ?? null);
       setActiveThinking(lockedSettings?.thinking ?? null);
       setActiveTemperature(lockedSettings?.temperature ?? null);
-      setActiveShowThoughts(lockedSettings?.showThoughts ?? null);
       setActiveSmallModelMode(lockedSettings?.smallModelMode ?? null);
       setActiveSystemInstruction(lockedSettings?.systemInstruction ?? null);
     },
@@ -99,7 +91,6 @@ export function useActiveSettings(): UseActiveSettingsReturn {
     setActiveProvider(null);
     setActiveThinking(null);
     setActiveTemperature(null);
-    setActiveShowThoughts(null);
     setActiveSmallModelMode(null);
     setActiveSystemInstruction(null);
   }, []);
@@ -109,7 +100,6 @@ export function useActiveSettings(): UseActiveSettingsReturn {
     activeProvider,
     activeThinking,
     activeTemperature,
-    activeShowThoughts,
     activeSmallModelMode,
     activeSystemInstruction,
     lockSettings,

--- a/webui/src/hooks/chat/helpers/use-conversations-helpers.ts
+++ b/webui/src/hooks/chat/helpers/use-conversations-helpers.ts
@@ -28,7 +28,6 @@ export interface ActiveMeta {
   provider: Provider | null;
   thinking: string | null;
   temperature: number | null;
-  showThoughts: boolean | null;
   smallModelMode: boolean | null;
   /** Resolved system instruction in effect (snapshotted onto the record). */
   systemInstruction: string | null;
@@ -42,7 +41,6 @@ export const DEFAULT_META: ActiveMeta = {
   provider: null,
   thinking: null,
   temperature: null,
-  showThoughts: null,
   smallModelMode: null,
   systemInstruction: null,
 };
@@ -147,7 +145,6 @@ export function buildLockedSettings(
     provider: record.provider as Provider | null,
     thinking: record.thinking,
     temperature: record.temperature,
-    showThoughts: record.showThoughts,
     smallModelMode: record.smallModelMode,
     systemInstruction: record.systemInstruction ?? null,
   };
@@ -185,7 +182,6 @@ export function buildSaveRecord(
     modelLabel: refs.model ? getModelName(refs.model) : null,
     thinking: refs.thinking,
     temperature: refs.temperature,
-    showThoughts: refs.showThoughts,
     smallModelMode: refs.smallModelMode,
     totalUsage: sumMessageUsage(chatHistory),
     sessionType: "text",

--- a/webui/src/hooks/chat/helpers/use-sync-active-meta.ts
+++ b/webui/src/hooks/chat/helpers/use-sync-active-meta.ts
@@ -15,7 +15,6 @@ export interface SyncActiveMetaParams {
   activeProvider: Provider | null;
   activeThinking: string | null;
   activeTemperature: number | null;
-  activeShowThoughts: boolean | null;
   activeSmallModelMode: boolean | null;
   activeSystemInstruction: string | null;
 }
@@ -38,7 +37,6 @@ export function useSyncActiveMeta(
     activeProvider,
     activeThinking,
     activeTemperature,
-    activeShowThoughts,
     activeSmallModelMode,
     activeSystemInstruction,
   } = props;
@@ -51,7 +49,6 @@ export function useSyncActiveMeta(
     if (activeProvider != null) meta.provider = activeProvider;
     if (activeThinking != null) meta.thinking = activeThinking;
     if (activeTemperature != null) meta.temperature = activeTemperature;
-    if (activeShowThoughts != null) meta.showThoughts = activeShowThoughts;
     if (activeSmallModelMode != null)
       meta.smallModelMode = activeSmallModelMode;
     if (activeSystemInstruction != null)
@@ -62,7 +59,6 @@ export function useSyncActiveMeta(
     activeProvider,
     activeThinking,
     activeTemperature,
-    activeShowThoughts,
     activeSmallModelMode,
     activeSystemInstruction,
   ]);

--- a/webui/src/hooks/chat/tests/adapter.test.ts
+++ b/webui/src/hooks/chat/tests/adapter.test.ts
@@ -26,7 +26,6 @@ describe("chatAdapter", () => {
           provider: "openai",
           specificationVersion: "v3",
         } as never,
-        showThoughts: false,
       };
       const client = chatAdapter.createClient("test-key", config);
 
@@ -42,7 +41,6 @@ describe("chatAdapter", () => {
           provider: "openai",
           specificationVersion: "v3",
         } as never,
-        showThoughts: false,
         chatHistory,
       };
       const client = chatAdapter.createClient("test-key", config);
@@ -56,7 +54,6 @@ describe("chatAdapter", () => {
       provider: "openai",
       apiKey: "test-key",
       baseUrl: undefined,
-      showThoughts: false,
     };
 
     it("returns config with model and temperature", () => {
@@ -70,7 +67,6 @@ describe("chatAdapter", () => {
       );
 
       expect(config.temperature).toBe(0.7);
-      expect(config.showThoughts).toBe(false);
       expect(config.enabledTools).toStrictEqual({});
     });
 
@@ -166,7 +162,7 @@ describe("chatAdapter", () => {
       );
     });
 
-    it("sets reasoning effort for openai provider with Max thinking", () => {
+    it("sets reasoning effort and summary for openai reasoning model with Max thinking", () => {
       const config = chatAdapter.buildConfig(
         "o3-mini",
         1.0,
@@ -177,18 +173,18 @@ describe("chatAdapter", () => {
       );
 
       expect(config.providerOptions).toStrictEqual({
-        openai: { reasoningEffort: "high" },
+        openai: { reasoningEffort: "high", reasoningSummary: "auto" },
       });
     });
 
-    it("includes reasoningSummary for openai reasoning model with showThoughts", () => {
+    it("includes reasoningSummary for an openai reasoning model", () => {
       const config = chatAdapter.buildConfig(
         "gpt-5.2",
         1.0,
         "Max",
         {},
         undefined,
-        { ...extraParams, provider: "openai", showThoughts: true },
+        { ...extraParams, provider: "openai" },
       );
 
       expect(config.providerOptions).toStrictEqual({
@@ -203,12 +199,25 @@ describe("chatAdapter", () => {
         "Default",
         {},
         undefined,
-        { ...extraParams, provider: "openai", showThoughts: true },
+        { ...extraParams, provider: "openai" },
       );
 
       expect(config.providerOptions).toStrictEqual({
         openai: { reasoningEffort: "medium", reasoningSummary: "auto" },
       });
+    });
+
+    it("returns undefined providerOptions for an openai reasoning model with Off thinking", () => {
+      const config = chatAdapter.buildConfig(
+        "o3-mini",
+        1.0,
+        "Off",
+        {},
+        undefined,
+        { ...extraParams, provider: "openai" },
+      );
+
+      expect(config.providerOptions).toBeUndefined();
     });
 
     it("sets reasoning for openrouter provider with Max thinking", () => {
@@ -218,33 +227,13 @@ describe("chatAdapter", () => {
         "Max",
         {},
         undefined,
-        { ...extraParams, provider: "openrouter", showThoughts: true },
+        { ...extraParams, provider: "openrouter" },
       );
 
       expect(config.providerOptions).toStrictEqual({
         openrouter: {
           reasoning: {
             effort: "xhigh",
-          },
-        },
-      });
-    });
-
-    it("excludes reasoning for openrouter with showThoughts=false", () => {
-      const config = chatAdapter.buildConfig(
-        "some-model",
-        1.0,
-        "Max",
-        {},
-        undefined,
-        { ...extraParams, provider: "openrouter", showThoughts: false },
-      );
-
-      expect(config.providerOptions).toStrictEqual({
-        openrouter: {
-          reasoning: {
-            effort: "xhigh",
-            exclude: true,
           },
         },
       });
@@ -258,26 +247,6 @@ describe("chatAdapter", () => {
         {},
         undefined,
         { ...extraParams, provider: "gemini" },
-      );
-
-      expect(config.providerOptions).toStrictEqual({
-        google: {
-          thinkingConfig: {
-            thinkingBudget: 16384,
-            includeThoughts: false,
-          },
-        },
-      });
-    });
-
-    it("sets Gemini thinkingConfig with includeThoughts when showThoughts is true", () => {
-      const config = chatAdapter.buildConfig(
-        "gemini-2.5-flash",
-        1.0,
-        "Max",
-        {},
-        undefined,
-        { ...extraParams, provider: "gemini", showThoughts: true },
       );
 
       expect(config.providerOptions).toStrictEqual({
@@ -304,7 +273,7 @@ describe("chatAdapter", () => {
         google: {
           thinkingConfig: {
             thinkingBudget: -1,
-            includeThoughts: false,
+            includeThoughts: true,
           },
         },
       });
@@ -385,7 +354,6 @@ describe("chatAdapter", () => {
         openrouter: {
           reasoning: {
             effort: "medium",
-            exclude: true,
           },
         },
       });
@@ -398,7 +366,7 @@ describe("chatAdapter", () => {
         "Off",
         {},
         undefined,
-        { ...extraParams, provider: "openrouter", showThoughts: true },
+        { ...extraParams, provider: "openrouter" },
       );
 
       expect(config.providerOptions).toBeUndefined();

--- a/webui/src/hooks/chat/tests/conversations/use-conversations-metadata.test.ts
+++ b/webui/src/hooks/chat/tests/conversations/use-conversations-metadata.test.ts
@@ -130,12 +130,11 @@ describe("useConversations", () => {
   });
 
   describe("active ref sync", () => {
-    it("persists thinking/temperature/showThoughts from active refs", async () => {
+    it("persists thinking/temperature from active refs", async () => {
       const { props, state } = createProps();
 
       props.activeMeta.activeThinking = "enabled";
       props.activeMeta.activeTemperature = 0.7;
-      props.activeMeta.activeShowThoughts = true;
 
       const { result } = renderHook(() => useConversations(props));
 
@@ -148,13 +147,11 @@ describe("useConversations", () => {
       expect(record).toMatchObject({
         thinking: "enabled",
         temperature: 0.7,
-        showThoughts: true,
       });
 
       // Change props, wait for effect to sync refs, then save and verify
       props.activeMeta.activeThinking = "disabled";
       props.activeMeta.activeTemperature = 1.0;
-      props.activeMeta.activeShowThoughts = false;
       // saveWithMessage triggers rerender which runs the ref-sync useEffect
       await saveWithMessage(state, result, "ref sync 2");
       await waitForEffects();
@@ -167,7 +164,6 @@ describe("useConversations", () => {
       expect(updated).toMatchObject({
         thinking: "disabled",
         temperature: 1.0,
-        showThoughts: false,
       });
     });
   });

--- a/webui/src/hooks/chat/tests/conversations/use-conversations-test-helpers.ts
+++ b/webui/src/hooks/chat/tests/conversations/use-conversations-test-helpers.ts
@@ -31,7 +31,6 @@ export function createConversationsProps() {
         activeProvider: null as Provider | null,
         activeThinking: null as string | null,
         activeTemperature: null as number | null,
-        activeShowThoughts: null as boolean | null,
         activeSmallModelMode: null as boolean | null,
         activeSystemInstruction: null as string | null,
       },

--- a/webui/src/hooks/chat/tests/helpers/use-chat-test-helpers.ts
+++ b/webui/src/hooks/chat/tests/helpers/use-chat-test-helpers.ts
@@ -216,7 +216,6 @@ export function lockedSettings(
     provider: null,
     thinking: null,
     temperature: null,
-    showThoughts: null,
     smallModelMode: null,
     systemInstruction: null,
     ...over,

--- a/webui/src/hooks/chat/use-chat-mode-state.ts
+++ b/webui/src/hooks/chat/use-chat-mode-state.ts
@@ -141,7 +141,6 @@ export function useChatModeState(params: UseChatModeStateParams) {
     adapter: chatAdapter,
     extraParams: {
       baseUrl,
-      showThoughts: settings.showThoughts,
       provider: settings.provider,
       apiKey: resolvedApiKey,
       systemInstructionOverride,
@@ -177,7 +176,6 @@ export function useChatModeState(params: UseChatModeStateParams) {
       activeProvider: chat.activeProvider,
       activeThinking: chat.activeThinking,
       activeTemperature: chat.activeTemperature,
-      activeShowThoughts: chat.activeShowThoughts,
       activeSmallModelMode: chat.activeSmallModelMode,
       // Snapshot the LOCKED instruction (what this conversation actually ran
       // with), not the current global override — so editing the global later

--- a/webui/src/hooks/chat/use-chat-types.ts
+++ b/webui/src/hooks/chat/use-chat-types.ts
@@ -84,7 +84,6 @@ export interface ConversationLockedSettings {
   provider: Provider | null;
   thinking: string | null;
   temperature: number | null;
-  showThoughts: boolean | null;
   smallModelMode: boolean | null;
   /**
    * The resolved system instruction the conversation runs with. Locked like the
@@ -124,7 +123,6 @@ export interface UseChatReturn {
   activeProvider: Provider | null;
   activeThinking: string | null;
   activeTemperature: number | null;
-  activeShowThoughts: boolean | null;
   activeSmallModelMode: boolean | null;
   /** The resolved system instruction locked for the active conversation. */
   activeSystemInstruction: string | null;

--- a/webui/src/hooks/chat/use-chat.ts
+++ b/webui/src/hooks/chat/use-chat.ts
@@ -207,7 +207,6 @@ export function useChat<
         init.provider,
         effectiveThinking,
         temperature,
-        null,
         smallModelMode,
         init.systemInstruction,
       );

--- a/webui/src/hooks/chat/use-conversations.ts
+++ b/webui/src/hooks/chat/use-conversations.ts
@@ -531,7 +531,6 @@ function syncMetaRef(
     provider: record.provider as Provider | null,
     thinking: record.thinking,
     temperature: record.temperature,
-    showThoughts: record.showThoughts,
     smallModelMode: record.smallModelMode ?? null,
     systemInstruction: record.systemInstruction ?? null,
   };

--- a/webui/src/hooks/settings/presets/tests/preset-apply.test.ts
+++ b/webui/src/hooks/settings/presets/tests/preset-apply.test.ts
@@ -64,14 +64,13 @@ describe("useApplyPreset", () => {
     expect(setters.anthropic).not.toHaveBeenCalled();
 
     // The functional update swaps model+thinking but preserves everything else
-    // in the slice (apiKey/baseUrl and the phased-out temperature/showThoughts).
+    // in the slice (apiKey/baseUrl and the phased-out temperature).
     const prev: ProviderSettings = {
       apiKey: "KEEP",
       baseUrl: "http://keep",
       model: "old",
       thinking: "Default",
       temperature: 1,
-      showThoughts: true,
     };
 
     expect(captured.openai?.(prev)).toStrictEqual({
@@ -80,7 +79,6 @@ describe("useApplyPreset", () => {
       model: "gpt-x",
       thinking: "Max",
       temperature: 1,
-      showThoughts: true,
     });
 
     expect(setProvider).toHaveBeenCalledWith("openai");

--- a/webui/src/hooks/settings/settings-helpers.ts
+++ b/webui/src/hooks/settings/settings-helpers.ts
@@ -141,7 +141,6 @@ export interface ProviderSettings {
   port?: number;
   thinking: string;
   temperature: number;
-  showThoughts: boolean;
 }
 
 /**
@@ -161,35 +160,30 @@ export const DEFAULT_SETTINGS: Record<Provider, ProviderSettings> = {
     model: DEFAULT_MODELS.anthropic,
     thinking: "Default",
     temperature: 1.0,
-    showThoughts: true,
   },
   gemini: {
     apiKey: "",
     model: DEFAULT_MODELS.gemini,
     thinking: "Default",
     temperature: 1.0,
-    showThoughts: true,
   },
   openai: {
     apiKey: "",
     model: DEFAULT_MODELS.openai,
     thinking: "Default",
     temperature: 1.0,
-    showThoughts: true,
   },
   mistral: {
     apiKey: "",
     model: DEFAULT_MODELS.mistral,
     thinking: "Default",
     temperature: 1.0,
-    showThoughts: true,
   },
   openrouter: {
     apiKey: "",
     model: DEFAULT_MODELS.openrouter,
     thinking: "Default",
     temperature: 1.0,
-    showThoughts: true,
   },
   lmstudio: {
     apiKey: "",
@@ -197,7 +191,6 @@ export const DEFAULT_SETTINGS: Record<Provider, ProviderSettings> = {
     baseUrl: "http://localhost:1234",
     thinking: "Default",
     temperature: 1.0,
-    showThoughts: true,
   },
   ollama: {
     apiKey: "",
@@ -205,7 +198,6 @@ export const DEFAULT_SETTINGS: Record<Provider, ProviderSettings> = {
     baseUrl: "http://localhost:11434",
     thinking: "Default",
     temperature: 1.0,
-    showThoughts: true,
   },
   custom: {
     apiKey: "",
@@ -213,7 +205,6 @@ export const DEFAULT_SETTINGS: Record<Provider, ProviderSettings> = {
     baseUrl: "",
     thinking: "Default",
     temperature: 1.0,
-    showThoughts: true,
   },
 };
 
@@ -348,14 +339,6 @@ function readLegacyGeminiSettings(): ProviderSettings {
 
   if (temperature != null) {
     legacySettings.temperature = Number.parseFloat(temperature);
-  }
-
-  const showThoughts =
-    localStorage.getItem("showThoughts") ??
-    localStorage.getItem("gemini_showThoughts");
-
-  if (showThoughts != null) {
-    legacySettings.showThoughts = showThoughts === "true";
   }
 
   return { ...DEFAULT_SETTINGS.gemini, ...legacySettings };

--- a/webui/src/hooks/settings/tests/settings-helpers.test.ts
+++ b/webui/src/hooks/settings/tests/settings-helpers.test.ts
@@ -43,7 +43,6 @@ describe("settings-helpers", () => {
         model: "claude-sonnet-4-6",
         thinking: "Default",
         temperature: 1.0,
-        showThoughts: true,
       });
 
       const raw = JSON.parse(
@@ -60,7 +59,6 @@ describe("settings-helpers", () => {
         model: "claude-sonnet-4-6",
         thinking: "Default",
         temperature: 1.0,
-        showThoughts: true,
       });
 
       const loaded = await loadProviderSettingsAsync("anthropic");
@@ -74,7 +72,6 @@ describe("settings-helpers", () => {
         model: "claude-sonnet-4-6",
         thinking: "Default",
         temperature: 1.0,
-        showThoughts: true,
       });
 
       // The synchronous loader must not surface ciphertext; it returns "".
@@ -100,7 +97,6 @@ describe("settings-helpers", () => {
         model: "gemini-2.5-flash",
         thinking: "Default",
         temperature: 1.0,
-        showThoughts: true,
       });
 
       expect(localStorage.getItem("gemini_api_key")).toBeNull();
@@ -119,7 +115,6 @@ describe("settings-helpers", () => {
         model: "claude-sonnet-4-6",
         thinking: "Default",
         temperature: 1.0,
-        showThoughts: true,
       });
 
       expect(localStorage.getItem("gemini_api_key")).toBe("AIza-old-cleartext");
@@ -131,7 +126,6 @@ describe("settings-helpers", () => {
         model: "gpt-5.5",
         thinking: "Default",
         temperature: 1.0,
-        showThoughts: true,
       });
 
       const raw = JSON.parse(
@@ -151,7 +145,6 @@ describe("settings-helpers", () => {
         model: "claude-sonnet-4-6",
         thinking: "Default",
         temperature: 1.0,
-        showThoughts: true,
       });
 
       // Forge an undecryptable envelope for openai: a real IV paired with a
@@ -181,7 +174,6 @@ describe("settings-helpers", () => {
         model: "claude-sonnet-4-6",
         thinking: "Default",
         temperature: 1.0,
-        showThoughts: true,
       });
 
       expect(checkHasApiKey("anthropic")).toBe(true);

--- a/webui/src/hooks/settings/tests/use-has-unsaved-changes.test.ts
+++ b/webui/src/hooks/settings/tests/use-has-unsaved-changes.test.ts
@@ -32,7 +32,6 @@ function makeSettings(
     smallModelMode: false,
     thinking: "Default",
     temperature: 1,
-    showThoughts: true,
     enabledTools: {},
     realtimeVoice: "marin",
     voiceSpeed: 1,

--- a/webui/src/hooks/settings/tests/use-settings.test.ts
+++ b/webui/src/hooks/settings/tests/use-settings.test.ts
@@ -48,7 +48,6 @@ describe("useSettings", () => {
       model: "gemini-3.6-flash",
       thinking: "Default",
       temperature: 1.0,
-      showThoughts: true,
       hasApiKey: false,
     });
   });
@@ -58,7 +57,6 @@ describe("useSettings", () => {
     localStorage.setItem("gemini_model", "gemini-2.5-pro");
     localStorage.setItem("thinking", "High");
     localStorage.setItem("temperature", "0.7");
-    localStorage.setItem("showThoughts", "false");
 
     const { result } = renderHook(() => useSettings());
 
@@ -69,7 +67,6 @@ describe("useSettings", () => {
       model: "gemini-2.5-pro",
       thinking: "High",
       temperature: 0.7,
-      showThoughts: false,
     });
     await waitFor(() => expect(result.current.apiKey).toBe("test-key"));
     expect(result.current.hasApiKey).toBe(true);
@@ -83,7 +80,6 @@ describe("useSettings", () => {
         model: "gemini-3.6-flash",
         thinking: "Max",
         temperature: 1.5,
-        showThoughts: false,
       }),
     );
 
@@ -93,7 +89,6 @@ describe("useSettings", () => {
       model: "gemini-3.6-flash",
       thinking: "Max",
       temperature: 1.5,
-      showThoughts: false,
     });
     await waitFor(() => expect(result.current.apiKey).toBe("new-key"));
     expect(result.current.hasApiKey).toBe(true);
@@ -110,7 +105,6 @@ describe("useSettings", () => {
         model: "gemini-3.6-flash",
         thinking: "Adaptive",
         temperature: 1.0,
-        showThoughts: true,
       }),
     );
 
@@ -131,7 +125,6 @@ describe("useSettings", () => {
         baseUrl: "http://localhost:11434",
         thinking: "Max",
         temperature: 1.0,
-        showThoughts: true,
       }),
     );
 
@@ -241,16 +234,6 @@ describe("useSettings", () => {
     expect(result.current.temperature).toBe(0.5);
   });
 
-  it("updates showThoughts when setShowThoughts is called", async () => {
-    const { result } = renderHook(() => useSettings());
-
-    await act(() => {
-      result.current.setShowThoughts(false);
-    });
-
-    expect(result.current.showThoughts).toBe(false);
-  });
-
   it("saveSettings before post-mount decrypt does not wipe stored apiKeys", async () => {
     // Seed two providers with encrypted apiKeys so we can detect a wipe.
     for (const provider of ["gemini", "openai"] as const) {
@@ -261,7 +244,6 @@ describe("useSettings", () => {
           model: "stored-model",
           thinking: "Default",
           temperature: 1.0,
-          showThoughts: true,
         }),
       );
     }
@@ -301,7 +283,6 @@ describe("useSettings", () => {
       result.current.setModel("gemini-3.6-flash");
       result.current.setThinking("Max");
       result.current.setTemperature(0.8);
-      result.current.setShowThoughts(false);
     });
 
     await act(async () => {
@@ -327,7 +308,6 @@ describe("useSettings", () => {
       model: "gemini-3.6-flash",
       thinking: "Max",
       temperature: 0.8,
-      showThoughts: false,
     });
   });
 
@@ -509,14 +489,12 @@ describe("useSettings", () => {
       result.current.setModel("gemini-2.5-pro");
       result.current.setThinking("Max");
       result.current.setTemperature(0.5);
-      result.current.setShowThoughts(false);
     });
 
     expect(result.current).toMatchObject({
       model: "gemini-2.5-pro",
       thinking: "Max",
       temperature: 0.5,
-      showThoughts: false,
     });
 
     // Switch to OpenAI - should use defaults
@@ -529,7 +507,6 @@ describe("useSettings", () => {
       model: "gpt-5.6-terra",
       thinking: "Default",
       temperature: 1.0,
-      showThoughts: true,
     });
 
     // Configure OpenAI with different settings
@@ -538,7 +515,6 @@ describe("useSettings", () => {
       result.current.setModel("gpt-5.4-mini");
       result.current.setThinking("Off");
       result.current.setTemperature(1.5);
-      result.current.setShowThoughts(false);
     });
 
     // Switch back to Gemini - should restore Gemini settings
@@ -551,7 +527,6 @@ describe("useSettings", () => {
       model: "gemini-2.5-pro",
       thinking: "Max",
       temperature: 0.5,
-      showThoughts: false,
     });
 
     // Switch back to OpenAI - should restore OpenAI settings
@@ -564,7 +539,6 @@ describe("useSettings", () => {
       model: "gpt-5.4-mini",
       thinking: "Off",
       temperature: 1.5,
-      showThoughts: false,
     });
   });
 
@@ -725,20 +699,18 @@ describe("useSettings", () => {
     expect(result.current.saveError).toBeNull();
   });
 
-  it("resetBehaviorToDefaults resets temperature, thinking, and showThoughts", async () => {
+  it("resetBehaviorToDefaults resets temperature and thinking", async () => {
     const { result } = renderHook(() => useSettings());
 
     // Set some non-default values
     await act(() => {
       result.current.setTemperature(0.5);
       result.current.setThinking("Off");
-      result.current.setShowThoughts(false);
     });
 
     expect(result.current).toMatchObject({
       temperature: 0.5,
       thinking: "Off",
-      showThoughts: false,
     });
 
     // Reset to defaults
@@ -749,7 +721,6 @@ describe("useSettings", () => {
     expect(result.current).toMatchObject({
       temperature: 1.0,
       thinking: "Default", // Default for gemini
-      showThoughts: true,
     });
   });
 
@@ -782,13 +753,13 @@ describe("useSettings", () => {
   });
 
   it.each(["mistral", "openrouter", "lmstudio", "ollama", "custom"] as const)(
-    "setShowThoughts works for %s provider",
+    "setTemperature works for %s provider",
     async (provider) => {
       const { result } = renderHook(() => useSettings());
 
       await act(() => result.current.setProvider(provider));
-      await act(() => result.current.setShowThoughts(false));
-      expect(result.current.showThoughts).toBe(false);
+      await act(() => result.current.setTemperature(0.5));
+      expect(result.current.temperature).toBe(0.5);
     },
   );
 

--- a/webui/src/hooks/settings/use-has-unsaved-changes.ts
+++ b/webui/src/hooks/settings/use-has-unsaved-changes.ts
@@ -31,7 +31,6 @@ function serialize(s: UseSettingsReturn, a: AppearanceSettings): string {
     model: s.model,
     thinking: s.thinking,
     temperature: s.temperature,
-    showThoughts: s.showThoughts,
     enabledTools: s.enabledTools,
     smallModelMode: s.smallModelMode,
     realtimeVoice: s.realtimeVoice,

--- a/webui/src/hooks/settings/use-settings.ts
+++ b/webui/src/hooks/settings/use-settings.ts
@@ -55,7 +55,6 @@ function useProviderSetters(
       setBaseUrl: hasBaseUrl ? createSetter("baseUrl") : undefined,
       setThinking: createSetter("thinking"),
       setTemperature: createSetter("temperature"),
-      setShowThoughts: createSetter("showThoughts"),
     };
   }, [provider, providerStateSetters]);
 }
@@ -243,14 +242,8 @@ export function useSettings(): UseSettingsReturn {
     setSaveError(null);
   }, [applyLoadedSettings, voiceModeSettings]);
 
-  const {
-    setApiKey,
-    setModel,
-    setBaseUrl,
-    setThinking,
-    setTemperature,
-    setShowThoughts,
-  } = useProviderSetters(provider, providerStateSetters);
+  const { setApiKey, setModel, setBaseUrl, setThinking, setTemperature } =
+    useProviderSetters(provider, providerStateSetters);
   // Reconcile presence with the *decrypted* in-memory key. decryptApiKey fails
   // safe to "" for an orphaned/undecryptable envelope (e.g. the IndexedDB crypto
   // key was reset while the localStorage envelope persisted), so reading the raw
@@ -269,8 +262,7 @@ export function useSettings(): UseSettingsReturn {
   const resetBehaviorToDefaults = useCallback(() => {
     setTemperature(1.0);
     setThinking(DEFAULT_SETTINGS[provider].thinking);
-    setShowThoughts(true);
-  }, [provider, setTemperature, setThinking, setShowThoughts]);
+  }, [provider, setTemperature, setThinking]);
   const hasBaseUrl = ["custom", "lmstudio", "ollama"].includes(provider);
 
   return {
@@ -298,8 +290,6 @@ export function useSettings(): UseSettingsReturn {
     savedThinking,
     temperature: currentSettings.temperature,
     setTemperature,
-    showThoughts: currentSettings.showThoughts,
-    setShowThoughts,
     applyPreset,
     saveSettings,
     cancelSettings,

--- a/webui/src/hooks/voice/use-voice-persistence.ts
+++ b/webui/src/hooks/voice/use-voice-persistence.ts
@@ -466,7 +466,6 @@ async function saveVoiceRecord(
     modelLabel: existing?.modelLabel ?? ctx.model,
     thinking: null,
     temperature: null,
-    showThoughts: null,
     smallModelMode: null,
     totalUsage: null,
     sessionType: "voice",

--- a/webui/src/lib/conversation-db.ts
+++ b/webui/src/lib/conversation-db.ts
@@ -25,7 +25,6 @@ export interface ConversationRecord {
   modelLabel: string | null;
   thinking: string | null;
   temperature: number | null;
-  showThoughts: boolean | null;
   smallModelMode: boolean | null;
   totalUsage: TokenUsage | null;
   sessionType: SessionType;
@@ -227,7 +226,6 @@ export async function listAllConversationSummaries(): Promise<
         modelLabel,
         thinking,
         temperature,
-        showThoughts,
         smallModelMode,
         totalUsage,
         sessionType,
@@ -244,7 +242,6 @@ export async function listAllConversationSummaries(): Promise<
         modelLabel,
         thinking,
         temperature,
-        showThoughts,
         smallModelMode,
         totalUsage,
         sessionType,
@@ -331,7 +328,6 @@ function normalizeLegacyRecord(
 ): ConversationRecord {
   raw.thinking ??= null;
   raw.temperature ??= null;
-  raw.showThoughts ??= null;
   raw.smallModelMode ??= null;
   raw.totalUsage ??= null;
   raw.sessionType ??= "text";

--- a/webui/src/lib/conversation-transfer.ts
+++ b/webui/src/lib/conversation-transfer.ts
@@ -253,7 +253,6 @@ function normalizeRecord(
     modelLabel: (record.modelLabel as string | null | undefined) ?? null,
     thinking: (record.thinking as string | null | undefined) ?? null,
     temperature: (record.temperature as number | null | undefined) ?? null,
-    showThoughts: (record.showThoughts as boolean | null | undefined) ?? null,
     smallModelMode:
       (record.smallModelMode as boolean | null | undefined) ?? null,
     totalUsage:

--- a/webui/src/lib/tests/conversation-db.test.ts
+++ b/webui/src/lib/tests/conversation-db.test.ts
@@ -121,7 +121,6 @@ describe("conversation-db", () => {
       modelLabel: null,
       thinking: null,
       temperature: null,
-      showThoughts: null,
       smallModelMode: null,
       totalUsage: null,
       sessionType: "text",
@@ -249,18 +248,16 @@ describe("conversation-db", () => {
     return await saveRecordWithoutFields([
       "thinking",
       "temperature",
-      "showThoughts",
       "smallModelMode",
     ]);
   }
 
-  it("defaults missing thinking/temperature/showThoughts to null on load", async () => {
+  it("defaults missing thinking/temperature to null on load", async () => {
     const record = await saveRecordWithMissingFields();
     const loaded = await loadConversation(record.id);
 
     expect(loaded?.thinking).toBeNull();
     expect(loaded?.temperature).toBeNull();
-    expect(loaded?.showThoughts).toBeNull();
     expect(loaded?.smallModelMode).toBeNull();
   });
 
@@ -309,7 +306,6 @@ describe("conversation-db", () => {
 
     expect(list[0]?.thinking).toBeNull();
     expect(list[0]?.temperature).toBeNull();
-    expect(list[0]?.showThoughts).toBeNull();
     expect(list[0]?.smallModelMode).toBeNull();
   });
 

--- a/webui/src/test-utils/conversation-test-helpers.ts
+++ b/webui/src/test-utils/conversation-test-helpers.ts
@@ -54,7 +54,6 @@ function sharedDefaults(): ConversationSummary {
     modelLabel: null,
     thinking: null,
     temperature: null,
-    showThoughts: null,
     smallModelMode: null,
     totalUsage: null,
     sessionType: "text",

--- a/webui/src/types/settings.ts
+++ b/webui/src/types/settings.ts
@@ -155,8 +155,6 @@ export interface UseSettingsReturn extends VoiceModeSettingsFields {
   savedThinking: string;
   temperature: number;
   setTemperature: (temp: number) => void;
-  showThoughts: boolean;
-  setShowThoughts: (show: boolean) => void;
   /** Load a saved preset into the live editable buffer: writes the preset's
    * model/thinking into that preset's *own* provider
    * slice (a functional update, so it's correct even when the preset switches


### PR DESCRIPTION
Removes the phased-out `showThoughts` chat setting end-to-end.

## Context
`showThoughts` had no UI control (a code comment said it was "preserved for when the UI toggle is re-introduced"), defaulted to `true` for every provider, and was never locked per-conversation. It read as a view concern rather than a model/inference setting, and the collapsible thought disclosures already cover hiding reasoning.

## Change
- Removed from provider slices, `useSettings`, the unsaved-changes snapshot, `ChatClientConfig`, the conversation lock/record plumbing, IndexedDB persistence + transfer, the legacy localStorage migration, and docs.
- Adapter: thoughts are now always requested when thinking ≠ Off. openrouter no longer sets `exclude`; gemini `includeThoughts: true`; openai `reasoningSummary` gated on the model being a reasoning model **and** thinking ≠ Off.

## Behavior
Behavior-preserving — the value was already effectively always `true` at runtime (`thinking !== "Off"`), so every provider path sends the same request it did before. Off-thinking correctly suppresses reasoning for all providers, including OpenAI reasoning models (a guard test was added for that path).

## Verification
`npm run check` (10090 tests, 100% functions), `npm run check:build`, and `npm run ui:test` (14/14) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)