### PR TITLE
fix(evals): Codex eval transport fixes

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -185,6 +185,10 @@ Interactive chat for manual testing and debugging.
 scripts/chat [options] [text...]
 ```
 
+Every provider except `codex-code` is supported: codex-code runs through the
+Codex CLI transport (a spawned `codex exec` subprocess), which only the eval CLI
+drives.
+
 ### Options
 
 | Flag                             | Description                                  |

--- a/evals/chat/codex/codex-cli-protocol.test.ts
+++ b/evals/chat/codex/codex-cli-protocol.test.ts
@@ -1,6 +1,6 @@
 // Producer Pal
-// Copyright (C) 2026 Taylor Haun
-// AI assistance: Codex (OpenAI)
+// Copyright (C) 2026 Taylor Haun, Adam Murray
+// AI assistance: Codex (OpenAI), Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
@@ -12,6 +12,24 @@ import {
   resolveCodexModel,
   scrubOpenAiKeys,
 } from "./codex-cli-protocol.ts";
+
+/**
+ * Assert every sandbox restriction survives on one argv. `evals/**` is excluded
+ * from coverage, so these assertions are the only guard against a dropped flag.
+ * @param args - Codex CLI arguments to check
+ */
+function expectRestrictions(args: string[]): void {
+  const flat = args.join(" ");
+
+  expect(flat).toContain("--disable shell_tool");
+  expect(flat).toContain("--disable unified_exec");
+  expect(flat).toContain("--disable multi_agent");
+  expect(args).toContain("--ignore-user-config");
+  expect(args).toContain("--ignore-rules");
+  expect(args).toContain('approval_policy="never"');
+  expect(args).toContain('web_search="disabled"');
+  expect(args).toContain('sandbox_mode="read-only"');
+}
 
 describe("codexCliProtocol", () => {
   const input = {
@@ -27,7 +45,7 @@ describe("codexCliProtocol", () => {
     expect(args).toStrictEqual(
       expect.arrayContaining(["--model", "gpt-5.6-terra"]),
     );
-    expect(args).toContain('sandbox_mode="read-only"');
+    expectRestrictions(args);
     expect(args).toContain("mcp_servers.producer-pal.required=true");
     expect(args).toContain(
       'mcp_servers.producer-pal.default_tools_approval_mode="approve"',
@@ -35,12 +53,12 @@ describe("codexCliProtocol", () => {
     expect(args.at(-1)).toBe("-");
   });
 
-  it("pins resumed turns to the read-only sandbox through config", () => {
+  it("pins resumed turns to every restriction through config", () => {
     const args = codexCliProtocol({ ...input, resumeThreadId: "thread-123" });
 
     expect(args.slice(0, 2)).toStrictEqual(["exec", "resume"]);
     expect(args).not.toContain("--sandbox");
-    expect(args).toContain('sandbox_mode="read-only"');
+    expectRestrictions(args);
     expect(args.slice(-2)).toStrictEqual(["thread-123", "-"]);
   });
 });
@@ -53,6 +71,7 @@ describe("codexJudgeArgs", () => {
     expect(args).toStrictEqual(
       expect.arrayContaining(["--model", "gpt-5.6-luna"]),
     );
+    expectRestrictions(args);
     expect(args.join(" ")).not.toContain("mcp_servers");
   });
 });
@@ -142,6 +161,97 @@ describe("parseCodexStream", () => {
       cacheReadTokens: 80,
       reasoningTokens: 5,
     });
+  });
+
+  it("pairs an id-less started/completed item into one call", () => {
+    const stdout = [
+      {
+        type: "item.started",
+        item: {
+          type: "mcp_tool_call",
+          tool: "ppal-create-clip",
+          arguments: "",
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          type: "mcp_tool_call",
+          tool: "ppal-create-clip",
+          arguments: { trackIndex: 0 },
+          status: "completed",
+          result: "created",
+        },
+      },
+    ]
+      .map((event) => JSON.stringify(event))
+      .join("\n");
+
+    expect(parseCodexStream(stdout).toolCalls).toStrictEqual([
+      { name: "ppal-create-clip", args: { trackIndex: 0 }, result: "created" },
+    ]);
+  });
+
+  it("keeps repeat calls to one tool separate", () => {
+    const stdout = ["1", "2"]
+      .flatMap((sceneIndex) => [
+        {
+          type: "item.started",
+          item: {
+            type: "mcp_tool_call",
+            tool: "ppal-create-clip",
+            status: "in_progress",
+          },
+        },
+        {
+          type: "item.completed",
+          item: {
+            type: "mcp_tool_call",
+            tool: "ppal-create-clip",
+            arguments: { sceneIndex },
+            status: "completed",
+          },
+        },
+      ])
+      .map((event) => JSON.stringify(event))
+      .join("\n");
+
+    expect(parseCodexStream(stdout).toolCalls).toStrictEqual([
+      { name: "ppal-create-clip", args: { sceneIndex: "1" } },
+      { name: "ppal-create-clip", args: { sceneIndex: "2" } },
+    ]);
+  });
+
+  it("refreshes args when the started event reported none", () => {
+    const stdout = [
+      {
+        type: "item.started",
+        item: {
+          id: "call-1",
+          type: "mcp_tool_call",
+          tool: "ppal-update-clip",
+          arguments: {},
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          id: "call-1",
+          type: "mcp_tool_call",
+          tool: "ppal-update-clip",
+          arguments: { ids: "1/1" },
+          status: "completed",
+        },
+      },
+    ]
+      .map((event) => JSON.stringify(event))
+      .join("\n");
+
+    expect(parseCodexStream(stdout).toolCalls).toStrictEqual([
+      { name: "ppal-update-clip", args: { ids: "1/1" } },
+    ]);
   });
 
   it("records a failed MCP result without failing the whole turn", () => {

--- a/evals/chat/codex/codex-cli-protocol.test.ts
+++ b/evals/chat/codex/codex-cli-protocol.test.ts
@@ -146,14 +146,10 @@ describe("parseCodexStream", () => {
 
     expect(parsed.text).toBe("Connected.");
     expect(parsed.threadId).toBe("thread-abc");
+    // The MCP envelope is unwrapped to its text block, matching what the AI SDK
+    // path records — this string reaches the console, reports, and judge prompt.
     expect(parsed.toolCalls).toStrictEqual([
-      {
-        name: "ppal-connect",
-        args: {},
-        result: JSON.stringify({
-          content: [{ type: "text", text: "connected" }],
-        }),
-      },
+      { name: "ppal-connect", args: {}, result: "connected" },
     ]);
     expect(parsed.usage).toStrictEqual({
       inputTokens: 100,
@@ -252,6 +248,24 @@ describe("parseCodexStream", () => {
     expect(parseCodexStream(stdout).toolCalls).toStrictEqual([
       { name: "ppal-update-clip", args: { ids: "1/1" } },
     ]);
+  });
+
+  it("falls back to JSON for a result carrying no text block", () => {
+    const stdout = JSON.stringify({
+      type: "item.completed",
+      item: {
+        id: "call-1",
+        type: "mcp_tool_call",
+        tool: "ppal-connect",
+        arguments: {},
+        status: "completed",
+        result: { content: [{ type: "image", data: "…" }] },
+      },
+    });
+
+    expect(parseCodexStream(stdout).toolCalls[0]?.result).toBe(
+      JSON.stringify({ content: [{ type: "image", data: "…" }] }),
+    );
   });
 
   it("records a failed MCP result without failing the whole turn", () => {

--- a/evals/chat/codex/codex-cli-protocol.ts
+++ b/evals/chat/codex/codex-cli-protocol.ts
@@ -1,6 +1,6 @@
 // Producer Pal
-// Copyright (C) 2026 Taylor Haun
-// AI assistance: Codex (OpenAI)
+// Copyright (C) 2026 Taylor Haun, Adam Murray
+// AI assistance: Codex (OpenAI), Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { type TokenUsage } from "#webui/chat/sdk/types.ts";
@@ -102,7 +102,7 @@ export function parseCodexStream(stdout: string): ParsedCodexTurn {
   const state: CodexStreamState = {
     text: "",
     toolCalls: [],
-    callsById: new Map(),
+    openCalls: new Map(),
   };
 
   for (const line of stdout.split("\n")) {
@@ -124,7 +124,8 @@ export function parseCodexStream(stdout: string): ParsedCodexTurn {
 interface CodexStreamState {
   text: string;
   toolCalls: ToolCall[];
-  callsById: Map<string, ToolCall>;
+  /** In-flight MCP calls awaiting completion, keyed by callKey(). */
+  openCalls: Map<string, ToolCall>;
   threadId?: string;
   usage?: TokenUsage;
   error?: string;
@@ -243,19 +244,25 @@ function collectMcpCall(
   item: Record<string, unknown>,
   state: CodexStreamState,
 ): void {
-  const id = typeof item.id === "string" ? item.id : undefined;
-  let call = id == null ? undefined : state.callsById.get(id);
+  const key = callKey(item);
 
-  if (call == null && typeof item.tool === "string") {
-    call = {
-      name: item.tool,
-      args: toArguments(item.arguments),
-    };
+  if (key == null) return;
+
+  let call = state.openCalls.get(key);
+
+  if (call == null) {
+    if (typeof item.tool !== "string") return;
+    call = { name: item.tool, args: toArguments(item.arguments) };
     state.toolCalls.push(call);
-    if (id != null) state.callsById.set(id, call);
+    state.openCalls.set(key, call);
+  } else {
+    // `item.started` can carry empty `arguments`, with the real ones only on
+    // completion — so let a non-empty payload replace what landed first.
+    const args = toArguments(item.arguments);
+
+    if (Object.keys(args).length > 0) call.args = args;
   }
 
-  if (call == null) return;
   if (item.result != null) call.result = stringifyResult(item.result);
 
   if (item.status === "failed") {
@@ -263,6 +270,37 @@ function collectMcpCall(
 
     call.result ??= `ERROR: ${message}`;
   }
+
+  // Stop tracking once the call is done, so a later call to the same tool
+  // starts a fresh entry instead of merging into this one.
+  if (isFinishedCall(item)) state.openCalls.delete(key);
+}
+
+/**
+ * Key an MCP item so `item.started` and `item.completed` collapse into one
+ * entry. `item.id` is optional in the stream; without it, pair the events by
+ * tool name (only one call per tool is ever in flight at a time).
+ * @param item - MCP tool-call item
+ * @returns Dedup key, or undefined when the item identifies neither
+ */
+function callKey(item: Record<string, unknown>): string | undefined {
+  if (typeof item.id === "string") return `id:${item.id}`;
+  if (typeof item.tool === "string") return `tool:${item.tool}`;
+
+  return undefined;
+}
+
+/**
+ * Report whether an MCP item represents a finished call.
+ * @param item - MCP tool-call item
+ * @returns True when the call succeeded, failed, or carries a result
+ */
+function isFinishedCall(item: Record<string, unknown>): boolean {
+  return (
+    item.status === "completed" ||
+    item.status === "failed" ||
+    item.result != null
+  );
 }
 
 /**

--- a/evals/chat/codex/codex-cli-protocol.ts
+++ b/evals/chat/codex/codex-cli-protocol.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { type TokenUsage } from "#webui/chat/sdk/types.ts";
+import { mcpResultText } from "../shared/mcp-result-text.ts";
 import { type ToolCall } from "../shared/types.ts";
 
 export const CODEX_MODEL_ALIASES: Record<string, string> = {
@@ -366,11 +367,18 @@ function numberValue(value: unknown): number {
 
 /**
  * Serialize a Codex MCP result for eval reports.
+ *
+ * Codex reports the whole MCP envelope (`{ content: [...] }`); unwrap its first
+ * text block so results read like the AI SDK path's. This string is what the
+ * console, the JSON report, and the judge prompt all show.
+ *
  * @param value - Raw MCP result
  * @returns String result
  */
 function stringifyResult(value: unknown): string {
-  return typeof value === "string" ? value : JSON.stringify(value);
+  if (typeof value === "string") return value;
+
+  return mcpResultText(value) || JSON.stringify(value);
 }
 
 /**

--- a/evals/chat/codex/codex-cli-session.ts
+++ b/evals/chat/codex/codex-cli-session.ts
@@ -8,6 +8,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type EvalSession } from "#evals/scenarios/eval-session.ts";
 import { logTurnStart } from "#evals/scenarios/helpers/eval-session-base.ts";
+import { isQuietMode } from "#evals/scenarios/helpers/output-config.ts";
 import { MCP_URL } from "#evals/shared/mcp-url.ts";
 import { CODEX_CODE_CONFIG } from "#evals/shared/provider-configs.ts";
 import { type TokenUsage } from "#webui/chat/sdk/types.ts";
@@ -20,6 +21,7 @@ import {
   parseCodexStream,
 } from "./codex-cli-protocol.ts";
 import { spawnCodex } from "./codex-cli.ts";
+import { formatCodexTurn } from "./format-codex-turn.ts";
 
 export interface CodexCliSessionOptions {
   instructions?: string;
@@ -85,11 +87,17 @@ export async function createCodexCliSession(
       // eslint-disable-next-line require-atomic-updates -- turns run sequentially
       if (parsed.threadId != null) threadId = parsed.threadId;
 
-      if (options.usage && parsed.usage != null) {
+      const usage = options.usage === true ? parsed.usage : undefined;
+
+      if (!isQuietMode()) {
+        process.stdout.write(formatCodexTurn(parsed, usage != null));
+      }
+
+      if (usage != null) {
         // Codex reports usage once per turn (turn.completed), not per step, so
         // there is one line per turn rather than one per tool round-trip.
-        printStepUsage(parsed.usage, prevUsage, true);
-        prevUsage = parsed.usage;
+        printStepUsage(usage, prevUsage, true);
+        prevUsage = usage;
       }
 
       return {

--- a/evals/chat/codex/codex-cli-session.ts
+++ b/evals/chat/codex/codex-cli-session.ts
@@ -10,7 +10,9 @@ import { type EvalSession } from "#evals/scenarios/eval-session.ts";
 import { logTurnStart } from "#evals/scenarios/helpers/eval-session-base.ts";
 import { MCP_URL } from "#evals/shared/mcp-url.ts";
 import { CODEX_CODE_CONFIG } from "#evals/shared/provider-configs.ts";
+import { type TokenUsage } from "#webui/chat/sdk/types.ts";
 import { connectMcp } from "../mcp.ts";
+import { printStepUsage } from "../shared/formatting.ts";
 import { type TurnResult } from "../shared/types.ts";
 import {
   codexCliProtocol,
@@ -23,6 +25,8 @@ export interface CodexCliSessionOptions {
   instructions?: string;
   mcpUrl?: string;
   model?: string;
+  /** Print per-turn token usage (the CLI's -u/--usage flag). */
+  usage?: boolean;
 }
 
 /**
@@ -59,6 +63,7 @@ export async function createCodexCliSession(
   }
 
   let threadId: string | undefined;
+  let prevUsage: TokenUsage | undefined;
 
   return {
     mcpClient,
@@ -79,6 +84,13 @@ export async function createCodexCliSession(
 
       // eslint-disable-next-line require-atomic-updates -- turns run sequentially
       if (parsed.threadId != null) threadId = parsed.threadId;
+
+      if (options.usage && parsed.usage != null) {
+        // Codex reports usage once per turn (turn.completed), not per step, so
+        // there is one line per turn rather than one per tool round-trip.
+        printStepUsage(parsed.usage, prevUsage, true);
+        prevUsage = parsed.usage;
+      }
 
       return {
         text: parsed.text,

--- a/evals/chat/codex/codex-cli-session.ts
+++ b/evals/chat/codex/codex-cli-session.ts
@@ -1,6 +1,6 @@
 // Producer Pal
-// Copyright (C) 2026 Taylor Haun
-// AI assistance: Codex (OpenAI)
+// Copyright (C) 2026 Taylor Haun, Adam Murray
+// AI assistance: Codex (OpenAI), Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
@@ -8,6 +8,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type EvalSession } from "#evals/scenarios/eval-session.ts";
 import { logTurnStart } from "#evals/scenarios/helpers/eval-session-base.ts";
+import { MCP_URL } from "#evals/shared/mcp-url.ts";
+import { CODEX_CODE_CONFIG } from "#evals/shared/provider-configs.ts";
 import { connectMcp } from "../mcp.ts";
 import { type TurnResult } from "../shared/types.ts";
 import {
@@ -16,9 +18,6 @@ import {
   parseCodexStream,
 } from "./codex-cli-protocol.ts";
 import { spawnCodex } from "./codex-cli.ts";
-
-export const CODEX_CODE_DEFAULT_MODEL = "terra";
-const DEFAULT_MCP_URL = "http://localhost:3350/mcp";
 
 export interface CodexCliSessionOptions {
   instructions?: string;
@@ -34,8 +33,8 @@ export interface CodexCliSessionOptions {
 export async function createCodexCliSession(
   options: CodexCliSessionOptions,
 ): Promise<EvalSession> {
-  const model = options.model ?? CODEX_CODE_DEFAULT_MODEL;
-  const mcpUrl = options.mcpUrl ?? process.env.MCP_URL ?? DEFAULT_MCP_URL;
+  const model = options.model ?? CODEX_CODE_CONFIG.defaultModel;
+  const mcpUrl = options.mcpUrl ?? MCP_URL;
   const sessionDir = await mkdtemp(join(tmpdir(), "producer-pal-codex-"));
   const instructionsFile = join(sessionDir, "instructions.md");
 

--- a/evals/chat/codex/codex-cli.ts
+++ b/evals/chat/codex/codex-cli.ts
@@ -7,6 +7,8 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { parseCodexStream, scrubOpenAiKeys } from "./codex-cli-protocol.ts";
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+/** Grace period between SIGTERM and SIGKILL when a turn times out. */
+const SIGKILL_GRACE_MS = 2000;
 
 export interface SpawnCodexOptions {
   cwd: string;
@@ -37,11 +39,22 @@ export function spawnCodex(
     let stdout = "";
     let stderr = "";
     let timedOut = false;
+    let killTimer: NodeJS.Timeout | undefined;
     const timer = setTimeout(() => {
       timedOut = true;
       child.kill("SIGTERM");
-      setTimeout(() => child.kill("SIGKILL"), 2000);
+      // Escalate only if SIGTERM is ignored. Captured so clearTimers() can drop
+      // it — left pending it holds the event loop open past the rejection.
+      killTimer = setTimeout(() => child.kill("SIGKILL"), SIGKILL_GRACE_MS);
     }, timeoutMs);
+
+    /**
+     * Drop both timers so neither keeps the event loop alive after settling.
+     */
+    const clearTimers = (): void => {
+      clearTimeout(timer);
+      if (killTimer != null) clearTimeout(killTimer);
+    };
 
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
@@ -52,11 +65,11 @@ export function spawnCodex(
       stderr += data;
     });
     child.on("error", (error) => {
-      clearTimeout(timer);
+      clearTimers();
       reject(error);
     });
     child.on("close", (code) => {
-      clearTimeout(timer);
+      clearTimers();
 
       if (timedOut) {
         reject(new Error(`codex CLI timed out after ${timeoutMs / 1000}s`));
@@ -67,7 +80,7 @@ export function spawnCodex(
       }
     });
     child.stdin.on("error", (error) => {
-      clearTimeout(timer);
+      clearTimers();
       child.kill("SIGKILL");
       reject(error);
     });

--- a/evals/chat/codex/format-codex-turn.test.ts
+++ b/evals/chat/codex/format-codex-turn.test.ts
@@ -1,0 +1,54 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+
+import { formatCodexTurn } from "./format-codex-turn.ts";
+
+describe("formatCodexTurn", () => {
+  const turn = {
+    text: "Added a kick pattern.",
+    toolCalls: [
+      { name: "ppal-connect", args: {}, result: "connected" },
+      { name: "ppal-create-clip", args: { trackIndex: 0 }, result: "created" },
+    ],
+  };
+
+  it("renders tool calls, results, and the reply", () => {
+    const output = formatCodexTurn(turn, false);
+
+    expect(output).toBe(
+      "🔧 ppal-connect({})\n" +
+        "   ↳ connected\n" +
+        "🔧 ppal-create-clip({ trackIndex: 0 })\n" +
+        "   ↳ created\n" +
+        "\n" +
+        "Added a kick pattern.\n",
+    );
+  });
+
+  it("drops the trailing newline when a usage line follows", () => {
+    expect(formatCodexTurn(turn, true)).toMatch(/Added a kick pattern\.$/);
+  });
+
+  it("omits the result line for a call that never reported one", () => {
+    const output = formatCodexTurn(
+      { text: "", toolCalls: [{ name: "ppal-connect", args: {} }] },
+      false,
+    );
+
+    expect(output).toBe("🔧 ppal-connect({})\n\n");
+  });
+
+  it("renders reply-only turns without a leading blank line", () => {
+    expect(
+      formatCodexTurn({ text: "No tools needed.", toolCalls: [] }, false),
+    ).toBe("No tools needed.\n");
+  });
+
+  it("returns nothing for an empty turn", () => {
+    expect(formatCodexTurn({ text: "", toolCalls: [] }, false)).toBe("");
+  });
+});

--- a/evals/chat/codex/format-codex-turn.ts
+++ b/evals/chat/codex/format-codex-turn.ts
@@ -1,0 +1,53 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Render a parsed Codex turn for the console.
+ *
+ * The AI SDK providers print as they stream (evals/chat/stream.ts); the Codex
+ * transport only has the finished JSONL, so it renders the whole turn at once
+ * with the same shapes — `🔧 tool(args)` / `   ↳ result` lines, then the reply.
+ */
+
+import {
+  formatToolCall,
+  formatToolResult,
+} from "#evals/chat/shared/formatting.ts";
+import { type ParsedCodexTurn } from "./codex-cli-protocol.ts";
+
+/**
+ * Format one Codex turn's tool calls and reply text for stdout.
+ *
+ * Tool calls come first, then the reply: parseCodexStream concatenates every
+ * `agent_message` into one string, so text/tool interleaving is not recoverable
+ * (and Codex emits its message last in practice anyway).
+ *
+ * @param parsed - The parsed turn
+ * @param showUsage - Whether a usage line follows (it supplies its own leading
+ *   blank line, so the trailing newline is left off)
+ * @returns Text to write to stdout, "" when there is nothing to show
+ */
+export function formatCodexTurn(
+  parsed: ParsedCodexTurn,
+  showUsage: boolean,
+): string {
+  const parts: string[] = [];
+
+  for (const call of parsed.toolCalls) {
+    parts.push(formatToolCall(call.name, call.args) + "\n");
+
+    if (call.result != null) parts.push(formatToolResult(call.result));
+  }
+
+  if (parsed.text !== "") {
+    if (parts.length > 0) parts.push("\n");
+    parts.push(parsed.text);
+  }
+
+  if (parts.length === 0) return "";
+  if (!showUsage) parts.push("\n");
+
+  return parts.join("");
+}

--- a/evals/chat/index.ts
+++ b/evals/chat/index.ts
@@ -110,6 +110,20 @@ program
     }
 
     const { provider, model } = spec;
+
+    // codex-code runs through the Codex CLI transport (a spawned subprocess),
+    // not the AI SDK this CLI streams from. Without this the provider factory
+    // throws past commander's handler as a raw stack trace.
+    if (provider === "codex-code") {
+      program.error(
+        `Provider "codex-code" is only supported by the eval CLI, which drives ` +
+          `the Codex CLI transport instead of the AI SDK. ` +
+          `Try: scripts/eval -m ${provider}/${model} -t <scenario>`,
+      );
+
+      return;
+    }
+
     const instructions = rawOptions.instructions ?? SYSTEM_INSTRUCTION;
     const options: ChatOptions = {
       ...rawOptions,

--- a/evals/chat/mcp.ts
+++ b/evals/chat/mcp.ts
@@ -13,6 +13,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { type ToolSet, jsonSchema } from "ai";
 import { MCP_URL } from "#evals/shared/mcp-url.ts";
 import { parseCompactJSLiteral } from "#src/shared/compact/compact-parser.ts";
+import { mcpResultText } from "./shared/mcp-result-text.ts";
 
 const MCP_CLIENT_NAME = "producer-pal-chat";
 const MCP_CLIENT_VERSION = "1.0.0";
@@ -96,9 +97,7 @@ export async function createMcpTools(url: string = MCP_URL): Promise<McpTools> {
  * @returns The text content from the first content item, or empty string
  */
 export function extractToolResultText(result: unknown): string {
-  const typed = result as { content?: Array<{ text?: string }> } | null;
-
-  return typed?.content?.[0]?.text ?? "";
+  return mcpResultText(result);
 }
 
 /**

--- a/evals/chat/mcp.ts
+++ b/evals/chat/mcp.ts
@@ -11,9 +11,9 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { type ToolSet, jsonSchema } from "ai";
+import { MCP_URL } from "#evals/shared/mcp-url.ts";
 import { parseCompactJSLiteral } from "#src/shared/compact/compact-parser.ts";
 
-const DEFAULT_MCP_URL = "http://localhost:3350/mcp";
 const MCP_CLIENT_NAME = "producer-pal-chat";
 const MCP_CLIENT_VERSION = "1.0.0";
 
@@ -37,7 +37,7 @@ export interface McpTools {
  * @returns MCP connection with client and transport
  */
 export async function connectMcp(
-  url: string = DEFAULT_MCP_URL,
+  url: string = MCP_URL,
 ): Promise<McpConnection> {
   const transport = new StreamableHTTPClientTransport(new URL(url));
   const client = new Client({
@@ -57,9 +57,7 @@ export async function connectMcp(
  * @param url - MCP server URL
  * @returns AI SDK tools and the underlying MCP client
  */
-export async function createMcpTools(
-  url: string = DEFAULT_MCP_URL,
-): Promise<McpTools> {
+export async function createMcpTools(url: string = MCP_URL): Promise<McpTools> {
   const transport = new StreamableHTTPClientTransport(new URL(url));
   const mcpClient = new Client({
     name: MCP_CLIENT_NAME,

--- a/evals/chat/shared/mcp-result-text.ts
+++ b/evals/chat/shared/mcp-result-text.ts
@@ -1,0 +1,31 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Shared unwrapping of MCP tool results into display text, so every eval
+ * transport shows (and grades) the same string for the same tool call.
+ */
+
+/**
+ * Extract the first text block from an MCP tool result.
+ *
+ * Accepts both shapes the transports see: the AI SDK hands over `result.content`
+ * (a bare array of content blocks) while the Codex CLI reports the whole
+ * envelope (`{ content: [...] }`).
+ *
+ * @param value - Raw MCP result, or its content array
+ * @returns The first text block, or "" when the value carries none
+ */
+export function mcpResultText(value: unknown): string {
+  const blocks = Array.isArray(value)
+    ? value
+    : (value as { content?: unknown } | null | undefined)?.content;
+
+  if (!Array.isArray(blocks)) return "";
+
+  const first = blocks[0] as { text?: unknown } | undefined;
+
+  return typeof first?.text === "string" ? first.text : "";
+}

--- a/evals/chat/stream.ts
+++ b/evals/chat/stream.ts
@@ -20,6 +20,7 @@ import {
   formatWarning,
   startThought,
 } from "./shared/formatting.ts";
+import { mcpResultText } from "./shared/mcp-result-text.ts";
 import { type TurnResult } from "./shared/types.ts";
 
 /** Mutable state tracked during stream processing */
@@ -340,11 +341,5 @@ function formatOutput(output: unknown): string {
   if (output == null) return "";
 
   // MCP content array format: [{ type: "text", text: "..." }]
-  if (Array.isArray(output)) {
-    const first = output[0] as { text?: string } | undefined;
-
-    if (first?.text) return first.text;
-  }
-
-  return JSON.stringify(output);
+  return mcpResultText(output) || JSON.stringify(output);
 }

--- a/evals/scenarios/eval-session.ts
+++ b/evals/scenarios/eval-session.ts
@@ -93,6 +93,7 @@ export async function createEvalSession(
       ...(options.instructions != null
         ? { instructions: options.instructions }
         : {}),
+      ...(options.usage != null ? { usage: options.usage } : {}),
     });
   }
 

--- a/evals/scenarios/eval-session.ts
+++ b/evals/scenarios/eval-session.ts
@@ -9,16 +9,14 @@
 
 import { type Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { type ModelMessage, stepCountIs, streamText } from "ai";
-import {
-  CODEX_CODE_DEFAULT_MODEL,
-  createCodexCliSession,
-} from "#evals/chat/codex/codex-cli-session.ts";
+import { createCodexCliSession } from "#evals/chat/codex/codex-cli-session.ts";
 import { createMcpTools } from "#evals/chat/mcp.ts";
 import { createProviderModel } from "#evals/chat/provider.ts";
 import { printStepUsage } from "#evals/chat/shared/formatting.ts";
 import { processCliStream } from "#evals/chat/stream.ts";
 import {
   ANTHROPIC_CONFIG,
+  CODEX_CODE_CONFIG,
   GEMINI_CONFIG,
   OPENAI_CONFIG,
   OPENROUTER_CONFIG,
@@ -41,7 +39,7 @@ export function getDefaultModel(provider: EvalProvider): string {
     case "anthropic":
       return ANTHROPIC_CONFIG.defaultModel;
     case "codex-code":
-      return CODEX_CODE_DEFAULT_MODEL;
+      return CODEX_CODE_CONFIG.defaultModel;
     case "google":
       return GEMINI_CONFIG.defaultModel;
     case "openai":

--- a/evals/scenarios/open-live-set.ts
+++ b/evals/scenarios/open-live-set.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
@@ -22,10 +23,10 @@ import { existsSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { MCP_URL } from "#evals/shared/mcp-url.ts";
 
 const ABLETON_APP = "Ableton Live 12 Suite"; // For `open -a`
 const ABLETON_PROCESS = "Live"; // For System Events
-const MCP_URL = "http://localhost:3350/mcp";
 const DIALOG_POLL_INTERVAL_MS = 250;
 const DIALOG_TIMEOUT_MS = 2500;
 const MCP_POLL_INTERVAL_MS = 500;

--- a/evals/shared/config.ts
+++ b/evals/shared/config.ts
@@ -6,10 +6,9 @@
  * Configuration utilities for MCP server settings
  */
 
+import { MCP_URL } from "#evals/shared/mcp-url.ts";
 import { TOOL_NAMES } from "#src/mcp-server/create-mcp-server.ts";
 import { DEFAULT_NOTATION, type Notation } from "#src/shared/notation.ts";
-
-const MCP_URL = process.env.MCP_URL ?? "http://localhost:3350/mcp";
 
 export const CONFIG_URL = MCP_URL.replace("/mcp", "/config");
 

--- a/evals/shared/list-models.ts
+++ b/evals/shared/list-models.ts
@@ -11,6 +11,7 @@
  * or an eval run.
  */
 
+import { CODEX_MODEL_ALIASES } from "#evals/chat/codex/codex-cli-protocol.ts";
 import { type EvalProvider } from "#evals/scenarios/types.ts";
 import {
   PROVIDERS,
@@ -173,7 +174,9 @@ async function fetchModelsForProvider(
       );
 
     case "codex-code":
-      return ["luna", "sol", "terra"];
+      // Fixed alias set (no models endpoint); read from the transport so the
+      // listing can't advertise an alias the CLI can't resolve.
+      return Object.keys(CODEX_MODEL_ALIASES).sort();
 
     case "google":
       return await fetchGoogleModels();

--- a/evals/shared/mcp-url.ts
+++ b/evals/shared/mcp-url.ts
@@ -1,0 +1,14 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * The Producer Pal MCP endpoint every eval-side client connects to.
+ *
+ * Single source of truth: the chat CLI, the Codex CLI transport, the /config
+ * helpers, and the Live Set launcher all read this, so `MCP_URL=...` reaches
+ * every path instead of only whichever one happened to check the env var.
+ */
+
+export const MCP_URL = process.env.MCP_URL ?? "http://localhost:3350/mcp";


### PR DESCRIPTION
Sweep of the follow-ups from the Codex subscription eval transport review.

- **MCP call dedup** — `collectMcpCall` keyed started/completed pairs purely on `item.id`; without one, each event pushed a separate entry (double-counting calls in eval assertions). Now keys on `item.id` with a tool-name fallback, released on completion so repeat calls to a tool stay separate. `args` also refresh on completion instead of letting an empty `arguments` on `item.started` win permanently.
- **Restrictions pinned in tests** — `--disable shell_tool` / `unified_exec` / `multi_agent`, `web_search="disabled"`, `approval_policy`, `--ignore-user-config`, `--ignore-rules` are now asserted on the initial, resume, and judge argv paths. `evals/**` is coverage-excluded, so these assertions are the only regression guard.
- **SIGKILL escalation timer** — captured and cleared, so it no longer holds the event loop ~2s past the timeout rejection.
- **Duplicated constants** — `CODEX_CODE_DEFAULT_MODEL` folded into `CODEX_CODE_CONFIG.defaultModel`; the four copies of the MCP URL collapsed into `evals/shared/mcp-url.ts`, so `MCP_URL=…` now reaches `createMcpTools()` and the Live Set launcher instead of only the codex path. `--list-models codex-code` derives its aliases from `CODEX_MODEL_ALIASES`.
- **`scripts/chat -m codex-code/sol`** — rejected up front with a message pointing at the eval CLI, instead of the provider factory's throw escaping commander as a raw stack trace. Noted in the README's Chat CLI section.
- **`-u/--usage` for codex-code** — forwarded into the session and printed (one line per turn, since Codex reports usage on `turn.completed` rather than per step). JSON reports were already unaffected.
- **Codex turns now echo their output** (found while fixing `-u`, fixed at the user's request) — the transport printed nothing at all, so every codex turn showed an empty `[Assistant]` block. It now renders `🔧 tool(args)` / `   ↳ result` lines and the reply, matching the AI SDK path. Tool results are also unwrapped from Codex's `{ content: [{ text }] }` envelope to plain text, which the two paths stringified differently — that string is embedded in the LLM judge's prompt, so it affected grading, not just display. The unwrap all three call sites needed now lives in `evals/chat/shared/mcp-result-text.ts`.

**Left alone deliberately:** `evals/schema-compat/probe-schema-compat.ts` already catches the codex-code resolve failure and renders the row as `no-key` with an `unresolved: codex-code uses the Codex CLI transport…` detail — graceful, just an imprecise symbol; adding a `Status` for a one-off probe isn't worth it.

Verified: `npm run check` and `npm run check:build` green; chat CLI error path, `--list-models codex-code`, `scripts/eval -l`, the `MCP_URL` override, and the rendered turn output smoke-tested by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)