### PR TITLE
build: enable warp markers in debug builds

### DIFF
--- a/.github/workflows/run-checks-and-tests.yml
+++ b/.github/workflows/run-checks-and-tests.yml
@@ -38,16 +38,19 @@ jobs:
         run: npm ci
 
       - name: Guard against dev-only env vars in CI
-        # These flags enable Live API access, arbitrary code execution, and
-        # wildcard CORS. They must never be baked into release artifacts.
+        # These flags enable Live API access, arbitrary code execution,
+        # wildcard CORS, and the unfinished warp-marker params. They must never
+        # be baked into release artifacts.
         run: |
           if [ "${ENABLE_LIVE_API:-}" = "true" ] || \
              [ "${ENABLE_CODE_EXEC:-}" = "true" ] || \
-             [ "${ENABLE_REMOTE_CORS:-}" = "true" ]; then
+             [ "${ENABLE_REMOTE_CORS:-}" = "true" ] || \
+             [ "${ENABLE_WARP_MARKERS:-}" = "true" ]; then
             echo "::error::Dev-only env vars must not be set in CI builds:"
             echo "  ENABLE_LIVE_API=${ENABLE_LIVE_API:-}"
             echo "  ENABLE_CODE_EXEC=${ENABLE_CODE_EXEC:-}"
             echo "  ENABLE_REMOTE_CORS=${ENABLE_REMOTE_CORS:-}"
+            echo "  ENABLE_WARP_MARKERS=${ENABLE_WARP_MARKERS:-}"
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,9 +95,13 @@ architecture.
 
 - **Testing builds**: Always use `npm run build:debug` for development. It sets
   `ENABLE_LIVE_API=true` (forces `liveApiEnabled` on so the Direct Live API tool
-  is always available — the Setup-tab toggle can't disable it in this build) and
-  `ENABLE_CODE_EXEC=true`. `POST /config { liveApiEnabled }` still works either
-  direction (used by e2e to test the disabled state).
+  is always available — the Setup-tab toggle can't disable it in this build),
+  `ENABLE_CODE_EXEC=true`, and `ENABLE_WARP_MARKERS=true` (work-in-progress warp
+  markers: `warpMarkers` in `ppal-read-clip`'s `warp` include and the `warpOp` /
+  `warpBeatTime` / `warpSampleTime` / `warpDistance` params on
+  `ppal-update-clip` — absent from release builds).
+  `POST /config { liveApiEnabled }` still works either direction (used by e2e to
+  test the disabled state).
 
 - **Exact dependency versions**: All package.json versions must be exact (no
   `^`/`~`/ranges). `.npmrc` enforces it for `npm install`;

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -25,15 +25,20 @@ which require v24+.
    → Settings → Extension
 
 **Note**: For development and testing, use `npm run build:debug` to enable
-debug-only flags (`ENABLE_LIVE_API`, `ENABLE_CODE_EXEC`). `ENABLE_LIVE_API=true`
-forces the runtime `liveApiEnabled` flag on so the Direct Live API tool
-(`ppal-live-api`) is always available — the Setup-tab toggle cannot disable it
-in this build. `POST /config { liveApiEnabled }` still works in either direction
-so e2e tests can exercise both states. Chat UI development (`npm run ui:dev`)
-works against any build: the MCP server reflects CORS for localhost origins by
-default, so a browser page on another local port can reach it. Set
-`ENABLE_REMOTE_CORS=true` before a build only if you need to reach the server
-from a non-localhost browser origin (a remote inspector, or over the LAN).
+debug-only flags (`ENABLE_LIVE_API`, `ENABLE_CODE_EXEC`, `ENABLE_WARP_MARKERS`).
+`ENABLE_LIVE_API=true` forces the runtime `liveApiEnabled` flag on so the Direct
+Live API tool (`ppal-live-api`) is always available — the Setup-tab toggle
+cannot disable it in this build. `POST /config { liveApiEnabled }` still works
+in either direction so e2e tests can exercise both states.
+`ENABLE_WARP_MARKERS=true` exposes the work-in-progress warp-marker surface —
+`warpMarkers` in `ppal-read-clip`'s `warp` include, and the `warpOp` /
+`warpBeatTime` / `warpSampleTime` / `warpDistance` params on `ppal-update-clip`
+— so it can be exercised by hand; release builds omit it entirely. Chat UI
+development (`npm run ui:dev`) works against any build: the MCP server reflects
+CORS for localhost origins by default, so a browser page on another local port
+can reach it. Set `ENABLE_REMOTE_CORS=true` before a build only if you need to
+reach the server from a non-localhost browser origin (a remote inspector, or
+over the LAN).
 
 ## Core Development Scripts
 

--- a/dev/Read-Tool-Includes.md
+++ b/dev/Read-Tool-Includes.md
@@ -286,6 +286,10 @@ Adds warp/time-stretch properties for audio clips. No effect on MIDI clips.
 | `warpMode`     | `string`       | Warp algorithm (beats, tones, etc.) |
 | `warpMarkers`  | `WarpMarker[]` | Warp markers (if any exist)         |
 
+`warpMarkers` is work-in-progress and gated behind the `ENABLE_WARP_MARKERS`
+build flag: it appears in `npm run build:debug` builds (and in tests) only, not
+in release builds. The examples below show it as it appears in a debug build.
+
 ### Include: `"color"`
 
 | Field   | Type     | Description                       |

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
   ],
   "scripts": {
     "build": "npm run parser:build && npm run ui:build && rollup -c config/rollup.config.mjs && npm run dxt:build",
-    "build:debug": "ENABLE_LIVE_API=true ENABLE_CODE_EXEC=true npm run build",
+    "build:debug": "ENABLE_LIVE_API=true ENABLE_CODE_EXEC=true ENABLE_WARP_MARKERS=true npm run build",
     "build:watch": "npm run build && rollup -c config/rollup.config.mjs -w",
     "dev": "npm run parser:build && rollup -c config/rollup.config.mjs -w",
-    "dev:debug": "ENABLE_LIVE_API=true ENABLE_CODE_EXEC=true npm run dev",
+    "dev:debug": "ENABLE_LIVE_API=true ENABLE_CODE_EXEC=true ENABLE_WARP_MARKERS=true npm run dev",
     "test": "npm run test:setup && vitest run --reporter=./config/vitest-minimal-reporter.mjs --silent=true",
     "test:watch": "npm run test:setup && vitest --reporter=dot --silent=true",
     "test:coverage": "npm run test:setup && vitest run --coverage --reporter=./config/vitest-minimal-reporter.mjs --reporter=json --outputFile.json=test-reports/vitest.json --silent=true",

--- a/src/test/meta/build-flags.test.ts
+++ b/src/test/meta/build-flags.test.ts
@@ -1,0 +1,110 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  findSourceFiles,
+  projectRoot,
+} from "#src/test/helpers/meta-test-helpers.ts";
+import packageJson from "../../../package.json" with { type: "json" };
+
+// Build flags gate code out of release bundles: rollup substitutes their value
+// at build time, so every flag needs a documented way to switch it ON —
+// otherwise the code it guards is unreachable in every build and can never be
+// exercised by hand.
+//
+// Debug flags are turned on by build:debug / dev:debug, so a development build
+// always has them. Opt-in flags are deliberately left off and set by hand for a
+// specific need (a LAN/remote browser origin, in the CORS case).
+const DEBUG_FLAGS = [
+  "ENABLE_LIVE_API",
+  "ENABLE_CODE_EXEC",
+  "ENABLE_WARP_MARKERS",
+];
+const OPT_IN_FLAGS = ["ENABLE_REMOTE_CORS"];
+const BUILD_FLAGS = [...DEBUG_FLAGS, ...OPT_IN_FLAGS];
+
+// Runtime flags are read from the real environment when the portal runs (users
+// set them in their MCP client config), so they must stay out of the rollup
+// replacements — substituting one would freeze it off at build time.
+const RUNTIME_FLAGS = ["ENABLE_LOGGING"];
+
+const FLAG_READ = /process\.env\.(ENABLE_[A-Z0-9_]+)/g;
+
+const scripts = packageJson.scripts as Record<string, string>;
+const rollupConfig = readRepoFile("config/rollup.config.mjs");
+const ciWorkflow = readRepoFile(".github/workflows/run-checks-and-tests.yml");
+
+describe("build flags", () => {
+  it("only reads flags that are classified as build-time or runtime", () => {
+    expect([...flagsReadInSrc()].sort()).toStrictEqual(
+      [...BUILD_FLAGS, ...RUNTIME_FLAGS].sort(),
+    );
+  });
+
+  it("declares every build flag in the rollup replacements", () => {
+    // Unreplaced process.env references would throw in the Max V8 runtime.
+    for (const flag of BUILD_FLAGS) {
+      expect(rollupConfig).toContain(`process.env.${flag}`);
+    }
+  });
+
+  it("keeps runtime flags out of the rollup replacements", () => {
+    for (const flag of RUNTIME_FLAGS) {
+      expect(rollupConfig).not.toContain(flag);
+    }
+  });
+
+  it("enables every debug flag in build:debug and dev:debug", () => {
+    for (const flag of DEBUG_FLAGS) {
+      expect(scripts["build:debug"]).toContain(`${flag}=true`);
+      expect(scripts["dev:debug"]).toContain(`${flag}=true`);
+    }
+  });
+
+  it("leaves every flag off in production build scripts", () => {
+    expect(scripts.build).not.toMatch(/ENABLE_/);
+    expect(scripts.dev).not.toMatch(/ENABLE_/);
+  });
+
+  it("never enables opt-in flags from an npm script", () => {
+    for (const flag of OPT_IN_FLAGS) {
+      expect(Object.values(scripts).join("\n")).not.toContain(flag);
+    }
+  });
+
+  it("guards every build flag against leaking into CI builds", () => {
+    for (const flag of BUILD_FLAGS) {
+      expect(ciWorkflow).toContain(`"\${${flag}:-}" = "true"`);
+    }
+  });
+});
+
+/**
+ * Collect the build flags read from process.env anywhere in src/
+ * @returns Set of flag names
+ */
+function flagsReadInSrc(): Set<string> {
+  const flags = new Set<string>();
+
+  for (const file of findSourceFiles(path.join(projectRoot, "src"), true)) {
+    for (const match of fs.readFileSync(file, "utf8").matchAll(FLAG_READ)) {
+      flags.add(match[1] as string);
+    }
+  }
+
+  return flags;
+}
+
+/**
+ * Read a repo file as text
+ * @param relativePath - Path relative to the project root
+ * @returns File contents
+ */
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(projectRoot, relativePath), "utf8");
+}

--- a/src/tools/clip/read/read-clip.ts
+++ b/src/tools/clip/read/read-clip.ts
@@ -358,6 +358,7 @@ function processAudioClip(
 
     result.warpMode = WARP_MODE_MAPPING[warpModeValue] ?? "unknown";
 
+    // Warp markers are work-in-progress: debug builds only (build:debug)
     if (process.env.ENABLE_WARP_MARKERS === "true") {
       const warpMarkers = processWarpMarkers(clip);
 

--- a/src/tools/clip/update/update-clip.def.ts
+++ b/src/tools/clip/update/update-clip.def.ts
@@ -183,26 +183,25 @@ export const toolDefUpdateClip = defineTool("ppal-update-clip", {
       smallModel: null,
     }),
 
-    // Warp marker parameters
+    // Warp marker parameters (debug builds only - see ENABLE_WARP_MARKERS)
     ...(process.env.ENABLE_WARP_MARKERS === "true"
       ? {
           warpOp: param(z.enum(["add", "move", "remove"]).optional(), {
             default:
-              'warp marker operation: "add" (create at beat), "move" (shift by distance), "remove" (delete at beat)',
+              'warp marker operation (audio clips only): "add" (create at warpBeatTime), "move" (shift by warpDistance), "remove" (delete at warpBeatTime)',
             smallModel: null,
           }),
           warpBeatTime: param(z.coerce.number().optional(), {
             default:
-              "beat position from clip 1.1.1 (exact value from read-clip for move/remove, target for add)",
+              "warp marker position in beats from clip start (a number, not bar|beat); for move/remove use the exact beatTime from ppal-read-clip warpMarkers",
             smallModel: null,
           }),
           warpSampleTime: param(z.coerce.number().optional(), {
-            default:
-              "sample time in seconds (optional for add - omit to preserve timing)",
+            default: "sample time in seconds for add (omit to preserve timing)",
             smallModel: null,
           }),
           warpDistance: param(z.coerce.number().optional(), {
-            default: "beats to shift (+forward, -backward) for move operation",
+            default: "beats to shift (+forward, -backward) for move",
             smallModel: null,
           }),
         }


### PR DESCRIPTION
`ENABLE_WARP_MARKERS` gated the `warpMarkers` output in `ppal-read-clip` and the warp-marker params on `ppal-update-clip`, but no npm script ever set it — only `vitest.config.ts` did. The feature was fully tested and unreachable in every build, including `build:debug`, so it could not be exercised by hand.

## Changes

- `build:debug` / `dev:debug` set `ENABLE_WARP_MARKERS=true`, alongside `ENABLE_LIVE_API` and `ENABLE_CODE_EXEC`.
- The CI dev-only-env-var guard now covers it, so it can't be baked into release artifacts.
- Corrected the param descriptions now that they reach the LLM in debug builds: `warpBeatTime` described its position as "clip 1.1.1", which is neither this project's bar|beat spelling nor the raw beat number the param actually takes.
- New meta test (`src/test/meta/build-flags.test.ts`) classifies every `ENABLE_*` flag read in `src/` as build-time or runtime and checks each one's lifecycle: build flags declared in the rollup replacements, debug flags on in `build:debug`/`dev:debug` and off in the production scripts, every build flag present in the CI guard, and the runtime flag (`ENABLE_LOGGING`, read by the portal from the user's environment) kept *out* of the rollup replacements — replacing it would freeze it off.

## Verification

- `npm run check` green; `npm run build`, `npm run docs:build` green.
- Real bundles: a `build:debug` bundle carries `warpOp`/`warpBeatTime` in `mcp-server.mjs` and `warp_markers` reads in `live-api-adapter.js`; a production `build` carries neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)