### PR TITLE
docs(examples): add analyze-audio skill (render Live audio + Gemini analysis)

### DIFF
--- a/examples/skills/README.md
+++ b/examples/skills/README.md
@@ -35,6 +35,17 @@ drag. Those skills still let Producer Pal do the hard part (generate a correct
 file and optionally stage it as a draggable Session clip); only the final drop
 is manual.
 
+## Render and analyze
+
+| Skill                                 | Does                                                                                                                                                                                                                             |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **[`analyze-audio`](analyze-audio/)** | Render audio out of Live (export the Main mix / a track over a time range, or bounce a clip to a new track) and analyze the `.wav` with Google's Gemini API. **macOS only** (AppleScript UI automation); needs `GEMINI_API_KEY`. |
+
+Ableton exposes no Live API for rendering, so this one drives Live's
+menus/dialogs with AppleScript and then polls for the rendered file — a
+different shape from the generators above, which synthesize files directly in
+Node.
+
 ## Shared conventions
 
 - **Plain-Node DSP** — oscillators, envelopes, filters, and a hand-written WAV

--- a/examples/skills/analyze-audio/SKILL.md
+++ b/examples/skills/analyze-audio/SKILL.md
@@ -88,21 +88,28 @@ node analyze-audio.mjs "$WAV" --prompt "How's the arrangement and mix over these
 
 ## Prototype status
 
-This is a **first pass**. What's solid vs. what needs a live spike:
+This is a **first pass**, partly verified against a live Ableton Live 12 (macOS)
+via AX inspection and read-only ppal calls.
 
-- **Solid:** the reliability model (artifact polling), the macOS save panel
-  automation (`⌘⇧G` + filename + Save — a standard `NSSavePanel`), unique
-  filenames to dodge the overwrite sheet, and the Gemini upload/analyze paths.
-- **Needs a live spike (marked `VERIFY-FIRST` / `SPIKE` in the code):**
-  - Ableton's **custom Export dialog** internals — setting the Rendered Track
-    popup and the Render Start/Length fields is index-based and unverified.
-    Whether those fields inherit the Arrangement time selection (so they could
-    be pre-set via `ppal-live-api` instead of typed) is the key open question.
-    Until then, prefer the no-`--track`/`--start`/`--length` form and configure
-    the dialog once by hand.
-  - **Bounce mode:** whether `⌘B` renders offline or realtime for your device
-    chains, its exact clip-vs-track scope, and the `ppal-read-track` /
-    delete-track tool shapes used to find and clean up the new track.
+- **Verified:**
+  - Accessibility automation works; the Export dialog is reachable and its
+    controls were inspected.
+  - **Rendered Track** is the first pop-up button (the dialog's controls have no
+    accessible names, so it's addressed by index; a track is chosen by name from
+    its menu).
+  - Export is committed with **Return** (the default button — you can't click
+    "Export" by name).
+  - ppal shapes used by bounce mode: `regularTrackCount`, `ppal-read-track` →
+    `id` + `arrangementClips[]`, cleanup via `ppal-delete` (`ids` + `type`).
+- **Known limitation:** the **Render Start/Length** number boxes are NOT
+  accessible, so the range can't be set from the dialog. It comes from the
+  current **Arrangement selection/loop** — select the range in Live first.
+  (`--start`/`--length` only print a reminder.)
+- **Not yet run end-to-end (needs the machine free of other input):**
+  - The full export → save-panel → file poll, and the Gemini analyze path
+    against a real key.
+  - Bounce mode live (`⌘B` offline-vs-realtime, clip-vs-track scope, and the
+    exact `ppal-read-clip` key that carries the audio sample path).
 
 ## Gotchas
 

--- a/examples/skills/analyze-audio/SKILL.md
+++ b/examples/skills/analyze-audio/SKILL.md
@@ -1,124 +1,102 @@
 ---
 name: analyze-audio
 description:
-  Render audio out of Ableton Live (export the Main mix or a track over a time
-  range, or bounce a clip to a new audio track) and analyze it with Google's
-  Gemini API. Use when the user wants to hear/analyze how something sounds,
-  render a mixdown or stem, or get feedback on timbre, mix, or arrangement.
-  macOS only. Requires the producer-pal skill for the bounce mode.
+  Render audio out of Ableton Live (the whole mix or a single track) and analyze
+  it with Google's Gemini API. Use when the user wants to hear/analyze how
+  something sounds, render a mixdown or stem, or get feedback on timbre, mix, or
+  arrangement. macOS + Ableton Live 12 only.
 ---
 
 # Analyze Audio
 
 Get audio **out** of Ableton Live and hand it to an audio-capable LLM for
-feedback. Ableton exposes no Live API for rendering, so this skill drives Live's
-menus/dialogs with AppleScript (macOS accessibility automation), then analyzes
-the resulting `.wav` with Gemini.
+feedback. Ableton exposes no Live API for rendering, so `render.mjs` drives
+Live's Export dialog with AppleScript (macOS accessibility automation), then
+`analyze-audio.mjs` sends the result to Gemini.
 
 **Why a skill and not a Producer Pal tool?** Rendering needs UI automation and
 analysis needs an API key + network — neither fits the Max-for-Live runtime
 (`child_process` is banned there, and it has no secrets story). A coding-agent
 skill runs in an environment that has both.
 
+**Non-destructive.** Export never alters the Set. By default the render goes to
+a temp file that you delete after analysis; pass `--out <dir>` to keep it.
+
 ## Prerequisites
 
-- **macOS.** The render step is AppleScript GUI automation; there is no
-  cross-platform path yet.
-- **Accessibility permission** for whatever app runs the agent (Terminal, your
-  IDE, etc.): System Settings → Privacy & Security → Accessibility. Without it,
-  the keystrokes/clicks silently do nothing.
-- **Ableton Live 12** running and frontmost. `Bounce to New Track` is a Live 12
-  feature.
-- **`GEMINI_API_KEY`** in the environment (or pass `--api-key`). Model IDs move
-  — override with `--model` / `GEMINI_MODEL`.
+- **macOS** with **Accessibility permission** for whatever app runs the agent
+  (Terminal, your IDE, etc.): System Settings → Privacy & Security →
+  Accessibility. Without it the keystrokes silently do nothing.
+- **Ableton Live 12** running and **frontmost**, with the material you want in
+  the **Arrangement** (Export renders the arrangement timeline).
+- A **`GEMINI_KEY`** (or `GEMINI_API_KEY`) in the environment, or pass
+  `--api-key`. Model IDs move — override with `--model` / `GEMINI_MODEL`.
 - **Node.js 18+** (global `fetch`; no npm packages).
-- For **bounce mode only**: the **`producer-pal`** skill (this skill calls its
-  sibling `../producer-pal/ppal.mjs` to detect the new track).
+- English Live UI and default shortcuts are assumed.
 
-## How it works
+## Render — whole mix or one track
 
-The guiding principle is **poll for the completion artifact, never sleep** — an
-offline render takes an unknown amount of time, so we fire the UI action and
-then wait for the concrete result (the file on disk, or the new track).
-
-### Export mode — Main mix or a track, over a time range
+`render.mjs` focuses the Arrangement and Selects All (so the render range is the
+whole arrangement), opens **File ▸ Export Audio/Video** (⇧⌘R), sets **Rendered
+Track**, turns **Encode MP3** on and distracting options off, exports
+**offline** (faster than realtime), and saves into a fresh temp dir. It prints
+JSON.
 
 ```bash
-# Render with the Export dialog's current settings (most reliable):
-node render.mjs --mode export --out ~/renders
-
-# Also set the Rendered Track and time range (experimental — see status below):
-node render.mjs --mode export --track Main --start 1.1.1 --length 4.0.0 --out ~/renders
+node render.mjs                 # whole mix (Rendered Track = Main) → temp .mp3
+node render.mjs --track "Bass"  # one track by name → temp .mp3
+node render.mjs --out ~/renders # move the render into a chosen dir instead
 ```
 
-`render.mjs` opens File → Export Audio/Video (`⇧⌘R`), commits, drives the
-standard macOS save panel (`⌘⇧G` + a unique filename), then polls the filesystem
-until the `.wav` appears and its size is stable. It prints the absolute `.wav`
-path on stdout. `--track Main` renders the whole mix; a track name renders that
-track. Export renders **offline** (faster than realtime).
+Output on stdout:
 
-### Bounce mode — clip → new audio track
-
-```bash
-# Select the target clip in Live first (or have Producer Pal select it), then:
-node render.mjs --mode bounce            # leaves the new audio track in the Set
-node render.mjs --mode bounce --cleanup  # deletes the new track after reporting it
+```json
+{
+  "audio": "/…/ppal-Main-<stamp>.mp3",
+  "created": ["/…/ppal-Main-<stamp>.mp3", "/…/ppal-Main-<stamp>.wav"]
+}
 ```
 
-Fires Edit → Bounce to New Track (`⌘B`), polls Producer Pal until a new track
-appears, and reads that track's audio clip `file_path`. `--cleanup` removes the
-track afterward (for a pure analysis pass that shouldn't alter the Set).
+- `audio` — the `.mp3` to analyze.
+- `created` — **every** file the render produced. Live also honors its PCM
+  setting, so a `.wav`/`.aiff`/`.flac` twin usually appears next to the `.mp3`;
+  delete everything in `created` when you're done.
 
-### Analyze the rendered file
+To render a specific track you need its **name** (the Rendered Track value).
+Producer Pal's `ppal-read-live-set` / `ppal-read-track` will list track names.
+
+## Analyze the rendered file
 
 ```bash
-node analyze-audio.mjs ~/renders/ppal-export-Main-<stamp>.wav \
+node analyze-audio.mjs /…/ppal-Main-<stamp>.mp3 \
   --prompt "Describe the timbre and flag any mix problems."
 ```
 
-Small files are sent inline; larger renders go through Gemini's Files API.
-Output is the model's text analysis on stdout.
+MP3 is the default render format because it's a fraction of a WAV's size — this
+matters for upload speed and for staying under Gemini's 20 MB inline-data limit
+on full songs. It does **not** change token cost (Gemini prices audio by
+duration and downsamples internally, so MP3 and WAV cost the same and analyze
+the same). Files under ~14 MB are sent inline; larger go through the Files API.
 
-### End to end
+## End to end
 
 ```bash
-WAV=$(node render.mjs --mode export --track Main --start 1.1.1 --length 8.0.0 --out ~/renders)
-node analyze-audio.mjs "$WAV" --prompt "How's the arrangement and mix over these 8 bars?"
+OUT=$(node render.mjs --track "Bass")
+MP3=$(printf '%s' "$OUT" | node -e 'process.stdin.once("data",d=>console.log(JSON.parse(d).audio))')
+node analyze-audio.mjs "$MP3" --prompt "How does this bass part sound? Tone, groove, problems?"
+# cleanup: delete every file the render created
+printf '%s' "$OUT" | node -e 'const fs=require("fs");process.stdin.once("data",d=>JSON.parse(d).created.forEach(f=>fs.rmSync(f,{force:true})))'
 ```
-
-## Prototype status
-
-This is a **first pass**, partly verified against a live Ableton Live 12 (macOS)
-via AX inspection and read-only ppal calls.
-
-- **Verified:**
-  - Accessibility automation works; the Export dialog is reachable and its
-    controls were inspected.
-  - **Rendered Track** is the first pop-up button (the dialog's controls have no
-    accessible names, so it's addressed by index; a track is chosen by name from
-    its menu).
-  - Export is committed with **Return** (the default button — you can't click
-    "Export" by name).
-  - ppal shapes used by bounce mode: `regularTrackCount`, `ppal-read-track` →
-    `id` + `arrangementClips[]`, cleanup via `ppal-delete` (`ids` + `type`).
-- **Known limitation:** the **Render Start/Length** number boxes are NOT
-  accessible, so the range can't be set from the dialog. It comes from the
-  current **Arrangement selection/loop** — select the range in Live first.
-  (`--start`/`--length` only print a reminder.)
-- **Not yet run end-to-end (needs the machine free of other input):**
-  - The full export → save-panel → file poll, and the Gemini analyze path
-    against a real key.
-  - Bounce mode live (`⌘B` offline-vs-realtime, clip-vs-track scope, and the
-    exact `ppal-read-clip` key that carries the audio sample path).
 
 ## Gotchas
 
-- **Localization/shortcuts:** the AppleScript matches English UI text (`Export`,
-  `Save`) and the default `⇧⌘R` / `⌘B` shortcuts. Remapped shortcuts or a
-  non-English Live will need adjustment.
-- **Large renders:** a full Main-mix export can be tens of MB; those route
-  through the Files API automatically. Expect analysis to be **qualitative** —
-  Gemini describes character and flags obvious issues but is not a precise
-  tempo/key/onset detector.
-- **Keep Live frontmost** during a render; the keystrokes go to the frontmost
-  app.
+- **Keep Live frontmost** during a render — the keystrokes go to the frontmost
+  app. `render.mjs` re-activates Live, but don't click away mid-render.
+- **Localization/shortcuts:** the automation matches English Export-dialog
+  labels and the default ⇧⌘R / ⌥2 / ⌘A shortcuts. A remapped or non-English Live
+  needs adjustment.
+- **Qualitative, not measurement:** Gemini describes character and flags obvious
+  issues (imbalance, harshness, clipping) well, but is not a precise tempo/key/
+  onset detector — measure those with DSP if you need exact numbers.
+- **Rendered Track remembers its last value** across exports; `render.mjs`
+  always forces it, so an earlier manual choice won't leak into your render.

--- a/examples/skills/analyze-audio/SKILL.md
+++ b/examples/skills/analyze-audio/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: analyze-audio
+description:
+  Render audio out of Ableton Live (export the Main mix or a track over a time
+  range, or bounce a clip to a new audio track) and analyze it with Google's
+  Gemini API. Use when the user wants to hear/analyze how something sounds,
+  render a mixdown or stem, or get feedback on timbre, mix, or arrangement.
+  macOS only. Requires the producer-pal skill for the bounce mode.
+---
+
+# Analyze Audio
+
+Get audio **out** of Ableton Live and hand it to an audio-capable LLM for
+feedback. Ableton exposes no Live API for rendering, so this skill drives Live's
+menus/dialogs with AppleScript (macOS accessibility automation), then analyzes
+the resulting `.wav` with Gemini.
+
+**Why a skill and not a Producer Pal tool?** Rendering needs UI automation and
+analysis needs an API key + network — neither fits the Max-for-Live runtime
+(`child_process` is banned there, and it has no secrets story). A coding-agent
+skill runs in an environment that has both.
+
+## Prerequisites
+
+- **macOS.** The render step is AppleScript GUI automation; there is no
+  cross-platform path yet.
+- **Accessibility permission** for whatever app runs the agent (Terminal, your
+  IDE, etc.): System Settings → Privacy & Security → Accessibility. Without it,
+  the keystrokes/clicks silently do nothing.
+- **Ableton Live 12** running and frontmost. `Bounce to New Track` is a Live 12
+  feature.
+- **`GEMINI_API_KEY`** in the environment (or pass `--api-key`). Model IDs move
+  — override with `--model` / `GEMINI_MODEL`.
+- **Node.js 18+** (global `fetch`; no npm packages).
+- For **bounce mode only**: the **`producer-pal`** skill (this skill calls its
+  sibling `../producer-pal/ppal.mjs` to detect the new track).
+
+## How it works
+
+The guiding principle is **poll for the completion artifact, never sleep** — an
+offline render takes an unknown amount of time, so we fire the UI action and
+then wait for the concrete result (the file on disk, or the new track).
+
+### Export mode — Main mix or a track, over a time range
+
+```bash
+# Render with the Export dialog's current settings (most reliable):
+node render.mjs --mode export --out ~/renders
+
+# Also set the Rendered Track and time range (experimental — see status below):
+node render.mjs --mode export --track Main --start 1.1.1 --length 4.0.0 --out ~/renders
+```
+
+`render.mjs` opens File → Export Audio/Video (`⇧⌘R`), commits, drives the
+standard macOS save panel (`⌘⇧G` + a unique filename), then polls the filesystem
+until the `.wav` appears and its size is stable. It prints the absolute `.wav`
+path on stdout. `--track Main` renders the whole mix; a track name renders that
+track. Export renders **offline** (faster than realtime).
+
+### Bounce mode — clip → new audio track
+
+```bash
+# Select the target clip in Live first (or have Producer Pal select it), then:
+node render.mjs --mode bounce            # leaves the new audio track in the Set
+node render.mjs --mode bounce --cleanup  # deletes the new track after reporting it
+```
+
+Fires Edit → Bounce to New Track (`⌘B`), polls Producer Pal until a new track
+appears, and reads that track's audio clip `file_path`. `--cleanup` removes the
+track afterward (for a pure analysis pass that shouldn't alter the Set).
+
+### Analyze the rendered file
+
+```bash
+node analyze-audio.mjs ~/renders/ppal-export-Main-<stamp>.wav \
+  --prompt "Describe the timbre and flag any mix problems."
+```
+
+Small files are sent inline; larger renders go through Gemini's Files API.
+Output is the model's text analysis on stdout.
+
+### End to end
+
+```bash
+WAV=$(node render.mjs --mode export --track Main --start 1.1.1 --length 8.0.0 --out ~/renders)
+node analyze-audio.mjs "$WAV" --prompt "How's the arrangement and mix over these 8 bars?"
+```
+
+## Prototype status
+
+This is a **first pass**. What's solid vs. what needs a live spike:
+
+- **Solid:** the reliability model (artifact polling), the macOS save panel
+  automation (`⌘⇧G` + filename + Save — a standard `NSSavePanel`), unique
+  filenames to dodge the overwrite sheet, and the Gemini upload/analyze paths.
+- **Needs a live spike (marked `VERIFY-FIRST` / `SPIKE` in the code):**
+  - Ableton's **custom Export dialog** internals — setting the Rendered Track
+    popup and the Render Start/Length fields is index-based and unverified.
+    Whether those fields inherit the Arrangement time selection (so they could
+    be pre-set via `ppal-live-api` instead of typed) is the key open question.
+    Until then, prefer the no-`--track`/`--start`/`--length` form and configure
+    the dialog once by hand.
+  - **Bounce mode:** whether `⌘B` renders offline or realtime for your device
+    chains, its exact clip-vs-track scope, and the `ppal-read-track` /
+    delete-track tool shapes used to find and clean up the new track.
+
+## Gotchas
+
+- **Localization/shortcuts:** the AppleScript matches English UI text (`Export`,
+  `Save`) and the default `⇧⌘R` / `⌘B` shortcuts. Remapped shortcuts or a
+  non-English Live will need adjustment.
+- **Large renders:** a full Main-mix export can be tens of MB; those route
+  through the Files API automatically. Expect analysis to be **qualitative** —
+  Gemini describes character and flags obvious issues but is not a precise
+  tempo/key/onset detector.
+- **Keep Live frontmost** during a render; the keystrokes go to the frontmost
+  app.

--- a/examples/skills/analyze-audio/analyze-audio.mjs
+++ b/examples/skills/analyze-audio/analyze-audio.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+// analyze-audio.mjs — send a rendered .wav to Google's Gemini API and print the
+// model's analysis. Zero dependencies (Node 18+ global fetch).
+//
+// Auth: set GEMINI_API_KEY in the environment (or pass --api-key). This is the
+// whole reason audio analysis lives in a coding-agent skill instead of the
+// Producer Pal device — the Max-for-Live runtime has no clean secrets story.
+//
+// Small files are sent inline; larger ones go through the Files API (upload,
+// wait for ACTIVE, then reference). NOTE: model IDs and request limits move —
+// override the model with --model / GEMINI_MODEL and check Google's docs.
+//
+// Usage:
+//   node analyze-audio.mjs render.wav
+//   node analyze-audio.mjs render.wav --prompt "Describe the timbre and any mix issues."
+//   GEMINI_MODEL=gemini-2.5-pro node analyze-audio.mjs render.wav
+//
+// Expectations: Gemini gives strong QUALITATIVE description (timbre, character,
+// obvious problems, transcription). It is not a precise MIR tool — don't trust
+// it for exact tempo/key/onset numbers; measure those with DSP if you need them.
+
+import { readFile, stat } from "node:fs/promises";
+import { basename } from "node:path";
+
+const API_ROOT = "https://generativelanguage.googleapis.com";
+const INLINE_MAX_BYTES = 12 * 1024 * 1024; // above this, use the Files API
+const DEFAULT_MODEL = "gemini-2.5-flash";
+const DEFAULT_PROMPT =
+  "You are an audio engineer. Analyze this rendered audio: describe the " +
+  "instrumentation and timbre, the overall character and mood, and flag any " +
+  "obvious problems (clipping, noise, imbalance). Keep it concise.";
+
+// Options that consume the following argument; everything else is positional.
+const VALUE_OPTS = new Set(["--prompt", "-p", "--model", "--api-key"]);
+
+/**
+ * Split argv into positionals and a value map, honoring value-taking options.
+ * @param {string[]} argv - Arguments after the node script name.
+ * @returns {{positionals: string[], opts: Record<string, string>}} Parsed args.
+ */
+function parseArgs(argv) {
+  const positionals = [];
+  const opts = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (VALUE_OPTS.has(arg)) opts[arg] = argv[++i];
+    else if (arg.startsWith("--"))
+      opts[arg] = "true"; // bare boolean flag
+    else positionals.push(arg);
+  }
+  return { positionals, opts };
+}
+
+async function main() {
+  const { positionals, opts } = parseArgs(process.argv.slice(2));
+  const file = positionals[0];
+  if (!file)
+    throw new Error(
+      "Usage: node analyze-audio.mjs <file.wav> [--prompt <text>]",
+    );
+
+  const apiKey = opts["--api-key"] ?? process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "Missing GEMINI_API_KEY (set the env var or pass --api-key).",
+    );
+  }
+  const model = opts["--model"] ?? process.env.GEMINI_MODEL ?? DEFAULT_MODEL;
+  const prompt = opts["--prompt"] ?? opts["-p"] ?? DEFAULT_PROMPT;
+  const mimeType = "audio/wav";
+
+  const { size } = await stat(file);
+  process.stderr.write(
+    `Analyzing ${basename(file)} (${(size / 1e6).toFixed(1)} MB) with ${model}…\n`,
+  );
+
+  const audioPart =
+    size <= INLINE_MAX_BYTES
+      ? await inlinePart(file, mimeType)
+      : await filesApiPart(file, mimeType, apiKey);
+
+  const text = await generate({ apiKey, model, prompt, audioPart });
+  process.stdout.write(text + "\n");
+}
+
+/**
+ * Build an inline_data part (base64) for a small audio file.
+ * @param {string} file - Path to the audio file.
+ * @param {string} mimeType - Audio MIME type.
+ * @returns {Promise<object>} A generateContent part.
+ */
+async function inlinePart(file, mimeType) {
+  const bytes = await readFile(file);
+  const data = bytes.toString("base64");
+  return { inline_data: { mime_type: mimeType, data } };
+}
+
+/**
+ * Upload a large file via the Files API and return a file_data part once it is
+ * ACTIVE (audio must finish server-side processing before generateContent).
+ * @param {string} file - Path to the audio file.
+ * @param {string} mimeType - Audio MIME type.
+ * @param {string} apiKey - Gemini API key.
+ * @returns {Promise<object>} A generateContent part referencing the uploaded file.
+ */
+async function filesApiPart(file, mimeType, apiKey) {
+  const bytes = await readFile(file);
+  process.stderr.write(`Uploading via Files API…\n`);
+
+  const startRes = await fetch(
+    `${API_ROOT}/upload/v1beta/files?key=${apiKey}`,
+    {
+      method: "POST",
+      headers: {
+        "X-Goog-Upload-Protocol": "resumable",
+        "X-Goog-Upload-Command": "start",
+        "X-Goog-Upload-Header-Content-Length": String(bytes.length),
+        "X-Goog-Upload-Header-Content-Type": mimeType,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ file: { display_name: basename(file) } }),
+    },
+  );
+  if (!startRes.ok)
+    throw new Error(`Files API start failed: ${await startRes.text()}`);
+  const uploadUrl = startRes.headers.get("x-goog-upload-url");
+  if (!uploadUrl) throw new Error("Files API did not return an upload URL");
+
+  const upRes = await fetch(uploadUrl, {
+    method: "POST",
+    headers: {
+      "X-Goog-Upload-Offset": "0",
+      "X-Goog-Upload-Command": "upload, finalize",
+      "Content-Length": String(bytes.length),
+    },
+    body: bytes,
+  });
+  if (!upRes.ok)
+    throw new Error(`Files API upload failed: ${await upRes.text()}`);
+  const uploaded = await upRes.json();
+  let fileInfo = uploaded.file;
+
+  // Poll until the uploaded audio is ACTIVE.
+  const deadline = Date.now() + 120_000;
+  while (fileInfo.state === "PROCESSING" && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 1500));
+    const poll = await fetch(
+      `${API_ROOT}/v1beta/${fileInfo.name}?key=${apiKey}`,
+    );
+    if (!poll.ok)
+      throw new Error(`Files API poll failed: ${await poll.text()}`);
+    fileInfo = await poll.json();
+  }
+  if (fileInfo.state !== "ACTIVE") {
+    throw new Error(`Uploaded file not ACTIVE (state: ${fileInfo.state})`);
+  }
+  return { file_data: { mime_type: mimeType, file_uri: fileInfo.uri } };
+}
+
+/**
+ * Call generateContent with the prompt + audio part and return the text output.
+ * @param {object} o - Options.
+ * @param {string} o.apiKey - Gemini API key.
+ * @param {string} o.model - Model id.
+ * @param {string} o.prompt - Text prompt.
+ * @param {object} o.audioPart - inline_data or file_data part.
+ * @returns {Promise<string>} The concatenated text of the first candidate.
+ */
+async function generate({ apiKey, model, prompt, audioPart }) {
+  const res = await fetch(
+    `${API_ROOT}/v1beta/models/${model}:generateContent?key=${apiKey}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }, audioPart] }],
+      }),
+    },
+  );
+  if (!res.ok) throw new Error(`generateContent failed: ${await res.text()}`);
+  const data = await res.json();
+  const parts = data.candidates?.[0]?.content?.parts ?? [];
+  const text = parts
+    .map((p) => p.text ?? "")
+    .join("")
+    .trim();
+  if (!text) throw new Error(`No text in response: ${JSON.stringify(data)}`);
+  return text;
+}
+
+try {
+  await main();
+} catch (err) {
+  process.stderr.write(`Error: ${err.message ?? err}\n`);
+  process.exit(1);
+}

--- a/examples/skills/analyze-audio/analyze-audio.mjs
+++ b/examples/skills/analyze-audio/analyze-audio.mjs
@@ -21,10 +21,23 @@
 // it for exact tempo/key/onset numbers; measure those with DSP if you need them.
 
 import { readFile, stat } from "node:fs/promises";
-import { basename } from "node:path";
+import { basename, extname } from "node:path";
 
 const API_ROOT = "https://generativelanguage.googleapis.com";
-const INLINE_MAX_BYTES = 12 * 1024 * 1024; // above this, use the Files API
+// Gemini caps a request's inline data at 20 MB and base64 inflates bytes by ~4/3,
+// so keep the raw file under ~14 MB inline; larger goes through the Files API.
+const INLINE_MAX_BYTES = 14 * 1024 * 1024;
+// Gemini audio MIME types, keyed by file extension (all accepted natively).
+const AUDIO_MIME = {
+  ".mp3": "audio/mp3",
+  ".wav": "audio/wav",
+  ".flac": "audio/flac",
+  ".aiff": "audio/aiff",
+  ".aif": "audio/aiff",
+  ".aac": "audio/aac",
+  ".ogg": "audio/ogg",
+  ".m4a": "audio/mp4",
+};
 const DEFAULT_MODEL = "gemini-2.5-flash";
 const DEFAULT_PROMPT =
   "You are an audio engineer. Analyze this rendered audio: describe the " +
@@ -60,15 +73,16 @@ async function main() {
       "Usage: node analyze-audio.mjs <file.wav> [--prompt <text>]",
     );
 
-  const apiKey = opts["--api-key"] ?? process.env.GEMINI_API_KEY;
+  const apiKey =
+    opts["--api-key"] ?? process.env.GEMINI_API_KEY ?? process.env.GEMINI_KEY;
   if (!apiKey) {
     throw new Error(
-      "Missing GEMINI_API_KEY (set the env var or pass --api-key).",
+      "Missing API key (set GEMINI_API_KEY or GEMINI_KEY, or pass --api-key).",
     );
   }
   const model = opts["--model"] ?? process.env.GEMINI_MODEL ?? DEFAULT_MODEL;
   const prompt = opts["--prompt"] ?? opts["-p"] ?? DEFAULT_PROMPT;
-  const mimeType = "audio/wav";
+  const mimeType = AUDIO_MIME[extname(file).toLowerCase()] ?? "audio/wav";
 
   const { size } = await stat(file);
   process.stderr.write(

--- a/examples/skills/analyze-audio/render.mjs
+++ b/examples/skills/analyze-audio/render.mjs
@@ -65,14 +65,24 @@ async function main() {
  * Render the Main mix or a single track to a .wav via File ▸ Export Audio/Video.
  * @param {object} o - Options.
  * @param {string} [o.track] - Rendered Track value (e.g. "Main" or a track name).
- * @param {string} [o.start] - Render Start as bar.beat.sixteenth.
- * @param {string} [o.length] - Render Length as bar.beat.sixteenth.
+ * @param {string} [o.start] - Render Start (advisory — see note in body).
+ * @param {string} [o.length] - Render Length (advisory — see note in body).
  * @param {string} o.outDir - Directory to write the .wav into.
  * @param {string} [o.filename] - Explicit output filename; defaults to a unique name.
  * @returns {Promise<string>} Absolute path of the rendered .wav.
  */
 async function exportAudio({ track, start, length, outDir, filename }) {
   mkdirSync(outDir, { recursive: true });
+  if (start || length) {
+    // Verified via AX inspection: the Render Start/Length number boxes are NOT
+    // exposed as accessible controls, so they can't be set from here. The render
+    // range is whatever is currently selected/looped in the Arrangement.
+    process.stderr.write(
+      "Note: --start/--length can't be set through the Export dialog (its number " +
+        "boxes aren't accessible). Select the range in Live's Arrangement first; " +
+        "rendering uses the current selection/loop.\n",
+    );
+  }
   const name = filename ?? `ppal-export-${slug(track ?? "mix")}-${stamp()}.wav`;
   const outFile = resolve(outDir, name);
   if (existsSync(outFile)) {
@@ -82,7 +92,7 @@ async function exportAudio({ track, start, length, outDir, filename }) {
   }
 
   process.stderr.write(`Opening Export dialog…\n`);
-  await runAppleScript(buildExportScript({ track, start, length, outFile }));
+  await runAppleScript(buildExportScript({ track, outFile }));
 
   process.stderr.write(`Rendering (polling for ${name})…\n`);
   await pollForStableFile(outFile);
@@ -92,41 +102,31 @@ async function exportAudio({ track, start, length, outDir, filename }) {
 /**
  * Build the AppleScript that drives the Export dialog and the macOS save panel.
  *
- * VERIFY-FIRST (needs a live spike to confirm element identities): setting the
- * Rendered Track popup and the Render Start/Length fields targets Ableton's
- * CUSTOM dialog by index — the fragile part. Everything from the Export button
- * onward drives the STANDARD macOS save panel (⌘⇧G + filename + Save), which is
- * well-understood and localization-tolerant. Omit --track/--start/--length to
- * skip the custom-field block entirely and render with the dialog's current
- * settings (the reliable core path).
+ * Grounded in an AX inspection of Live 12's dialog: its controls have NO
+ * accessible names, so we address the Rendered Track pop-up by index (it's the
+ * first pop-up button) and commit with Return (the default button) rather than
+ * clicking "Export" by name. The Render Start/Length boxes aren't accessible at
+ * all — range comes from the Arrangement selection (see exportAudio). From the
+ * save panel on it's the STANDARD macOS panel (⌘⇧G + filename + Save).
  * @param {object} o - Options.
- * @param {string} [o.track] - Rendered Track value.
- * @param {string} [o.start] - Render Start (bar.beat.sixteenth).
- * @param {string} [o.length] - Render Length (bar.beat.sixteenth).
+ * @param {string} [o.track] - Rendered Track value (e.g. "Main" or a track name).
  * @param {string} o.outFile - Absolute output path.
  * @returns {string} The AppleScript source.
  */
-function buildExportScript({ track, start, length, outFile }) {
+function buildExportScript({ track, outFile }) {
   const dir = dirname(outFile);
   const base = basename(outFile);
 
-  // Optional: set the custom dialog fields (index-based → SPIKE-VERIFY).
+  // Rendered Track is the first pop-up button (controls are unnamed → by index).
   const setTrack = track
     ? `
       try
         click pop up button 1 of exportWin
         delay 0.2
         click menu item ${as(track)} of menu 1 of pop up button 1 of exportWin
+        delay 0.2
       end try`
     : "";
-  const setRange =
-    start || length
-      ? `
-      try
-        ${start ? `set value of text field 1 of exportWin to ${as(start)}` : ""}
-        ${length ? `set value of text field 2 of exportWin to ${as(length)}` : ""}
-      end try`
-      : "";
 
   return `
     tell application "System Events"
@@ -135,12 +135,12 @@ function buildExportScript({ track, start, length, outFile }) {
         delay 0.3
         keystroke "r" using {command down, shift down}
 
-        -- Wait for the Export dialog (title contains "Export").
+        -- Wait for the Export dialog (window titled "Export…", subrole AXDialog).
         set exportWin to missing value
         repeat 40 times
           repeat with w in windows
             if name of w contains "Export" then
-              set exportWin to w
+              set exportWin to contents of w
               exit repeat
             end if
           end repeat
@@ -148,17 +148,18 @@ function buildExportScript({ track, start, length, outFile }) {
           delay 0.25
         end repeat
         if exportWin is missing value then error "Export dialog did not appear"
-        ${setTrack}${setRange}
+        ${setTrack}
 
-        -- Commit → opens the standard macOS save panel.
-        click button "Export" of exportWin
+        -- Commit via the default button (Export). The dialog's buttons have no
+        -- accessible names, so we press Return instead of clicking by name.
+        keystroke return
 
-        -- Wait for the save panel (a window/sheet exposing a "Save" button).
+        -- Wait for the standard macOS save panel (exposes a named "Save" button).
         set savePanel to missing value
         repeat 40 times
           repeat with w in windows
             if exists (button "Save" of w) then
-              set savePanel to w
+              set savePanel to contents of w
               exit repeat
             end if
           end repeat
@@ -172,13 +173,17 @@ function buildExportScript({ track, start, length, outFile }) {
         delay 0.2
         -- Go to folder: ⌘⇧G, type the absolute directory, confirm.
         keystroke "g" using {command down, shift down}
-        delay 0.4
+        delay 0.5
         keystroke ${as(dir)}
-        delay 0.2
+        delay 0.3
         keystroke return
-        delay 0.4
-        -- Save.
-        click button "Save" of savePanel
+        delay 0.5
+        -- Save (named button on the standard panel; Return as a fallback).
+        try
+          click button "Save" of savePanel
+        on error
+          keystroke return
+        end try
       end tell
     end tell
     return "ok"
@@ -232,52 +237,75 @@ async function bounceClip({ cleanup }) {
     throw new Error("No new track appeared after ⌘B (timed out)");
 
   const newIndex = after - 1; // Bounce to New Track appends the audio track.
-  const filePath = await newTrackAudioFile(callTool, newIndex);
-  process.stderr.write(`New audio track at index ${newIndex}.\n`);
+  const track = await readTrack(callTool, newIndex);
+  const filePath = await clipFilePath(callTool, track);
+  process.stderr.write(
+    `New audio track "${track?.name}" at index ${newIndex} (id ${track?.id}).\n`,
+  );
 
-  if (cleanup) {
-    process.stderr.write(`Cleaning up track ${newIndex}…\n`);
-    // TODO(spike): confirm the delete-track tool name/args against a live device.
-    await callTool("ppal-delete-track", { trackIndex: newIndex }).catch((e) =>
-      process.stderr.write(`Cleanup skipped: ${e.message}\n`),
-    );
+  if (cleanup && track?.id != null) {
+    process.stderr.write(`Cleaning up track id ${track.id}…\n`);
+    await callTool("ppal-delete", {
+      ids: String(track.id),
+      type: "track",
+    }).catch((e) => process.stderr.write(`Cleanup skipped: ${e.message}\n`));
   }
 
   return (
     filePath ??
-    `<unresolved: read file_path of the audio clip on track index ${newIndex}>`
+    `<unresolved: read the sample file path of a clip on track index ${newIndex}>`
   );
 }
 
 /**
- * Count tracks in the current Live Set via ppal-read-live-set.
+ * Count regular (audio/MIDI) tracks in the current Live Set.
  * @param {Function} callTool - The ppal callTool function.
- * @returns {Promise<number>} Number of tracks.
+ * @returns {Promise<number>} The regular track count.
  */
 async function trackCount(callTool) {
   const { result } = await callTool("ppal-read-live-set");
-  const tracks = result?.tracks ?? [];
-  return Array.isArray(tracks) ? tracks.length : 0;
+  return result?.regularTrackCount ?? 0;
 }
 
 /**
- * Read the audio file backing the first clip on a freshly bounced track.
+ * Read a track (with its arrangement clips) by index.
  * @param {Function} callTool - The ppal callTool function.
- * @param {number} trackIndex - Index of the new audio track.
- * @returns {Promise<string|null>} The clip's file_path, or null if not resolvable.
+ * @param {number} trackIndex - 0-based track index.
+ * @returns {Promise<object|null>} The track object, or null.
  */
-async function newTrackAudioFile(callTool, trackIndex) {
+async function readTrack(callTool, trackIndex) {
+  const { result } = await callTool("ppal-read-track", {
+    trackIndex,
+    include: ["arrangement-clips"],
+  });
+  return result ?? null;
+}
+
+/**
+ * Resolve the audio file backing a track's first arrangement clip.
+ * @param {Function} callTool - The ppal callTool function.
+ * @param {object|null} track - A track object from readTrack().
+ * @returns {Promise<string|null>} The clip's sample file path, or null.
+ */
+async function clipFilePath(callTool, track) {
+  const clip = track?.arrangementClips?.[0];
+  if (clip?.id == null) return null;
   try {
-    const { result } = await callTool("ppal-read-track", { trackIndex });
-    const clips = result?.clips ?? result?.arrangementClips ?? [];
-    for (const clip of clips) {
-      if (clip?.filePath) return clip.filePath;
-      if (clip?.file_path) return clip.file_path;
-    }
+    const { result } = await callTool("ppal-read-clip", {
+      clipId: String(clip.id),
+      include: ["sample"],
+    });
+    // The audio path may surface under a few keys depending on ppal version.
+    return (
+      result?.filePath ??
+      result?.file_path ??
+      result?.sample?.filePath ??
+      result?.sample?.path ??
+      null
+    );
   } catch {
-    // fall through — caller reports an unresolved-path note
+    return null;
   }
-  return null;
 }
 
 // --- shared helpers ----------------------------------------------------------

--- a/examples/skills/analyze-audio/render.mjs
+++ b/examples/skills/analyze-audio/render.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+
+// render.mjs — get audio OUT of Ableton Live so it can be analyzed.
+//
+// Two modes (both drive Live's menus/dialogs via AppleScript — macOS only):
+//   export  File ▸ Export Audio/Video (⇧⌘R): render the Main mix or one track
+//           over a time range to a .wav you name. Offline (faster-than-realtime).
+//   bounce  Edit ▸ Bounce to New Track (⌘B): bounce the selected clip to a new
+//           audio track that stays in the Set (optionally deleted after).
+//
+// RELIABILITY PRINCIPLE — never sleep-and-hope. We fire the UI, then POLL for the
+// completion ARTIFACT: the .wav appearing+stabilizing on disk (export), or a new
+// track appearing via Producer Pal (bounce). This is what makes an offline render
+// of unknown duration safe to wait on.
+//
+// PREREQUISITE: the app running this (Terminal / your agent host) needs
+// Accessibility permission — System Settings ▸ Privacy & Security ▸ Accessibility.
+//
+// Usage:
+//   node render.mjs --mode export --out ~/renders                       # current dialog settings
+//   node render.mjs --mode export --track Main --start 1.1.1 --length 4.0.0 --out ~/renders
+//   node render.mjs --mode bounce [--cleanup]                           # bounce the selected clip
+//
+// Prints the absolute .wav path on stdout. Status/progress → stderr.
+
+import { execFile } from "node:child_process";
+import { existsSync, mkdirSync, statSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const PROCESS = "Live"; // System Events process name for Ableton Live
+
+// --- CLI ---------------------------------------------------------------------
+
+const argv = process.argv.slice(2);
+const opt = (name, def) => {
+  const i = argv.indexOf(name);
+  return i >= 0 ? argv[i + 1] : def;
+};
+const flag = (name) => argv.includes(name);
+
+async function main() {
+  const mode = opt("--mode", "export");
+  if (mode === "export") {
+    const out = await exportAudio({
+      track: opt("--track"), // e.g. "Main" or a track name; omit to keep dialog's setting
+      start: opt("--start"), // bar.beat.sixteenth, e.g. "1.1.1"; omit to keep setting
+      length: opt("--length"), // bar.beat.sixteenth, e.g. "4.0.0"; omit to keep setting
+      outDir: resolve(opt("--out", "./renders")),
+      filename: opt("--name"), // optional explicit filename; default is unique
+    });
+    process.stdout.write(out + "\n");
+  } else if (mode === "bounce") {
+    const out = await bounceClip({ cleanup: flag("--cleanup") });
+    process.stdout.write(out + "\n");
+  } else {
+    throw new Error(`Unknown --mode ${mode} (expected "export" or "bounce")`);
+  }
+}
+
+// --- Export Audio/Video ------------------------------------------------------
+
+/**
+ * Render the Main mix or a single track to a .wav via File ▸ Export Audio/Video.
+ * @param {object} o - Options.
+ * @param {string} [o.track] - Rendered Track value (e.g. "Main" or a track name).
+ * @param {string} [o.start] - Render Start as bar.beat.sixteenth.
+ * @param {string} [o.length] - Render Length as bar.beat.sixteenth.
+ * @param {string} o.outDir - Directory to write the .wav into.
+ * @param {string} [o.filename] - Explicit output filename; defaults to a unique name.
+ * @returns {Promise<string>} Absolute path of the rendered .wav.
+ */
+async function exportAudio({ track, start, length, outDir, filename }) {
+  mkdirSync(outDir, { recursive: true });
+  const name = filename ?? `ppal-export-${slug(track ?? "mix")}-${stamp()}.wav`;
+  const outFile = resolve(outDir, name);
+  if (existsSync(outFile)) {
+    // A unique name normally avoids the macOS "Replace?" sheet; bail rather than
+    // risk a modal we don't drive.
+    throw new Error(`Output already exists, refusing to overwrite: ${outFile}`);
+  }
+
+  process.stderr.write(`Opening Export dialog…\n`);
+  await runAppleScript(buildExportScript({ track, start, length, outFile }));
+
+  process.stderr.write(`Rendering (polling for ${name})…\n`);
+  await pollForStableFile(outFile);
+  return outFile;
+}
+
+/**
+ * Build the AppleScript that drives the Export dialog and the macOS save panel.
+ *
+ * VERIFY-FIRST (needs a live spike to confirm element identities): setting the
+ * Rendered Track popup and the Render Start/Length fields targets Ableton's
+ * CUSTOM dialog by index — the fragile part. Everything from the Export button
+ * onward drives the STANDARD macOS save panel (⌘⇧G + filename + Save), which is
+ * well-understood and localization-tolerant. Omit --track/--start/--length to
+ * skip the custom-field block entirely and render with the dialog's current
+ * settings (the reliable core path).
+ * @param {object} o - Options.
+ * @param {string} [o.track] - Rendered Track value.
+ * @param {string} [o.start] - Render Start (bar.beat.sixteenth).
+ * @param {string} [o.length] - Render Length (bar.beat.sixteenth).
+ * @param {string} o.outFile - Absolute output path.
+ * @returns {string} The AppleScript source.
+ */
+function buildExportScript({ track, start, length, outFile }) {
+  const dir = dirname(outFile);
+  const base = basename(outFile);
+
+  // Optional: set the custom dialog fields (index-based → SPIKE-VERIFY).
+  const setTrack = track
+    ? `
+      try
+        click pop up button 1 of exportWin
+        delay 0.2
+        click menu item ${as(track)} of menu 1 of pop up button 1 of exportWin
+      end try`
+    : "";
+  const setRange =
+    start || length
+      ? `
+      try
+        ${start ? `set value of text field 1 of exportWin to ${as(start)}` : ""}
+        ${length ? `set value of text field 2 of exportWin to ${as(length)}` : ""}
+      end try`
+      : "";
+
+  return `
+    tell application "System Events"
+      tell process "${PROCESS}"
+        set frontmost to true
+        delay 0.3
+        keystroke "r" using {command down, shift down}
+
+        -- Wait for the Export dialog (title contains "Export").
+        set exportWin to missing value
+        repeat 40 times
+          repeat with w in windows
+            if name of w contains "Export" then
+              set exportWin to w
+              exit repeat
+            end if
+          end repeat
+          if exportWin is not missing value then exit repeat
+          delay 0.25
+        end repeat
+        if exportWin is missing value then error "Export dialog did not appear"
+        ${setTrack}${setRange}
+
+        -- Commit → opens the standard macOS save panel.
+        click button "Export" of exportWin
+
+        -- Wait for the save panel (a window/sheet exposing a "Save" button).
+        set savePanel to missing value
+        repeat 40 times
+          repeat with w in windows
+            if exists (button "Save" of w) then
+              set savePanel to w
+              exit repeat
+            end if
+          end repeat
+          if savePanel is not missing value then exit repeat
+          delay 0.25
+        end repeat
+        if savePanel is missing value then error "Save panel did not appear"
+
+        -- The Save As field is focused with the default name selected: type ours.
+        keystroke ${as(base)}
+        delay 0.2
+        -- Go to folder: ⌘⇧G, type the absolute directory, confirm.
+        keystroke "g" using {command down, shift down}
+        delay 0.4
+        keystroke ${as(dir)}
+        delay 0.2
+        keystroke return
+        delay 0.4
+        -- Save.
+        click button "Save" of savePanel
+      end tell
+    end tell
+    return "ok"
+  `;
+}
+
+// --- Bounce to New Track -----------------------------------------------------
+
+/**
+ * Bounce the currently selected clip to a new audio track via Edit ▸ Bounce to
+ * New Track (⌘B), poll Producer Pal for the new track, and report its audio
+ * file. Requires Ableton Live running with the Producer Pal device and the
+ * TARGET CLIP already selected in Live (e.g. you just created/selected it).
+ *
+ * VERIFY-FIRST: bounce render mode (offline vs realtime) and the exact clip vs
+ * track vs time-selection scope of ⌘B want a live spike; the poll-for-new-track
+ * completion signal below is robust regardless of duration.
+ * @param {object} o - Options.
+ * @param {boolean} o.cleanup - Delete the created audio track after reporting it.
+ * @returns {Promise<string>} The bounced audio clip's file_path (or a note if unresolved).
+ */
+async function bounceClip({ cleanup }) {
+  const { callTool } = await import(
+    new URL("../producer-pal/ppal.mjs", import.meta.url)
+  );
+
+  const before = await trackCount(callTool);
+  process.stderr.write(
+    `Bouncing selected clip (⌘B); ${before} tracks before…\n`,
+  );
+  await runAppleScript(`
+    tell application "System Events"
+      tell process "${PROCESS}"
+        set frontmost to true
+        delay 0.3
+        keystroke "b" using {command down}
+      end tell
+    end tell
+    return "ok"
+  `);
+
+  // Poll for the new track (offline or realtime — duration-agnostic).
+  const deadline = Date.now() + 120_000;
+  let after = before;
+  while (Date.now() < deadline) {
+    after = await trackCount(callTool);
+    if (after > before) break;
+    await sleep(500);
+  }
+  if (after <= before)
+    throw new Error("No new track appeared after ⌘B (timed out)");
+
+  const newIndex = after - 1; // Bounce to New Track appends the audio track.
+  const filePath = await newTrackAudioFile(callTool, newIndex);
+  process.stderr.write(`New audio track at index ${newIndex}.\n`);
+
+  if (cleanup) {
+    process.stderr.write(`Cleaning up track ${newIndex}…\n`);
+    // TODO(spike): confirm the delete-track tool name/args against a live device.
+    await callTool("ppal-delete-track", { trackIndex: newIndex }).catch((e) =>
+      process.stderr.write(`Cleanup skipped: ${e.message}\n`),
+    );
+  }
+
+  return (
+    filePath ??
+    `<unresolved: read file_path of the audio clip on track index ${newIndex}>`
+  );
+}
+
+/**
+ * Count tracks in the current Live Set via ppal-read-live-set.
+ * @param {Function} callTool - The ppal callTool function.
+ * @returns {Promise<number>} Number of tracks.
+ */
+async function trackCount(callTool) {
+  const { result } = await callTool("ppal-read-live-set");
+  const tracks = result?.tracks ?? [];
+  return Array.isArray(tracks) ? tracks.length : 0;
+}
+
+/**
+ * Read the audio file backing the first clip on a freshly bounced track.
+ * @param {Function} callTool - The ppal callTool function.
+ * @param {number} trackIndex - Index of the new audio track.
+ * @returns {Promise<string|null>} The clip's file_path, or null if not resolvable.
+ */
+async function newTrackAudioFile(callTool, trackIndex) {
+  try {
+    const { result } = await callTool("ppal-read-track", { trackIndex });
+    const clips = result?.clips ?? result?.arrangementClips ?? [];
+    for (const clip of clips) {
+      if (clip?.filePath) return clip.filePath;
+      if (clip?.file_path) return clip.file_path;
+    }
+  } catch {
+    // fall through — caller reports an unresolved-path note
+  }
+  return null;
+}
+
+// --- shared helpers ----------------------------------------------------------
+
+/**
+ * Run an AppleScript source string via `osascript -e`.
+ * @param {string} script - AppleScript source.
+ * @returns {Promise<string>} Trimmed stdout.
+ */
+async function runAppleScript(script) {
+  const { stdout } = await execFileAsync("osascript", ["-e", script]);
+  return stdout.trim();
+}
+
+/**
+ * Poll until a file exists and its size is stable across two consecutive checks
+ * (Live writes the .wav, then an .asd analysis sidecar — size settles first).
+ * @param {string} path - Absolute file path to watch.
+ * @param {object} [o] - Options.
+ * @param {number} [o.timeoutMs] - Overall timeout.
+ * @param {number} [o.intervalMs] - Poll interval.
+ * @returns {Promise<void>} Resolves once the file is present and stable.
+ */
+async function pollForStableFile(
+  path,
+  { timeoutMs = 300_000, intervalMs = 500 } = {},
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastSize = -1;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) {
+      const size = statSync(path).size;
+      if (size > 0 && size === lastSize) return;
+      lastSize = size;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(`Timed out waiting for ${path}`);
+}
+
+/**
+ * Escape a JS string as an AppleScript double-quoted string literal.
+ * @param {string} s - Raw string.
+ * @returns {string} AppleScript literal, including surrounding quotes.
+ */
+function as(s) {
+  return '"' + String(s).replaceAll("\\", "\\\\").replaceAll('"', '\\"') + '"';
+}
+
+/**
+ * A filesystem-safe slug for filenames.
+ * @param {string} s - Raw string.
+ * @returns {string} Slugified string.
+ */
+function slug(s) {
+  return String(s)
+    .replaceAll(/[^A-Za-z0-9._-]+/g, "-")
+    .replaceAll(/^-+|-+$/g, "");
+}
+
+/**
+ * A filename-safe timestamp (colons/dots replaced) for unique output names.
+ * @returns {string} e.g. "2026-07-23T18-04-05-123Z".
+ */
+function stamp() {
+  return new Date().toISOString().replaceAll(/[:.]/g, "-");
+}
+
+/**
+ * Promise-based sleep.
+ * @param {number} ms - Milliseconds to wait.
+ * @returns {Promise<void>} Resolves after the delay.
+ */
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+try {
+  await main();
+} catch (err) {
+  process.stderr.write(`Error: ${err.message ?? err}\n`);
+  process.exit(1);
+}

--- a/examples/skills/analyze-audio/render.mjs
+++ b/examples/skills/analyze-audio/render.mjs
@@ -2,30 +2,54 @@
 
 // render.mjs — get audio OUT of Ableton Live so it can be analyzed.
 //
-// Two modes (both drive Live's menus/dialogs via AppleScript — macOS only):
-//   export  File ▸ Export Audio/Video (⇧⌘R): render the Main mix or one track
-//           over a time range to a .wav you name. Offline (faster-than-realtime).
-//   bounce  Edit ▸ Bounce to New Track (⌘B): bounce the selected clip to a new
-//           audio track that stays in the Set (optionally deleted after).
+// Renders the Main mix OR any single track via File ▸ Export Audio/Video (⇧⌘R),
+// driving the dialog with AppleScript (macOS only). It's automatable because
+// every Export-dialog control exposes a stable AX `description`, and the
+// Rendered Track pop-up is set by type-to-select.
 //
-// RELIABILITY PRINCIPLE — never sleep-and-hope. We fire the UI, then POLL for the
-// completion ARTIFACT: the .wav appearing+stabilizing on disk (export), or a new
-// track appearing via Producer Pal (bounce). This is what makes an offline render
-// of unknown duration safe to wait on.
+// The render range is the whole arrangement: we focus the Arrangement view
+// (Option-2) and Select All (⌘A), which sets the dialog's Render Start/Length
+// automatically (those number boxes aren't otherwise settable via AX).
+//
+// Filenames: we do NOT type into the save panel (reliably replacing its field
+// is fragile — a track export pre-fills the track name). Instead we render into
+// a fresh, empty temp dir via the panel's Go-to-Folder (⌘⇧G) and let Live use
+// its default name, then find the render by extension and rename it cleanly.
+//
+// Non-destructive: Export never alters the Set. Output is MP3 (small enough to
+// send to an audio LLM inline). Because the dialog also honors its PCM setting,
+// a .wav/.aiff/.flac twin is usually produced alongside the .mp3 — every file is
+// reported so the caller can clean them all up.
+//
+// RELIABILITY: never sleep-and-hope. We fire the UI, then POLL for an .mp3
+// appearing in the temp dir and its size stabilizing (offline render of unknown
+// duration). Reading the Export dialog uses DIRECT navigation of "group 1"
+// (its "entire contents" intermittently returns an empty tree).
 //
 // PREREQUISITE: the app running this (Terminal / your agent host) needs
 // Accessibility permission — System Settings ▸ Privacy & Security ▸ Accessibility.
+// English Live UI and default shortcuts are assumed.
 //
 // Usage:
-//   node render.mjs --mode export --out ~/renders                       # current dialog settings
-//   node render.mjs --mode export --track Main --start 1.1.1 --length 4.0.0 --out ~/renders
-//   node render.mjs --mode bounce [--cleanup]                           # bounce the selected clip
+//   node render.mjs                          # whole mix (Main) → temp .mp3
+//   node render.mjs --track "Bass"           # one track by name → temp .mp3
+//   node render.mjs --out ~/renders          # move the files into a chosen dir
 //
-// Prints the absolute .wav path on stdout. Status/progress → stderr.
+// Prints JSON on stdout: {"audio":"<path.mp3>","created":["<path.mp3>", ...]}.
+// Status/progress → stderr.
 
 import { execFile } from "node:child_process";
-import { existsSync, mkdirSync, statSync } from "node:fs";
-import { basename, dirname, resolve } from "node:path";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { extname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -38,274 +62,183 @@ const opt = (name, def) => {
   const i = argv.indexOf(name);
   return i >= 0 ? argv[i + 1] : def;
 };
-const flag = (name) => argv.includes(name);
 
 async function main() {
-  const mode = opt("--mode", "export");
-  if (mode === "export") {
-    const out = await exportAudio({
-      track: opt("--track"), // e.g. "Main" or a track name; omit to keep dialog's setting
-      start: opt("--start"), // bar.beat.sixteenth, e.g. "1.1.1"; omit to keep setting
-      length: opt("--length"), // bar.beat.sixteenth, e.g. "4.0.0"; omit to keep setting
-      outDir: resolve(opt("--out", "./renders")),
-      filename: opt("--name"), // optional explicit filename; default is unique
-    });
-    process.stdout.write(out + "\n");
-  } else if (mode === "bounce") {
-    const out = await bounceClip({ cleanup: flag("--cleanup") });
-    process.stdout.write(out + "\n");
-  } else {
-    throw new Error(`Unknown --mode ${mode} (expected "export" or "bounce")`);
-  }
+  const track = opt("--track", "Main"); // "Main" = full mix, or a track name
+  const outDir = opt("--out"); // omit → leave the files in the temp dir
+  const result = await renderAudio({ track, outDir });
+  process.stdout.write(JSON.stringify(result) + "\n");
 }
 
-// --- Export Audio/Video ------------------------------------------------------
-
 /**
- * Render the Main mix or a single track to a .wav via File ▸ Export Audio/Video.
+ * Render the Main mix or one track to an .mp3 and report every file produced.
  * @param {object} o - Options.
- * @param {string} [o.track] - Rendered Track value (e.g. "Main" or a track name).
- * @param {string} [o.start] - Render Start (advisory — see note in body).
- * @param {string} [o.length] - Render Length (advisory — see note in body).
- * @param {string} o.outDir - Directory to write the .wav into.
- * @param {string} [o.filename] - Explicit output filename; defaults to a unique name.
- * @returns {Promise<string>} Absolute path of the rendered .wav.
+ * @param {string} o.track - Rendered Track value: "Main" or a track name.
+ * @param {string} [o.outDir] - Directory to move the render into; omit to leave
+ *   it in a temp dir.
+ * @returns {Promise<{audio: string, created: string[]}>} The .mp3 path plus all
+ *   rendered files (for cleanup).
  */
-async function exportAudio({ track, start, length, outDir, filename }) {
-  mkdirSync(outDir, { recursive: true });
-  if (start || length) {
-    // Verified via AX inspection: the Render Start/Length number boxes are NOT
-    // exposed as accessible controls, so they can't be set from here. The render
-    // range is whatever is currently selected/looped in the Arrangement.
-    process.stderr.write(
-      "Note: --start/--length can't be set through the Export dialog (its number " +
-        "boxes aren't accessible). Select the range in Live's Arrangement first; " +
-        "rendering uses the current selection/loop.\n",
-    );
-  }
-  const name = filename ?? `ppal-export-${slug(track ?? "mix")}-${stamp()}.wav`;
-  const outFile = resolve(outDir, name);
-  if (existsSync(outFile)) {
-    // A unique name normally avoids the macOS "Replace?" sheet; bail rather than
-    // risk a modal we don't drive.
-    throw new Error(`Output already exists, refusing to overwrite: ${outFile}`);
-  }
+async function renderAudio({ track, outDir }) {
+  // Always render into a fresh, empty temp dir so Live's default filename can't
+  // collide (which would pop a "Replace?" sheet) and so the .mp3 is trivially
+  // found by extension afterward.
+  const tmp = mkdtempSync(join(tmpdir(), "ppal-render-"));
+  const label = track === "Main" ? "the Main mix" : `track "${track}"`;
+  process.stderr.write(`Exporting ${label}…\n`);
+  await runAppleScript(buildExportScript({ track, dir: tmp }));
 
-  process.stderr.write(`Opening Export dialog…\n`);
-  await runAppleScript(buildExportScript({ track, outFile }));
+  process.stderr.write(`Rendering (polling for the .mp3)…\n`);
+  await pollForMp3(tmp);
 
-  process.stderr.write(`Rendering (polling for ${name})…\n`);
-  await pollForStableFile(outFile);
-  return outFile;
+  // Rename Live's default-named files to a clean, unique base, moving them to
+  // outDir if requested. The PCM twin (.wav/.aiff/.flac) rides along by stem.
+  const destDir = outDir ? resolve(outDir) : tmp;
+  if (outDir) mkdirSync(destDir, { recursive: true });
+  const base = `ppal-${slug(track)}-${stamp()}`;
+  const created = [];
+  let audio;
+  for (const f of readdirSync(tmp)) {
+    const ext = extname(f);
+    const dest = join(destDir, base + ext);
+    moveFile(join(tmp, f), dest);
+    created.push(dest);
+    if (ext.toLowerCase() === ".mp3") audio = dest;
+  }
+  if (outDir) rmSync(tmp, { recursive: true, force: true });
+  if (!audio) throw new Error("Export finished but produced no .mp3");
+  return { audio, created };
 }
 
 /**
- * Build the AppleScript that drives the Export dialog and the macOS save panel.
+ * Build the AppleScript that focuses the Arrangement, selects all, opens the
+ * Export dialog, configures it (Rendered Track, MP3 on, distracting toggles
+ * off), commits, and drives the macOS save panel to `dir` (default filename).
  *
- * Grounded in an AX inspection of Live 12's dialog: its controls have NO
- * accessible names, so we address the Rendered Track pop-up by index (it's the
- * first pop-up button) and commit with Return (the default button) rather than
- * clicking "Export" by name. The Render Start/Length boxes aren't accessible at
- * all — range comes from the Arrangement selection (see exportAudio). From the
- * save panel on it's the STANDARD macOS panel (⌘⇧G + filename + Save).
+ * Grounded in live AX inspection of Live 12's Export dialog: controls live in
+ * "group 1" with stable `description`s (read by direct navigation — "entire
+ * contents" is flaky); the Rendered Track pop-up ignores "set value" and its
+ * menu isn't AX-navigable, so it's set by click + type-to-select; the save
+ * panel is a separate "Save" window whose Save button is nested (Return, the
+ * default button, commits).
  * @param {object} o - Options.
- * @param {string} [o.track] - Rendered Track value (e.g. "Main" or a track name).
- * @param {string} o.outFile - Absolute output path.
+ * @param {string} o.track - Rendered Track value ("Main" or a track name).
+ * @param {string} o.dir - Absolute output directory (fresh/empty).
  * @returns {string} The AppleScript source.
  */
-function buildExportScript({ track, outFile }) {
-  const dir = dirname(outFile);
-  const base = basename(outFile);
-
-  // Rendered Track is the first pop-up button (controls are unnamed → by index).
-  const setTrack = track
-    ? `
-      try
-        click pop up button 1 of exportWin
-        delay 0.2
-        click menu item ${as(track)} of menu 1 of pop up button 1 of exportWin
-        delay 0.2
-      end try`
-    : "";
-
+function buildExportScript({ track, dir }) {
   return `
     tell application "System Events"
       tell process "${PROCESS}"
         set frontmost to true
         delay 0.3
-        keystroke "r" using {command down, shift down}
-
-        -- Wait for the Export dialog (window titled "Export…", subrole AXDialog).
-        set exportWin to missing value
-        repeat 40 times
+        -- Dismiss any Export dialog already open (else ⇧⌘R hits a stale window).
+        repeat 4 times
+          set isOpen to false
           repeat with w in windows
-            if name of w contains "Export" then
-              set exportWin to contents of w
-              exit repeat
-            end if
+            if name of w contains "Export" then set isOpen to true
           end repeat
-          if exportWin is not missing value then exit repeat
-          delay 0.25
+          if isOpen then
+            key code 53
+            delay 0.3
+          else
+            exit repeat
+          end if
         end repeat
-        if exportWin is missing value then error "Export dialog did not appear"
-        ${setTrack}
-
-        -- Commit via the default button (Export). The dialog's buttons have no
-        -- accessible names, so we press Return instead of clicking by name.
-        keystroke return
-
-        -- Wait for the standard macOS save panel (exposes a named "Save" button).
-        set savePanel to missing value
-        repeat 40 times
-          repeat with w in windows
-            if exists (button "Save" of w) then
-              set savePanel to contents of w
-              exit repeat
-            end if
-          end repeat
-          if savePanel is not missing value then exit repeat
-          delay 0.25
-        end repeat
-        if savePanel is missing value then error "Save panel did not appear"
-
-        -- The Save As field is focused with the default name selected: type ours.
-        keystroke ${as(base)}
-        delay 0.2
-        -- Go to folder: ⌘⇧G, type the absolute directory, confirm.
-        keystroke "g" using {command down, shift down}
-        delay 0.5
-        keystroke ${as(dir)}
+        -- Whole-arrangement range: focus Arrangement (⌥2) then Select All (⌘A).
+        keystroke "2" using option down
         delay 0.3
-        keystroke return
+        keystroke "a" using command down
+        delay 0.3
+        -- Open the Export dialog and wait for it to exist.
+        keystroke "r" using {command down, shift down}
+        set appeared to false
+        repeat 40 times
+          if (exists (first window whose name contains "Export")) then
+            set appeared to true
+            exit repeat
+          end if
+          delay 0.25
+        end repeat
+        if not appeared then error "Export dialog did not appear"
+        set frontmost to true
         delay 0.5
-        -- Save (named button on the standard panel; Return as a fallback).
-        try
-          click button "Save" of savePanel
-        on error
+
+        -- Every control lives in "group 1" of the dialog. Read by DIRECT
+        -- navigation — "entire contents" intermittently returns an empty tree.
+        -- Retry: the group populates lazily just after the dialog opens.
+        set trackPop to missing value
+        repeat 20 times
+          try
+            repeat with p in (pop up buttons of group 1 of (first window whose name contains "Export"))
+              if (description of p is "Rendered Track Chooser") then set trackPop to p
+            end repeat
+          end try
+          if trackPop is not missing value then exit repeat
+          delay 0.3
+        end repeat
+        if trackPop is missing value then error "Rendered Track control not found"
+
+        -- Rendered Track -> ${track}. "set value" is a no-op and the menu is not
+        -- AX-navigable, so: click to open, type-to-select, Return. Verify + retry
+        -- (a mistimed open would otherwise proceed with the wrong track).
+        repeat 4 times
+          if (value of trackPop as text) is ${as(track)} then exit repeat
+          click trackPop
+          delay 0.6
+          keystroke ${as(track)}
+          delay 0.5
           keystroke return
-        end try
+          delay 0.5
+        end repeat
+        if (value of trackPop as text) is not ${as(track)} then error "Could not set Rendered Track to ${track}"
+
+        -- MP3 on; distracting options off (idempotent: click only to change).
+        -- Grab the Export button in the same pass over group 1's buttons.
+        set offList to {"Render as Loop", "Convert to Mono", "Normalize", "Create Analysis File", "Create Video with Rendered Audio"}
+        set exportBtn to missing value
+        repeat with b in (buttons of group 1 of (first window whose name contains "Export"))
+          try
+            set d to description of b
+            if offList contains d then
+              if (value of b as text) is "On" then click b
+            else if d is "Encode MP3" then
+              if (value of b as text) is "Off" then click b
+            else if d is "Export" then
+              set exportBtn to b
+            end if
+          end try
+        end repeat
+        delay 0.2
+
+        -- Commit via the Export button.
+        if exportBtn is missing value then error "Export button not found"
+        click exportBtn
+
+        -- Drive the standard macOS save panel (a separate window named "Save").
+        set panel to missing value
+        repeat 60 times
+          repeat with w in windows
+            if name of w is "Save" then set panel to w
+          end repeat
+          if panel is not missing value then exit repeat
+          delay 0.25
+        end repeat
+        if panel is missing value then error "Save panel did not appear"
+        delay 0.5
+        -- Navigate to our empty temp folder and save with Live's default name
+        -- (no filename typing — the caller finds the render by extension there).
+        keystroke "g" using {command down, shift down}
+        delay 0.7
+        keystroke ${as(dir)}
+        delay 0.5
+        keystroke return
+        delay 0.7
+        keystroke return
       end tell
     end tell
     return "ok"
   `;
-}
-
-// --- Bounce to New Track -----------------------------------------------------
-
-/**
- * Bounce the currently selected clip to a new audio track via Edit ▸ Bounce to
- * New Track (⌘B), poll Producer Pal for the new track, and report its audio
- * file. Requires Ableton Live running with the Producer Pal device and the
- * TARGET CLIP already selected in Live (e.g. you just created/selected it).
- *
- * VERIFY-FIRST: bounce render mode (offline vs realtime) and the exact clip vs
- * track vs time-selection scope of ⌘B want a live spike; the poll-for-new-track
- * completion signal below is robust regardless of duration.
- * @param {object} o - Options.
- * @param {boolean} o.cleanup - Delete the created audio track after reporting it.
- * @returns {Promise<string>} The bounced audio clip's file_path (or a note if unresolved).
- */
-async function bounceClip({ cleanup }) {
-  const { callTool } = await import(
-    new URL("../producer-pal/ppal.mjs", import.meta.url)
-  );
-
-  const before = await trackCount(callTool);
-  process.stderr.write(
-    `Bouncing selected clip (⌘B); ${before} tracks before…\n`,
-  );
-  await runAppleScript(`
-    tell application "System Events"
-      tell process "${PROCESS}"
-        set frontmost to true
-        delay 0.3
-        keystroke "b" using {command down}
-      end tell
-    end tell
-    return "ok"
-  `);
-
-  // Poll for the new track (offline or realtime — duration-agnostic).
-  const deadline = Date.now() + 120_000;
-  let after = before;
-  while (Date.now() < deadline) {
-    after = await trackCount(callTool);
-    if (after > before) break;
-    await sleep(500);
-  }
-  if (after <= before)
-    throw new Error("No new track appeared after ⌘B (timed out)");
-
-  const newIndex = after - 1; // Bounce to New Track appends the audio track.
-  const track = await readTrack(callTool, newIndex);
-  const filePath = await clipFilePath(callTool, track);
-  process.stderr.write(
-    `New audio track "${track?.name}" at index ${newIndex} (id ${track?.id}).\n`,
-  );
-
-  if (cleanup && track?.id != null) {
-    process.stderr.write(`Cleaning up track id ${track.id}…\n`);
-    await callTool("ppal-delete", {
-      ids: String(track.id),
-      type: "track",
-    }).catch((e) => process.stderr.write(`Cleanup skipped: ${e.message}\n`));
-  }
-
-  return (
-    filePath ??
-    `<unresolved: read the sample file path of a clip on track index ${newIndex}>`
-  );
-}
-
-/**
- * Count regular (audio/MIDI) tracks in the current Live Set.
- * @param {Function} callTool - The ppal callTool function.
- * @returns {Promise<number>} The regular track count.
- */
-async function trackCount(callTool) {
-  const { result } = await callTool("ppal-read-live-set");
-  return result?.regularTrackCount ?? 0;
-}
-
-/**
- * Read a track (with its arrangement clips) by index.
- * @param {Function} callTool - The ppal callTool function.
- * @param {number} trackIndex - 0-based track index.
- * @returns {Promise<object|null>} The track object, or null.
- */
-async function readTrack(callTool, trackIndex) {
-  const { result } = await callTool("ppal-read-track", {
-    trackIndex,
-    include: ["arrangement-clips"],
-  });
-  return result ?? null;
-}
-
-/**
- * Resolve the audio file backing a track's first arrangement clip.
- * @param {Function} callTool - The ppal callTool function.
- * @param {object|null} track - A track object from readTrack().
- * @returns {Promise<string|null>} The clip's sample file path, or null.
- */
-async function clipFilePath(callTool, track) {
-  const clip = track?.arrangementClips?.[0];
-  if (clip?.id == null) return null;
-  try {
-    const { result } = await callTool("ppal-read-clip", {
-      clipId: String(clip.id),
-      include: ["sample"],
-    });
-    // The audio path may surface under a few keys depending on ppal version.
-    return (
-      result?.filePath ??
-      result?.file_path ??
-      result?.sample?.filePath ??
-      result?.sample?.path ??
-      null
-    );
-  } catch {
-    return null;
-  }
 }
 
 // --- shared helpers ----------------------------------------------------------
@@ -321,29 +254,44 @@ async function runAppleScript(script) {
 }
 
 /**
- * Poll until a file exists and its size is stable across two consecutive checks
- * (Live writes the .wav, then an .asd analysis sidecar — size settles first).
- * @param {string} path - Absolute file path to watch.
+ * Poll a directory until an .mp3 appears and its size is stable across two
+ * consecutive checks (the offline render writes for an unknown duration).
+ * @param {string} dir - Directory to watch.
  * @param {object} [o] - Options.
  * @param {number} [o.timeoutMs] - Overall timeout.
  * @param {number} [o.intervalMs] - Poll interval.
- * @returns {Promise<void>} Resolves once the file is present and stable.
+ * @returns {Promise<string>} Absolute path of the stable .mp3.
  */
-async function pollForStableFile(
-  path,
-  { timeoutMs = 300_000, intervalMs = 500 } = {},
-) {
+async function pollForMp3(dir, { timeoutMs = 300_000, intervalMs = 500 } = {}) {
   const deadline = Date.now() + timeoutMs;
   let lastSize = -1;
   while (Date.now() < deadline) {
-    if (existsSync(path)) {
-      const size = statSync(path).size;
-      if (size > 0 && size === lastSize) return;
+    const mp3 = readdirSync(dir).find((f) => f.toLowerCase().endsWith(".mp3"));
+    if (mp3 != null) {
+      const size = statSync(join(dir, mp3)).size;
+      if (size > 0 && size === lastSize) return join(dir, mp3);
       lastSize = size;
     }
     await sleep(intervalMs);
   }
-  throw new Error(`Timed out waiting for ${path}`);
+  throw new Error(`Timed out waiting for an .mp3 in ${dir}`);
+}
+
+/**
+ * Move a file, falling back to copy+delete across filesystems (temp dir → an
+ * --out dir on another volume would make a plain rename fail with EXDEV).
+ * @param {string} src - Source path.
+ * @param {string} dest - Destination path.
+ * @returns {void}
+ */
+function moveFile(src, dest) {
+  try {
+    renameSync(src, dest);
+  } catch (err) {
+    if (err.code !== "EXDEV") throw err;
+    copyFileSync(src, dest);
+    rmSync(src, { force: true });
+  }
 }
 
 /**
@@ -368,7 +316,7 @@ function slug(s) {
 
 /**
  * A filename-safe timestamp (colons/dots replaced) for unique output names.
- * @returns {string} e.g. "2026-07-23T18-04-05-123Z".
+ * @returns {string} e.g. "2026-07-24T18-04-05-123Z".
  */
 function stamp() {
   return new Date().toISOString().replaceAll(/[:.]/g, "-");


### PR DESCRIPTION
Adds a reference example skill (`examples/skills/analyze-audio/`) that renders audio **out** of Ableton Live and analyzes it with Google's Gemini API. macOS + Ableton Live 12 only (rendering is AppleScript accessibility automation; there is no Live API for it).

## What it does

- **`render.mjs`** — one non-destructive export path via File ▸ Export Audio/Video, parameterized by the Rendered Track dropdown:
  - `node render.mjs` → whole mix (Main) → temp `.mp3`
  - `node render.mjs --track "Bass"` → a single track → temp `.mp3`
  - `--out <dir>` to keep the files; default is a temp dir the caller deletes.
  - The whole-arrangement range is set with Select All, so no manual time-range selection is needed. Prints `{"audio","created"}` (the `.mp3` plus every file produced, incl. the PCM twin, for cleanup).
- **`analyze-audio.mjs`** — sends the render to Gemini (MIME picked by extension; inline under ~14 MB, else the Files API); accepts `GEMINI_KEY` / `GEMINI_API_KEY` / `--api-key`.

## Why the rewrite

The prior version used Edit ▸ Bounce to New Track (⌘B), which requires an Arrangement **time-range selection** that couldn't be automated — a dead end. Export + Select All sidesteps it and is non-destructive (it never alters the Set), and the Rendered Track dropdown covers both "whole song" and "single track" from one code path.

## Implementation notes (validated live against Live 12 / macOS)

- Read the Export dialog by **direct navigation of its control group** — its accessibility `entire contents` intermittently returns an empty tree. Controls are addressed by their stable AX `description`s; the Rendered Track pop-up is set by click + type-to-select.
- **No save-panel filename typing** (unreliable — a track export pre-fills the track name). Render into a fresh temp dir with Live's default name, then find the `.mp3` by extension and rename it cleanly.

## Testing

Verified end-to-end on macOS + Ableton Live 12: whole-song mix and a single track each render to MP3 and return a coherent Gemini mix analysis; cleanup removes all produced files. `npm run check` passes (lint, typecheck, format, 10k+ tests, coverage, duplication).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
