### PR TITLE
refactor(webui): remove phased-out temperature setting

### DIFF
--- a/dev/Chat-UI.md
+++ b/dev/Chat-UI.md
@@ -162,7 +162,7 @@ the underlying provider implementation is swappable):
 
 - `messages` - UI-formatted message history (`UIMessage[]`)
 - `isAssistantResponding` - Loading state
-- `activeModel/Thinking/Temperature` - Locked settings during chat
+- `activeModel/Thinking` - Locked settings during chat
 
 **Operations:**
 
@@ -229,7 +229,6 @@ interface ConversationRecord {
   model: string | null; // model ID
   modelLabel: string | null; // display name
   thinking: string | null; // thinking level (e.g., "High", "Off")
-  temperature: number | null; // temperature setting
   messages: ChatMessage[]; // full history including toolCalls, toolResults, reasoning, responseModel
 }
 ```
@@ -293,16 +292,15 @@ through this single code path via provider-specific model factories in
 
 **Locked Settings:**
 
-Provider, model, thinking level, and temperature are locked per conversation.
-When a conversation is saved, these settings are stored on the
-`ConversationRecord`. When restored, they're passed as
-`ConversationLockedSettings` to prevent settings changes from affecting the
-active conversation.
+Provider, model, and thinking level are locked per conversation. When a
+conversation is saved, these settings are stored on the `ConversationRecord`.
+When restored, they're passed as `ConversationLockedSettings` to prevent
+settings changes from affecting the active conversation.
 
-Per-message overrides (`MessageOverrides`) can still override
-thinking/temperature for individual messages. When used, the overridden values
-are stamped on the assistant `ChatMessage` as `thinkingOverride` and
-`temperatureOverride` — only when they differ from the conversation defaults.
+Per-message overrides (`MessageOverrides`) can still override thinking for
+individual messages. When used, the overridden value is stamped on the assistant
+`ChatMessage` as `thinkingOverride` — only when it differs from the conversation
+default.
 
 **Response Model Tracking:**
 

--- a/webui/src/chat/sdk/client.ts
+++ b/webui/src/chat/sdk/client.ts
@@ -266,7 +266,6 @@ export class ChatSdkClient {
       ),
       tools: Object.keys(this.tools).length > 0 ? this.tools : undefined,
       stopWhen: stepCountIs(this.maxSteps),
-      temperature: this.config.temperature,
       providerOptions,
       abortSignal,
       onError: errorSignal.onError,

--- a/webui/src/chat/sdk/tests/client/client.test.ts
+++ b/webui/src/chat/sdk/tests/client/client.test.ts
@@ -549,6 +549,15 @@ describe("ChatSdkClient", () => {
       expect(callArgs.messages[1].content).toBe("Hello!");
     });
 
+    it("omits temperature from the request so each provider uses its default", async () => {
+      // Temperature was removed as dead config: the request must carry no
+      // temperature field at all, so adaptive/reasoning models that 400 on a
+      // non-default sampling temperature are never sent one.
+      const callArgs = await sendWithHistory([], "Hello");
+
+      expect(callArgs).not.toHaveProperty("temperature");
+    });
+
     it("skips isError messages when building model messages", async () => {
       const chatHistory: ChatMessage[] = [
         { role: "user", content: "Hi" },

--- a/webui/src/chat/sdk/tests/spawn-subagent-tool.test.ts
+++ b/webui/src/chat/sdk/tests/spawn-subagent-tool.test.ts
@@ -54,16 +54,14 @@ describe("buildWorkerConfig", () => {
     expect(worker.chatHistory).toStrictEqual([]);
   });
 
-  it("inherits model, temperature, and system instruction", () => {
+  it("inherits model and system instruction", () => {
     const config = createConfig({
-      temperature: 0.7,
       systemInstruction: "custom prompt",
     });
 
     const worker = buildWorkerConfig(config);
 
     expect(worker.model).toBe(config.model);
-    expect(worker.temperature).toBe(0.7);
     expect(worker.systemInstruction).toBe("custom prompt");
   });
 

--- a/webui/src/chat/sdk/types.ts
+++ b/webui/src/chat/sdk/types.ts
@@ -95,7 +95,6 @@ export function toTokenUsage(sdkUsage: LanguageModelUsage): TokenUsage {
 /** Configuration for the AI SDK client */
 export interface ChatClientConfig {
   model: LanguageModel;
-  temperature?: number;
   systemInstruction?: string;
   mcpUrl?: string;
   enabledTools?: Record<string, boolean>;

--- a/webui/src/components/chat/tests/ChatStart.test.tsx
+++ b/webui/src/components/chat/tests/ChatStart.test.tsx
@@ -19,7 +19,6 @@ import {
 
 const defaultOverrides = {
   thinking: "Default",
-  temperature: 1.0,
 };
 
 type RenderProps = Partial<ChatStartProps> & {
@@ -64,7 +63,6 @@ describe("ChatStart", () => {
     it("calls handleSend with Connect to Ableton and overrides when Quick Connect is clicked", () => {
       const overrides = {
         thinking: "Max",
-        temperature: 0.5,
       };
       const { handleSend } = renderChatStart({ overrides });
 

--- a/webui/src/components/settings/tests/PresetControls.test.tsx
+++ b/webui/src/components/settings/tests/PresetControls.test.tsx
@@ -25,7 +25,6 @@ function makeSettings(over?: Partial<UseSettingsReturn>): UseSettingsReturn {
     provider: "anthropic",
     model: "claude",
     thinking: "Default",
-    temperature: 1,
     smallModelMode: false,
     applyPreset: vi.fn(),
     ...over,

--- a/webui/src/components/settings/tests/SettingsScreen.test.tsx
+++ b/webui/src/components/settings/tests/SettingsScreen.test.tsx
@@ -127,8 +127,6 @@ describe("SettingsScreen", () => {
     thinking: "Default",
     setThinking: vi.fn(),
     savedThinking: "Default",
-    temperature: 1,
-    setTemperature: vi.fn(),
     applyPreset: vi.fn(),
     saveSettings: vi.fn(),
     cancelSettings: vi.fn(),

--- a/webui/src/components/tests/App-test-helpers.ts
+++ b/webui/src/components/tests/App-test-helpers.ts
@@ -23,7 +23,6 @@ export const mockChatHook = {
   stopResponse: vi.fn(),
   activeModel: "test-model",
   activeThinking: null,
-  activeTemperature: 1.0,
   activeSmallModelMode: null,
   queuedMessages: [],
   enqueueMessage: vi.fn(),
@@ -50,8 +49,6 @@ export const mockSettingsHook = {
   savedProvider: "gemini" as const,
   thinking: "default" as const,
   setThinking: vi.fn(),
-  temperature: 1.0,
-  setTemperature: vi.fn(),
 
   enabledTools: {},
   setEnabledTools: vi.fn(),

--- a/webui/src/hooks/chat/adapter.ts
+++ b/webui/src/hooks/chat/adapter.ts
@@ -180,7 +180,6 @@ export const chatAdapter: ChatAdapter<
 
   buildConfig(
     model: string,
-    temperature: number,
     thinking: string,
     enabledTools: Record<string, boolean>,
     chatHistory: ChatMessage[] | undefined,
@@ -209,22 +208,13 @@ export const chatAdapter: ChatAdapter<
     const languageModel = createProviderModel(provider, model, apiKey, baseUrl);
     const providerOptions = buildProviderOptions(provider, thinking, model);
 
-    // Adaptive-family Anthropic models (Sonnet 5, Opus 4.6+, Fable) reject any
-    // non-default sampling parameter with a 400 — suppress temperature for them
-    // regardless of thinking level, including "Off". Haiku uses legacy enabled
-    // thinking, which requires temperature=1 only when thinking is active, so
-    // suppress there only when thinking is on; "Off" on Haiku keeps temperature.
-    // Pre-3.7 models (via the "Other..." input) support temperature normally and
-    // aren't adaptive, so always keep it — dropping it there was a regression.
-    const suppressTemperature =
-      (provider === "openai" && isOpenAIReasoningModel(model)) ||
-      (provider === "anthropic" &&
-        !isLegacyNonThinkingModel(model) &&
-        (!isLegacyThinkingModel(model) || thinking !== "Off"));
+    // Temperature is no longer sent: it was phased-out dead config (no UI, pinned
+    // at 1.0) so the request now carries no `temperature` and each provider
+    // applies its own default. Adaptive Anthropic / OpenAI reasoning models — the
+    // ones that 400 on a non-default temperature — are satisfied by sending none.
 
     return {
       model: languageModel,
-      temperature: suppressTemperature ? undefined : temperature,
       systemInstruction,
       enabledTools,
       smallModelMode,

--- a/webui/src/hooks/chat/helpers/tests/use-conversation-lock.test.ts
+++ b/webui/src/hooks/chat/helpers/tests/use-conversation-lock.test.ts
@@ -52,7 +52,7 @@ describe("useConversationLock", () => {
   it("passes message options to handleSend", async () => {
     const chat = createMockChat();
     const { result } = renderHook(() => useConversationLock({ chat }));
-    const options = { thinking: "Max", temperature: 0.5 };
+    const options = { thinking: "Max" };
 
     await act(async () => {
       await result.current.wrappedHandleSend("Hello", options);

--- a/webui/src/hooks/chat/helpers/tests/use-conversations-helpers.test.ts
+++ b/webui/src/hooks/chat/helpers/tests/use-conversations-helpers.test.ts
@@ -33,7 +33,6 @@ function refs(over: Partial<ActiveRefs> = {}): ActiveRefs {
     model: null,
     provider: null,
     thinking: null,
-    temperature: null,
     smallModelMode: null,
     systemInstruction: null,
     ...over,

--- a/webui/src/hooks/chat/helpers/tests/use-sync-active-meta.test.ts
+++ b/webui/src/hooks/chat/helpers/tests/use-sync-active-meta.test.ts
@@ -21,7 +21,6 @@ const ALL_NULL: SyncActiveMetaParams = {
   activeModel: null,
   activeProvider: null,
   activeThinking: null,
-  activeTemperature: null,
   activeSmallModelMode: null,
   activeSystemInstruction: null,
 };
@@ -43,7 +42,6 @@ describe("useSyncActiveMeta", () => {
         activeModel: "claude-sonnet-5",
         activeProvider: "anthropic",
         activeThinking: "high",
-        activeTemperature: 0.7,
         activeSmallModelMode: false,
         activeSystemInstruction: "Be brief.",
       }),
@@ -54,7 +52,6 @@ describe("useSyncActiveMeta", () => {
       model: "claude-sonnet-5",
       provider: "anthropic",
       thinking: "high",
-      temperature: 0.7,
       smallModelMode: false,
       systemInstruction: "Be brief.",
     });

--- a/webui/src/hooks/chat/helpers/use-active-settings.ts
+++ b/webui/src/hooks/chat/helpers/use-active-settings.ts
@@ -12,7 +12,6 @@ export interface ActiveSettings {
   activeModel: string | null;
   activeProvider: Provider | null;
   activeThinking: string | null;
-  activeTemperature: number | null;
   activeSmallModelMode: boolean | null;
   activeSystemInstruction: string | null;
 }
@@ -23,7 +22,6 @@ interface ActiveSettingsActions {
     model: string,
     provider: Provider,
     thinking: string,
-    temperature: number,
     smallModelMode: boolean,
     systemInstruction: string,
   ) => void;
@@ -45,9 +43,6 @@ export function useActiveSettings(): UseActiveSettingsReturn {
   const [activeModel, setActiveModel] = useState<string | null>(null);
   const [activeProvider, setActiveProvider] = useState<Provider | null>(null);
   const [activeThinking, setActiveThinking] = useState<string | null>(null);
-  const [activeTemperature, setActiveTemperature] = useState<number | null>(
-    null,
-  );
   const [activeSmallModelMode, setActiveSmallModelMode] = useState<
     boolean | null
   >(null);
@@ -60,14 +55,12 @@ export function useActiveSettings(): UseActiveSettingsReturn {
       model: string,
       provider: Provider,
       thinking: string,
-      temperature: number,
       smallModelMode: boolean,
       systemInstruction: string,
     ) => {
       setActiveModel(model);
       setActiveProvider(provider);
       setActiveThinking(thinking);
-      setActiveTemperature(temperature);
       setActiveSmallModelMode(smallModelMode);
       setActiveSystemInstruction(systemInstruction);
     },
@@ -79,7 +72,6 @@ export function useActiveSettings(): UseActiveSettingsReturn {
       setActiveModel(lockedSettings?.model ?? null);
       setActiveProvider(lockedSettings?.provider ?? null);
       setActiveThinking(lockedSettings?.thinking ?? null);
-      setActiveTemperature(lockedSettings?.temperature ?? null);
       setActiveSmallModelMode(lockedSettings?.smallModelMode ?? null);
       setActiveSystemInstruction(lockedSettings?.systemInstruction ?? null);
     },
@@ -90,7 +82,6 @@ export function useActiveSettings(): UseActiveSettingsReturn {
     setActiveModel(null);
     setActiveProvider(null);
     setActiveThinking(null);
-    setActiveTemperature(null);
     setActiveSmallModelMode(null);
     setActiveSystemInstruction(null);
   }, []);
@@ -99,7 +90,6 @@ export function useActiveSettings(): UseActiveSettingsReturn {
     activeModel,
     activeProvider,
     activeThinking,
-    activeTemperature,
     activeSmallModelMode,
     activeSystemInstruction,
     lockSettings,

--- a/webui/src/hooks/chat/helpers/use-conversations-helpers.ts
+++ b/webui/src/hooks/chat/helpers/use-conversations-helpers.ts
@@ -27,7 +27,6 @@ export interface ActiveMeta {
   model: string | null;
   provider: Provider | null;
   thinking: string | null;
-  temperature: number | null;
   smallModelMode: boolean | null;
   /** Resolved system instruction in effect (snapshotted onto the record). */
   systemInstruction: string | null;
@@ -40,7 +39,6 @@ export const DEFAULT_META: ActiveMeta = {
   model: null,
   provider: null,
   thinking: null,
-  temperature: null,
   smallModelMode: null,
   systemInstruction: null,
 };
@@ -144,7 +142,6 @@ export function buildLockedSettings(
     model: record.model,
     provider: record.provider as Provider | null,
     thinking: record.thinking,
-    temperature: record.temperature,
     smallModelMode: record.smallModelMode,
     systemInstruction: record.systemInstruction ?? null,
   };
@@ -181,7 +178,6 @@ export function buildSaveRecord(
     model: refs.model,
     modelLabel: refs.model ? getModelName(refs.model) : null,
     thinking: refs.thinking,
-    temperature: refs.temperature,
     smallModelMode: refs.smallModelMode,
     totalUsage: sumMessageUsage(chatHistory),
     sessionType: "text",

--- a/webui/src/hooks/chat/helpers/use-sync-active-meta.ts
+++ b/webui/src/hooks/chat/helpers/use-sync-active-meta.ts
@@ -14,7 +14,6 @@ export interface SyncActiveMetaParams {
   activeModel: string | null;
   activeProvider: Provider | null;
   activeThinking: string | null;
-  activeTemperature: number | null;
   activeSmallModelMode: boolean | null;
   activeSystemInstruction: string | null;
 }
@@ -36,7 +35,6 @@ export function useSyncActiveMeta(
     activeModel,
     activeProvider,
     activeThinking,
-    activeTemperature,
     activeSmallModelMode,
     activeSystemInstruction,
   } = props;
@@ -48,7 +46,6 @@ export function useSyncActiveMeta(
     if (activeModel != null) meta.model = activeModel;
     if (activeProvider != null) meta.provider = activeProvider;
     if (activeThinking != null) meta.thinking = activeThinking;
-    if (activeTemperature != null) meta.temperature = activeTemperature;
     if (activeSmallModelMode != null)
       meta.smallModelMode = activeSmallModelMode;
     if (activeSystemInstruction != null)
@@ -58,7 +55,6 @@ export function useSyncActiveMeta(
     activeModel,
     activeProvider,
     activeThinking,
-    activeTemperature,
     activeSmallModelMode,
     activeSystemInstruction,
   ]);

--- a/webui/src/hooks/chat/tests/adapter.test.ts
+++ b/webui/src/hooks/chat/tests/adapter.test.ts
@@ -56,39 +56,17 @@ describe("chatAdapter", () => {
       baseUrl: undefined,
     };
 
-    it("returns config with model and temperature", () => {
-      const config = chatAdapter.buildConfig(
-        "gpt-4o",
-        0.7,
-        "default",
-        {},
-        undefined,
-        extraParams,
-      );
-
-      expect(config.temperature).toBe(0.7);
-      expect(config.enabledTools).toStrictEqual({});
-    });
-
     it("carries smallModelMode from extraParams onto the config", () => {
-      const on = chatAdapter.buildConfig(
-        "gpt-4o",
-        1.0,
-        "default",
-        {},
-        undefined,
-        {
-          ...extraParams,
-          smallModelMode: true,
-        },
-      );
+      const on = chatAdapter.buildConfig("gpt-4o", "default", {}, undefined, {
+        ...extraParams,
+        smallModelMode: true,
+      });
 
       expect(on.smallModelMode).toBe(true);
 
       // Absent in extraParams coerces to false so the header is always explicit.
       const off = chatAdapter.buildConfig(
         "gpt-4o",
-        1.0,
         "default",
         {},
         undefined,
@@ -102,7 +80,6 @@ describe("chatAdapter", () => {
       const enabledTools = { "ppal-connect": true, "ppal-read": false };
       const config = chatAdapter.buildConfig(
         "gpt-4o",
-        1.0,
         "default",
         enabledTools,
         undefined,
@@ -116,7 +93,6 @@ describe("chatAdapter", () => {
       const history: ChatMessage[] = [{ role: "user", content: "Hello" }];
       const config = chatAdapter.buildConfig(
         "gpt-4o",
-        1.0,
         "default",
         {},
         history,
@@ -129,7 +105,6 @@ describe("chatAdapter", () => {
     it("uses the built-in system instruction when no override is provided", () => {
       const config = chatAdapter.buildConfig(
         "gpt-4o",
-        1.0,
         "default",
         {},
         undefined,
@@ -142,7 +117,6 @@ describe("chatAdapter", () => {
     it("fully replaces the system instruction with a non-blank override", () => {
       const config = chatAdapter.buildConfig(
         "gpt-4o",
-        1.0,
         "default",
         {},
         undefined,
@@ -158,7 +132,6 @@ describe("chatAdapter", () => {
     it("falls back to the built-in instruction when the override is blank", () => {
       const config = chatAdapter.buildConfig(
         "gpt-4o",
-        1.0,
         "default",
         {},
         undefined,
@@ -174,7 +147,6 @@ describe("chatAdapter", () => {
       // with.
       const config = chatAdapter.buildConfig(
         "gpt-4o",
-        1.0,
         "default",
         {},
         undefined,
@@ -191,14 +163,10 @@ describe("chatAdapter", () => {
     });
 
     it("sets reasoning effort and summary for openai reasoning model with Max thinking", () => {
-      const config = chatAdapter.buildConfig(
-        "o3-mini",
-        1.0,
-        "Max",
-        {},
-        undefined,
-        { ...extraParams, provider: "openai" },
-      );
+      const config = chatAdapter.buildConfig("o3-mini", "Max", {}, undefined, {
+        ...extraParams,
+        provider: "openai",
+      });
 
       expect(config.providerOptions).toStrictEqual({
         openai: { reasoningEffort: "high", reasoningSummary: "auto" },
@@ -206,14 +174,10 @@ describe("chatAdapter", () => {
     });
 
     it("includes reasoningSummary for an openai reasoning model", () => {
-      const config = chatAdapter.buildConfig(
-        "gpt-5.2",
-        1.0,
-        "Max",
-        {},
-        undefined,
-        { ...extraParams, provider: "openai" },
-      );
+      const config = chatAdapter.buildConfig("gpt-5.2", "Max", {}, undefined, {
+        ...extraParams,
+        provider: "openai",
+      });
 
       expect(config.providerOptions).toStrictEqual({
         openai: { reasoningEffort: "xhigh", reasoningSummary: "auto" },
@@ -223,7 +187,6 @@ describe("chatAdapter", () => {
     it("sets reasoningEffort and reasoningSummary for openai reasoning model with Default thinking", () => {
       const config = chatAdapter.buildConfig(
         "gpt-5.2",
-        1.0,
         "Default",
         {},
         undefined,
@@ -236,14 +199,10 @@ describe("chatAdapter", () => {
     });
 
     it("returns undefined providerOptions for an openai reasoning model with Off thinking", () => {
-      const config = chatAdapter.buildConfig(
-        "o3-mini",
-        1.0,
-        "Off",
-        {},
-        undefined,
-        { ...extraParams, provider: "openai" },
-      );
+      const config = chatAdapter.buildConfig("o3-mini", "Off", {}, undefined, {
+        ...extraParams,
+        provider: "openai",
+      });
 
       expect(config.providerOptions).toBeUndefined();
     });
@@ -251,7 +210,6 @@ describe("chatAdapter", () => {
     it("sets reasoning for openrouter provider with Max thinking", () => {
       const config = chatAdapter.buildConfig(
         "some-model",
-        1.0,
         "Max",
         {},
         undefined,
@@ -270,7 +228,6 @@ describe("chatAdapter", () => {
     it("sets Gemini thinkingConfig for Max thinking", () => {
       const config = chatAdapter.buildConfig(
         "gemini-2.5-flash",
-        1.0,
         "Max",
         {},
         undefined,
@@ -290,7 +247,6 @@ describe("chatAdapter", () => {
     it("sets Gemini thinkingConfig with -1 budget for Default thinking", () => {
       const config = chatAdapter.buildConfig(
         "gemini-2.0-flash",
-        1.0,
         "Default",
         {},
         undefined,
@@ -310,7 +266,6 @@ describe("chatAdapter", () => {
     it("returns undefined providerOptions for Gemini with Off thinking", () => {
       const config = chatAdapter.buildConfig(
         "gemini-2.0-flash",
-        1.0,
         "Off",
         {},
         undefined,
@@ -323,7 +278,6 @@ describe("chatAdapter", () => {
     it("returns undefined providerOptions for default thinking", () => {
       const config = chatAdapter.buildConfig(
         "gpt-4o",
-        1.0,
         "default",
         {},
         undefined,
@@ -334,7 +288,7 @@ describe("chatAdapter", () => {
     });
 
     it("sets ollama think option for supported model", () => {
-      const config = chatAdapter.buildConfig("qwq", 1.0, "Max", {}, undefined, {
+      const config = chatAdapter.buildConfig("qwq", "Max", {}, undefined, {
         ...extraParams,
         provider: "ollama",
       });
@@ -345,7 +299,7 @@ describe("chatAdapter", () => {
     });
 
     it("sets ollama think:false for Off thinking", () => {
-      const config = chatAdapter.buildConfig("qwq", 1.0, "Off", {}, undefined, {
+      const config = chatAdapter.buildConfig("qwq", "Off", {}, undefined, {
         ...extraParams,
         provider: "ollama",
       });
@@ -358,7 +312,6 @@ describe("chatAdapter", () => {
     it("returns undefined providerOptions for ollama with Default thinking", () => {
       const config = chatAdapter.buildConfig(
         "llama3",
-        1.0,
         "Default",
         {},
         undefined,
@@ -371,7 +324,6 @@ describe("chatAdapter", () => {
     it("sets medium reasoning effort for openrouter with Default thinking", () => {
       const config = chatAdapter.buildConfig(
         "some-model",
-        1.0,
         "Default",
         {},
         undefined,
@@ -390,7 +342,6 @@ describe("chatAdapter", () => {
     it("returns undefined providerOptions for openrouter with Off thinking", () => {
       const config = chatAdapter.buildConfig(
         "some-model",
-        1.0,
         "Off",
         {},
         undefined,
@@ -403,7 +354,6 @@ describe("chatAdapter", () => {
     it("sets anthropic adaptive thinking with max effort for Max thinking", () => {
       const config = chatAdapter.buildConfig(
         "claude-sonnet-4-6-20250514",
-        1.0,
         "Max",
         {},
         undefined,
@@ -421,7 +371,6 @@ describe("chatAdapter", () => {
     it("sets anthropic adaptive thinking with high effort for Default thinking", () => {
       const config = chatAdapter.buildConfig(
         "claude-sonnet-4-6-20250514",
-        1.0,
         "Default",
         {},
         undefined,
@@ -436,36 +385,9 @@ describe("chatAdapter", () => {
       });
     });
 
-    it("suppresses temperature for anthropic when thinking is active", () => {
-      const config = chatAdapter.buildConfig(
-        "claude-sonnet-4-6-20250514",
-        0.7,
-        "Max",
-        {},
-        undefined,
-        { ...extraParams, provider: "anthropic" },
-      );
-
-      expect(config.temperature).toBeUndefined();
-    });
-
-    it("suppresses temperature for anthropic with Default thinking", () => {
-      const config = chatAdapter.buildConfig(
-        "claude-sonnet-4-6-20250514",
-        0.7,
-        "Default",
-        {},
-        undefined,
-        { ...extraParams, provider: "anthropic" },
-      );
-
-      expect(config.temperature).toBeUndefined();
-    });
-
     it("returns undefined provider options for anthropic with Off thinking", () => {
       const config = chatAdapter.buildConfig(
         "claude-sonnet-4-6-20250514",
-        1.0,
         "Off",
         {},
         undefined,
@@ -475,52 +397,9 @@ describe("chatAdapter", () => {
       expect(config.providerOptions).toBeUndefined();
     });
 
-    it("suppresses temperature for adaptive-family anthropic with Off thinking", () => {
-      // Sonnet 5 / Opus 4.6+ / Fable reject non-default sampling params (400),
-      // so temperature must be dropped even when thinking is Off.
-      const config = chatAdapter.buildConfig(
-        "claude-sonnet-5",
-        0.7,
-        "Off",
-        {},
-        undefined,
-        { ...extraParams, provider: "anthropic" },
-      );
-
-      expect(config.temperature).toBeUndefined();
-    });
-
-    it("preserves temperature for haiku with Off thinking", () => {
-      const config = chatAdapter.buildConfig(
-        "claude-haiku-4-5",
-        0.7,
-        "Off",
-        {},
-        undefined,
-        { ...extraParams, provider: "anthropic" },
-      );
-
-      expect(config.temperature).toBe(0.7);
-    });
-
-    it("suppresses temperature for haiku when thinking is active", () => {
-      // Legacy enabled thinking requires temperature=1, so suppress it there.
-      const config = chatAdapter.buildConfig(
-        "claude-haiku-4-5",
-        0.7,
-        "Max",
-        {},
-        undefined,
-        { ...extraParams, provider: "anthropic" },
-      );
-
-      expect(config.temperature).toBeUndefined();
-    });
-
     it("uses legacy enabled thinking for haiku model", () => {
       const config = chatAdapter.buildConfig(
         "claude-haiku-4-5",
-        1.0,
         "Max",
         {},
         undefined,
@@ -539,7 +418,6 @@ describe("chatAdapter", () => {
       // `thinking` field with a 400, so no adaptive payload must be sent.
       const config = chatAdapter.buildConfig(
         "claude-3-5-sonnet-20241022",
-        1.0,
         "Max",
         {},
         undefined,
@@ -549,38 +427,9 @@ describe("chatAdapter", () => {
       expect(config.providerOptions).toBeUndefined();
     });
 
-    it("preserves temperature for a pre-3.7 anthropic model with active thinking", () => {
-      // Pre-3.7 models support temperature normally and aren't adaptive, so it
-      // must be kept regardless of the UI thinking level (regression guard).
-      const config = chatAdapter.buildConfig(
-        "claude-3-opus-20240229",
-        0.7,
-        "Max",
-        {},
-        undefined,
-        { ...extraParams, provider: "anthropic" },
-      );
-
-      expect(config.temperature).toBe(0.7);
-    });
-
-    it("preserves temperature for a pre-3.7 anthropic model with Off thinking", () => {
-      const config = chatAdapter.buildConfig(
-        "claude-3-5-sonnet-20241022",
-        0.7,
-        "Off",
-        {},
-        undefined,
-        { ...extraParams, provider: "anthropic" },
-      );
-
-      expect(config.temperature).toBe(0.7);
-    });
-
     it("returns undefined provider options for mistral provider", () => {
       const config = chatAdapter.buildConfig(
         "mistral-large",
-        1.0,
         "Max",
         {},
         undefined,
@@ -593,7 +442,6 @@ describe("chatAdapter", () => {
     it("buildProviderOptions callback rebuilds options with overridden thinking", () => {
       const config = chatAdapter.buildConfig(
         "claude-sonnet-4-6-20250514",
-        1.0,
         "Max",
         {},
         undefined,

--- a/webui/src/hooks/chat/tests/conversations/use-conversations-metadata.test.ts
+++ b/webui/src/hooks/chat/tests/conversations/use-conversations-metadata.test.ts
@@ -130,11 +130,10 @@ describe("useConversations", () => {
   });
 
   describe("active ref sync", () => {
-    it("persists thinking/temperature from active refs", async () => {
+    it("persists thinking from active refs", async () => {
       const { props, state } = createProps();
 
       props.activeMeta.activeThinking = "enabled";
-      props.activeMeta.activeTemperature = 0.7;
 
       const { result } = renderHook(() => useConversations(props));
 
@@ -146,12 +145,10 @@ describe("useConversations", () => {
 
       expect(record).toMatchObject({
         thinking: "enabled",
-        temperature: 0.7,
       });
 
       // Change props, wait for effect to sync refs, then save and verify
       props.activeMeta.activeThinking = "disabled";
-      props.activeMeta.activeTemperature = 1.0;
       // saveWithMessage triggers rerender which runs the ref-sync useEffect
       await saveWithMessage(state, result, "ref sync 2");
       await waitForEffects();
@@ -163,7 +160,6 @@ describe("useConversations", () => {
 
       expect(updated).toMatchObject({
         thinking: "disabled",
-        temperature: 1.0,
       });
     });
   });

--- a/webui/src/hooks/chat/tests/conversations/use-conversations-test-helpers.ts
+++ b/webui/src/hooks/chat/tests/conversations/use-conversations-test-helpers.ts
@@ -30,7 +30,6 @@ export function createConversationsProps() {
         activeModel: null as string | null,
         activeProvider: null as Provider | null,
         activeThinking: null as string | null,
-        activeTemperature: null as number | null,
         activeSmallModelMode: null as boolean | null,
         activeSystemInstruction: null as string | null,
       },

--- a/webui/src/hooks/chat/tests/helpers/use-chat-test-helpers.ts
+++ b/webui/src/hooks/chat/tests/helpers/use-chat-test-helpers.ts
@@ -23,7 +23,6 @@ export interface TestMessage {
 /** Test configuration for mock adapter */
 export interface TestConfig {
   model: string;
-  temperature: number;
   thinking: string;
 }
 
@@ -87,13 +86,10 @@ export function createMockAdapter(): ChatAdapter<
   const adapter: ChatAdapter<MockChatClient, TestMessage, TestConfig> = {
     createClient: vi.fn(() => new MockChatClient()),
 
-    buildConfig: vi.fn(
-      (model: string, temperature: number, thinking: string): TestConfig => ({
-        model,
-        temperature,
-        thinking,
-      }),
-    ),
+    buildConfig: vi.fn((model: string, thinking: string): TestConfig => ({
+      model,
+      thinking,
+    })),
 
     formatMessages: vi.fn((messages: TestMessage[]): UIMessage[] => {
       return messages.map((msg, idx) => ({
@@ -180,7 +176,6 @@ export function createDefaultProps(
     apiKey: "test-key",
     model: "test-model",
     thinking: "Default",
-    temperature: 1.0,
     enabledTools: {},
     smallModelMode: false,
     mcpStatus: "connected" as const,
@@ -215,7 +210,6 @@ export function lockedSettings(
     model: null,
     provider: null,
     thinking: null,
-    temperature: null,
     smallModelMode: null,
     systemInstruction: null,
     ...over,

--- a/webui/src/hooks/chat/tests/use-chat-retry.test.ts
+++ b/webui/src/hooks/chat/tests/use-chat-retry.test.ts
@@ -392,7 +392,6 @@ describe("useChat", () => {
       expect(resolveConnection).toHaveBeenCalledWith("anthropic");
       expect(mockAdapter.buildConfig).toHaveBeenCalledWith(
         "claude-x",
-        1.0,
         "Default",
         {},
         expect.anything(),
@@ -435,7 +434,6 @@ describe("useChat", () => {
       // the resolved connection for the (unlocked → current) provider.
       expect(mockAdapter.buildConfig).toHaveBeenCalledWith(
         "test-model",
-        1.0,
         "Default",
         {},
         history,

--- a/webui/src/hooks/chat/tests/use-chat-system-instruction.test.ts
+++ b/webui/src/hooks/chat/tests/use-chat-system-instruction.test.ts
@@ -44,7 +44,6 @@ describe("useChat system instruction locking", () => {
       expect.anything(),
       expect.anything(),
       expect.anything(),
-      expect.anything(),
       expect.objectContaining({
         lockedSystemInstruction: "Locked prompt from when the chat started.",
       }),

--- a/webui/src/hooks/chat/tests/use-chat.test.ts
+++ b/webui/src/hooks/chat/tests/use-chat.test.ts
@@ -139,7 +139,6 @@ describe("useChat", () => {
       expect(result.current.isAssistantResponding).toBe(false);
       expect(result.current.activeModel).toBeNull();
       expect(result.current.activeThinking).toBeNull();
-      expect(result.current.activeTemperature).toBeNull();
     });
   });
 
@@ -159,7 +158,6 @@ describe("useChat", () => {
       expect(result.current.messages).toStrictEqual([]);
       expect(result.current.activeModel).toBeNull();
       expect(result.current.activeThinking).toBeNull();
-      expect(result.current.activeTemperature).toBeNull();
     });
 
     it("disposes the client so its MCP connection is released", async () => {
@@ -348,17 +346,15 @@ describe("useChat", () => {
 
       expect(mockAdapter.createClient).toHaveBeenCalledWith("test-key", {
         model: "test-model",
-        temperature: 1.0,
         thinking: "Default",
       });
     });
 
-    it("sets active model, thinking, and temperature after initialization", async () => {
+    it("sets active model and thinking after initialization", async () => {
       const result = await renderAndSend();
 
       expect(result.current.activeModel).toBe("test-model");
       expect(result.current.activeThinking).toBe("Default");
-      expect(result.current.activeTemperature).toBe(1.0);
     });
 
     it("reuses existing client on subsequent messages", async () => {

--- a/webui/src/hooks/chat/use-chat-mode-state.ts
+++ b/webui/src/hooks/chat/use-chat-mode-state.ts
@@ -131,7 +131,6 @@ export function useChatModeState(params: UseChatModeStateParams) {
     apiKey: resolvedApiKey,
     model: settings.model,
     thinking: settings.thinking,
-    temperature: settings.temperature,
     enabledTools: settings.enabledTools,
     smallModelMode: settings.smallModelMode,
     mcpStatus,
@@ -176,7 +175,6 @@ export function useChatModeState(params: UseChatModeStateParams) {
       activeModel: chat.activeModel,
       activeProvider: chat.activeProvider,
       activeThinking: chat.activeThinking,
-      activeTemperature: chat.activeTemperature,
       activeSmallModelMode: chat.activeSmallModelMode,
       // Snapshot the LOCKED instruction (what this conversation actually ran
       // with), not the current global override — so editing the global later

--- a/webui/src/hooks/chat/use-chat-types.ts
+++ b/webui/src/hooks/chat/use-chat-types.ts
@@ -55,7 +55,6 @@ export interface ChatAdapter<
   /** Build provider-specific configuration */
   buildConfig: (
     model: string,
-    temperature: number,
     thinking: string,
     enabledTools: Record<string, boolean>,
     chatHistory: TMessage[] | undefined,
@@ -83,7 +82,6 @@ export interface ConversationLockedSettings {
   model: string | null;
   provider: Provider | null;
   thinking: string | null;
-  temperature: number | null;
   smallModelMode: boolean | null;
   /**
    * The resolved system instruction the conversation runs with. Locked like the
@@ -122,7 +120,6 @@ export interface UseChatReturn {
   activeModel: string | null;
   activeProvider: Provider | null;
   activeThinking: string | null;
-  activeTemperature: number | null;
   activeSmallModelMode: boolean | null;
   /** The resolved system instruction locked for the active conversation. */
   activeSystemInstruction: string | null;
@@ -166,7 +163,6 @@ export interface UseChatProps<
   apiKey: string;
   model: string;
   thinking: string;
-  temperature: number;
   enabledTools: Record<string, boolean>;
   mcpStatus: "connected" | "connecting" | "error";
   mcpError: string | null;

--- a/webui/src/hooks/chat/use-chat.ts
+++ b/webui/src/hooks/chat/use-chat.ts
@@ -42,7 +42,6 @@ export function useChat<
   apiKey,
   model,
   thinking,
-  temperature,
   enabledTools,
   smallModelMode,
   mcpStatus,
@@ -189,7 +188,6 @@ export function useChat<
 
       const config = adapter.buildConfig(
         init.model,
-        temperature,
         effectiveThinking,
         enabledTools,
         chatHistory,
@@ -206,7 +204,6 @@ export function useChat<
         init.model,
         init.provider,
         effectiveThinking,
-        temperature,
         smallModelMode,
         init.systemInstruction,
       );
@@ -218,7 +215,6 @@ export function useChat<
       checkMcpConnection,
       model,
       provider,
-      temperature,
       thinking,
       enabledTools,
       resolveConnection,

--- a/webui/src/hooks/chat/use-conversations.ts
+++ b/webui/src/hooks/chat/use-conversations.ts
@@ -530,7 +530,6 @@ function syncMetaRef(
     model: record.model,
     provider: record.provider as Provider | null,
     thinking: record.thinking,
-    temperature: record.temperature,
     smallModelMode: record.smallModelMode ?? null,
     systemInstruction: record.systemInstruction ?? null,
   };

--- a/webui/src/hooks/settings/config-builders.ts
+++ b/webui/src/hooks/settings/config-builders.ts
@@ -173,7 +173,9 @@ export function isO1O3Model(model: string): boolean {
 }
 
 /**
- * Checks if an OpenAI model is a reasoning model that doesn't support temperature.
+ * Checks if an OpenAI model is a reasoning model (emits reasoning tokens and
+ * rejects a non-default sampling temperature). Gates the reasoning-summary
+ * request in the adapter.
  * Covers GPT-5 family (gpt-5, gpt-5.4-mini, gpt-5.2, gpt-5.3-codex, etc.) and o-series.
  * @param {string} model - Model identifier
  * @returns {boolean} - True if reasoning model

--- a/webui/src/hooks/settings/presets/preset-extra-params.ts
+++ b/webui/src/hooks/settings/presets/preset-extra-params.ts
@@ -16,10 +16,9 @@ type GetProviderConnection = (provider: Provider) => {
  * bag that `chatAdapter.buildConfig` consumes, resolving the
  * provider's key/baseUrl live from the encrypted per-provider store (a preset
  * only *names* the provider). A worker's cloned config is then built exactly
- * like the main chat's — `buildConfig(preset.model, temperature, preset.thinking,
+ * like the main chat's — `buildConfig(preset.model, preset.thinking,
  * enabledTools, chatHistory, presetToExtraParams(preset, …))`. model/thinking
- * are positional args to buildConfig, so they stay out of this bag by design
- * (temperature is a phased-out param the caller passes as the default).
+ * are positional args to buildConfig, so they stay out of this bag by design.
  * @param preset - The preset a worker runs under
  * @param getProviderConnection - Reads the provider's stored key/baseUrl
  * @returns The extraParams object for buildConfig

--- a/webui/src/hooks/settings/presets/tests/preset-apply.test.ts
+++ b/webui/src/hooks/settings/presets/tests/preset-apply.test.ts
@@ -64,13 +64,12 @@ describe("useApplyPreset", () => {
     expect(setters.anthropic).not.toHaveBeenCalled();
 
     // The functional update swaps model+thinking but preserves everything else
-    // in the slice (apiKey/baseUrl and the phased-out temperature).
+    // in the slice (apiKey/baseUrl).
     const prev: ProviderSettings = {
       apiKey: "KEEP",
       baseUrl: "http://keep",
       model: "old",
       thinking: "Default",
-      temperature: 1,
     };
 
     expect(captured.openai?.(prev)).toStrictEqual({
@@ -78,7 +77,6 @@ describe("useApplyPreset", () => {
       baseUrl: "http://keep",
       model: "gpt-x",
       thinking: "Max",
-      temperature: 1,
     });
 
     expect(setProvider).toHaveBeenCalledWith("openai");

--- a/webui/src/hooks/settings/settings-helpers.ts
+++ b/webui/src/hooks/settings/settings-helpers.ts
@@ -140,7 +140,6 @@ export interface ProviderSettings {
   baseUrl?: string;
   port?: number;
   thinking: string;
-  temperature: number;
 }
 
 /**
@@ -159,52 +158,44 @@ export const DEFAULT_SETTINGS: Record<Provider, ProviderSettings> = {
     apiKey: "",
     model: DEFAULT_MODELS.anthropic,
     thinking: "Default",
-    temperature: 1.0,
   },
   gemini: {
     apiKey: "",
     model: DEFAULT_MODELS.gemini,
     thinking: "Default",
-    temperature: 1.0,
   },
   openai: {
     apiKey: "",
     model: DEFAULT_MODELS.openai,
     thinking: "Default",
-    temperature: 1.0,
   },
   mistral: {
     apiKey: "",
     model: DEFAULT_MODELS.mistral,
     thinking: "Default",
-    temperature: 1.0,
   },
   openrouter: {
     apiKey: "",
     model: DEFAULT_MODELS.openrouter,
     thinking: "Default",
-    temperature: 1.0,
   },
   lmstudio: {
     apiKey: "",
     model: DEFAULT_MODELS.lmstudio,
     baseUrl: "http://localhost:1234",
     thinking: "Default",
-    temperature: 1.0,
   },
   ollama: {
     apiKey: "",
     model: DEFAULT_MODELS.ollama,
     baseUrl: "http://localhost:11434",
     thinking: "Default",
-    temperature: 1.0,
   },
   custom: {
     apiKey: "",
     model: DEFAULT_MODELS.custom,
     baseUrl: "",
     thinking: "Default",
-    temperature: 1.0,
   },
 };
 
@@ -332,14 +323,6 @@ function readLegacyGeminiSettings(): ProviderSettings {
     localStorage.getItem("thinking") ?? localStorage.getItem("gemini_thinking");
 
   if (thinking) legacySettings.thinking = thinking;
-
-  const temperature =
-    localStorage.getItem("temperature") ??
-    localStorage.getItem("gemini_temperature");
-
-  if (temperature != null) {
-    legacySettings.temperature = Number.parseFloat(temperature);
-  }
 
   return { ...DEFAULT_SETTINGS.gemini, ...legacySettings };
 }

--- a/webui/src/hooks/settings/tests/settings-helpers.test.ts
+++ b/webui/src/hooks/settings/tests/settings-helpers.test.ts
@@ -42,7 +42,6 @@ describe("settings-helpers", () => {
         apiKey: "sk-ant-secret",
         model: "claude-sonnet-4-6",
         thinking: "Default",
-        temperature: 1.0,
       });
 
       const raw = JSON.parse(
@@ -58,7 +57,6 @@ describe("settings-helpers", () => {
         apiKey: "sk-ant-secret",
         model: "claude-sonnet-4-6",
         thinking: "Default",
-        temperature: 1.0,
       });
 
       const loaded = await loadProviderSettingsAsync("anthropic");
@@ -71,7 +69,6 @@ describe("settings-helpers", () => {
         apiKey: "sk-ant-secret",
         model: "claude-sonnet-4-6",
         thinking: "Default",
-        temperature: 1.0,
       });
 
       // The synchronous loader must not surface ciphertext; it returns "".
@@ -96,7 +93,6 @@ describe("settings-helpers", () => {
         apiKey: "AIza-new",
         model: "gemini-2.5-flash",
         thinking: "Default",
-        temperature: 1.0,
       });
 
       expect(localStorage.getItem("gemini_api_key")).toBeNull();
@@ -114,7 +110,6 @@ describe("settings-helpers", () => {
         apiKey: "sk-ant-secret",
         model: "claude-sonnet-4-6",
         thinking: "Default",
-        temperature: 1.0,
       });
 
       expect(localStorage.getItem("gemini_api_key")).toBe("AIza-old-cleartext");
@@ -125,7 +120,6 @@ describe("settings-helpers", () => {
         apiKey: "",
         model: "gpt-5.5",
         thinking: "Default",
-        temperature: 1.0,
       });
 
       const raw = JSON.parse(
@@ -144,7 +138,6 @@ describe("settings-helpers", () => {
         apiKey: "sk-anthropic-good",
         model: "claude-sonnet-4-6",
         thinking: "Default",
-        temperature: 1.0,
       });
 
       // Forge an undecryptable envelope for openai: a real IV paired with a
@@ -173,7 +166,6 @@ describe("settings-helpers", () => {
         apiKey: "sk-ant-secret",
         model: "claude-sonnet-4-6",
         thinking: "Default",
-        temperature: 1.0,
       });
 
       expect(checkHasApiKey("anthropic")).toBe(true);

--- a/webui/src/hooks/settings/tests/use-has-unsaved-changes.test.ts
+++ b/webui/src/hooks/settings/tests/use-has-unsaved-changes.test.ts
@@ -31,7 +31,6 @@ function makeSettings(
     apiKey: "k",
     smallModelMode: false,
     thinking: "Default",
-    temperature: 1,
     enabledTools: {},
     realtimeVoice: "marin",
     voiceSpeed: 1,

--- a/webui/src/hooks/settings/tests/use-settings-providers.test.ts
+++ b/webui/src/hooks/settings/tests/use-settings-providers.test.ts
@@ -34,26 +34,6 @@ describe("useSettings - provider-specific settings", () => {
       expect(result.current.thinking).toBe(thinking);
     });
   });
-  describe("setTemperature for all providers", () => {
-    it.each([
-      ["anthropic", 0.8],
-      ["mistral", 0.8],
-      ["openrouter", 0.5],
-      ["lmstudio", 0.9],
-      ["ollama", 0.7],
-      ["custom", 0.6],
-    ] as const)("sets temperature for %s provider", async (provider, temp) => {
-      const { result } = renderHook(() => useSettings());
-
-      await act(() => {
-        result.current.setProvider(provider);
-      });
-      await act(() => {
-        result.current.setTemperature(temp);
-      });
-      expect(result.current.temperature).toBe(temp);
-    });
-  });
   describe("setBaseUrl", () => {
     it("setBaseUrl is undefined for non-baseUrl providers", async () => {
       const { result } = renderHook(() => useSettings());

--- a/webui/src/hooks/settings/tests/use-settings.test.ts
+++ b/webui/src/hooks/settings/tests/use-settings.test.ts
@@ -47,7 +47,6 @@ describe("useSettings", () => {
       apiKey: "",
       model: "gemini-3.6-flash",
       thinking: "Default",
-      temperature: 1.0,
       hasApiKey: false,
     });
   });
@@ -56,7 +55,6 @@ describe("useSettings", () => {
     localStorage.setItem("gemini_api_key", "test-key");
     localStorage.setItem("gemini_model", "gemini-2.5-pro");
     localStorage.setItem("thinking", "High");
-    localStorage.setItem("temperature", "0.7");
 
     const { result } = renderHook(() => useSettings());
 
@@ -66,7 +64,6 @@ describe("useSettings", () => {
     expect(result.current).toMatchObject({
       model: "gemini-2.5-pro",
       thinking: "High",
-      temperature: 0.7,
     });
     await waitFor(() => expect(result.current.apiKey).toBe("test-key"));
     expect(result.current.hasApiKey).toBe(true);
@@ -79,7 +76,6 @@ describe("useSettings", () => {
         apiKey: "new-key",
         model: "gemini-3.6-flash",
         thinking: "Max",
-        temperature: 1.5,
       }),
     );
 
@@ -88,7 +84,6 @@ describe("useSettings", () => {
     expect(result.current).toMatchObject({
       model: "gemini-3.6-flash",
       thinking: "Max",
-      temperature: 1.5,
     });
     await waitFor(() => expect(result.current.apiKey).toBe("new-key"));
     expect(result.current.hasApiKey).toBe(true);
@@ -104,7 +99,6 @@ describe("useSettings", () => {
         apiKey: "new-key",
         model: "gemini-3.6-flash",
         thinking: "Adaptive",
-        temperature: 1.0,
       }),
     );
 
@@ -124,7 +118,6 @@ describe("useSettings", () => {
         model: "qwen3.6",
         baseUrl: "http://localhost:11434",
         thinking: "Max",
-        temperature: 1.0,
       }),
     );
 
@@ -224,16 +217,6 @@ describe("useSettings", () => {
     expect(result.current.thinking).toBe("Off");
   });
 
-  it("updates temperature when setTemperature is called", async () => {
-    const { result } = renderHook(() => useSettings());
-
-    await act(() => {
-      result.current.setTemperature(0.5);
-    });
-
-    expect(result.current.temperature).toBe(0.5);
-  });
-
   it("saveSettings before post-mount decrypt does not wipe stored apiKeys", async () => {
     // Seed two providers with encrypted apiKeys so we can detect a wipe.
     for (const provider of ["gemini", "openai"] as const) {
@@ -243,7 +226,6 @@ describe("useSettings", () => {
           apiKey: await encryptApiKey(`${provider}-stored`),
           model: "stored-model",
           thinking: "Default",
-          temperature: 1.0,
         }),
       );
     }
@@ -282,7 +264,6 @@ describe("useSettings", () => {
       result.current.setApiKey("new-key");
       result.current.setModel("gemini-3.6-flash");
       result.current.setThinking("Max");
-      result.current.setTemperature(0.8);
     });
 
     await act(async () => {
@@ -307,7 +288,6 @@ describe("useSettings", () => {
     await expectStored("gemini", "new-key", {
       model: "gemini-3.6-flash",
       thinking: "Max",
-      temperature: 0.8,
     });
   });
 
@@ -488,13 +468,11 @@ describe("useSettings", () => {
       result.current.setApiKey("gemini-key");
       result.current.setModel("gemini-2.5-pro");
       result.current.setThinking("Max");
-      result.current.setTemperature(0.5);
     });
 
     expect(result.current).toMatchObject({
       model: "gemini-2.5-pro",
       thinking: "Max",
-      temperature: 0.5,
     });
 
     // Switch to OpenAI - should use defaults
@@ -506,7 +484,6 @@ describe("useSettings", () => {
       apiKey: "",
       model: "gpt-5.6-terra",
       thinking: "Default",
-      temperature: 1.0,
     });
 
     // Configure OpenAI with different settings
@@ -514,7 +491,6 @@ describe("useSettings", () => {
       result.current.setApiKey("openai-key");
       result.current.setModel("gpt-5.4-mini");
       result.current.setThinking("Off");
-      result.current.setTemperature(1.5);
     });
 
     // Switch back to Gemini - should restore Gemini settings
@@ -526,7 +502,6 @@ describe("useSettings", () => {
       apiKey: "gemini-key",
       model: "gemini-2.5-pro",
       thinking: "Max",
-      temperature: 0.5,
     });
 
     // Switch back to OpenAI - should restore OpenAI settings
@@ -538,7 +513,6 @@ describe("useSettings", () => {
       apiKey: "openai-key",
       model: "gpt-5.4-mini",
       thinking: "Off",
-      temperature: 1.5,
     });
   });
 
@@ -548,7 +522,6 @@ describe("useSettings", () => {
       apiKey: string;
       model: string;
       thinking?: string;
-      temperature: number;
     }
     const setups: ProviderSetup[] = [
       {
@@ -556,26 +529,22 @@ describe("useSettings", () => {
         apiKey: "gemini-key",
         model: "gemini-2.5-pro",
         thinking: "Max",
-        temperature: 0.5,
       },
       {
         provider: "openai",
         apiKey: "openai-key",
         model: "gpt-5.4-mini",
         thinking: "Off",
-        temperature: 1.5,
       },
       {
         provider: "openrouter",
         apiKey: "openrouter-key",
         model: "minimax/minimax-m2:free",
-        temperature: 0.8,
       },
       {
         provider: "mistral",
         apiKey: "mistral-key",
         model: "mistral-small-latest",
-        temperature: 1.2,
       },
     ];
     const last = setups.at(-1)!;
@@ -591,7 +560,6 @@ describe("useSettings", () => {
         result.current.setApiKey(s.apiKey);
         result.current.setModel(s.model);
         if (s.thinking != null) result.current.setThinking(s.thinking);
-        result.current.setTemperature(s.temperature);
       });
     }
 
@@ -623,7 +591,6 @@ describe("useSettings", () => {
     expect(result2.current).toMatchObject({
       provider: last.provider,
       model: last.model,
-      temperature: last.temperature,
     });
     await waitFor(() => expect(result2.current.apiKey).toBe(last.apiKey));
 
@@ -632,7 +599,6 @@ describe("useSettings", () => {
       await act(() => result2.current.setProvider(s.provider));
       expect(result2.current).toMatchObject({
         model: s.model,
-        temperature: s.temperature,
         ...(s.thinking != null ? { thinking: s.thinking } : {}),
       });
       await waitFor(() => expect(result2.current.apiKey).toBe(s.apiKey));
@@ -699,17 +665,15 @@ describe("useSettings", () => {
     expect(result.current.saveError).toBeNull();
   });
 
-  it("resetBehaviorToDefaults resets temperature and thinking", async () => {
+  it("resetBehaviorToDefaults resets thinking", async () => {
     const { result } = renderHook(() => useSettings());
 
-    // Set some non-default values
+    // Set a non-default value
     await act(() => {
-      result.current.setTemperature(0.5);
       result.current.setThinking("Off");
     });
 
     expect(result.current).toMatchObject({
-      temperature: 0.5,
       thinking: "Off",
     });
 
@@ -719,7 +683,6 @@ describe("useSettings", () => {
     });
 
     expect(result.current).toMatchObject({
-      temperature: 1.0,
       thinking: "Default", // Default for gemini
     });
   });
@@ -751,17 +714,6 @@ describe("useSettings", () => {
     // Unknown tools default to enabled
     expect(result.current.isToolEnabled("unknown-tool")).toBe(true);
   });
-
-  it.each(["mistral", "openrouter", "lmstudio", "ollama", "custom"] as const)(
-    "setTemperature works for %s provider",
-    async (provider) => {
-      const { result } = renderHook(() => useSettings());
-
-      await act(() => result.current.setProvider(provider));
-      await act(() => result.current.setTemperature(0.5));
-      expect(result.current.temperature).toBe(0.5);
-    },
-  );
 
   it("setProvider preserves thinking value when switching providers", async () => {
     const { result } = renderHook(() => useSettings());

--- a/webui/src/hooks/settings/use-has-unsaved-changes.ts
+++ b/webui/src/hooks/settings/use-has-unsaved-changes.ts
@@ -30,7 +30,6 @@ function serialize(s: UseSettingsReturn, a: AppearanceSettings): string {
     baseUrl: s.baseUrl,
     model: s.model,
     thinking: s.thinking,
-    temperature: s.temperature,
     enabledTools: s.enabledTools,
     smallModelMode: s.smallModelMode,
     realtimeVoice: s.realtimeVoice,

--- a/webui/src/hooks/settings/use-settings.ts
+++ b/webui/src/hooks/settings/use-settings.ts
@@ -54,7 +54,6 @@ function useProviderSetters(
       setModel: createSetter("model"),
       setBaseUrl: hasBaseUrl ? createSetter("baseUrl") : undefined,
       setThinking: createSetter("thinking"),
-      setTemperature: createSetter("temperature"),
     };
   }, [provider, providerStateSetters]);
 }
@@ -242,8 +241,10 @@ export function useSettings(): UseSettingsReturn {
     setSaveError(null);
   }, [applyLoadedSettings, voiceModeSettings]);
 
-  const { setApiKey, setModel, setBaseUrl, setThinking, setTemperature } =
-    useProviderSetters(provider, providerStateSetters);
+  const { setApiKey, setModel, setBaseUrl, setThinking } = useProviderSetters(
+    provider,
+    providerStateSetters,
+  );
   // Reconcile presence with the *decrypted* in-memory key. decryptApiKey fails
   // safe to "" for an orphaned/undecryptable envelope (e.g. the IndexedDB crypto
   // key was reset while the localStorage envelope persisted), so reading the raw
@@ -260,9 +261,8 @@ export function useSettings(): UseSettingsReturn {
     [enabledTools],
   );
   const resetBehaviorToDefaults = useCallback(() => {
-    setTemperature(1.0);
     setThinking(DEFAULT_SETTINGS[provider].thinking);
-  }, [provider, setTemperature, setThinking]);
+  }, [provider, setThinking]);
   const hasBaseUrl = ["custom", "lmstudio", "ollama"].includes(provider);
 
   return {
@@ -288,8 +288,6 @@ export function useSettings(): UseSettingsReturn {
     thinking: currentSettings.thinking,
     setThinking,
     savedThinking,
-    temperature: currentSettings.temperature,
-    setTemperature,
     applyPreset,
     saveSettings,
     cancelSettings,

--- a/webui/src/hooks/voice/use-voice-persistence.ts
+++ b/webui/src/hooks/voice/use-voice-persistence.ts
@@ -465,7 +465,6 @@ async function saveVoiceRecord(
     model: existing?.model ?? ctx.model,
     modelLabel: existing?.modelLabel ?? ctx.model,
     thinking: null,
-    temperature: null,
     smallModelMode: null,
     totalUsage: null,
     sessionType: "voice",

--- a/webui/src/lib/conversation-db.ts
+++ b/webui/src/lib/conversation-db.ts
@@ -24,7 +24,6 @@ export interface ConversationRecord {
   model: string | null;
   modelLabel: string | null;
   thinking: string | null;
-  temperature: number | null;
   smallModelMode: boolean | null;
   totalUsage: TokenUsage | null;
   sessionType: SessionType;
@@ -225,7 +224,6 @@ export async function listAllConversationSummaries(): Promise<
         model,
         modelLabel,
         thinking,
-        temperature,
         smallModelMode,
         totalUsage,
         sessionType,
@@ -241,7 +239,6 @@ export async function listAllConversationSummaries(): Promise<
         model,
         modelLabel,
         thinking,
-        temperature,
         smallModelMode,
         totalUsage,
         sessionType,
@@ -327,7 +324,6 @@ function normalizeLegacyRecord(
   raw: Partial<ConversationRecord>,
 ): ConversationRecord {
   raw.thinking ??= null;
-  raw.temperature ??= null;
   raw.smallModelMode ??= null;
   raw.totalUsage ??= null;
   raw.sessionType ??= "text";

--- a/webui/src/lib/conversation-transfer.ts
+++ b/webui/src/lib/conversation-transfer.ts
@@ -252,7 +252,6 @@ function normalizeRecord(
     model: (record.model as string | null | undefined) ?? null,
     modelLabel: (record.modelLabel as string | null | undefined) ?? null,
     thinking: (record.thinking as string | null | undefined) ?? null,
-    temperature: (record.temperature as number | null | undefined) ?? null,
     smallModelMode:
       (record.smallModelMode as boolean | null | undefined) ?? null,
     totalUsage:

--- a/webui/src/lib/tests/conversation-db.test.ts
+++ b/webui/src/lib/tests/conversation-db.test.ts
@@ -120,7 +120,6 @@ describe("conversation-db", () => {
       model: null,
       modelLabel: null,
       thinking: null,
-      temperature: null,
       smallModelMode: null,
       totalUsage: null,
       sessionType: "text",
@@ -245,19 +244,14 @@ describe("conversation-db", () => {
    * @returns The saved record
    */
   async function saveRecordWithMissingFields(): Promise<ConversationRecord> {
-    return await saveRecordWithoutFields([
-      "thinking",
-      "temperature",
-      "smallModelMode",
-    ]);
+    return await saveRecordWithoutFields(["thinking", "smallModelMode"]);
   }
 
-  it("defaults missing thinking/temperature to null on load", async () => {
+  it("defaults missing thinking/smallModelMode to null on load", async () => {
     const record = await saveRecordWithMissingFields();
     const loaded = await loadConversation(record.id);
 
     expect(loaded?.thinking).toBeNull();
-    expect(loaded?.temperature).toBeNull();
     expect(loaded?.smallModelMode).toBeNull();
   });
 
@@ -305,7 +299,6 @@ describe("conversation-db", () => {
     const list = await listConversations();
 
     expect(list[0]?.thinking).toBeNull();
-    expect(list[0]?.temperature).toBeNull();
     expect(list[0]?.smallModelMode).toBeNull();
   });
 

--- a/webui/src/test-utils/conversation-test-helpers.ts
+++ b/webui/src/test-utils/conversation-test-helpers.ts
@@ -53,7 +53,6 @@ function sharedDefaults(): ConversationSummary {
     model: null,
     modelLabel: null,
     thinking: null,
-    temperature: null,
     smallModelMode: null,
     totalUsage: null,
     sessionType: "text",

--- a/webui/src/types/settings.ts
+++ b/webui/src/types/settings.ts
@@ -153,8 +153,6 @@ export interface UseSettingsReturn extends VoiceModeSettingsFields {
    * mid-session edit doesn't leak into the active session — applied on the next
    * Stop → Talk, matching savedRealtimeVoice/savedVoiceSpeed/savedTurnDetection. */
   savedThinking: string;
-  temperature: number;
-  setTemperature: (temp: number) => void;
   /** Load a saved preset into the live editable buffer: writes the preset's
    * model/thinking into that preset's *own* provider
    * slice (a functional update, so it's correct even when the preset switches


### PR DESCRIPTION
## Summary

Removes the phased-out `temperature` chat setting end-to-end. It was dead config: no UI control (removed earlier), pinned at `1.0`, and suppressed entirely for adaptive Anthropic / OpenAI reasoning models in the adapter. The request now carries **no** `temperature` at all, so each provider applies its own default — which already satisfies the adaptive models that used to 400 on a non-default value.

## Changes

- **Settings storage/defaults** — drop `temperature` from `ProviderSettings`, all 8 `DEFAULT_SETTINGS`, `useSettings` (`setTemperature`, the `resetBehaviorToDefaults` reset, and the return), the legacy `"temperature"`/`"gemini_temperature"` localStorage migration, and the unsaved-changes snapshot.
- **Adapter + SDK client** — remove the `temperature` positional param from `buildConfig`, delete the now-moot `suppressTemperature` branch, and stop passing `temperature` to `streamText`.
- **Conversation lock/record plumbing** — strip `temperature`/`activeTemperature` from `ConversationLockedSettings`, `ActiveMeta`, `ActiveSettings`, `UseChatProps/Return`, `ChatClientConfig`, the IndexedDB `ConversationRecord`, conversation transfer, and voice persistence. Records are schemaless, so no `DB_VERSION` bump.
- **Docs** — update `dev/Chat-UI.md`; also drops the stale `temperatureOverride` note (per-message overrides only ever implemented `thinkingOverride`).
- **Tests** — update fixtures/mocks and delete the obsolete temperature-only tests (including the whole `suppressTemperature` suite).

If per-model temperature control is ever wanted, it should come back as a real UI feature rather than resurrecting this dead field.

## Verification

- `npm run check` — 10087 passed, 0 failed, 100% function coverage
- `npm run ui:test` — 14/14 (stubbed Playwright)
- `npm run check:build` — bundles + docs site compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)