### PR TITLE
feat(webui): toolsets in presets + dedicated Presets tab

### DIFF
--- a/docs/guide/chat-ui.md
+++ b/docs/guide/chat-ui.md
@@ -350,6 +350,28 @@ setting).
   headphones — without them, the assistant's own voice can trigger
   interruptions.
 
+### Presets
+
+A preset is a named, one-click bundle of a full chat setup: **provider**,
+**model**, **thinking** level, **small model mode**, and the **enabled
+toolset**. Because a preset spans both the Connection and Tools tabs, it gets
+its own home here.
+
+- **Preset** dropdown - Select a saved preset to load its whole bundle into the
+  form. It doesn't take effect until you **Save** the settings, so you can
+  review or tweak it first.
+- **Save as…** - Capture the current settings as a new named preset. You can add
+  an optional **Description** to note what it's for (e.g. "cheap bulk-edit
+  worker").
+- **Update** / **Delete** - Overwrite or remove the selected preset. An "unsaved
+  edits" note appears when the form has drifted from the selected preset.
+
+Configure the model and inference on the **Connection** tab and the toolset on
+the **Tools** tab, then come here to save them together. API keys (kept
+per-provider) and appearance preferences are never part of a preset — a preset
+only _names_ which provider to use and resolves its key from your stored
+settings.
+
 ### Tools
 
 The Tools tab controls which tools are available to the AI when using the chat

--- a/webui/src/components/settings/ConnectionTab.tsx
+++ b/webui/src/components/settings/ConnectionTab.tsx
@@ -4,6 +4,8 @@
 
 import { type TurnDetectionSettings } from "#webui/hooks/settings/turn-detection-helpers";
 import { type Provider } from "#webui/types/settings";
+import { ModelSelector } from "./controls/ModelSelector";
+import { ProviderSelector } from "./controls/ProviderSelector";
 import {
   API_KEY_URLS,
   DEFAULT_LOCAL_URLS,
@@ -11,9 +13,7 @@ import {
   SmallModelToggle,
   ThinkingSelector,
   VoiceSettings,
-} from "./connection-tab-helpers";
-import { ModelSelector } from "./controls/ModelSelector";
-import { ProviderSelector } from "./controls/ProviderSelector";
+} from "./helpers/connection-tab-helpers";
 import { TestConnectionButton } from "./TestConnectionButton";
 
 interface ConnectionTabProps {

--- a/webui/src/components/settings/PresetControls.tsx
+++ b/webui/src/components/settings/PresetControls.tsx
@@ -7,26 +7,26 @@ import { useState } from "preact/hooks";
 import { presetMatchesFields } from "#webui/hooks/settings/presets/preset-storage";
 import { usePresets } from "#webui/hooks/settings/presets/use-presets";
 import {
-  type ChatPreset,
   type PresetFields,
   type UseSettingsReturn,
 } from "#webui/types/settings";
+import {
+  PresetCreateForm,
+  PresetDescriptionField,
+  PresetPickerRow,
+} from "./helpers/preset-controls-parts";
 
 interface PresetControlsProps {
   settings: UseSettingsReturn;
 }
 
-const buttonClass =
-  "px-3 py-2 text-sm rounded border border-zinc-300 dark:border-zinc-600 bg-zinc-200 dark:bg-zinc-700 hover:bg-zinc-300 dark:hover:bg-zinc-600 whitespace-nowrap";
-const inputClass =
-  "px-3 py-2 bg-white dark:bg-zinc-700 border border-zinc-300 dark:border-zinc-600 rounded";
-
 /**
- * Preset picker + Save-as/Update/Delete controls at the top of the Connection
- * tab. Selecting a preset loads it into the live editable settings buffer
- * (settings.applyPreset); the user then Saves through the normal footer flow.
- * Presets capture provider/model/thinking + small-model mode — never the API
- * key (that stays in the per-provider store).
+ * Preset picker + Save-as/Update/Delete controls plus the description editor,
+ * shown on the dedicated Presets tab. Selecting a preset loads its full bundle
+ * — provider/model/thinking + small-model mode + toolset — into the live
+ * editable settings buffer (settings.applyPreset); the user then Saves through
+ * the normal footer flow. Presets never capture the API key (that stays in the
+ * per-provider store).
  * @param {PresetControlsProps} props - Component props
  * @param {UseSettingsReturn} props.settings - The live settings buffer + actions
  * @returns {JSX.Element} The preset controls
@@ -36,6 +36,8 @@ export function PresetControls({ settings }: PresetControlsProps) {
   const [selectedId, setSelectedId] = useState<string>("");
   const [naming, setNaming] = useState<boolean>(false);
   const [draftName, setDraftName] = useState<string>("");
+  const [draftDescription, setDraftDescription] = useState<string>("");
+  const [editDescription, setEditDescription] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
 
   const fields: PresetFields = {
@@ -43,9 +45,13 @@ export function PresetControls({ settings }: PresetControlsProps) {
     model: settings.model,
     thinking: settings.thinking,
     smallModelMode: settings.smallModelMode,
+    enabledTools: settings.enabledTools,
   };
   const selected = presets.find((p) => p.id === selectedId) ?? null;
-  const isModified = selected != null && !presetMatchesFields(selected, fields);
+  const fieldsModified =
+    selected != null && !presetMatchesFields(selected, fields);
+  const descriptionModified =
+    selected != null && editDescription.trim() !== (selected.description ?? "");
 
   const handleSelect = (id: string): void => {
     setSelectedId(id);
@@ -53,10 +59,11 @@ export function PresetControls({ settings }: PresetControlsProps) {
     const preset = presets.find((p) => p.id === id);
 
     if (preset) settings.applyPreset(preset);
+    setEditDescription(preset?.description ?? "");
   };
 
   const confirmCreate = (): void => {
-    const result = createPreset(draftName, fields);
+    const result = createPreset(draftName, fields, draftDescription);
 
     if (!result.ok) {
       setError(result.error);
@@ -65,14 +72,17 @@ export function PresetControls({ settings }: PresetControlsProps) {
     }
 
     setSelectedId(result.preset.id);
+    setEditDescription(result.preset.description ?? "");
     setNaming(false);
     setDraftName("");
+    setDraftDescription("");
     setError(null);
   };
 
   const cancelNaming = (): void => {
     setNaming(false);
     setDraftName("");
+    setDraftDescription("");
     setError(null);
   };
 
@@ -90,16 +100,20 @@ export function PresetControls({ settings }: PresetControlsProps) {
         onStartNaming={() => {
           setNaming(true);
           setDraftName("");
+          setDraftDescription("");
           setError(null);
         }}
-        onUpdate={() => selected && updatePreset(selected.id, fields)}
+        onUpdate={() =>
+          selected && updatePreset(selected.id, fields, editDescription)
+        }
         onDelete={() => {
           if (selected) deletePreset(selected.id);
           setSelectedId("");
+          setEditDescription("");
         }}
       />
 
-      {selected && isModified && (
+      {selected && (fieldsModified || descriptionModified) && (
         <p className="text-xs text-amber-600 dark:text-amber-400">
           Unsaved edits — “Update” overwrites “{selected.name}”, or “Save as…”
           keeps a new one.
@@ -107,11 +121,20 @@ export function PresetControls({ settings }: PresetControlsProps) {
       )}
 
       {naming && (
-        <PresetNameForm
+        <PresetCreateForm
           draftName={draftName}
-          onDraftChange={setDraftName}
+          draftDescription={draftDescription}
+          onNameChange={setDraftName}
+          onDescriptionChange={setDraftDescription}
           onConfirm={confirmCreate}
           onCancel={cancelNaming}
+        />
+      )}
+
+      {selected && !naming && (
+        <PresetDescriptionField
+          value={editDescription}
+          onChange={setEditDescription}
         />
       )}
 
@@ -123,123 +146,6 @@ export function PresetControls({ settings }: PresetControlsProps) {
           {error}
         </p>
       )}
-
-      <div className="border-b border-zinc-300 dark:border-zinc-600" />
-    </div>
-  );
-}
-
-interface PresetPickerRowProps {
-  presets: ChatPreset[];
-  selectedId: string;
-  selected: ChatPreset | null;
-  naming: boolean;
-  onSelect: (id: string) => void;
-  onStartNaming: () => void;
-  onUpdate: () => void;
-  onDelete: () => void;
-}
-
-/**
- * The preset dropdown plus the Save-as / Update / Delete action buttons.
- * Update/Delete appear only when a preset is selected.
- * @param {PresetPickerRowProps} props - Picker row props
- * @returns {JSX.Element} The picker + action row
- */
-function PresetPickerRow(props: PresetPickerRowProps) {
-  const { presets, selectedId, selected, naming } = props;
-
-  return (
-    <div className="flex items-center gap-2 flex-wrap">
-      <select
-        id="preset-select"
-        value={selectedId}
-        onChange={(e) => props.onSelect((e.target as HTMLSelectElement).value)}
-        className={`flex-1 min-w-40 ${inputClass}`}
-        data-testid="preset-select"
-      >
-        <option value="">— Select a preset —</option>
-        {presets.map((p) => (
-          <option key={p.id} value={p.id}>
-            {p.name}
-          </option>
-        ))}
-      </select>
-      {!naming && (
-        <button
-          type="button"
-          onClick={props.onStartNaming}
-          className={buttonClass}
-          data-testid="preset-save-as"
-        >
-          Save as…
-        </button>
-      )}
-      {selected && (
-        <>
-          <button
-            type="button"
-            onClick={props.onUpdate}
-            className={buttonClass}
-            data-testid="preset-update"
-          >
-            Update
-          </button>
-          <button
-            type="button"
-            onClick={props.onDelete}
-            className={`${buttonClass} text-red-600 dark:text-red-400`}
-            data-testid="preset-delete"
-          >
-            Delete
-          </button>
-        </>
-      )}
-    </div>
-  );
-}
-
-interface PresetNameFormProps {
-  draftName: string;
-  onDraftChange: (value: string) => void;
-  onConfirm: () => void;
-  onCancel: () => void;
-}
-
-/**
- * The inline "name this preset" row shown after Save-as: a text field plus
- * Save/Cancel. Enter confirms, Escape cancels.
- * @param {PresetNameFormProps} props - Name form props
- * @returns {JSX.Element} The name-entry row
- */
-function PresetNameForm(props: PresetNameFormProps) {
-  return (
-    <div className="flex items-center gap-2">
-      <input
-        type="text"
-        value={props.draftName}
-        onInput={(e) =>
-          props.onDraftChange((e.target as HTMLInputElement).value)
-        }
-        onKeyDown={(e) => {
-          if (e.key === "Enter") props.onConfirm();
-          if (e.key === "Escape") props.onCancel();
-        }}
-        placeholder="Preset name"
-        className={`flex-1 ${inputClass}`}
-        data-testid="preset-name-input"
-      />
-      <button
-        type="button"
-        onClick={props.onConfirm}
-        className={buttonClass}
-        data-testid="preset-name-save"
-      >
-        Save
-      </button>
-      <button type="button" onClick={props.onCancel} className={buttonClass}>
-        Cancel
-      </button>
     </div>
   );
 }

--- a/webui/src/components/settings/PresetsTab.tsx
+++ b/webui/src/components/settings/PresetsTab.tsx
@@ -1,0 +1,34 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type UseSettingsReturn } from "#webui/types/settings";
+import { PresetControls } from "./PresetControls";
+
+interface PresetsTabProps {
+  settings: UseSettingsReturn;
+}
+
+/**
+ * Presets tab: a preset's dedicated home. A preset bundles everything a chat
+ * session runs with — provider, model, inference, and toolset — cutting across
+ * the Connection and Tools tabs so it lives here rather than crowding either.
+ * API keys and UI preferences are never part of a preset.
+ * @param {PresetsTabProps} props - Component props
+ * @param {UseSettingsReturn} props.settings - The live settings buffer + actions
+ * @returns {JSX.Element} The Presets tab
+ */
+export function PresetsTab({ settings }: PresetsTabProps) {
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-zinc-500">
+        A preset saves and recalls a full chat setup — provider, model,
+        thinking, small-model mode, and the enabled toolset — in one click. Set
+        those up on the Connection and Tools tabs, then save them here as a
+        named preset. API keys and appearance preferences are never included.
+      </p>
+      <PresetControls settings={settings} />
+    </div>
+  );
+}

--- a/webui/src/components/settings/SettingsScreen.tsx
+++ b/webui/src/components/settings/SettingsScreen.tsx
@@ -18,7 +18,7 @@ import {
   LockedSettingsNotice,
 } from "./LockedSettingsNotice";
 import { PreferencesTab } from "./PreferencesTab";
-import { PresetControls } from "./PresetControls";
+import { PresetsTab } from "./PresetsTab";
 import { SettingsFooter } from "./SettingsFooter";
 import { type TabId, SettingsTabs } from "./SettingsTabs";
 
@@ -132,36 +132,35 @@ function SettingsTabContent(props: SettingsScreenProps) {
   return (
     <div className="space-y-4">
       {activeTab === "connection" && (
-        <>
-          <PresetControls settings={settings} />
-          <ConnectionTab
-            provider={settings.provider}
-            setProvider={settings.setProvider}
-            apiKey={settings.apiKey}
-            setApiKey={settings.setApiKey}
-            baseUrl={settings.baseUrl}
-            setBaseUrl={settings.setBaseUrl}
-            model={settings.model}
-            setModel={settings.setModel}
-            providerLabel={providerLabel}
-            thinking={settings.thinking}
-            setThinking={settings.setThinking}
-            smallModelMode={settings.smallModelMode}
-            setSmallModelMode={settings.setSmallModelMode}
-            realtimeVoice={settings.realtimeVoice}
-            setRealtimeVoice={settings.setRealtimeVoice}
-            voiceLanguage={settings.voiceLanguage}
-            setVoiceLanguage={settings.setVoiceLanguage}
-            voiceVolume={settings.voiceVolume}
-            setVoiceVolume={settings.setVoiceVolume}
-            voiceSpeed={settings.voiceSpeed}
-            setVoiceSpeed={settings.setVoiceSpeed}
-            turnDetection={settings.turnDetection}
-            setTurnDetection={settings.setTurnDetection}
-            activeVoice={props.activeVoice}
-          />
-        </>
+        <ConnectionTab
+          provider={settings.provider}
+          setProvider={settings.setProvider}
+          apiKey={settings.apiKey}
+          setApiKey={settings.setApiKey}
+          baseUrl={settings.baseUrl}
+          setBaseUrl={settings.setBaseUrl}
+          model={settings.model}
+          setModel={settings.setModel}
+          providerLabel={providerLabel}
+          thinking={settings.thinking}
+          setThinking={settings.setThinking}
+          smallModelMode={settings.smallModelMode}
+          setSmallModelMode={settings.setSmallModelMode}
+          realtimeVoice={settings.realtimeVoice}
+          setRealtimeVoice={settings.setRealtimeVoice}
+          voiceLanguage={settings.voiceLanguage}
+          setVoiceLanguage={settings.setVoiceLanguage}
+          voiceVolume={settings.voiceVolume}
+          setVoiceVolume={settings.setVoiceVolume}
+          voiceSpeed={settings.voiceSpeed}
+          setVoiceSpeed={settings.setVoiceSpeed}
+          turnDetection={settings.turnDetection}
+          setTurnDetection={settings.setTurnDetection}
+          activeVoice={props.activeVoice}
+        />
       )}
+
+      {activeTab === "presets" && <PresetsTab settings={settings} />}
 
       {activeTab === "tools" && (
         <ToolToggles

--- a/webui/src/components/settings/SettingsTabs.tsx
+++ b/webui/src/components/settings/SettingsTabs.tsx
@@ -4,7 +4,7 @@
 
 import { type VNode } from "preact";
 
-export type TabId = "connection" | "tools" | "preferences";
+export type TabId = "connection" | "presets" | "tools" | "preferences";
 
 interface Tab {
   id: TabId;
@@ -19,6 +19,7 @@ interface SettingsTabsProps {
 
 const tabs: Tab[] = [
   { id: "connection", label: "Connection" },
+  { id: "presets", label: "Presets" },
   { id: "tools", label: "Tools" },
   { id: "preferences", label: "Preferences" },
 ];

--- a/webui/src/components/settings/helpers/connection-tab-helpers.tsx
+++ b/webui/src/components/settings/helpers/connection-tab-helpers.tsx
@@ -5,6 +5,13 @@
 
 import { DisclosureChevron } from "#webui/components/chat/controls/header/HeaderIcons";
 import { ThinkingStateIcon } from "#webui/components/chat/controls/ThinkingToggle";
+import { GeminiTurnDetectionControls } from "#webui/components/settings/controls/GeminiTurnDetectionControls";
+import { THINKING_LEVELS } from "#webui/components/settings/controls/helpers/thinking-levels";
+import { Tooltip } from "#webui/components/settings/controls/Tooltip";
+import { TurnDetectionControls } from "#webui/components/settings/controls/TurnDetectionControls";
+import { VoiceSelector } from "#webui/components/settings/controls/VoiceSelector";
+import { VoiceSpeedSlider } from "#webui/components/settings/controls/VoiceSpeedSlider";
+import { VoiceVolumeSlider } from "#webui/components/settings/controls/VoiceVolumeSlider";
 import { type TurnDetectionSettings } from "#webui/hooks/settings/turn-detection-helpers";
 import {
   GEMINI_REALTIME_VOICES,
@@ -13,13 +20,6 @@ import {
 } from "#webui/lib/constants/models";
 import { VOICE_LANGUAGES } from "#webui/lib/constants/voice-language";
 import { type Provider } from "#webui/types/settings";
-import { GeminiTurnDetectionControls } from "./controls/GeminiTurnDetectionControls";
-import { THINKING_LEVELS } from "./controls/helpers/thinking-levels";
-import { Tooltip } from "./controls/Tooltip";
-import { TurnDetectionControls } from "./controls/TurnDetectionControls";
-import { VoiceSelector } from "./controls/VoiceSelector";
-import { VoiceSpeedSlider } from "./controls/VoiceSpeedSlider";
-import { VoiceVolumeSlider } from "./controls/VoiceVolumeSlider";
 
 export const API_KEY_URLS: Record<string, string | undefined> = {
   anthropic: "https://console.anthropic.com/settings/keys",

--- a/webui/src/components/settings/helpers/preset-controls-parts.tsx
+++ b/webui/src/components/settings/helpers/preset-controls-parts.tsx
@@ -1,0 +1,169 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type ChatPreset } from "#webui/types/settings";
+
+export const BUTTON_CLASS =
+  "px-3 py-2 text-sm rounded border border-zinc-300 dark:border-zinc-600 bg-zinc-200 dark:bg-zinc-700 hover:bg-zinc-300 dark:hover:bg-zinc-600 whitespace-nowrap";
+export const INPUT_CLASS =
+  "px-3 py-2 bg-white dark:bg-zinc-700 border border-zinc-300 dark:border-zinc-600 rounded";
+
+interface PresetPickerRowProps {
+  presets: ChatPreset[];
+  selectedId: string;
+  selected: ChatPreset | null;
+  naming: boolean;
+  onSelect: (id: string) => void;
+  onStartNaming: () => void;
+  onUpdate: () => void;
+  onDelete: () => void;
+}
+
+/**
+ * The preset dropdown plus the Save-as / Update / Delete action buttons.
+ * Update/Delete appear only when a preset is selected.
+ * @param {PresetPickerRowProps} props - Picker row props
+ * @returns {JSX.Element} The picker + action row
+ */
+export function PresetPickerRow(props: PresetPickerRowProps) {
+  const { presets, selectedId, selected, naming } = props;
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <select
+        id="preset-select"
+        value={selectedId}
+        onChange={(e) => props.onSelect((e.target as HTMLSelectElement).value)}
+        className={`flex-1 min-w-40 ${INPUT_CLASS}`}
+        data-testid="preset-select"
+      >
+        <option value="">— Select a preset —</option>
+        {presets.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.name}
+          </option>
+        ))}
+      </select>
+      {!naming && (
+        <button
+          type="button"
+          onClick={props.onStartNaming}
+          className={BUTTON_CLASS}
+          data-testid="preset-save-as"
+        >
+          Save as…
+        </button>
+      )}
+      {selected && (
+        <>
+          <button
+            type="button"
+            onClick={props.onUpdate}
+            className={BUTTON_CLASS}
+            data-testid="preset-update"
+          >
+            Update
+          </button>
+          <button
+            type="button"
+            onClick={props.onDelete}
+            className={`${BUTTON_CLASS} text-red-600 dark:text-red-400`}
+            data-testid="preset-delete"
+          >
+            Delete
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface PresetCreateFormProps {
+  draftName: string;
+  draftDescription: string;
+  onNameChange: (value: string) => void;
+  onDescriptionChange: (value: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * The inline "name this preset" form shown after Save-as: a name field, an
+ * optional description, and Save/Cancel. Enter in the name field confirms,
+ * Escape cancels; the description is a textarea so Enter inserts a newline.
+ * @param {PresetCreateFormProps} props - Create form props
+ * @returns {JSX.Element} The create-preset form
+ */
+export function PresetCreateForm(props: PresetCreateFormProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={props.draftName}
+          onInput={(e) =>
+            props.onNameChange((e.target as HTMLInputElement).value)
+          }
+          onKeyDown={(e) => {
+            if (e.key === "Enter") props.onConfirm();
+            if (e.key === "Escape") props.onCancel();
+          }}
+          placeholder="Preset name"
+          className={`flex-1 ${INPUT_CLASS}`}
+          data-testid="preset-name-input"
+        />
+        <button
+          type="button"
+          onClick={props.onConfirm}
+          className={BUTTON_CLASS}
+          data-testid="preset-name-save"
+        >
+          Save
+        </button>
+        <button type="button" onClick={props.onCancel} className={BUTTON_CLASS}>
+          Cancel
+        </button>
+      </div>
+      <PresetDescriptionField
+        value={props.draftDescription}
+        onChange={props.onDescriptionChange}
+      />
+    </div>
+  );
+}
+
+interface PresetDescriptionFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+/**
+ * Optional freeform description for a preset. Currently informational only —
+ * reserved for the future "orchestrator picks a preset" feature. Shared by the
+ * create form and the selected-preset editor.
+ * @param {PresetDescriptionFieldProps} props - Description field props
+ * @returns {JSX.Element} A labeled description textarea
+ */
+export function PresetDescriptionField(props: PresetDescriptionFieldProps) {
+  return (
+    <div>
+      <label
+        className="block text-xs text-zinc-500 mb-1"
+        htmlFor="preset-description"
+      >
+        Description (optional)
+      </label>
+      <textarea
+        id="preset-description"
+        value={props.value}
+        onInput={(e) => props.onChange((e.target as HTMLTextAreaElement).value)}
+        rows={2}
+        placeholder="What this preset is for (e.g. cheap bulk-edit worker)"
+        className={`w-full resize-y ${INPUT_CLASS}`}
+        data-testid="preset-description-input"
+      />
+    </div>
+  );
+}

--- a/webui/src/components/settings/tests/PresetControls.test.tsx
+++ b/webui/src/components/settings/tests/PresetControls.test.tsx
@@ -26,6 +26,8 @@ function makeSettings(over?: Partial<UseSettingsReturn>): UseSettingsReturn {
     model: "claude",
     thinking: "Default",
     smallModelMode: false,
+    enabledTools: {},
+    setEnabledTools: vi.fn(),
     applyPreset: vi.fn(),
     ...over,
   } as unknown as UseSettingsReturn;
@@ -109,6 +111,49 @@ describe("PresetControls", () => {
 
     expect(screen.getByTestId("preset-error")).toBeTruthy();
     expect(loadPresets()).toHaveLength(0);
+  });
+
+  it("captures the description and enabled toolset in a new preset", () => {
+    render(
+      <PresetControls
+        settings={makeSettings({ enabledTools: { "ppal-delete": false } })}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("preset-save-as"));
+    fireEvent.input(screen.getByTestId("preset-name-input"), {
+      target: { value: "Worker" },
+    });
+    fireEvent.input(screen.getByTestId("preset-description-input"), {
+      target: { value: "cheap bulk editor" },
+    });
+    fireEvent.click(screen.getByTestId("preset-name-save"));
+
+    expect(loadPresets()[0]).toMatchObject({
+      name: "Worker",
+      description: "cheap bulk editor",
+      enabledTools: { "ppal-delete": false },
+    });
+  });
+
+  it("shows and persists the description of the selected preset", () => {
+    savePresets([{ ...seeded, description: "existing note" }]);
+    render(<PresetControls settings={makeSettings()} />);
+
+    fireEvent.change(screen.getByTestId("preset-select"), {
+      target: { value: "seed" },
+    });
+
+    const editor = screen.getByTestId(
+      "preset-description-input",
+    ) as HTMLTextAreaElement;
+
+    expect(editor.value).toBe("existing note");
+
+    fireEvent.input(editor, { target: { value: "updated note" } });
+    fireEvent.click(screen.getByTestId("preset-update"));
+
+    expect(loadPresets()[0]?.description).toBe("updated note");
   });
 
   it("applies a preset into the settings buffer on select", () => {

--- a/webui/src/components/settings/tests/PresetsTab.test.tsx
+++ b/webui/src/components/settings/tests/PresetsTab.test.tsx
@@ -1,0 +1,42 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @vitest-environment happy-dom
+ */
+import { render, screen } from "@testing-library/preact";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PresetsTab } from "#webui/components/settings/PresetsTab";
+import { type UseSettingsReturn } from "#webui/types/settings";
+
+/**
+ * Minimal settings stub exposing the fields the embedded PresetControls reads.
+ * @returns A UseSettingsReturn-shaped stub
+ */
+function makeSettings(): UseSettingsReturn {
+  return {
+    provider: "anthropic",
+    model: "claude",
+    thinking: "Default",
+    smallModelMode: false,
+    enabledTools: {},
+    setEnabledTools: vi.fn(),
+    applyPreset: vi.fn(),
+  } as unknown as UseSettingsReturn;
+}
+
+describe("PresetsTab", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders intro copy and the preset picker", () => {
+    render(<PresetsTab settings={makeSettings()} />);
+
+    expect(screen.getByText(/A preset saves and recalls/)).toBeTruthy();
+    expect(screen.getByTestId("preset-select")).toBeTruthy();
+    expect(screen.getByTestId("preset-save-as")).toBeTruthy();
+  });
+});

--- a/webui/src/components/settings/tests/SettingsScreen.test.tsx
+++ b/webui/src/components/settings/tests/SettingsScreen.test.tsx
@@ -15,7 +15,7 @@ import { DEFAULT_TURN_DETECTION } from "#webui/hooks/settings/turn-detection-hel
 // Mock child components
 vi.mock(import("#webui/components/settings/ConnectionTab"), async () => {
   const { API_KEY_URLS, MODEL_DOCS_URLS, DEFAULT_LOCAL_URLS } =
-    await import("#webui/components/settings/connection-tab-helpers");
+    await import("#webui/components/settings/helpers/connection-tab-helpers");
 
   return {
     ConnectionTab: ({

--- a/webui/src/components/settings/tests/connection-tab-helpers.test.tsx
+++ b/webui/src/components/settings/tests/connection-tab-helpers.test.tsx
@@ -12,7 +12,7 @@ import {
   SmallModelToggle,
   ThinkingSelector,
   VoiceSettings,
-} from "#webui/components/settings/connection-tab-helpers";
+} from "#webui/components/settings/helpers/connection-tab-helpers";
 import {
   GEMINI_REALTIME_MODEL,
   OPENAI_REALTIME_MODEL,

--- a/webui/src/hooks/settings/presets/preset-apply.ts
+++ b/webui/src/hooks/settings/presets/preset-apply.ts
@@ -18,15 +18,21 @@ import { type ChatPreset, type Provider } from "#webui/types/settings";
  * a preset only names which provider to run, and the key resolves live from the
  * encrypted per-provider store.
  *
+ * The captured toolset is applied verbatim, but only when the preset carries
+ * one: a legacy preset (saved before toolsets) has no `enabledTools`, and
+ * applying it must leave the current tools untouched ("inherit").
+ *
  * @param providerStateSetters - Per-provider slice setters
  * @param setProvider - Switches the active provider
  * @param setSmallModelMode - Sets the global small-model-mode flag
+ * @param setEnabledTools - Replaces the global tool-enablement map
  * @returns Callback that loads a preset into the live editable settings buffer
  */
 export function useApplyPreset(
   providerStateSetters: ProviderStateSetters,
   setProvider: (provider: Provider) => void,
   setSmallModelMode: (enabled: boolean) => void,
+  setEnabledTools: (tools: Record<string, boolean>) => void,
 ): (preset: ChatPreset) => void {
   return useCallback(
     (preset: ChatPreset) => {
@@ -37,7 +43,8 @@ export function useApplyPreset(
       }));
       setProvider(preset.provider);
       setSmallModelMode(preset.smallModelMode);
+      if (preset.enabledTools) setEnabledTools({ ...preset.enabledTools });
     },
-    [providerStateSetters, setProvider, setSmallModelMode],
+    [providerStateSetters, setProvider, setSmallModelMode, setEnabledTools],
   );
 }

--- a/webui/src/hooks/settings/presets/preset-storage.ts
+++ b/webui/src/hooks/settings/presets/preset-storage.ts
@@ -58,7 +58,8 @@ export function createPresetId(): string {
 /**
  * Whether a preset's captured settings equal the given live buffer fields —
  * used to flag "unsaved edits" when the buffer has drifted from the selected
- * preset.
+ * preset. A preset with no captured toolset (legacy / "inherit") never counts
+ * the toolset toward the comparison, so it isn't perpetually "modified".
  * @param preset - A saved preset
  * @param fields - The live editable settings buffer
  * @returns True when every captured field matches
@@ -71,8 +72,33 @@ export function presetMatchesFields(
     preset.provider === fields.provider &&
     preset.model === fields.model &&
     preset.thinking === fields.thinking &&
-    preset.smallModelMode === fields.smallModelMode
+    preset.smallModelMode === fields.smallModelMode &&
+    (preset.enabledTools == null ||
+      enabledToolsEqual(preset.enabledTools, fields.enabledTools))
   );
+}
+
+/**
+ * Order-independent equality for two tool-enablement maps. Absent maps are
+ * treated as empty. This is exact key/value equality (a missing key differs
+ * from an explicit true/false) — sufficient because applyPreset copies the
+ * preset's map into the buffer verbatim, so a matched preset and its buffer
+ * carry identical keys.
+ * @param a - First tool map (or undefined)
+ * @param b - Second tool map (or undefined)
+ * @returns True when both maps enable exactly the same tools
+ */
+export function enabledToolsEqual(
+  a: Record<string, boolean> = {},
+  b: Record<string, boolean> = {},
+): boolean {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+
+  for (const key of keys) {
+    if (a[key] !== b[key]) return false;
+  }
+
+  return true;
 }
 
 /**
@@ -94,6 +120,24 @@ function isValidPreset(value: unknown): value is ChatPreset {
     isValidProvider(p.provider) &&
     typeof p.model === "string" &&
     typeof p.thinking === "string" &&
-    typeof p.smallModelMode === "boolean"
+    typeof p.smallModelMode === "boolean" &&
+    // Both additive fields are optional; reject only a present-but-wrong-typed
+    // value so a hand-edited entry can't crash the picker.
+    (p.description === undefined || typeof p.description === "string") &&
+    (p.enabledTools === undefined || isBooleanMap(p.enabledTools))
   );
+}
+
+/**
+ * Type guard for a plain object whose every value is a boolean — the shape of a
+ * captured toolset map.
+ * @param value - A parsed value
+ * @returns True when value is a Record<string, boolean>
+ */
+function isBooleanMap(value: unknown): value is Record<string, boolean> {
+  if (typeof value !== "object" || value == null || Array.isArray(value)) {
+    return false;
+  }
+
+  return Object.values(value).every((v) => typeof v === "boolean");
 }

--- a/webui/src/hooks/settings/presets/tests/preset-apply.test.ts
+++ b/webui/src/hooks/settings/presets/tests/preset-apply.test.ts
@@ -43,9 +43,10 @@ describe("useApplyPreset", () => {
 
     const setProvider = vi.fn();
     const setSmallModelMode = vi.fn();
+    const setEnabledTools = vi.fn();
 
     const { result } = renderHook(() =>
-      useApplyPreset(setters, setProvider, setSmallModelMode),
+      useApplyPreset(setters, setProvider, setSmallModelMode, setEnabledTools),
     );
 
     const preset: ChatPreset = {
@@ -55,6 +56,7 @@ describe("useApplyPreset", () => {
       model: "gpt-x",
       thinking: "Max",
       smallModelMode: true,
+      enabledTools: { "ppal-delete": false },
     };
 
     await act(() => result.current(preset));
@@ -81,5 +83,33 @@ describe("useApplyPreset", () => {
 
     expect(setProvider).toHaveBeenCalledWith("openai");
     expect(setSmallModelMode).toHaveBeenCalledWith(true);
+    // The captured toolset is applied verbatim (as a fresh copy).
+    expect(setEnabledTools).toHaveBeenCalledWith({ "ppal-delete": false });
+  });
+
+  it("leaves the toolset untouched for a preset with no captured tools", async () => {
+    const setters = {} as ProviderStateSetters;
+
+    for (const p of ALL_PROVIDERS) setters[p] = vi.fn();
+
+    const setEnabledTools = vi.fn();
+
+    const { result } = renderHook(() =>
+      useApplyPreset(setters, vi.fn(), vi.fn(), setEnabledTools),
+    );
+
+    const legacy: ChatPreset = {
+      id: "1",
+      name: "Legacy",
+      provider: "anthropic",
+      model: "claude",
+      thinking: "Default",
+      smallModelMode: false,
+    };
+
+    await act(() => result.current(legacy));
+
+    // No enabledTools captured => "inherit": the current tools stay as-is.
+    expect(setEnabledTools).not.toHaveBeenCalled();
   });
 });

--- a/webui/src/hooks/settings/presets/tests/preset-storage.test.ts
+++ b/webui/src/hooks/settings/presets/tests/preset-storage.test.ts
@@ -9,6 +9,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   createPresetId,
+  enabledToolsEqual,
   loadPresets,
   PRESETS_STORAGE_KEY,
   presetMatchesFields,
@@ -67,6 +68,9 @@ describe("preset-storage", () => {
       { id: "x" }, // missing fields
       makePreset({ id: "y", provider: "bogus" as ChatPreset["provider"] }),
       { ...makePreset({ id: "z" }), smallModelMode: "true" }, // wrong type
+      { ...makePreset({ id: "d" }), description: 42 }, // wrong description type
+      { ...makePreset({ id: "t" }), enabledTools: { "ppal-delete": "no" } }, // non-boolean
+      { ...makePreset({ id: "a" }), enabledTools: ["ppal-delete"] }, // not a map
       null,
       "string",
     ];
@@ -74,6 +78,17 @@ describe("preset-storage", () => {
     localStorage.setItem(PRESETS_STORAGE_KEY, JSON.stringify(stored));
 
     expect(loadPresets()).toStrictEqual([good]);
+  });
+
+  it("keeps the optional description and enabledTools fields", () => {
+    const withExtras = makePreset({
+      description: "cheap worker",
+      enabledTools: { "ppal-delete": false, "ppal-read-clip": true },
+    });
+
+    savePresets([withExtras]);
+
+    expect(loadPresets()).toStrictEqual([withExtras]);
   });
 
   it("generates unique ids", () => {
@@ -103,6 +118,43 @@ describe("preset-storage", () => {
       expect(
         presetMatchesFields(makePreset({ smallModelMode: true }), fields),
       ).toBe(false);
+    });
+
+    it("compares the toolset only when the preset captured one", () => {
+      const tools = { "ppal-delete": false };
+
+      // Legacy preset (no enabledTools) ignores the toolset entirely.
+      expect(
+        presetMatchesFields(makePreset(), { ...fields, enabledTools: tools }),
+      ).toBe(true);
+
+      // A captured toolset must match the buffer's toolset.
+      expect(
+        presetMatchesFields(makePreset({ enabledTools: tools }), {
+          ...fields,
+          enabledTools: tools,
+        }),
+      ).toBe(true);
+      expect(
+        presetMatchesFields(makePreset({ enabledTools: tools }), {
+          ...fields,
+          enabledTools: { "ppal-delete": true },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("enabledToolsEqual", () => {
+    it("treats absent maps as empty and ignores key order", () => {
+      expect(enabledToolsEqual(undefined, {})).toBe(true);
+      expect(
+        enabledToolsEqual({ a: true, b: false }, { b: false, a: true }),
+      ).toBe(true);
+    });
+
+    it("is false when a key is missing or a value differs", () => {
+      expect(enabledToolsEqual({ a: true }, { a: true, b: false })).toBe(false);
+      expect(enabledToolsEqual({ a: true }, { a: false })).toBe(false);
     });
   });
 });

--- a/webui/src/hooks/settings/presets/tests/use-presets.test.ts
+++ b/webui/src/hooks/settings/presets/tests/use-presets.test.ts
@@ -96,6 +96,44 @@ describe("usePresets", () => {
     expect(loadPresets()[0]?.model).toBe("new-model");
   });
 
+  it("stores a trimmed description and the captured toolset", async () => {
+    const { result } = renderHook(() => usePresets());
+
+    await act(() => {
+      result.current.createPreset(
+        "Worker",
+        { ...fields, enabledTools: { "ppal-delete": false } },
+        "  cheap bulk editor  ",
+      );
+    });
+
+    expect(result.current.presets[0]).toMatchObject({
+      description: "cheap bulk editor",
+      enabledTools: { "ppal-delete": false },
+    });
+  });
+
+  it("preserves the description on a bare update, clears it on blank", async () => {
+    const { result } = renderHook(() => usePresets());
+    let id = "";
+
+    await act(() => {
+      id = expectCreatedId(result.current.createPreset("P", fields, "keep me"));
+    });
+
+    // No description arg => existing description is preserved.
+    await act(() => {
+      result.current.updatePreset(id, { ...fields, model: "m2" });
+    });
+    expect(result.current.presets[0]?.description).toBe("keep me");
+
+    // Blank description => the field is dropped.
+    await act(() => {
+      result.current.updatePreset(id, fields, "   ");
+    });
+    expect(result.current.presets[0]).not.toHaveProperty("description");
+  });
+
   it("deletes a preset", async () => {
     const { result } = renderHook(() => usePresets());
     let id = "";

--- a/webui/src/hooks/settings/presets/use-presets.ts
+++ b/webui/src/hooks/settings/presets/use-presets.ts
@@ -14,8 +14,16 @@ export type CreatePresetResult =
 /** Browser-local preset collection: list + create/update/delete. */
 export interface UsePresetsReturn {
   presets: ChatPreset[];
-  createPreset: (name: string, fields: PresetFields) => CreatePresetResult;
-  updatePreset: (id: string, fields: PresetFields) => void;
+  createPreset: (
+    name: string,
+    fields: PresetFields,
+    description?: string,
+  ) => CreatePresetResult;
+  updatePreset: (
+    id: string,
+    fields: PresetFields,
+    description?: string,
+  ) => void;
   deletePreset: (id: string) => void;
 }
 
@@ -35,7 +43,11 @@ export function usePresets(): UsePresetsReturn {
   }, []);
 
   const createPreset = useCallback(
-    (name: string, fields: PresetFields): CreatePresetResult => {
+    (
+      name: string,
+      fields: PresetFields,
+      description?: string,
+    ): CreatePresetResult => {
       const trimmed = name.trim();
 
       if (trimmed.length === 0) {
@@ -46,11 +58,10 @@ export function usePresets(): UsePresetsReturn {
         return { ok: false, error: "A preset with that name already exists." };
       }
 
-      const preset: ChatPreset = {
-        id: createPresetId(),
-        name: trimmed,
-        ...fields,
-      };
+      const preset: ChatPreset = withDescription(
+        { id: createPresetId(), name: trimmed, ...fields },
+        description,
+      );
 
       persist([...presets, preset]);
 
@@ -60,8 +71,12 @@ export function usePresets(): UsePresetsReturn {
   );
 
   const updatePreset = useCallback(
-    (id: string, fields: PresetFields) => {
-      persist(presets.map((p) => (p.id === id ? { ...p, ...fields } : p)));
+    (id: string, fields: PresetFields, description?: string) => {
+      persist(
+        presets.map((p) =>
+          p.id === id ? withDescription({ ...p, ...fields }, description) : p,
+        ),
+      );
     },
     [presets, persist],
   );
@@ -74,4 +89,25 @@ export function usePresets(): UsePresetsReturn {
   );
 
   return { presets, createPreset, updatePreset, deletePreset };
+}
+
+/**
+ * Return a copy of the preset with its description set from the given value:
+ * trimmed and stored when non-empty, dropped when blank. A `undefined` value
+ * leaves any existing description untouched (so an update that doesn't touch the
+ * description — e.g. a bare "Update" re-capturing fields — preserves it).
+ * @param preset - The preset to adjust
+ * @param description - New description, "" to clear, or undefined to keep
+ * @returns The preset with its description normalized
+ */
+function withDescription(preset: ChatPreset, description?: string): ChatPreset {
+  if (description === undefined) return preset;
+
+  const trimmed = description.trim();
+  const next = { ...preset };
+
+  if (trimmed) next.description = trimmed;
+  else delete next.description;
+
+  return next;
 }

--- a/webui/src/hooks/settings/use-settings.ts
+++ b/webui/src/hooks/settings/use-settings.ts
@@ -157,6 +157,7 @@ export function useSettings(): UseSettingsReturn {
     providerStateSetters,
     setProviderState,
     setSmallModelModeState,
+    setEnabledToolsState,
   );
 
   const applyLoadedSettings = useCallback(

--- a/webui/src/types/settings.ts
+++ b/webui/src/types/settings.ts
@@ -32,12 +32,13 @@ export type Provider =
   | "custom";
 
 /**
- * A named, reusable bundle of the model/inference settings a chat conversation
- * runs with — the saved twin of what {@link UseSettingsReturn} exposes for the
- * active provider. Excludes the per-provider apiKey/baseUrl (resolved live from
- * the encrypted provider store via getProviderConnection, so a preset only
- * *names* which provider to use) and excludes system prompt / skills / toolset
- * (those layer on top as personas and toolset scoping).
+ * A named, reusable bundle of everything a chat conversation runs with — the
+ * saved twin of what {@link UseSettingsReturn} exposes — EXCEPT the per-provider
+ * apiKey/baseUrl (resolved live from the encrypted provider store via
+ * getProviderConnection, so a preset only *names* which provider to use) and UI
+ * preferences (theme/timestamps). A preset bundles the client-side localStorage
+ * layer: provider + model + inference + toolset. The server-side content layer
+ * (skills / system-instruction) is a future "persona" that wraps a preset.
  *
  * The stable `id` is the handle a subagent worker persists to say "run with
  * preset X" by reference, so renaming a preset never breaks that link.
@@ -47,14 +48,24 @@ export interface ChatPreset extends PresetFields {
   id: string;
   /** Unique, user-facing label shown in the preset picker. */
   name: string;
+  /** Optional freeform note. Currently informational only — reserved for the
+   * future "orchestrator picks a preset per spawn" feature, where a spawned
+   * worker matches its task against this text. Absent/blank until then. */
+  description?: string;
 }
 
-/** The settings a preset captures (everything but its identity). */
+/** The settings a preset captures (everything but its identity/metadata). */
 export interface PresetFields {
   provider: Provider;
   model: string;
   thinking: string;
   smallModelMode: boolean;
+  /** Captured tool-enablement map (the client-side toolset). Additive/optional:
+   * localStorage is schemaless, so a preset saved before toolsets existed omits
+   * it, meaning "inherit the current toolset" (applying such a preset leaves the
+   * tools untouched). A present map is applied verbatim; a missing key within it
+   * falls back to that tool's own default (all on except the opt-in Subagent). */
+  enabledTools?: Record<string, boolean>;
 }
 
 /**
@@ -157,8 +168,10 @@ export interface UseSettingsReturn extends VoiceModeSettingsFields {
    * model/thinking into that preset's *own* provider
    * slice (a functional update, so it's correct even when the preset switches
    * provider — the per-field setters otherwise target only the active slice),
-   * switches the active provider, and sets the global small-model mode. The
-   * provider's apiKey/baseUrl are left untouched. The user then Saves normally. */
+   * switches the active provider, sets the global small-model mode, and applies
+   * the captured toolset (skipped when the preset carries none, so a legacy
+   * preset inherits the current tools). The provider's apiKey/baseUrl are left
+   * untouched. The user then Saves normally. */
   applyPreset: (preset: ChatPreset) => void;
   /** Persists in-modal settings and resolves only after the at-rest envelope
    * has landed. Returns true on durable success, false on failure (saveError


### PR DESCRIPTION
Implements AJM-157. Extends the chat-settings preset system (AJM-147, #1011) so a preset captures the full **client-side bundle** a session runs with — provider, model, thinking, small-model mode, and now the **enabled toolset** — and moves preset management into its own settings tab.

## What changed

**Data model** (`ChatPreset` / `PresetFields`)
- Add optional `enabledTools` (the captured toolset) and optional `description`. Both additive — localStorage is schemaless, so no migration.
- A preset with **no** `enabledTools` means *inherit the current tools*: `applyPreset` leaves them untouched and `presetMatchesFields` skips the toolset in its comparison. A present map is applied verbatim (and compared with order-independent equality).
- `applyPreset` now also sets the toolset; `isValidPreset` tolerantly validates the two new optional fields.

**Description**
- Freeform, informational only for now — reserved for the future orchestrator-picks-a-preset feature (AJM-722). Editable in the preset editor; trimmed and dropped when blank; preserved across a bare Update.

**Dedicated Presets tab**
- New tab order: **Connection · Presets · Tools · Preferences**.
- Picker + Save-as / Update / Delete move off the Connection tab into `PresetsTab`, extended with the description field. The toolset is captured on save, so a preset that spans the Connection and Tools tabs travels together.
- Extracted the picker/form parts into a `helpers/` subdir (and moved `connection-tab-helpers` alongside) to stay under the folder-item cap.

**Docs**
- Added a Presets section to the chat-ui guide, which also fixes the settings **?** help link now anchoring to `#presets`.

## Invariant note
The no-nested-spawn guarantee is unaffected: `buildWorkerConfig` still strips `spawn_subagent` from any cloned worker config regardless of the toolset. Wiring a preset's toolset onto a subagent worker is a later ticket (AJM-722/713).

## Out of scope (by design)
- `liveApiEnabled` and `notation` stay excluded from presets — they're server-mirrored device state, not the client-side localStorage layer the ticket scopes a preset to.
- Device-side (Max patch) toolset storage — dropped from the original ticket; webui-first.

## Testing
- `npm run check` — green (10098 passed, 100% function coverage)
- `npm run check:build` — production + docs build OK
- `npm run ui:test` — 14/14 stubbed Playwright tests pass
- `npm run docs:test` — 51/51 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)