### PR TITLE
feat(webui): choose subagent spawn config — inherit or a preset (with toolset)

### DIFF
--- a/docs/guide/chat-ui.md
+++ b/docs/guide/chat-ui.md
@@ -376,9 +376,10 @@ settings.
   experimental **Subagent** tool is enabled (on the Tools tab). Leave it on
   **Inherit current settings** and each subagent clones your current chat
   config. Pick a preset instead and every subagent runs on that preset's
-  **model**, **thinking**, and **small model mode** — so you can pair a strong
-  planner with uniform, cheaper workers. The subagent's tools still come from
-  the current conversation; a preset only swaps the model and inference here.
+  **model**, **thinking**, **small model mode**, and **toolset** — so you can
+  pair a strong planner with uniform, cheaper workers. (A preset that never
+  saved a toolset keeps the current conversation's tools.) Subagents can never
+  spawn their own subagents, whatever a preset's toolset enables.
 
 ### Tools
 

--- a/docs/guide/chat-ui.md
+++ b/docs/guide/chat-ui.md
@@ -372,6 +372,14 @@ per-provider) and appearance preferences are never part of a preset — a preset
 only _names_ which provider to use and resolves its key from your stored
 settings.
 
+- **Default subagent** - Choose what a spawned subagent runs under when the
+  experimental **Subagent** tool is enabled (on the Tools tab). Leave it on
+  **Inherit current settings** and each subagent clones your current chat
+  config. Pick a preset instead and every subagent runs on that preset's
+  **model**, **thinking**, and **small model mode** — so you can pair a strong
+  planner with uniform, cheaper workers. The subagent's tools still come from
+  the current conversation; a preset only swaps the model and inference here.
+
 ### Tools
 
 The Tools tab controls which tools are available to the AI when using the chat

--- a/docs/guide/chat-ui.md
+++ b/docs/guide/chat-ui.md
@@ -365,13 +365,6 @@ its own home here.
   worker").
 - **Update** / **Delete** - Overwrite or remove the selected preset. An "unsaved
   edits" note appears when the form has drifted from the selected preset.
-
-Configure the model and inference on the **Connection** tab and the toolset on
-the **Tools** tab, then come here to save them together. API keys (kept
-per-provider) and appearance preferences are never part of a preset — a preset
-only _names_ which provider to use and resolves its key from your stored
-settings.
-
 - **Default subagent** - Choose what a spawned subagent runs under when the
   experimental **Subagent** tool is enabled (on the Tools tab). Leave it on
   **Inherit current settings** and each subagent clones your current chat
@@ -380,6 +373,12 @@ settings.
   pair a strong planner with uniform, cheaper workers. (A preset that never
   saved a toolset keeps the current conversation's tools.) Subagents can never
   spawn their own subagents, whatever a preset's toolset enables.
+
+Configure the model and inference on the **Connection** tab and the toolset on
+the **Tools** tab, then come here to save them together. API keys (kept
+per-provider) and appearance preferences are never part of a preset — a preset
+only _names_ which provider to use and resolves its key from your stored
+settings.
 
 ### Tools
 

--- a/webui/src/chat/sdk/spawn-subagent-tool.ts
+++ b/webui/src/chat/sdk/spawn-subagent-tool.ts
@@ -49,7 +49,10 @@ const TASK_DESCRIPTION =
 
 /** Dependencies the spawn tool needs from its owning ChatSdkClient. */
 export interface SpawnSubagentDeps {
-  /** The orchestrator config, cloned per worker (inherits model, thinking, tools). */
+  /** The orchestrator config, cloned per worker. The clone inherits model,
+   * thinking, small-model mode, and tools by default, but a chosen "Default
+   * subagent" preset (carried as config.subagentConfig) overrides those in
+   * buildWorkerConfig. */
   config: ChatClientConfig;
   /**
    * Run a fully self-contained worker session for `task` and resolve with the
@@ -132,10 +135,13 @@ export function createSpawnSubagentTool(deps: SpawnSubagentDeps): Tool {
  * When the user picked a "Default subagent" preset, the orchestrator config
  * carries a resolved `subagentConfig` whose model/inference AND toolset (when
  * the preset saved one) are layered over the clone — so a strong planner can
- * drive uniform cheaper workers. A preset that carries a toolset replaces the
- * worker's tools; a preset without one (and the no-preset case) inherits the
- * orchestrator's. The system instruction always inherits (subagentConfig never
- * carries it).
+ * drive uniform cheaper workers. A preset that carries a toolset supplies the
+ * worker's tools as-is (its captured sparse map; it does NOT carry over the
+ * orchestrator's explicit disables, so a tool the preset never captured stays at
+ * its default-enabled state downstream — same as applying the preset in the
+ * picker). A preset without one (and the no-preset case) inherits the
+ * orchestrator's tools. The system instruction always inherits (subagentConfig
+ * never carries it).
  *
  * The spawn_subagent recursion guard is applied LAST — over whatever toolset
  * wins — so a worker can never spawn its own subagents, regardless of what a
@@ -155,8 +161,10 @@ export function buildWorkerConfig(config: ChatClientConfig): ChatClientConfig {
     chatHistory: [],
     maxSteps: MAX_WORKER_STEPS,
     enabledTools: {
-      // Preset toolset (if the preset saved one) replaces the inherited tools;
-      // otherwise inherit the orchestrator's. Guard applied last, unconditionally.
+      // Preset toolset (if the preset saved one), used as-is; otherwise inherit
+      // the orchestrator's. It's a sparse map — absent keys stay default-enabled
+      // downstream (filterEnabledTools), so this does not carry over the
+      // orchestrator's disables. Guard applied last, unconditionally.
       ...(subagentConfig?.enabledTools ?? enabledTools),
       [SPAWN_SUBAGENT_TOOL_NAME]: false,
     },

--- a/webui/src/chat/sdk/spawn-subagent-tool.ts
+++ b/webui/src/chat/sdk/spawn-subagent-tool.ts
@@ -130,17 +130,23 @@ export function createSpawnSubagentTool(deps: SpawnSubagentDeps): Tool {
  * enabled), so workers cannot spawn their own subagents.
  *
  * When the user picked a "Default subagent" preset, the orchestrator config
- * carries a resolved `subagentConfig` whose model/inference fields are layered
- * over the clone — so a strong planner can drive uniform cheaper workers. Tools
- * and the system instruction still come from the orchestrator (subagentConfig
- * omits them), so those always inherit. Absent = the worker inherits the
- * orchestrator's model/inference too.
+ * carries a resolved `subagentConfig` whose model/inference AND toolset (when
+ * the preset saved one) are layered over the clone — so a strong planner can
+ * drive uniform cheaper workers. A preset that carries a toolset replaces the
+ * worker's tools; a preset without one (and the no-preset case) inherits the
+ * orchestrator's. The system instruction always inherits (subagentConfig never
+ * carries it).
+ *
+ * The spawn_subagent recursion guard is applied LAST — over whatever toolset
+ * wins — so a worker can never spawn its own subagents, regardless of what a
+ * chosen preset's toolset enables. (The worker's ToolSet then omits the spawn
+ * tool anyway, since client.initialize only injects it when enabled.)
  * @param config - The orchestrator config to clone
  * @returns A worker config that inherits everything but can't delegate further
  */
 export function buildWorkerConfig(config: ChatClientConfig): ChatClientConfig {
   // Drop subagentConfig from the worker (workers never spawn) and pull
-  // enabledTools out so it's rebuilt from the orchestrator's, not the preset's.
+  // enabledTools out so the worker's toolset is rebuilt explicitly below.
   const { subagentConfig, enabledTools, ...rest } = config;
 
   return {
@@ -149,7 +155,9 @@ export function buildWorkerConfig(config: ChatClientConfig): ChatClientConfig {
     chatHistory: [],
     maxSteps: MAX_WORKER_STEPS,
     enabledTools: {
-      ...enabledTools,
+      // Preset toolset (if the preset saved one) replaces the inherited tools;
+      // otherwise inherit the orchestrator's. Guard applied last, unconditionally.
+      ...(subagentConfig?.enabledTools ?? enabledTools),
       [SPAWN_SUBAGENT_TOOL_NAME]: false,
     },
   };

--- a/webui/src/chat/sdk/spawn-subagent-tool.ts
+++ b/webui/src/chat/sdk/spawn-subagent-tool.ts
@@ -128,16 +128,28 @@ export function createSpawnSubagentTool(deps: SpawnSubagentDeps): Tool {
  * budget, and spawn_subagent disabled. Disabling it is the recursion guard — the
  * worker's ToolSet omits the spawn tool (client.initialize only injects it when
  * enabled), so workers cannot spawn their own subagents.
+ *
+ * When the user picked a "Default subagent" preset, the orchestrator config
+ * carries a resolved `subagentConfig` whose model/inference fields are layered
+ * over the clone — so a strong planner can drive uniform cheaper workers. Tools
+ * and the system instruction still come from the orchestrator (subagentConfig
+ * omits them), so those always inherit. Absent = the worker inherits the
+ * orchestrator's model/inference too.
  * @param config - The orchestrator config to clone
  * @returns A worker config that inherits everything but can't delegate further
  */
 export function buildWorkerConfig(config: ChatClientConfig): ChatClientConfig {
+  // Drop subagentConfig from the worker (workers never spawn) and pull
+  // enabledTools out so it's rebuilt from the orchestrator's, not the preset's.
+  const { subagentConfig, enabledTools, ...rest } = config;
+
   return {
-    ...config,
+    ...rest,
+    ...subagentConfig,
     chatHistory: [],
     maxSteps: MAX_WORKER_STEPS,
     enabledTools: {
-      ...config.enabledTools,
+      ...enabledTools,
       [SPAWN_SUBAGENT_TOOL_NAME]: false,
     },
   };

--- a/webui/src/chat/sdk/tests/spawn-subagent-tool.test.ts
+++ b/webui/src/chat/sdk/tests/spawn-subagent-tool.test.ts
@@ -12,7 +12,11 @@ import {
   createSpawnSubagentTool,
   extractWorkerResult,
 } from "#webui/chat/sdk/spawn-subagent-tool";
-import { type ChatClientConfig, type ChatMessage } from "#webui/chat/sdk/types";
+import {
+  type ChatClientConfig,
+  type ChatMessage,
+  type SubagentConfigOverride,
+} from "#webui/chat/sdk/types";
 import { createConfig } from "./client-test-helpers";
 
 type RunWorker = (
@@ -69,6 +73,59 @@ describe("buildWorkerConfig", () => {
     const worker = buildWorkerConfig(createConfig({ smallModelMode: true }));
 
     expect(worker.smallModelMode).toBe(true);
+  });
+
+  describe("with a default-subagent preset override", () => {
+    const override: SubagentConfigOverride = {
+      model: { modelId: "cheap-worker", provider: "openai" } as never,
+      smallModelMode: true,
+      providerOptions: { openai: { reasoningEffort: "low" } },
+      buildProviderOptions: () => {},
+    };
+
+    it("swaps in the override's model and inference", () => {
+      const config = createConfig({
+        model: { modelId: "orchestrator", provider: "anthropic" } as never,
+        smallModelMode: false,
+        subagentConfig: override,
+      });
+
+      const worker = buildWorkerConfig(config);
+
+      expect(worker.model).toBe(override.model);
+      expect(worker.smallModelMode).toBe(true);
+      expect(worker.providerOptions).toStrictEqual({
+        openai: { reasoningEffort: "low" },
+      });
+      expect(worker.buildProviderOptions).toBe(override.buildProviderOptions);
+    });
+
+    it("still inherits tools and system instruction from the orchestrator", () => {
+      const config = createConfig({
+        systemInstruction: "orchestrator prompt",
+        enabledTools: {
+          "ppal-read-live-set": true,
+          [SPAWN_SUBAGENT_TOOL_NAME]: true,
+        },
+        subagentConfig: override,
+      });
+
+      const worker = buildWorkerConfig(config);
+
+      // System instruction is not part of the override, so it inherits.
+      expect(worker.systemInstruction).toBe("orchestrator prompt");
+      // Tools inherit (minus the recursion guard) regardless of the preset.
+      expect(worker.enabledTools?.["ppal-read-live-set"]).toBe(true);
+      expect(worker.enabledTools?.[SPAWN_SUBAGENT_TOOL_NAME]).toBe(false);
+    });
+
+    it("drops the override from the worker config (workers never spawn)", () => {
+      const worker = buildWorkerConfig(
+        createConfig({ subagentConfig: override }),
+      );
+
+      expect(worker.subagentConfig).toBeUndefined();
+    });
   });
 });
 

--- a/webui/src/chat/sdk/tests/spawn-subagent-tool.test.ts
+++ b/webui/src/chat/sdk/tests/spawn-subagent-tool.test.ts
@@ -119,9 +119,9 @@ describe("buildWorkerConfig", () => {
       expect(worker.enabledTools?.[SPAWN_SUBAGENT_TOOL_NAME]).toBe(false);
     });
 
-    it("replaces the toolset with the preset's, still stripping spawn_subagent", () => {
+    it("uses the preset's captured toolset as-is, still stripping spawn_subagent", () => {
       const config = createConfig({
-        enabledTools: { "ppal-read-live-set": true, "ppal-delete": true },
+        enabledTools: { "ppal-read-live-set": true, "ppal-delete": false },
         subagentConfig: {
           ...override,
           // A preset toolset that omits a tool the orchestrator had AND tries to
@@ -136,9 +136,13 @@ describe("buildWorkerConfig", () => {
 
       const worker = buildWorkerConfig(config);
 
-      // Worker tools come from the preset, replacing the orchestrator's.
+      // Worker tools are the preset's captured map, not a merge with the
+      // orchestrator's. The orchestrator's explicit `ppal-delete: false` is NOT
+      // carried over — it's absent here, which downstream (filterEnabledTools)
+      // means enabled. So the preset map is used verbatim, sparse semantics and
+      // all; it does not restrict the worker to only its listed tools.
       expect(worker.enabledTools?.["ppal-create-clip"]).toBe(true);
-      expect(worker.enabledTools?.["ppal-delete"]).toBeUndefined();
+      expect(worker.enabledTools).not.toHaveProperty("ppal-delete");
       // The recursion guard overrides the preset's attempt to enable spawning.
       expect(worker.enabledTools?.[SPAWN_SUBAGENT_TOOL_NAME]).toBe(false);
     });

--- a/webui/src/chat/sdk/tests/spawn-subagent-tool.test.ts
+++ b/webui/src/chat/sdk/tests/spawn-subagent-tool.test.ts
@@ -100,22 +100,46 @@ describe("buildWorkerConfig", () => {
       expect(worker.buildProviderOptions).toBe(override.buildProviderOptions);
     });
 
-    it("still inherits tools and system instruction from the orchestrator", () => {
+    it("inherits tools when the preset saved no toolset, always the system instruction", () => {
       const config = createConfig({
         systemInstruction: "orchestrator prompt",
         enabledTools: {
           "ppal-read-live-set": true,
           [SPAWN_SUBAGENT_TOOL_NAME]: true,
         },
-        subagentConfig: override,
+        subagentConfig: override, // no enabledTools on this override
       });
 
       const worker = buildWorkerConfig(config);
 
-      // System instruction is not part of the override, so it inherits.
+      // System instruction is never part of the override, so it always inherits.
       expect(worker.systemInstruction).toBe("orchestrator prompt");
-      // Tools inherit (minus the recursion guard) regardless of the preset.
+      // No preset toolset → inherit the orchestrator's tools (minus the guard).
       expect(worker.enabledTools?.["ppal-read-live-set"]).toBe(true);
+      expect(worker.enabledTools?.[SPAWN_SUBAGENT_TOOL_NAME]).toBe(false);
+    });
+
+    it("replaces the toolset with the preset's, still stripping spawn_subagent", () => {
+      const config = createConfig({
+        enabledTools: { "ppal-read-live-set": true, "ppal-delete": true },
+        subagentConfig: {
+          ...override,
+          // A preset toolset that omits a tool the orchestrator had AND tries to
+          // enable spawn_subagent — the guard must win regardless (no-nested-
+          // spawn invariant preserved under presets).
+          enabledTools: {
+            "ppal-create-clip": true,
+            [SPAWN_SUBAGENT_TOOL_NAME]: true,
+          },
+        },
+      });
+
+      const worker = buildWorkerConfig(config);
+
+      // Worker tools come from the preset, replacing the orchestrator's.
+      expect(worker.enabledTools?.["ppal-create-clip"]).toBe(true);
+      expect(worker.enabledTools?.["ppal-delete"]).toBeUndefined();
+      // The recursion guard overrides the preset's attempt to enable spawning.
       expect(worker.enabledTools?.[SPAWN_SUBAGENT_TOOL_NAME]).toBe(false);
     });
 

--- a/webui/src/chat/sdk/types.ts
+++ b/webui/src/chat/sdk/types.ts
@@ -92,6 +92,22 @@ export function toTokenUsage(sdkUsage: LanguageModelUsage): TokenUsage {
   };
 }
 
+/**
+ * Model/inference overrides a subagent worker runs under, resolved from the
+ * user's chosen "Default subagent" preset. Only the fields a v2.0.1 preset can
+ * swap live here — provider/model are baked into `model`, thinking into
+ * `providerOptions`/`buildProviderOptions`, plus `smallModelMode`. Tools and the
+ * system instruction are deliberately absent so a worker still inherits them
+ * from the orchestrator (buildWorkerConfig). Absent on the orchestrator config =
+ * "inherit current settings", the shipped phase-1 behavior.
+ */
+export interface SubagentConfigOverride {
+  model: LanguageModel;
+  smallModelMode: boolean;
+  providerOptions?: ProviderOptions;
+  buildProviderOptions?: (thinking: string) => ProviderOptions | undefined;
+}
+
 /** Configuration for the AI SDK client */
 export interface ChatClientConfig {
   model: LanguageModel;
@@ -116,4 +132,11 @@ export interface ChatClientConfig {
    * orchestrator with subagents enabled widens to MAX_ORCHESTRATOR_STEPS.
    */
   maxSteps?: number;
+  /**
+   * Preset-derived model/inference a spawned worker runs under. Set on the
+   * orchestrator config when the user picked a "Default subagent" preset; read
+   * only by buildWorkerConfig, which layers it over the cloned orchestrator
+   * config. Absent = the worker inherits the orchestrator's model/inference.
+   */
+  subagentConfig?: SubagentConfigOverride;
 }

--- a/webui/src/chat/sdk/types.ts
+++ b/webui/src/chat/sdk/types.ts
@@ -93,19 +93,23 @@ export function toTokenUsage(sdkUsage: LanguageModelUsage): TokenUsage {
 }
 
 /**
- * Model/inference overrides a subagent worker runs under, resolved from the
- * user's chosen "Default subagent" preset. Only the fields a v2.0.1 preset can
- * swap live here — provider/model are baked into `model`, thinking into
- * `providerOptions`/`buildProviderOptions`, plus `smallModelMode`. Tools and the
- * system instruction are deliberately absent so a worker still inherits them
- * from the orchestrator (buildWorkerConfig). Absent on the orchestrator config =
- * "inherit current settings", the shipped phase-1 behavior.
+ * Config a subagent worker runs under, resolved from the user's chosen "Default
+ * subagent" preset. Carries the fields a preset can swap: provider/model baked
+ * into `model`, thinking into `providerOptions`/`buildProviderOptions`,
+ * `smallModelMode`, and `enabledTools` (the preset's toolset, when it saved one;
+ * absent means the worker inherits the orchestrator's tools). The system
+ * instruction is deliberately NOT here, so a worker always inherits it
+ * (buildWorkerConfig). Absent on the orchestrator config = "inherit current
+ * settings", the shipped phase-1 behavior.
  */
 export interface SubagentConfigOverride {
   model: LanguageModel;
   smallModelMode: boolean;
   providerOptions?: ProviderOptions;
   buildProviderOptions?: (thinking: string) => ProviderOptions | undefined;
+  /** The preset's captured toolset. Absent = inherit the orchestrator's tools.
+   * buildWorkerConfig always re-strips spawn_subagent over this map. */
+  enabledTools?: Record<string, boolean>;
 }
 
 /** Configuration for the AI SDK client */

--- a/webui/src/chat/sdk/types.ts
+++ b/webui/src/chat/sdk/types.ts
@@ -107,8 +107,11 @@ export interface SubagentConfigOverride {
   smallModelMode: boolean;
   providerOptions?: ProviderOptions;
   buildProviderOptions?: (thinking: string) => ProviderOptions | undefined;
-  /** The preset's captured toolset. Absent = inherit the orchestrator's tools.
-   * buildWorkerConfig always re-strips spawn_subagent over this map. */
+  /** The preset's captured toolset, used as-is (a sparse map — an absent key
+   * means that tool keeps its default-enabled state downstream, same as applying
+   * the preset in the picker; it does NOT carry over the orchestrator's explicit
+   * disables). Absent = inherit the orchestrator's tools. buildWorkerConfig
+   * always re-strips spawn_subagent over this map. */
   enabledTools?: Record<string, boolean>;
 }
 
@@ -122,7 +125,8 @@ export interface ChatClientConfig {
    * Small-model mode for THIS client's MCP requests, sent as a per-request
    * header so the server shrinks tool schemas and serves the basic skills
    * variant for this caller alone. A subagent worker inherits it from the
-   * orchestrator config (buildWorkerConfig), so a small-model worker gets the
+   * orchestrator config unless a chosen "Default subagent" preset overrides it
+   * (buildWorkerConfig applies subagentConfig), so a small-model worker gets the
    * reduced context even while the orchestrator runs full-strength.
    */
   smallModelMode?: boolean;
@@ -137,10 +141,13 @@ export interface ChatClientConfig {
    */
   maxSteps?: number;
   /**
-   * Preset-derived model/inference a spawned worker runs under. Set on the
-   * orchestrator config when the user picked a "Default subagent" preset; read
-   * only by buildWorkerConfig, which layers it over the cloned orchestrator
-   * config. Absent = the worker inherits the orchestrator's model/inference.
+   * Preset-derived config a spawned worker runs under (model/inference + the
+   * preset's toolset when it saved one). Set on the orchestrator config when the
+   * user picked a "Default subagent" preset; read only by buildWorkerConfig,
+   * which layers it over the cloned orchestrator config. Absent = the worker
+   * inherits the orchestrator's config. This tracks the CURRENT global
+   * preference — it is deliberately not locked per conversation, so continuing a
+   * restored conversation spawns workers under whatever preset is selected now.
    */
   subagentConfig?: SubagentConfigOverride;
 }

--- a/webui/src/components/settings/PresetControls.tsx
+++ b/webui/src/components/settings/PresetControls.tsx
@@ -7,6 +7,7 @@ import { useState } from "preact/hooks";
 import { presetMatchesFields } from "#webui/hooks/settings/presets/preset-storage";
 import { usePresets } from "#webui/hooks/settings/presets/use-presets";
 import {
+  type ChatPreset,
   type PresetFields,
   type UseSettingsReturn,
 } from "#webui/types/settings";
@@ -154,7 +155,45 @@ export function PresetControls({ settings }: PresetControlsProps) {
         presets={presets}
         value={settings.defaultSubagentPresetId}
         onChange={settings.setDefaultSubagentPresetId}
+        missingKeyIds={presetsMissingApiKey(settings, presets)}
       />
     </div>
+  );
+}
+
+/**
+ * Preset ids whose provider has no usable API key, so the Default-subagent
+ * picker can flag them (such a preset builds a worker that fails at request time
+ * — after burning a spawn against the cap).
+ *
+ * Reads the DECRYPTED, buffer-live key via getProviderConnection — the exact
+ * value the worker will send (use-chat-mode-state's resolveConnection wraps the
+ * same call). Deliberately NOT checkHasApiKey, which reads the raw stored
+ * envelope: that both misses a just-typed unsaved key AND falsely reports a key
+ * for an orphaned/undecryptable envelope (the IndexedDB crypto key was reset
+ * while the localStorage envelope persisted) — the very case a warning should
+ * catch. See the same reasoning on `hasApiKey` in use-settings.
+ *
+ * Empty until settingsLoaded, since every provider's key is blank until the
+ * post-mount decrypt lands (else it would flash "no key" on all of them).
+ * lmstudio / ollama need no key, so they're never flagged.
+ * @param settings - The live settings buffer
+ * @param presets - The preset list
+ * @returns The set of preset ids missing a usable provider key
+ */
+function presetsMissingApiKey(
+  settings: UseSettingsReturn,
+  presets: ChatPreset[],
+): Set<string> {
+  if (!settings.settingsLoaded) return new Set();
+
+  return new Set(
+    presets
+      .filter((p) => {
+        if (p.provider === "lmstudio" || p.provider === "ollama") return false;
+
+        return !settings.getProviderConnection(p.provider).apiKey;
+      })
+      .map((p) => p.id),
   );
 }

--- a/webui/src/components/settings/PresetControls.tsx
+++ b/webui/src/components/settings/PresetControls.tsx
@@ -14,6 +14,7 @@ import {
   PresetCreateForm,
   PresetDescriptionField,
   PresetPickerRow,
+  SubagentDefaultRow,
 } from "./helpers/preset-controls-parts";
 
 interface PresetControlsProps {
@@ -21,11 +22,13 @@ interface PresetControlsProps {
 }
 
 /**
- * Preset picker + Save-as/Update/Delete controls plus the description editor,
- * shown on the dedicated Presets tab. Selecting a preset loads its full bundle
- * — provider/model/thinking + small-model mode + toolset — into the live
- * editable settings buffer (settings.applyPreset); the user then Saves through
- * the normal footer flow. Presets never capture the API key (that stays in the
+ * Preset picker + Save-as/Update/Delete controls, the description editor, and
+ * the "Default subagent" selector, shown on the dedicated Presets tab. Selecting
+ * a preset loads its full bundle — provider/model/thinking + small-model mode +
+ * toolset — into the live editable settings buffer (settings.applyPreset); the
+ * user then Saves through the normal footer flow. The Default subagent selector
+ * (SubagentDefaultRow) reuses this live preset list to pick which preset spawned
+ * subagents run under. Presets never capture the API key (that stays in the
  * per-provider store).
  * @param {PresetControlsProps} props - Component props
  * @param {UseSettingsReturn} props.settings - The live settings buffer + actions
@@ -146,6 +149,12 @@ export function PresetControls({ settings }: PresetControlsProps) {
           {error}
         </p>
       )}
+
+      <SubagentDefaultRow
+        presets={presets}
+        value={settings.defaultSubagentPresetId}
+        onChange={settings.setDefaultSubagentPresetId}
+      />
     </div>
   );
 }

--- a/webui/src/components/settings/controls/helpers/tool-toggles-helpers.ts
+++ b/webui/src/components/settings/controls/helpers/tool-toggles-helpers.ts
@@ -29,7 +29,8 @@ const SPAWN_SUBAGENT_TOOL: McpTool = {
   name: "Subagent",
   description:
     "Experimental: let the assistant delegate subtasks to nested subagents " +
-    "that work in the same Live Set and report back. Off by default.",
+    "that work in the same Live Set and report back. Off by default. Choose what " +
+    "they run as (inherit, or a preset) with Default subagent on the Presets tab.",
 };
 
 /**

--- a/webui/src/components/settings/helpers/preset-controls-parts.tsx
+++ b/webui/src/components/settings/helpers/preset-controls-parts.tsx
@@ -126,7 +126,7 @@ export function SubagentDefaultRow(props: SubagentDefaultRowProps) {
       <p className="text-xs text-zinc-500 mt-1">
         What spawned subagents run as when the Subagent tool is enabled. A
         preset runs each subagent on its own model, thinking, small-model mode,
-        and toolset (a preset with no saved toolset keeps this conversation’s
+        and toolset (a preset with no saved toolset keeps this conversation's
         tools). Subagents can never spawn their own subagents.
       </p>
     </div>

--- a/webui/src/components/settings/helpers/preset-controls-parts.tsx
+++ b/webui/src/components/settings/helpers/preset-controls-parts.tsx
@@ -90,9 +90,9 @@ interface SubagentDefaultRowProps {
 /**
  * The "Default subagent" selector: which preset a spawned subagent runs under.
  * "Inherit current settings" (the empty value) clones the orchestrator's config;
- * a preset swaps in its model/inference while tools still inherit. Shown below
- * the preset controls on the Presets tab. Falls back to "Inherit" when the saved
- * id no longer matches a preset (deleted), matching the runtime's graceful
+ * a preset runs each worker on that preset's model/inference and toolset. Shown
+ * below the preset controls on the Presets tab. Falls back to "Inherit" when the
+ * saved id no longer matches a preset (deleted), matching the runtime's graceful
  * inherit.
  * @param {SubagentDefaultRowProps} props - Selector props
  * @returns {JSX.Element} The default-subagent selector
@@ -125,8 +125,9 @@ export function SubagentDefaultRow(props: SubagentDefaultRowProps) {
       </select>
       <p className="text-xs text-zinc-500 mt-1">
         What spawned subagents run as when the Subagent tool is enabled. A
-        preset swaps the worker’s model, thinking, and small-model mode; tools
-        still inherit from this conversation.
+        preset runs each subagent on its own model, thinking, small-model mode,
+        and toolset (a preset with no saved toolset keeps this conversation’s
+        tools). Subagents can never spawn their own subagents.
       </p>
     </div>
   );

--- a/webui/src/components/settings/helpers/preset-controls-parts.tsx
+++ b/webui/src/components/settings/helpers/preset-controls-parts.tsx
@@ -85,20 +85,23 @@ interface SubagentDefaultRowProps {
   /** Saved default-subagent preset id, or null to inherit. */
   value: string | null;
   onChange: (id: string | null) => void;
+  /** Preset ids whose provider has no usable API key, annotated in the options
+   * (a worker on such a preset would fail at request time). */
+  missingKeyIds: Set<string>;
 }
 
 /**
  * The "Default subagent" selector: which preset a spawned subagent runs under.
  * "Inherit current settings" (the empty value) clones the orchestrator's config;
  * a preset runs each worker on that preset's model/inference and toolset. Shown
- * below the preset controls on the Presets tab. Falls back to "Inherit" when the
- * saved id no longer matches a preset (deleted), matching the runtime's graceful
- * inherit.
+ * below the preset controls on the Presets tab. Options whose provider has no
+ * API key are annotated. Falls back to "Inherit" when the saved id no longer
+ * matches a preset (deleted), matching the runtime's graceful inherit.
  * @param {SubagentDefaultRowProps} props - Selector props
  * @returns {JSX.Element} The default-subagent selector
  */
 export function SubagentDefaultRow(props: SubagentDefaultRowProps) {
-  const { presets, value } = props;
+  const { presets, value, missingKeyIds } = props;
   const selectValue =
     value != null && presets.some((p) => p.id === value) ? value : "";
 
@@ -120,6 +123,7 @@ export function SubagentDefaultRow(props: SubagentDefaultRowProps) {
         {presets.map((p) => (
           <option key={p.id} value={p.id}>
             {p.name}
+            {missingKeyIds.has(p.id) ? " (no API key)" : ""}
           </option>
         ))}
       </select>

--- a/webui/src/components/settings/helpers/preset-controls-parts.tsx
+++ b/webui/src/components/settings/helpers/preset-controls-parts.tsx
@@ -80,6 +80,58 @@ export function PresetPickerRow(props: PresetPickerRowProps) {
   );
 }
 
+interface SubagentDefaultRowProps {
+  presets: ChatPreset[];
+  /** Saved default-subagent preset id, or null to inherit. */
+  value: string | null;
+  onChange: (id: string | null) => void;
+}
+
+/**
+ * The "Default subagent" selector: which preset a spawned subagent runs under.
+ * "Inherit current settings" (the empty value) clones the orchestrator's config;
+ * a preset swaps in its model/inference while tools still inherit. Shown below
+ * the preset controls on the Presets tab. Falls back to "Inherit" when the saved
+ * id no longer matches a preset (deleted), matching the runtime's graceful
+ * inherit.
+ * @param {SubagentDefaultRowProps} props - Selector props
+ * @returns {JSX.Element} The default-subagent selector
+ */
+export function SubagentDefaultRow(props: SubagentDefaultRowProps) {
+  const { presets, value } = props;
+  const selectValue =
+    value != null && presets.some((p) => p.id === value) ? value : "";
+
+  return (
+    <div className="pt-3 border-t border-zinc-300 dark:border-zinc-600">
+      <label className="block text-sm mb-1" htmlFor="subagent-default-select">
+        Default subagent
+      </label>
+      <select
+        id="subagent-default-select"
+        value={selectValue}
+        onChange={(e) =>
+          props.onChange((e.target as HTMLSelectElement).value || null)
+        }
+        className={`w-full ${INPUT_CLASS}`}
+        data-testid="subagent-default-select"
+      >
+        <option value="">Inherit current settings</option>
+        {presets.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.name}
+          </option>
+        ))}
+      </select>
+      <p className="text-xs text-zinc-500 mt-1">
+        What spawned subagents run as when the Subagent tool is enabled. A
+        preset swaps the worker’s model, thinking, and small-model mode; tools
+        still inherit from this conversation.
+      </p>
+    </div>
+  );
+}
+
 interface PresetCreateFormProps {
   draftName: string;
   draftDescription: string;

--- a/webui/src/components/settings/tests/PresetControls.test.tsx
+++ b/webui/src/components/settings/tests/PresetControls.test.tsx
@@ -31,6 +31,8 @@ function makeSettings(over?: Partial<UseSettingsReturn>): UseSettingsReturn {
     applyPreset: vi.fn(),
     defaultSubagentPresetId: null,
     setDefaultSubagentPresetId: vi.fn(),
+    settingsLoaded: true,
+    getProviderConnection: vi.fn(() => ({ apiKey: "sk-test" })),
     ...over,
   } as unknown as UseSettingsReturn;
 }
@@ -223,6 +225,56 @@ describe("PresetControls", () => {
       target: { value: "" },
     });
     expect(setDefaultSubagentPresetId).toHaveBeenCalledWith(null);
+  });
+
+  it("flags Default subagent presets whose provider has no API key", () => {
+    savePresets([
+      { ...seeded, id: "keyed", name: "Keyed", provider: "anthropic" },
+      { ...seeded, id: "keyless", name: "Keyless", provider: "openai" },
+      { ...seeded, id: "local", name: "Local", provider: "ollama" },
+    ]);
+    render(
+      <PresetControls
+        settings={makeSettings({
+          getProviderConnection: vi.fn((p: string) => ({
+            apiKey: p === "anthropic" ? "sk-ok" : "",
+          })),
+        })}
+      />,
+    );
+
+    const labels = [
+      ...(screen.getByTestId("subagent-default-select") as HTMLSelectElement)
+        .options,
+    ].map((o) => o.textContent);
+
+    expect(labels).toStrictEqual([
+      "Inherit current settings",
+      "Keyed",
+      "Keyless (no API key)",
+      "Local", // ollama needs no key → never flagged
+    ]);
+  });
+
+  it("doesn't flag missing keys until settings finish loading", () => {
+    savePresets([
+      { ...seeded, id: "keyless", name: "Keyless", provider: "openai" },
+    ]);
+    render(
+      <PresetControls
+        settings={makeSettings({
+          settingsLoaded: false,
+          getProviderConnection: vi.fn(() => ({ apiKey: "" })),
+        })}
+      />,
+    );
+
+    const labels = [
+      ...(screen.getByTestId("subagent-default-select") as HTMLSelectElement)
+        .options,
+    ].map((o) => o.textContent);
+
+    expect(labels).toStrictEqual(["Inherit current settings", "Keyless"]);
   });
 
   it("shows Inherit when the saved default id no longer matches a preset", () => {

--- a/webui/src/components/settings/tests/PresetControls.test.tsx
+++ b/webui/src/components/settings/tests/PresetControls.test.tsx
@@ -29,6 +29,8 @@ function makeSettings(over?: Partial<UseSettingsReturn>): UseSettingsReturn {
     enabledTools: {},
     setEnabledTools: vi.fn(),
     applyPreset: vi.fn(),
+    defaultSubagentPresetId: null,
+    setDefaultSubagentPresetId: vi.fn(),
     ...over,
   } as unknown as UseSettingsReturn;
 }
@@ -182,6 +184,59 @@ describe("PresetControls", () => {
     fireEvent.click(screen.getByTestId("preset-delete"));
     expect(loadPresets()).toHaveLength(0);
     expect(screen.queryByTestId("preset-update")).toBeNull();
+  });
+
+  it("offers Inherit plus every preset in the Default subagent selector", () => {
+    savePresets([seeded]);
+    render(
+      <PresetControls
+        settings={makeSettings({ defaultSubagentPresetId: "seed" })}
+      />,
+    );
+
+    const select = screen.getByTestId(
+      "subagent-default-select",
+    ) as HTMLSelectElement;
+
+    expect(select.value).toBe("seed");
+    const optionLabels = [...select.options].map((o) => o.textContent);
+
+    expect(optionLabels).toStrictEqual(["Inherit current settings", "Seeded"]);
+  });
+
+  it("sets the default subagent preset (and null for Inherit)", () => {
+    savePresets([seeded]);
+    const setDefaultSubagentPresetId = vi.fn();
+
+    render(
+      <PresetControls
+        settings={makeSettings({ setDefaultSubagentPresetId })}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("subagent-default-select"), {
+      target: { value: "seed" },
+    });
+    expect(setDefaultSubagentPresetId).toHaveBeenCalledWith("seed");
+
+    fireEvent.change(screen.getByTestId("subagent-default-select"), {
+      target: { value: "" },
+    });
+    expect(setDefaultSubagentPresetId).toHaveBeenCalledWith(null);
+  });
+
+  it("shows Inherit when the saved default id no longer matches a preset", () => {
+    savePresets([seeded]);
+    render(
+      <PresetControls
+        settings={makeSettings({ defaultSubagentPresetId: "deleted" })}
+      />,
+    );
+
+    expect(
+      (screen.getByTestId("subagent-default-select") as HTMLSelectElement)
+        .value,
+    ).toBe("");
   });
 
   it("flags unsaved edits when the buffer drifts from the selected preset", () => {

--- a/webui/src/components/settings/tests/PresetsTab.test.tsx
+++ b/webui/src/components/settings/tests/PresetsTab.test.tsx
@@ -24,6 +24,8 @@ function makeSettings(): UseSettingsReturn {
     enabledTools: {},
     setEnabledTools: vi.fn(),
     applyPreset: vi.fn(),
+    defaultSubagentPresetId: null,
+    setDefaultSubagentPresetId: vi.fn(),
   } as unknown as UseSettingsReturn;
 }
 

--- a/webui/src/components/settings/tests/SettingsScreen.test.tsx
+++ b/webui/src/components/settings/tests/SettingsScreen.test.tsx
@@ -140,6 +140,8 @@ describe("SettingsScreen", () => {
     isToolEnabled: () => true,
     smallModelMode: false,
     setSmallModelMode: vi.fn(),
+    defaultSubagentPresetId: null,
+    setDefaultSubagentPresetId: vi.fn(),
     liveApiEnabled: false,
     liveApiEnabledDirty: false,
     setLiveApiEnabled: vi.fn(),

--- a/webui/src/hooks/chat/adapter.ts
+++ b/webui/src/hooks/chat/adapter.ts
@@ -7,7 +7,11 @@ import { type ProviderOptions } from "@ai-sdk/provider-utils";
 import { ChatSdkClient } from "#webui/chat/sdk/client";
 import { formatChatMessages } from "#webui/chat/sdk/formatter";
 import { createProviderModel } from "#webui/chat/sdk/provider-factories";
-import { type ChatClientConfig, type ChatMessage } from "#webui/chat/sdk/types";
+import {
+  type ChatClientConfig,
+  type ChatMessage,
+  type SubagentConfigOverride,
+} from "#webui/chat/sdk/types";
 import {
   isLegacyNonThinkingModel,
   isLegacyThinkingModel,
@@ -17,6 +21,7 @@ import {
   mapThinkingToOpenRouterEffort,
   mapThinkingToReasoningEffort,
 } from "#webui/hooks/settings/config-builders";
+import { type ResolvedSubagentPreset } from "#webui/hooks/settings/presets/preset-extra-params";
 import { getThinkingBudget, resolveSystemInstruction } from "#webui/lib/config";
 import { normalizeErrorMessage } from "#webui/lib/error-formatters";
 import { type Provider } from "#webui/types/settings";
@@ -166,6 +171,47 @@ function buildOpenAIOptions(
 }
 
 /**
+ * Build the model/inference override a spawned worker runs under from the
+ * user's resolved "Default subagent" preset. Returns undefined to inherit the
+ * orchestrator config (no preset chosen). A preset that can't build a model
+ * (e.g. a `custom` provider missing its base URL) must NOT break the
+ * orchestrator's own chat init, so failures warn and fall back to inherit.
+ * @param preset - The resolved subagent preset, or undefined to inherit
+ * @returns The worker override, or undefined to inherit
+ */
+function buildSubagentConfig(
+  preset: ResolvedSubagentPreset | undefined,
+): SubagentConfigOverride | undefined {
+  if (preset == null) return undefined;
+
+  try {
+    return {
+      model: createProviderModel(
+        preset.provider,
+        preset.model,
+        preset.apiKey,
+        preset.baseUrl,
+      ),
+      smallModelMode: preset.smallModelMode,
+      providerOptions: buildProviderOptions(
+        preset.provider,
+        preset.thinking,
+        preset.model,
+      ),
+      buildProviderOptions: (overrideThinking: string) =>
+        buildProviderOptions(preset.provider, overrideThinking, preset.model),
+    };
+  } catch (error) {
+    console.warn(
+      "Default subagent preset could not be built; subagents will inherit " +
+        `the current settings. ${error instanceof Error ? error.message : String(error)}`,
+    );
+
+    return undefined;
+  }
+}
+
+/**
  * AI SDK adapter for the generic useChat hook.
  * Routes all providers through the Vercel AI SDK's streamText function.
  */
@@ -207,6 +253,11 @@ export const chatAdapter: ChatAdapter<
 
     const languageModel = createProviderModel(provider, model, apiKey, baseUrl);
     const providerOptions = buildProviderOptions(provider, thinking, model);
+    // Resolve the "Default subagent" preset (if any) to the model/inference a
+    // spawned worker runs under; buildWorkerConfig layers it over the clone.
+    const subagentConfig = buildSubagentConfig(
+      extraParams?.subagentPreset as ResolvedSubagentPreset | undefined,
+    );
 
     // Temperature is no longer sent: it was phased-out dead config (no UI, pinned
     // at 1.0) so the request now carries no `temperature` and each provider
@@ -222,6 +273,7 @@ export const chatAdapter: ChatAdapter<
       buildProviderOptions: (overrideThinking: string) =>
         buildProviderOptions(provider, overrideThinking, model),
       chatHistory,
+      subagentConfig,
     };
   },
 

--- a/webui/src/hooks/chat/adapter.ts
+++ b/webui/src/hooks/chat/adapter.ts
@@ -21,7 +21,10 @@ import {
   mapThinkingToOpenRouterEffort,
   mapThinkingToReasoningEffort,
 } from "#webui/hooks/settings/config-builders";
-import { type ResolvedSubagentPreset } from "#webui/hooks/settings/presets/preset-extra-params";
+import {
+  type ResolvedSubagentPreset,
+  SUBAGENT_PRESET_PARAM,
+} from "#webui/hooks/settings/presets/preset-extra-params";
 import { getThinkingBudget, resolveSystemInstruction } from "#webui/lib/config";
 import { normalizeErrorMessage } from "#webui/lib/error-formatters";
 import { type Provider } from "#webui/types/settings";
@@ -259,7 +262,8 @@ export const chatAdapter: ChatAdapter<
     // Resolve the "Default subagent" preset (if any) to the model/inference a
     // spawned worker runs under; buildWorkerConfig layers it over the clone.
     const subagentConfig = buildSubagentConfig(
-      extraParams?.subagentPreset as ResolvedSubagentPreset | undefined,
+      extraParams?.[SUBAGENT_PRESET_PARAM] as
+        ResolvedSubagentPreset | undefined,
     );
 
     // Temperature is no longer sent: it was phased-out dead config (no UI, pinned

--- a/webui/src/hooks/chat/adapter.ts
+++ b/webui/src/hooks/chat/adapter.ts
@@ -200,6 +200,9 @@ function buildSubagentConfig(
       ),
       buildProviderOptions: (overrideThinking: string) =>
         buildProviderOptions(preset.provider, overrideThinking, preset.model),
+      // Carry the preset's toolset through; buildWorkerConfig replaces the
+      // worker's tools with it (and always re-strips spawn_subagent).
+      enabledTools: preset.enabledTools,
     };
   } catch (error) {
     console.warn(

--- a/webui/src/hooks/chat/tests/adapter.test.ts
+++ b/webui/src/hooks/chat/tests/adapter.test.ts
@@ -491,6 +491,29 @@ describe("chatAdapter", () => {
         ).toBeUndefined();
       });
 
+      it("carries the preset's toolset onto the override", () => {
+        const config = chatAdapter.buildConfig("gpt-4o", "Off", {}, undefined, {
+          ...extraParams,
+          subagentPreset: {
+            ...subagentPreset,
+            enabledTools: { "ppal-create-clip": true },
+          },
+        });
+
+        expect(config.subagentConfig?.enabledTools).toStrictEqual({
+          "ppal-create-clip": true,
+        });
+      });
+
+      it("leaves the override toolset undefined when the preset saved none", () => {
+        const config = chatAdapter.buildConfig("gpt-4o", "Off", {}, undefined, {
+          ...extraParams,
+          subagentPreset, // no enabledTools
+        });
+
+        expect(config.subagentConfig?.enabledTools).toBeUndefined();
+      });
+
       it("leaves subagentConfig undefined when no preset is chosen", () => {
         const config = chatAdapter.buildConfig(
           "gpt-4o",

--- a/webui/src/hooks/chat/tests/adapter.test.ts
+++ b/webui/src/hooks/chat/tests/adapter.test.ts
@@ -15,6 +15,7 @@ vi.mock(import("#webui/chat/sdk/provider-factories"), () => ({
   createProviderModel: vi.fn(() => mockModel),
 }));
 
+import { createProviderModel } from "#webui/chat/sdk/provider-factories";
 import { chatAdapter } from "#webui/hooks/chat/adapter";
 
 describe("chatAdapter", () => {
@@ -457,6 +458,80 @@ describe("chatAdapter", () => {
       const overridden = config.buildProviderOptions!("Off");
 
       expect(overridden).toBeUndefined();
+    });
+
+    describe("subagentConfig from a default-subagent preset", () => {
+      const subagentPreset = {
+        provider: "openai" as const,
+        apiKey: "worker-key",
+        baseUrl: undefined,
+        model: "gpt-5.2",
+        thinking: "Max",
+        smallModelMode: true,
+      };
+
+      it("builds the worker override from the resolved preset", () => {
+        const config = chatAdapter.buildConfig("gpt-4o", "Off", {}, undefined, {
+          ...extraParams,
+          subagentPreset,
+        });
+
+        expect(config.subagentConfig?.model).toBe(mockModel);
+        expect(config.subagentConfig?.smallModelMode).toBe(true);
+        // The worker override uses the PRESET's model+thinking (gpt-5.2 / Max),
+        // independent of the orchestrator's (gpt-4o / Off → no options).
+        expect(config.providerOptions).toBeUndefined();
+        expect(config.subagentConfig?.providerOptions).toStrictEqual({
+          openai: { reasoningEffort: "xhigh", reasoningSummary: "auto" },
+        });
+        // The worker's buildProviderOptions rebuilds against the preset's model
+        // (gpt-5.2 reasoning model) — Off yields no options.
+        expect(
+          config.subagentConfig?.buildProviderOptions?.("Off"),
+        ).toBeUndefined();
+      });
+
+      it("leaves subagentConfig undefined when no preset is chosen", () => {
+        const config = chatAdapter.buildConfig(
+          "gpt-4o",
+          "Default",
+          {},
+          undefined,
+          extraParams,
+        );
+
+        expect(config.subagentConfig).toBeUndefined();
+      });
+
+      it("falls back to inherit and warns when the worker model can't be built", () => {
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        // Only the worker model fails to build (e.g. custom provider with no
+        // URL); the orchestrator's own model must still succeed.
+        vi.mocked(createProviderModel).mockImplementation((_p, modelId) => {
+          if (modelId === "broken-worker") throw new Error("needs a URL");
+
+          return mockModel;
+        });
+
+        const config = chatAdapter.buildConfig(
+          "gpt-4o",
+          "Default",
+          {},
+          undefined,
+          {
+            ...extraParams,
+            subagentPreset: { ...subagentPreset, model: "broken-worker" },
+          },
+        );
+
+        expect(config.model).toBe(mockModel); // orchestrator unaffected
+        expect(config.subagentConfig).toBeUndefined();
+        expect(warnSpy).toHaveBeenCalledOnce();
+
+        vi.mocked(createProviderModel).mockImplementation(() => mockModel);
+        warnSpy.mockRestore();
+      });
     });
   });
 

--- a/webui/src/hooks/chat/use-chat-mode-state.ts
+++ b/webui/src/hooks/chat/use-chat-mode-state.ts
@@ -3,7 +3,13 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "preact/hooks";
 import { type ModeContext } from "#webui/components/mode-context";
 import { chatAdapter } from "#webui/hooks/chat/adapter";
 import { useChatModeReporting } from "#webui/hooks/chat/helpers/use-chat-mode-reporting";
@@ -22,8 +28,14 @@ import { type UseRemoteConfigReturn } from "#webui/hooks/connection/use-remote-c
 import { useSyncSmallModelMode } from "#webui/hooks/connection/use-sync-small-model-mode";
 import { useSystemPrompt } from "#webui/hooks/context/use-system-prompt";
 import { useSystemPromptSendGate } from "#webui/hooks/context/use-system-prompt-send-gate";
-import { resolveSubagentPreset } from "#webui/hooks/settings/presets/preset-extra-params";
-import { loadPresets } from "#webui/hooks/settings/presets/preset-storage";
+import {
+  resolveSubagentPreset,
+  SUBAGENT_PRESET_PARAM,
+} from "#webui/hooks/settings/presets/preset-extra-params";
+import {
+  loadPresets,
+  PRESETS_STORAGE_KEY,
+} from "#webui/hooks/settings/presets/preset-storage";
 import { type PreferencesSettings } from "#webui/hooks/use-preferences-settings";
 import { useClearViewingModeOnReset } from "#webui/hooks/view-state/use-clear-viewing-mode-on-reset";
 import { type ViewState } from "#webui/hooks/view-state/use-view-state";
@@ -128,13 +140,22 @@ export function useChatModeState(params: UseChatModeStateParams) {
     [getProviderConnection],
   );
 
-  // Resolve the chosen "Default subagent" preset fresh from storage each render
-  // (presets are edited in a separate hook instance, so a snapshot would go
-  // stale). Undefined = inherit; the adapter turns it into the worker override.
-  const subagentPreset = resolveSubagentPreset(
-    settings.defaultSubagentPresetId,
-    loadPresets(),
-    resolveConnection,
+  // Resolve the chosen "Default subagent" preset. Read the presets blob fresh
+  // each render (a usePresets snapshot would go stale — presets are edited in a
+  // separate hook instance), but key the actual parse/validate/resolve off that
+  // blob so it only recomputes when the presets or the selection change:
+  // useChatModeState re-renders per streamed token, so this avoids a JSON.parse +
+  // validation + allocation on every chunk. Undefined = inherit; the adapter
+  // turns it into the worker override.
+  const presetsBlob = localStorage.getItem(PRESETS_STORAGE_KEY);
+  const subagentPreset = useMemo(
+    () =>
+      resolveSubagentPreset(
+        settings.defaultSubagentPresetId,
+        presetsBlob ? loadPresets() : [],
+        resolveConnection,
+      ),
+    [presetsBlob, settings.defaultSubagentPresetId, resolveConnection],
   );
 
   const aiSdkChat = useChat({
@@ -155,7 +176,7 @@ export function useChatModeState(params: UseChatModeStateParams) {
       provider: settings.provider,
       apiKey: resolvedApiKey,
       systemInstructionOverride,
-      subagentPreset,
+      [SUBAGENT_PRESET_PARAM]: subagentPreset,
     },
     autoSaveRef,
     pendingForkRef,

--- a/webui/src/hooks/chat/use-chat-mode-state.ts
+++ b/webui/src/hooks/chat/use-chat-mode-state.ts
@@ -22,6 +22,8 @@ import { type UseRemoteConfigReturn } from "#webui/hooks/connection/use-remote-c
 import { useSyncSmallModelMode } from "#webui/hooks/connection/use-sync-small-model-mode";
 import { useSystemPrompt } from "#webui/hooks/context/use-system-prompt";
 import { useSystemPromptSendGate } from "#webui/hooks/context/use-system-prompt-send-gate";
+import { resolveSubagentPreset } from "#webui/hooks/settings/presets/preset-extra-params";
+import { loadPresets } from "#webui/hooks/settings/presets/preset-storage";
 import { type PreferencesSettings } from "#webui/hooks/use-preferences-settings";
 import { useClearViewingModeOnReset } from "#webui/hooks/view-state/use-clear-viewing-mode-on-reset";
 import { type ViewState } from "#webui/hooks/view-state/use-view-state";
@@ -126,6 +128,15 @@ export function useChatModeState(params: UseChatModeStateParams) {
     [getProviderConnection],
   );
 
+  // Resolve the chosen "Default subagent" preset fresh from storage each render
+  // (presets are edited in a separate hook instance, so a snapshot would go
+  // stale). Undefined = inherit; the adapter turns it into the worker override.
+  const subagentPreset = resolveSubagentPreset(
+    settings.defaultSubagentPresetId,
+    loadPresets(),
+    resolveConnection,
+  );
+
   const aiSdkChat = useChat({
     provider: settings.provider,
     apiKey: resolvedApiKey,
@@ -144,6 +155,7 @@ export function useChatModeState(params: UseChatModeStateParams) {
       provider: settings.provider,
       apiKey: resolvedApiKey,
       systemInstructionOverride,
+      subagentPreset,
     },
     autoSaveRef,
     pendingForkRef,

--- a/webui/src/hooks/settings/presets/preset-extra-params.ts
+++ b/webui/src/hooks/settings/presets/preset-extra-params.ts
@@ -11,6 +11,15 @@ type GetProviderConnection = (provider: Provider) => {
   baseUrl?: string;
 };
 
+/**
+ * The `extraParams` key carrying the resolved "Default subagent" preset from
+ * use-chat-mode-state (writer) to chatAdapter.buildConfig (reader). A shared
+ * const so a rename breaks the compile instead of silently degrading every
+ * worker to "inherit" — the two sides never talk through a typed contract
+ * (extraParams is Record<string, unknown>).
+ */
+export const SUBAGENT_PRESET_PARAM = "subagentPreset";
+
 /** The provider + live connection a preset resolves to (the extraParams bag). */
 export interface PresetConnection {
   provider: Provider;

--- a/webui/src/hooks/settings/presets/preset-extra-params.ts
+++ b/webui/src/hooks/settings/presets/preset-extra-params.ts
@@ -11,27 +11,73 @@ type GetProviderConnection = (provider: Provider) => {
   baseUrl?: string;
 };
 
+/** The provider + live connection a preset resolves to (the extraParams bag). */
+export interface PresetConnection {
+  provider: Provider;
+  apiKey: string;
+  baseUrl?: string;
+}
+
+/**
+ * A "Default subagent" preset resolved to everything buildWorkerConfig needs:
+ * the connection (provider + live key/baseUrl) plus the model/inference a
+ * v2.0.1 preset swaps. Tools and system instruction are absent by design — a
+ * worker inherits those from the orchestrator.
+ */
+export interface ResolvedSubagentPreset extends PresetConnection {
+  model: string;
+  thinking: string;
+  smallModelMode: boolean;
+}
+
 /**
  * The subagents integration seam: translate a preset into the `extraParams`
  * bag that `chatAdapter.buildConfig` consumes, resolving the
  * provider's key/baseUrl live from the encrypted per-provider store (a preset
- * only *names* the provider). A worker's cloned config is then built exactly
- * like the main chat's — `buildConfig(preset.model, preset.thinking,
- * enabledTools, chatHistory, presetToExtraParams(preset, …))`. model/thinking
- * are positional args to buildConfig, so they stay out of this bag by design.
+ * only *names* the provider). model/thinking are positional args to buildConfig,
+ * so they stay out of this bag by design.
  * @param preset - The preset a worker runs under
  * @param getProviderConnection - Reads the provider's stored key/baseUrl
- * @returns The extraParams object for buildConfig
+ * @returns The connection object for buildConfig's extraParams
  */
 export function presetToExtraParams(
   preset: ChatPreset,
   getProviderConnection: GetProviderConnection,
-): Record<string, unknown> {
+): PresetConnection {
   const { apiKey, baseUrl } = getProviderConnection(preset.provider);
 
   return {
     provider: preset.provider,
     apiKey,
     baseUrl,
+  };
+}
+
+/**
+ * Resolve the user's chosen "Default subagent" preset id into the full bundle a
+ * spawned worker runs under, or `undefined` to inherit the orchestrator config.
+ * Returns undefined for the inherit sentinel (null/empty) AND for a dangling id
+ * (a preset since deleted) so a stale setting degrades gracefully to inherit.
+ * @param presetId - The saved default-subagent preset id (null/empty = inherit)
+ * @param presets - The current preset list
+ * @param getProviderConnection - Reads the preset provider's key/baseUrl live
+ * @returns The resolved worker preset, or undefined to inherit
+ */
+export function resolveSubagentPreset(
+  presetId: string | null,
+  presets: ChatPreset[],
+  getProviderConnection: GetProviderConnection,
+): ResolvedSubagentPreset | undefined {
+  if (presetId == null || presetId === "") return undefined;
+
+  const preset = presets.find((p) => p.id === presetId);
+
+  if (preset == null) return undefined;
+
+  return {
+    ...presetToExtraParams(preset, getProviderConnection),
+    model: preset.model,
+    thinking: preset.thinking,
+    smallModelMode: preset.smallModelMode,
   };
 }

--- a/webui/src/hooks/settings/presets/preset-extra-params.ts
+++ b/webui/src/hooks/settings/presets/preset-extra-params.ts
@@ -20,14 +20,16 @@ export interface PresetConnection {
 
 /**
  * A "Default subagent" preset resolved to everything buildWorkerConfig needs:
- * the connection (provider + live key/baseUrl) plus the model/inference a
- * v2.0.1 preset swaps. Tools and system instruction are absent by design — a
- * worker inherits those from the orchestrator.
+ * the connection (provider + live key/baseUrl), the model/inference a preset
+ * swaps, and the preset's toolset when it saved one (absent = inherit the
+ * orchestrator's tools). The system instruction is absent by design — a worker
+ * always inherits it from the orchestrator.
  */
 export interface ResolvedSubagentPreset extends PresetConnection {
   model: string;
   thinking: string;
   smallModelMode: boolean;
+  enabledTools?: Record<string, boolean>;
 }
 
 /**
@@ -79,5 +81,8 @@ export function resolveSubagentPreset(
     model: preset.model,
     thinking: preset.thinking,
     smallModelMode: preset.smallModelMode,
+    // Only carry a toolset when the preset actually saved one; a legacy preset
+    // omits it, meaning the worker inherits the orchestrator's tools.
+    ...(preset.enabledTools ? { enabledTools: preset.enabledTools } : {}),
   };
 }

--- a/webui/src/hooks/settings/presets/tests/preset-extra-params.test.ts
+++ b/webui/src/hooks/settings/presets/tests/preset-extra-params.test.ts
@@ -4,25 +4,29 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, expect, it, vi } from "vitest";
-import { presetToExtraParams } from "#webui/hooks/settings/presets/preset-extra-params";
+import {
+  presetToExtraParams,
+  resolveSubagentPreset,
+} from "#webui/hooks/settings/presets/preset-extra-params";
 import { type ChatPreset } from "#webui/types/settings";
+
+const cheapWorker: ChatPreset = {
+  id: "1",
+  name: "Cheap worker",
+  provider: "ollama",
+  model: "llama3",
+  thinking: "Off",
+  smallModelMode: true,
+};
 
 describe("presetToExtraParams", () => {
   it("maps provider and resolves key+baseUrl live", () => {
-    const preset: ChatPreset = {
-      id: "1",
-      name: "Cheap worker",
-      provider: "ollama",
-      model: "llama3",
-      thinking: "Off",
-      smallModelMode: true,
-    };
     const getProviderConnection = vi.fn(() => ({
       apiKey: "resolved-key",
       baseUrl: "http://localhost:11434",
     }));
 
-    const params = presetToExtraParams(preset, getProviderConnection);
+    const params = presetToExtraParams(cheapWorker, getProviderConnection);
 
     expect(getProviderConnection).toHaveBeenCalledWith("ollama");
     // model/thinking are positional buildConfig args, not extraParams
@@ -31,5 +35,44 @@ describe("presetToExtraParams", () => {
       apiKey: "resolved-key",
       baseUrl: "http://localhost:11434",
     });
+  });
+});
+
+describe("resolveSubagentPreset", () => {
+  const getProviderConnection = vi.fn(() => ({
+    apiKey: "resolved-key",
+    baseUrl: "http://localhost:11434",
+  }));
+
+  it("returns the full worker bundle for a matching preset id", () => {
+    const resolved = resolveSubagentPreset(
+      "1",
+      [cheapWorker],
+      getProviderConnection,
+    );
+
+    expect(resolved).toStrictEqual({
+      provider: "ollama",
+      apiKey: "resolved-key",
+      baseUrl: "http://localhost:11434",
+      model: "llama3",
+      thinking: "Off",
+      smallModelMode: true,
+    });
+  });
+
+  it("returns undefined for the inherit sentinel (null / empty)", () => {
+    expect(
+      resolveSubagentPreset(null, [cheapWorker], getProviderConnection),
+    ).toBeUndefined();
+    expect(
+      resolveSubagentPreset("", [cheapWorker], getProviderConnection),
+    ).toBeUndefined();
+  });
+
+  it("degrades to inherit for a dangling id (preset since deleted)", () => {
+    expect(
+      resolveSubagentPreset("gone", [cheapWorker], getProviderConnection),
+    ).toBeUndefined();
   });
 });

--- a/webui/src/hooks/settings/presets/tests/preset-extra-params.test.ts
+++ b/webui/src/hooks/settings/presets/tests/preset-extra-params.test.ts
@@ -61,6 +61,34 @@ describe("resolveSubagentPreset", () => {
     });
   });
 
+  it("carries the preset's toolset when it saved one", () => {
+    const withTools: ChatPreset = {
+      ...cheapWorker,
+      enabledTools: { "ppal-create-clip": true, "ppal-delete": false },
+    };
+
+    const resolved = resolveSubagentPreset(
+      "1",
+      [withTools],
+      getProviderConnection,
+    );
+
+    expect(resolved?.enabledTools).toStrictEqual({
+      "ppal-create-clip": true,
+      "ppal-delete": false,
+    });
+  });
+
+  it("omits the toolset for a legacy preset that saved none", () => {
+    const resolved = resolveSubagentPreset(
+      "1",
+      [cheapWorker],
+      getProviderConnection,
+    );
+
+    expect(resolved).not.toHaveProperty("enabledTools");
+  });
+
   it("returns undefined for the inherit sentinel (null / empty)", () => {
     expect(
       resolveSubagentPreset(null, [cheapWorker], getProviderConnection),

--- a/webui/src/hooks/settings/settings-helpers.ts
+++ b/webui/src/hooks/settings/settings-helpers.ts
@@ -509,6 +509,33 @@ export function saveSmallModelMode(enabled: boolean): void {
   localStorage.setItem("producer_pal_small_model_mode", String(enabled));
 }
 
+const DEFAULT_SUBAGENT_PRESET_KEY = "producer_pal_default_subagent_preset";
+
+/**
+ * Loads the "Default subagent" preset id from localStorage — the preset a
+ * spawned subagent runs under. Null (missing/blank) means "inherit current
+ * settings", the shipped phase-1 behavior.
+ * @returns {string | null} The saved preset id, or null to inherit
+ */
+export function loadDefaultSubagentPresetId(): string | null {
+  // getItem already returns null when unset; saveDefaultSubagentPresetId never
+  // stores an empty string, and the resolver/selector treat "" as inherit too.
+  return localStorage.getItem(DEFAULT_SUBAGENT_PRESET_KEY);
+}
+
+/**
+ * Saves the "Default subagent" preset id to localStorage. Null clears it back
+ * to "inherit current settings".
+ * @param {string | null} presetId - The preset id, or null to inherit
+ */
+export function saveDefaultSubagentPresetId(presetId: string | null): void {
+  if (presetId) {
+    localStorage.setItem(DEFAULT_SUBAGENT_PRESET_KEY, presetId);
+  } else {
+    localStorage.removeItem(DEFAULT_SUBAGENT_PRESET_KEY);
+  }
+}
+
 /**
  * Type for setters that apply loaded settings to state
  * @returns {any} - Hook return value

--- a/webui/src/hooks/settings/tests/settings-helpers.test.ts
+++ b/webui/src/hooks/settings/tests/settings-helpers.test.ts
@@ -13,12 +13,14 @@ import {
   checkHasApiKey,
   loadAllProviderSettingsAsync,
   loadCurrentProvider,
+  loadDefaultSubagentPresetId,
   loadEnabledTools,
   loadProviderSettings,
   loadProviderSettingsAsync,
   loadVoiceLanguage,
   loadVoiceSpeed,
   loadVoiceVolume,
+  saveDefaultSubagentPresetId,
   saveProviderSettings,
   saveVoiceLanguage,
   saveVoiceSpeed,
@@ -264,6 +266,27 @@ describe("settings-helpers", () => {
       localStorage.setItem("producer_pal_enabled_tools", "not-json");
 
       expect(loadEnabledTools()).toStrictEqual({});
+    });
+  });
+
+  describe("default subagent preset persistence", () => {
+    it("returns null when nothing is stored (inherit)", () => {
+      expect(loadDefaultSubagentPresetId()).toBeNull();
+    });
+
+    it("round-trips a preset id through localStorage", () => {
+      saveDefaultSubagentPresetId("preset-abc");
+      expect(loadDefaultSubagentPresetId()).toBe("preset-abc");
+    });
+
+    it("clears the stored id when saving null (back to inherit)", () => {
+      saveDefaultSubagentPresetId("preset-abc");
+      saveDefaultSubagentPresetId(null);
+
+      expect(loadDefaultSubagentPresetId()).toBeNull();
+      expect(
+        localStorage.getItem("producer_pal_default_subagent_preset"),
+      ).toBeNull();
     });
   });
 

--- a/webui/src/hooks/settings/tests/use-has-unsaved-changes.test.ts
+++ b/webui/src/hooks/settings/tests/use-has-unsaved-changes.test.ts
@@ -164,6 +164,13 @@ describe("useHasUnsavedChanges", () => {
     expect(result.current).toBe(true);
   });
 
+  it("detects a default-subagent-preset change", () => {
+    const { result, update } = renderWithOpenModal(makeSettings());
+
+    update(makeSettings({ defaultSubagentPresetId: "cheap-worker" }));
+    expect(result.current).toBe(true);
+  });
+
   it("flags a notation change via its dirty flag (notation is not serialized)", () => {
     const { result, update } = renderWithOpenModal(makeSettings());
 

--- a/webui/src/hooks/settings/use-has-unsaved-changes.ts
+++ b/webui/src/hooks/settings/use-has-unsaved-changes.ts
@@ -32,6 +32,7 @@ function serialize(s: UseSettingsReturn, a: AppearanceSettings): string {
     thinking: s.thinking,
     enabledTools: s.enabledTools,
     smallModelMode: s.smallModelMode,
+    defaultSubagentPresetId: s.defaultSubagentPresetId,
     realtimeVoice: s.realtimeVoice,
     voiceSpeed: s.voiceSpeed,
     voiceVolume: s.voiceVolume,

--- a/webui/src/hooks/settings/use-settings.ts
+++ b/webui/src/hooks/settings/use-settings.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_SETTINGS,
   loadAllProviderSettingsAsync,
   loadCurrentProvider,
+  loadDefaultSubagentPresetId,
   loadEnabledTools,
   loadProviderSettings,
   loadSmallModelMode,
@@ -21,6 +22,7 @@ import {
   type ProviderSettingsApplier,
   type ProviderStateSetters,
   saveCurrentSettings,
+  saveDefaultSubagentPresetId,
   saveSmallModelMode,
 } from "./settings-helpers";
 import { useProviderSlices } from "./use-provider-connections";
@@ -94,6 +96,12 @@ export function useSettings(): UseSettingsReturn {
     useState<Record<string, boolean>>(loadEnabledTools);
   const [smallModelMode, setSmallModelModeState] =
     useState<boolean>(loadSmallModelMode);
+  // Which preset a spawned subagent runs under (null = inherit the orchestrator
+  // config). A modal-local buffer like smallModelMode: persisted on Save,
+  // reverted on Cancel.
+  const [defaultSubagentPresetId, setDefaultSubagentPresetId] = useState<
+    string | null
+  >(loadDefaultSubagentPresetId);
   // False until the post-mount async decrypt has applied the real apiKeys.
   // saveSettings gates on this — saving the placeholder blanks would wipe
   // every stored encrypted key.
@@ -198,6 +206,7 @@ export function useSettings(): UseSettingsReturn {
         enabledTools,
         providerSettings,
         smallModelMode,
+        defaultSubagentPresetId,
       );
     } catch (err) {
       console.error("Failed to save provider settings", err);
@@ -220,6 +229,7 @@ export function useSettings(): UseSettingsReturn {
     provider,
     enabledTools,
     smallModelMode,
+    defaultSubagentPresetId,
     voiceModeSettings,
     providerSettings,
   ]);
@@ -228,6 +238,7 @@ export function useSettings(): UseSettingsReturn {
     setProviderState(loadCurrentProvider());
     setEnabledToolsState(loadEnabledTools());
     setSmallModelModeState(loadSmallModelMode());
+    setDefaultSubagentPresetId(loadDefaultSubagentPresetId());
     voiceModeSettings.revert();
     // Re-decrypt and restore saved provider settings (async; the apiKey lands a
     // tick later, mirroring the post-mount load). Pass the same onLoaded as the
@@ -301,6 +312,8 @@ export function useSettings(): UseSettingsReturn {
     isToolEnabled,
     smallModelMode,
     setSmallModelMode: setSmallModelModeState,
+    defaultSubagentPresetId,
+    setDefaultSubagentPresetId,
     saveError,
     liveApiEnabled,
     liveApiEnabledDirty,
@@ -352,14 +365,17 @@ function warnIfNotLoaded(settingsLoaded: boolean): boolean {
  * @param {Record<string, boolean>} enabledTools - Tool enabled states
  * @param {AllProviderSettings} allSettings - Settings for every provider
  * @param {boolean} smallModelMode - Small-model-mode flag
+ * @param {string | null} defaultSubagentPresetId - Default subagent preset id (null = inherit)
  */
 async function persistAllSettings(
   provider: Provider,
   enabledTools: Record<string, boolean>,
   allSettings: AllProviderSettings,
   smallModelMode: boolean,
+  defaultSubagentPresetId: string | null,
 ): Promise<void> {
   saveSmallModelMode(smallModelMode);
+  saveDefaultSubagentPresetId(defaultSubagentPresetId);
   await saveCurrentSettings(provider, enabledTools, allSettings);
 }
 

--- a/webui/src/types/settings.ts
+++ b/webui/src/types/settings.ts
@@ -197,9 +197,11 @@ export interface UseSettingsReturn extends VoiceModeSettingsFields {
   isToolEnabled: (toolId: string) => boolean;
   smallModelMode: boolean;
   setSmallModelMode: (enabled: boolean) => void;
-  /** The preset a spawned subagent runs under (its model/inference; tools still
-   * inherit from the orchestrator). Null = "inherit current settings", the
-   * shipped phase-1 behavior. A modal-local buffer persisted on Save. */
+  /** The preset a spawned subagent runs under: its model/inference and, when the
+   * preset saved one, its toolset (a preset without one keeps the orchestrator's
+   * tools). The system instruction always inherits. Null = "inherit current
+   * settings", the shipped phase-1 behavior. A global preference (not locked per
+   * conversation) and a modal-local buffer persisted on Save. */
   defaultSubagentPresetId: string | null;
   setDefaultSubagentPresetId: (id: string | null) => void;
   // Mirrors server-side ProducerPalConfig.liveApiEnabled, kept in modal-local

--- a/webui/src/types/settings.ts
+++ b/webui/src/types/settings.ts
@@ -197,6 +197,11 @@ export interface UseSettingsReturn extends VoiceModeSettingsFields {
   isToolEnabled: (toolId: string) => boolean;
   smallModelMode: boolean;
   setSmallModelMode: (enabled: boolean) => void;
+  /** The preset a spawned subagent runs under (its model/inference; tools still
+   * inherit from the orchestrator). Null = "inherit current settings", the
+   * shipped phase-1 behavior. A modal-local buffer persisted on Save. */
+  defaultSubagentPresetId: string | null;
+  setDefaultSubagentPresetId: (id: string | null) => void;
   // Mirrors server-side ProducerPalConfig.liveApiEnabled, kept in modal-local
   // state. Source of truth is the server (which mirrors the device Setup-tab
   // toggle) — not localStorage. The dirty flag distinguishes "user toggled


### PR DESCRIPTION
## Summary

Adds a **Default subagent** selector on the Presets tab so the user chooses what a spawned subagent runs under:

- **Inherit current settings** (default) — the shipped phase-1 behavior; each worker clones the orchestrator's config.
- **A saved preset** — every worker runs on that preset's **model**, **thinking**, **small-model mode**, and **toolset**. This enables a strong planner driving uniform, cheaper workers.

A preset that saved a toolset **replaces** the worker's tools; a preset without one (and the inherit case) keeps the orchestrator's. The system instruction always inherits.

## How it's wired

- `ChatClientConfig` gains an optional `subagentConfig` override (built model + small-model mode + provider options + the preset's toolset). `buildWorkerConfig` layers it over the clone, still resetting history and capping steps.
- `resolveSubagentPreset` resolves the chosen preset id live from storage (so preset edits never go stale); the adapter turns it into the override at `buildConfig` time.
- **Failure-safe:** if a worker model can't be built (e.g. a `custom` provider missing its URL), it warns and falls back to inherit rather than breaking the orchestrator's own chat.
- `defaultSubagentPresetId` (null = inherit) persists alongside the other modal-buffered settings; a dangling id (deleted preset) degrades gracefully to inherit.

## No-nested-spawn guarantee

Because a preset toolset could otherwise re-enable spawning, this also locks the invariant:

- `buildWorkerConfig` strips `spawn_subagent` **last**, over whatever toolset wins — a worker can never spawn its own subagents regardless of what a preset enables.
- Regression tests cover both the clone path and a preset toolset that *tries* to turn spawning on.
- The constraint is surfaced in the tool description, the selector help text, and the docs.

## Testing

- `npm run check` — 10119 tests, 100% function coverage, lint/typecheck/format/duplication clean
- `npm run check:build`, `npm run ui:test` (14), `npm run docs:test` (51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
