### PR TITLE
Rate-limit handling across concurrent subagents

### DIFF
--- a/docs/guide/chat-ui.md
+++ b/docs/guide/chat-ui.md
@@ -374,6 +374,11 @@ its own home here.
   saved a toolset keeps the current conversation's tools.) Subagents can never
   spawn their own subagents, whatever a preset's toolset enables.
 
+If a provider rate-limits a subagent, its card shows a **rate limited**
+countdown and the subagent retries on its own instead of failing. Subagents
+running in parallel share that backoff, so one hitting a limit pauses the others
+rather than leaving them to hammer the provider.
+
 Configure the model and inference on the **Connection** tab and the toolset on
 the **Tools** tab, then come here to save them together. API keys (kept
 per-provider) and appearance preferences are never part of a preset — a preset

--- a/docs/guide/chat-ui.md
+++ b/docs/guide/chat-ui.md
@@ -374,11 +374,6 @@ its own home here.
   saved a toolset keeps the current conversation's tools.) Subagents can never
   spawn their own subagents, whatever a preset's toolset enables.
 
-If a provider rate-limits a subagent, its card shows a **rate limited**
-countdown and the subagent retries on its own instead of failing. Subagents
-running in parallel share that backoff, so one hitting a limit pauses the others
-rather than leaving them to hammer the provider.
-
 Configure the model and inference on the **Connection** tab and the toolset on
 the **Tools** tab, then come here to save them together. API keys (kept
 per-provider) and appearance preferences are never part of a preset — a preset
@@ -404,6 +399,20 @@ it wants to read in full. Turn it off to keep AI from changing them. Your
 project context, global context, and the memory index are attached when AI
 connects either way, so to stop it reading a layer, empty that layer. **Edit
 Context** below the checkbox opens the context editor.
+
+The experimental **Subagent** checkbox lets the AI delegate a self-contained
+subtask to a nested assistant working in the same Live Set. Each subagent
+appears as its own card in the transcript — expand it for the result it reported
+back, and expand the card inside that for its full work log. When the AI
+delegates several independent subtasks at once, the subagents run in parallel.
+Choose what they run under with **Default subagent** on the
+[Presets tab](#presets).
+
+If a provider rate-limits a subagent, its card shows a **rate limited**
+countdown and the subagent retries on its own instead of failing. Subagents
+running in parallel share that backoff: when one hits a limit the others show
+**waiting** and pause with it, rather than piling more requests onto the
+provider.
 
 The **Live API** checkbox under **Advanced** behaves differently from the other
 toggles. The rest only filter which tools the Chat UI's AI can see, but this one

--- a/webui/src/chat/sdk/client.ts
+++ b/webui/src/chat/sdk/client.ts
@@ -139,6 +139,12 @@ export class ChatSdkClient {
    * reach of useChat's executeWithRetry, so an unhandled 429 would come back as a
    * dead tool-error. Retries share this client's gate with the worker's siblings
    * and publish their backoff to the card.
+   *
+   * Each attempt is a fresh sendMessage, so it gets its own MAX_WORKER_STEPS
+   * budget rather than resuming under the first attempt's — a worker that
+   * rate-limits repeatedly can therefore run more total tool steps than one that
+   * doesn't. Accepted: retries are rare, and carrying a partial budget forward
+   * risks stranding a resumed worker mid-task with no steps left to finish.
    * @param workerConfig - Cloned config for the worker (spawn disabled)
    * @param task - The delegated instruction, sent as the worker's user message
    * @param toolCallId - The spawn tool-call id, used to key the card's live status

--- a/webui/src/chat/sdk/client.ts
+++ b/webui/src/chat/sdk/client.ts
@@ -18,6 +18,11 @@ import {
   createSpawnSubagentTool,
 } from "./spawn-subagent-tool";
 import { createStreamErrorSignal } from "./stream-with-error-signal";
+import {
+  RateLimitGate,
+  runSubagentWithRetry,
+  setSubagentRateLimit,
+} from "./subagent-rate-limit";
 import { type ChatClientConfig, type ChatMessage, toTokenUsage } from "./types";
 
 const MAX_TOOL_STEPS = 10;
@@ -62,6 +67,14 @@ export class ChatSdkClient {
    */
   private spawnTranscripts = new Map<string, ChatMessage[]>();
   /**
+   * Backoff window shared by every worker this client spawns. Parallel workers
+   * stream on separate connections, so without it a provider-wide 429 hits each
+   * one independently; with it, the first worker to be rate-limited parks its
+   * siblings for the same cooldown. Orchestrator turns keep using useChat's
+   * executeWithRetry — no worker is in flight while that retry runs.
+   */
+  private rateLimitGate = new RateLimitGate();
+  /**
    * The MCP client backing `tools`. Each tool's execute() closure calls
    * mcpClient.callTool(), so it must stay connected for this client's whole
    * lifetime and only close when the client is discarded — see dispose().
@@ -100,8 +113,8 @@ export class ChatSdkClient {
         ...tools,
         [SPAWN_SUBAGENT_TOOL_NAME]: createSpawnSubagentTool({
           config: this.config,
-          runWorker: (workerConfig, task, signal) =>
-            this.runSubagent(workerConfig, task, signal),
+          runWorker: (workerConfig, task, toolCallId, signal) =>
+            this.runSubagent(workerConfig, task, toolCallId, signal),
           spawnState: this.spawnState,
           recordTranscript: (toolCallId, transcript) =>
             this.spawnTranscripts.set(toolCallId, transcript),
@@ -120,8 +133,15 @@ export class ChatSdkClient {
    * history. The worker gets its OWN ChatSdkClient — own MCP client, own tools,
    * own abort — so aborting or disposing it never touches the orchestrator's
    * long-lived client. Injected into the spawn tool as runWorker.
+   *
+   * The run is wrapped in rate-limit backoff (runSubagentWithRetry) because
+   * nothing above it retries: the worker streams below the tool boundary, out of
+   * reach of useChat's executeWithRetry, so an unhandled 429 would come back as a
+   * dead tool-error. Retries share this client's gate with the worker's siblings
+   * and publish their backoff to the card.
    * @param workerConfig - Cloned config for the worker (spawn disabled)
    * @param task - The delegated instruction, sent as the worker's user message
+   * @param toolCallId - The spawn tool-call id, used to key the card's live status
    * @param abortSignal - The orchestrator turn's signal, forwarded so Stop also
    *   aborts the worker's in-flight stream
    * @returns The worker's complete chat history (kept UI-side, not sent to the model)
@@ -129,6 +149,7 @@ export class ChatSdkClient {
   private async runSubagent(
     workerConfig: ChatClientConfig,
     task: string,
+    toolCallId: string,
     abortSignal?: AbortSignal,
   ): Promise<ChatMessage[]> {
     const worker = new ChatSdkClient("", workerConfig);
@@ -136,14 +157,24 @@ export class ChatSdkClient {
     await worker.initialize();
 
     try {
-      // Drain the generator; we only need the accumulated final history.
-      const stream = worker.sendMessage(task, abortSignal);
-      let step = await stream.next();
+      await runSubagentWithRetry({
+        task,
+        runAttempt: async (message) => {
+          // Drain the generator; we only need the accumulated final history.
+          const stream = worker.sendMessage(message, abortSignal);
+          let step = await stream.next();
 
-      while (!step.done) step = await stream.next();
+          while (!step.done) step = await stream.next();
+        },
+        getHistory: () => worker.chatHistory,
+        gate: this.rateLimitGate,
+        abortSignal,
+        onStatus: (status) => setSubagentRateLimit(toolCallId, status),
+      });
 
       return worker.chatHistory;
     } finally {
+      setSubagentRateLimit(toolCallId, null);
       worker.dispose();
     }
   }

--- a/webui/src/chat/sdk/formatter.ts
+++ b/webui/src/chat/sdk/formatter.ts
@@ -56,6 +56,7 @@ function addToolParts(msg: ChatMessage, parts: UIPart[]): void {
 
     parts.push({
       type: "tool",
+      id: tc.id,
       name: tc.name,
       args: tc.args,
       result: resultStr,

--- a/webui/src/chat/sdk/spawn-subagent-tool.ts
+++ b/webui/src/chat/sdk/spawn-subagent-tool.ts
@@ -57,11 +57,14 @@ export interface SpawnSubagentDeps {
   /**
    * Run a fully self-contained worker session for `task` and resolve with the
    * worker's final chat history. Injected by the client so this module needs no
-   * ChatSdkClient import (avoids an import cycle) and stays unit-testable.
+   * ChatSdkClient import (avoids an import cycle) and stays unit-testable. The
+   * tool-call id goes along so the runner can publish the worker's live status
+   * (e.g. a rate-limit backoff) to the card this call renders as.
    */
   runWorker: (
     workerConfig: ChatClientConfig,
     task: string,
+    toolCallId: string,
     abortSignal?: AbortSignal,
   ) => Promise<ChatMessage[]>;
   /** Mutable per-conversation spawn counter; enforces MAX_SPAWNS. */
@@ -117,7 +120,12 @@ export function createSpawnSubagentTool(deps: SpawnSubagentDeps): Tool {
       deps.spawnState.count++;
 
       const workerConfig = buildWorkerConfig(deps.config);
-      const transcript = await deps.runWorker(workerConfig, task, abortSignal);
+      const transcript = await deps.runWorker(
+        workerConfig,
+        task,
+        toolCallId,
+        abortSignal,
+      );
 
       deps.recordTranscript?.(toolCallId, transcript);
 

--- a/webui/src/chat/sdk/subagent-rate-limit.ts
+++ b/webui/src/chat/sdk/subagent-rate-limit.ts
@@ -19,10 +19,19 @@ import {
   MAX_RETRY_ATTEMPTS,
   shouldRetry,
 } from "#webui/lib/rate-limit";
+import { abortableSleep } from "#webui/lib/utils/abortable-sleep";
 import { type ChatMessage } from "./types";
 
 /** Follow-up sent when a retry resumes a worker that already did some work. */
 const RESUME_MESSAGE = "continue";
+
+/**
+ * Longest single sleep inside a gate wait. The window can be extended by a
+ * sibling mid-wait, so waiting the whole remainder in one go would leave the
+ * published deadline (and the card's countdown) stale until it expired. Waking
+ * each second re-reads the window and republishes.
+ */
+const WAIT_SLICE_MS = 1000;
 
 /** Options for one worker's retry-wrapped run. */
 export interface SubagentRetryOptions {
@@ -56,6 +65,11 @@ export interface SubagentRetryOptions {
  * "continue" and keeps the work; with nothing to keep, the failed attempt's
  * echoed task is dropped so the retry sends one clean turn instead of stacking
  * duplicate user messages.
+ *
+ * NOTE: this and useChat's executeWithRetry encode the same retry strategy for
+ * two different layers (this one throws; that one writes UI state and an error
+ * message into history). They are deliberately separate, so a change to the
+ * budget, the delay schedule, or the resume rule has to be made in both.
  * @param options - Task, attempt runner, history accessor, gate, and callbacks
  * @throws The underlying error when it isn't a rate limit, when the retry
  *   budget is exhausted, or when the turn was aborted
@@ -65,12 +79,26 @@ export async function runSubagentWithRetry(
 ): Promise<void> {
   const { task, runAttempt, getHistory, gate, abortSignal, onStatus } = options;
   let attempt = 0;
+  // Which attempt the pending wait is for: null until this worker is itself
+  // rate-limited, so a wait forced purely by a sibling's backoff is reported as
+  // such rather than as this worker's own retry.
+  let waitingFor: number | null = null;
 
   try {
     for (;;) {
+      const pendingAttempt = waitingFor;
+
       // Hold off while any sibling is serving a shared cooldown, so N parallel
       // spawns don't all hammer a provider that just rate-limited one of them.
-      await gate.wait(abortSignal);
+      // The window can be extended mid-wait, so the deadline is republished as
+      // it moves instead of being snapshotted once.
+      await gate.wait(abortSignal, (retryAtMs) =>
+        onStatus?.({
+          attempt: pendingAttempt,
+          maxAttempts: MAX_RETRY_ATTEMPTS,
+          retryAtMs,
+        }),
+      );
       onStatus?.(null);
 
       try {
@@ -85,11 +113,7 @@ export async function runSubagentWithRetry(
         if (!shouldRetry(attempt + 1)) throw exhaustedError(error, attempt + 1);
 
         gate.penalize(calculateRetryDelay(attempt, rateLimitInfo.retryAfterMs));
-        onStatus?.({
-          attempt,
-          maxAttempts: MAX_RETRY_ATTEMPTS,
-          retryAtMs: Date.now() + gate.remainingMs,
-        });
+        waitingFor = attempt;
         attempt++;
       }
     }
@@ -131,15 +155,22 @@ export class RateLimitGate {
 
   /**
    * Resolve once the shared cooldown has elapsed (immediately when open).
-   * Re-checks after each sleep so a sibling extending the window mid-wait keeps
-   * this caller parked rather than releasing it early.
+   * Sleeps in slices, re-reading the window each time, so a sibling extending
+   * it mid-wait keeps this caller parked AND gets the new deadline reported
+   * promptly instead of after the original one passes.
    * @param abortSignal - Cancels the wait (rejects) when the turn is aborted
+   * @param onDeadline - Called with the current end-of-cooldown timestamp
+   *   before each slice; never called when the gate is already open
    */
-  async wait(abortSignal?: AbortSignal): Promise<void> {
+  async wait(
+    abortSignal?: AbortSignal,
+    onDeadline?: (deadlineMs: number) => void,
+  ): Promise<void> {
     let remaining = this.remainingMs;
 
     while (remaining > 0) {
-      await sleep(remaining, abortSignal);
+      onDeadline?.(this.cooldownUntilMs);
+      await abortableSleep(Math.min(remaining, WAIT_SLICE_MS), abortSignal);
       remaining = this.remainingMs;
     }
   }
@@ -147,11 +178,14 @@ export class RateLimitGate {
 
 /** A worker's in-progress rate-limit backoff, as shown on its card. */
 export interface SubagentRateLimitStatus {
-  /** 0-indexed retry attempt about to be made */
-  attempt: number;
+  /**
+   * 0-indexed retry attempt this wait leads to, or null when the worker was
+   * never rate-limited itself and is only holding for a sibling's backoff.
+   */
+  attempt: number | null;
   /** Retry budget, matching the main chat's MAX_RETRY_ATTEMPTS */
   maxAttempts: number;
-  /** Epoch ms when the backoff ends and the retry fires */
+  /** Epoch ms when the backoff ends and the wait releases */
   retryAtMs: number;
 }
 
@@ -170,8 +204,9 @@ const listeners = new Set<() => void>();
 
 /**
  * Publish (or clear, with null) a worker's rate-limit status and notify
- * subscribers. Clearing an id that has no status is a no-op — no notification,
- * so the common finish path doesn't re-render every card.
+ * subscribers. A write that changes nothing is a no-op — clearing an id that
+ * has no status (the common finish path) or republishing an unchanged deadline
+ * (every gate wait slice) must not re-render every card.
  * @param toolCallId - The spawn tool-call id identifying the worker's card
  * @param status - The backoff in progress, or null to clear
  */
@@ -182,6 +217,8 @@ export function setSubagentRateLimit(
   if (status == null) {
     if (!statuses.delete(toolCallId)) return;
   } else {
+    if (isSameStatus(statuses.get(toolCallId), status)) return;
+
     statuses.set(toolCallId, status);
   }
 
@@ -223,33 +260,22 @@ export function resetSubagentRateLimits(): void {
 }
 
 /**
- * Promise-based setTimeout that rejects instead of resolving when the signal
- * aborts, so an aborted turn unwinds its waiters rather than serving out a
- * minute-long backoff nobody is waiting for anymore.
- * @param ms - Delay in milliseconds
- * @param abortSignal - Signal that cancels the delay
+ * Whether a republished status is identical to what's already stored.
+ * @param previous - The stored status, if any
+ * @param next - The status being published
+ * @returns True when nothing subscribers care about changed
  */
-export function sleep(ms: number, abortSignal?: AbortSignal): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    if (abortSignal?.aborted) {
-      reject(new Error("Aborted"));
+function isSameStatus(
+  previous: SubagentRateLimitStatus | undefined,
+  next: SubagentRateLimitStatus,
+): boolean {
+  if (previous == null) return false;
 
-      return;
-    }
-
-    const timer: { id: ReturnType<typeof setTimeout> | null } = { id: null };
-
-    const onAbort = () => {
-      if (timer.id != null) clearTimeout(timer.id);
-      reject(new Error("Aborted"));
-    };
-
-    timer.id = setTimeout(() => {
-      abortSignal?.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-    abortSignal?.addEventListener("abort", onAbort, { once: true });
-  });
+  return (
+    previous.attempt === next.attempt &&
+    previous.maxAttempts === next.maxAttempts &&
+    previous.retryAtMs === next.retryAtMs
+  );
 }
 
 /**

--- a/webui/src/chat/sdk/subagent-rate-limit.ts
+++ b/webui/src/chat/sdk/subagent-rate-limit.ts
@@ -1,0 +1,301 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Rate-limit handling for subagent workers: the retry wrapper, the backoff
+ * window their orchestrator shares between them, and the side channel that gets
+ * a worker's wait onto its card.
+ *
+ * The main chat's 429s are handled a layer up, by useChat's executeWithRetry.
+ * Workers can't use it: they stream inside the spawn tool's execute(), below
+ * that hook, so everything they need lives here instead.
+ */
+
+import {
+  calculateRetryDelay,
+  detectRateLimit,
+  MAX_RETRY_ATTEMPTS,
+  shouldRetry,
+} from "#webui/lib/rate-limit";
+import { type ChatMessage } from "./types";
+
+/** Follow-up sent when a retry resumes a worker that already did some work. */
+const RESUME_MESSAGE = "continue";
+
+/** Options for one worker's retry-wrapped run. */
+export interface SubagentRetryOptions {
+  /** The delegated instruction, sent as the worker's first user message. */
+  task: string;
+  /** Run the worker's stream to completion with `message` as the user turn. */
+  runAttempt: (message: string) => Promise<void>;
+  /** The worker's live chat history (read to decide resume vs. restart). */
+  getHistory: () => ChatMessage[];
+  /** Backoff window shared with every sibling worker. */
+  gate: RateLimitGate;
+  /** The orchestrator turn's signal; aborts stop retrying immediately. */
+  abortSignal?: AbortSignal;
+  /** Publishes the current backoff (null = not waiting) for the card. */
+  onStatus?: (status: SubagentRateLimitStatus | null) => void;
+}
+
+/**
+ * Run one subagent worker with the same rate-limit backoff the main chat gets.
+ *
+ * Workers stream with `maxRetries: 0` like every other request, but they run
+ * inside a tool's execute() — out of reach of executeWithRetry — so a 429 used
+ * to reject straight out as a tool-error and kill the delegated work outright.
+ * This is that missing layer, plus the cross-worker coordination the main chat
+ * has no need for: every attempt parks on the shared gate first, and a 429 here
+ * penalizes the gate so siblings back off too instead of each rediscovering the
+ * limit on their own connection.
+ *
+ * Resuming mirrors executeWithRetry: once the worker has produced real output
+ * (text or a tool call — Live may already have been edited) the retry sends
+ * "continue" and keeps the work; with nothing to keep, the failed attempt's
+ * echoed task is dropped so the retry sends one clean turn instead of stacking
+ * duplicate user messages.
+ * @param options - Task, attempt runner, history accessor, gate, and callbacks
+ * @throws The underlying error when it isn't a rate limit, when the retry
+ *   budget is exhausted, or when the turn was aborted
+ */
+export async function runSubagentWithRetry(
+  options: SubagentRetryOptions,
+): Promise<void> {
+  const { task, runAttempt, getHistory, gate, abortSignal, onStatus } = options;
+  let attempt = 0;
+
+  try {
+    for (;;) {
+      // Hold off while any sibling is serving a shared cooldown, so N parallel
+      // spawns don't all hammer a provider that just rate-limited one of them.
+      await gate.wait(abortSignal);
+      onStatus?.(null);
+
+      try {
+        await runAttempt(nextMessage(task, getHistory()));
+
+        return;
+      } catch (error) {
+        const rateLimitInfo = detectRateLimit(error);
+
+        if (abortSignal?.aborted || !rateLimitInfo.isRateLimited) throw error;
+
+        if (!shouldRetry(attempt + 1)) throw exhaustedError(error, attempt + 1);
+
+        gate.penalize(calculateRetryDelay(attempt, rateLimitInfo.retryAfterMs));
+        onStatus?.({
+          attempt,
+          maxAttempts: MAX_RETRY_ATTEMPTS,
+          retryAtMs: Date.now() + gate.remainingMs,
+        });
+        attempt++;
+      }
+    }
+  } finally {
+    onStatus?.(null);
+  }
+}
+
+/**
+ * Shared backoff window for every worker under one orchestrator client.
+ *
+ * Parallel subagents each stream on their own provider connection, so a 429 hit
+ * by one worker says nothing to its siblings — without coordination they keep
+ * hammering the provider that just asked everyone to slow down, and each burns
+ * its own retry budget rediscovering the same limit. One gate instance lives on
+ * the orchestrator's ChatSdkClient and is shared by every worker it spawns.
+ *
+ * The window only ever moves later (penalize takes the max), so a longer
+ * Retry-After from a second worker mid-wait extends the wait for all of them.
+ */
+export class RateLimitGate {
+  private cooldownUntilMs = 0;
+
+  /**
+   * Milliseconds left in the shared cooldown; 0 when the gate is open.
+   * @returns Remaining cooldown in milliseconds
+   */
+  get remainingMs(): number {
+    return Math.max(0, this.cooldownUntilMs - Date.now());
+  }
+
+  /**
+   * Record a rate limit: hold everyone off for at least `delayMs` from now.
+   * @param delayMs - Backoff the caller intends to serve, in milliseconds
+   */
+  penalize(delayMs: number): void {
+    this.cooldownUntilMs = Math.max(this.cooldownUntilMs, Date.now() + delayMs);
+  }
+
+  /**
+   * Resolve once the shared cooldown has elapsed (immediately when open).
+   * Re-checks after each sleep so a sibling extending the window mid-wait keeps
+   * this caller parked rather than releasing it early.
+   * @param abortSignal - Cancels the wait (rejects) when the turn is aborted
+   */
+  async wait(abortSignal?: AbortSignal): Promise<void> {
+    let remaining = this.remainingMs;
+
+    while (remaining > 0) {
+      await sleep(remaining, abortSignal);
+      remaining = this.remainingMs;
+    }
+  }
+}
+
+/** A worker's in-progress rate-limit backoff, as shown on its card. */
+export interface SubagentRateLimitStatus {
+  /** 0-indexed retry attempt about to be made */
+  attempt: number;
+  /** Retry budget, matching the main chat's MAX_RETRY_ATTEMPTS */
+  maxAttempts: number;
+  /** Epoch ms when the backoff ends and the retry fires */
+  retryAtMs: number;
+}
+
+/**
+ * Live per-worker status keyed by the spawn tool-call id that owns the card.
+ *
+ * A worker runs entirely inside the spawn tool's execute(), so nothing it does
+ * reaches the orchestrator's fullStream — the card is frozen at "working…" for
+ * the whole worker run and cannot otherwise learn that the worker is sitting out
+ * a backoff. Module-level (not React state) because the writer is this
+ * framework-free client. Entries are transient: each is cleared when its worker
+ * finishes, and neither the history nor the model ever sees them.
+ */
+const statuses = new Map<string, SubagentRateLimitStatus>();
+const listeners = new Set<() => void>();
+
+/**
+ * Publish (or clear, with null) a worker's rate-limit status and notify
+ * subscribers. Clearing an id that has no status is a no-op — no notification,
+ * so the common finish path doesn't re-render every card.
+ * @param toolCallId - The spawn tool-call id identifying the worker's card
+ * @param status - The backoff in progress, or null to clear
+ */
+export function setSubagentRateLimit(
+  toolCallId: string,
+  status: SubagentRateLimitStatus | null,
+): void {
+  if (status == null) {
+    if (!statuses.delete(toolCallId)) return;
+  } else {
+    statuses.set(toolCallId, status);
+  }
+
+  for (const listener of listeners) listener();
+}
+
+/**
+ * Read a worker's current rate-limit status.
+ * @param toolCallId - The spawn tool-call id identifying the worker's card
+ * @returns The backoff in progress, or null when the worker isn't waiting
+ */
+export function getSubagentRateLimit(
+  toolCallId: string,
+): SubagentRateLimitStatus | null {
+  return statuses.get(toolCallId) ?? null;
+}
+
+/**
+ * Subscribe to every status change (the listener re-reads what it cares about).
+ * @param listener - Called after any status is set or cleared
+ * @returns Unsubscribe function
+ */
+export function subscribeToSubagentRateLimits(
+  listener: () => void,
+): () => void {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Drop all statuses without notifying. For test isolation only — production
+ * clears each entry through setSubagentRateLimit when its worker finishes.
+ */
+export function resetSubagentRateLimits(): void {
+  statuses.clear();
+}
+
+/**
+ * Promise-based setTimeout that rejects instead of resolving when the signal
+ * aborts, so an aborted turn unwinds its waiters rather than serving out a
+ * minute-long backoff nobody is waiting for anymore.
+ * @param ms - Delay in milliseconds
+ * @param abortSignal - Signal that cancels the delay
+ */
+export function sleep(ms: number, abortSignal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (abortSignal?.aborted) {
+      reject(new Error("Aborted"));
+
+      return;
+    }
+
+    const timer: { id: ReturnType<typeof setTimeout> | null } = { id: null };
+
+    const onAbort = () => {
+      if (timer.id != null) clearTimeout(timer.id);
+      reject(new Error("Aborted"));
+    };
+
+    timer.id = setTimeout(() => {
+      abortSignal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * The user turn the next attempt should send, dropping a leftover echo of the
+ * task when the failed attempt produced nothing worth resuming.
+ * @param task - The original delegated instruction
+ * @param history - The worker's chat history (cleared when restarting)
+ * @returns "continue" to resume partial work, or the task to start over
+ */
+function nextMessage(task: string, history: ChatMessage[]): string {
+  if (hasWorkerOutput(history)) return RESUME_MESSAGE;
+
+  history.length = 0;
+
+  return task;
+}
+
+/**
+ * Whether the worker produced output a retry must preserve. A tool call counts
+ * even with no text: it may already have changed the Live Set, so restarting
+ * from scratch would redo it.
+ * @param history - The worker's chat history
+ * @returns True when there is assistant output worth resuming from
+ */
+function hasWorkerOutput(history: ChatMessage[]): boolean {
+  return history.some(
+    (msg) =>
+      msg.role === "assistant" &&
+      !msg.isError &&
+      (msg.content.trim() !== "" || (msg.toolCalls?.length ?? 0) > 0),
+  );
+}
+
+/**
+ * Error surfaced to the orchestrator when a worker never got past the rate
+ * limit. Phrased so the model can act on it (wait, or do the work itself)
+ * rather than reading a raw provider 429.
+ * @param error - The last underlying rate-limit error
+ * @param attempts - How many attempts were made in total
+ * @returns The error to throw out of the spawn tool
+ */
+function exhaustedError(error: unknown, attempts: number): Error {
+  const detail = error instanceof Error ? error.message : String(error);
+
+  return new Error(
+    `Subagent gave up after ${attempts} rate-limited attempts: ${detail}. ` +
+      "Wait before delegating again, or do this part of the work yourself.",
+  );
+}

--- a/webui/src/chat/sdk/tests/client/client-subagent.test.ts
+++ b/webui/src/chat/sdk/tests/client/client-subagent.test.ts
@@ -26,10 +26,11 @@ vi.mock(import("#webui/utils/mcp-url"), () => ({
 }));
 
 // Shrink the worker's rate-limit backoff so the retry test doesn't wait seconds.
+// A vi.fn so the shared-gate test can lengthen it for its own window.
 vi.mock(import("#webui/lib/rate-limit"), async (importOriginal) => {
   const actual = await importOriginal();
 
-  return { ...actual, calculateRetryDelay: () => 10 };
+  return { ...actual, calculateRetryDelay: vi.fn(() => 10) };
 });
 
 import { streamText } from "ai";
@@ -43,6 +44,7 @@ import {
   createConfig,
   mockStreamParts,
 } from "#webui/chat/sdk/tests/client-test-helpers";
+import { calculateRetryDelay } from "#webui/lib/rate-limit";
 
 const streamTextMock = streamText as ReturnType<typeof vi.fn>;
 
@@ -105,6 +107,16 @@ function spawnToolExecute(): (
   };
 
   return tool.execute;
+}
+
+/**
+ * Wait real wall-clock time and let pending microtasks drain. Real timers (not
+ * fake ones) because the code under test interleaves timer waits with many
+ * awaits, and advancing fake timers doesn't reliably flush those.
+ * @param ms - Milliseconds to wait
+ */
+async function settle(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**
@@ -309,7 +321,10 @@ describe("ChatSdkClient runSubagent (delegation)", () => {
 describe("ChatSdkClient subagent rate-limit handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    streamTextMock.mockReset();
     resetSubagentRateLimits();
+    // Restore the file-wide short backoff; the shared-gate test lengthens it.
+    vi.mocked(calculateRetryDelay).mockReturnValue(10);
   });
 
   /**
@@ -354,6 +369,51 @@ describe("ChatSdkClient subagent rate-limit handling", () => {
     expect(result).toBe("Worker done.");
     // Cleared on the way out, so the card never keeps a stale countdown.
     expect(getSubagentRateLimit("t1")).toBeNull();
+  });
+
+  it("shares one backoff window across parallel workers", async () => {
+    // The gate lives on the orchestrator client, not per worker: a 429 in the
+    // first parallel spawn must stop the second from issuing its own request
+    // until the cooldown elapses. Moving the gate into runSubagent would break
+    // this and nothing else in the suite.
+    const execute = await orchestratorSpawnTool();
+    const cooldownMs = 300;
+
+    vi.mocked(calculateRetryDelay).mockReturnValue(cooldownMs);
+    streamTextMock
+      .mockReturnValueOnce(
+        throwingStream(
+          Object.assign(new Error("Too Many Requests"), { statusCode: 429 }),
+        ),
+      )
+      .mockImplementation(() =>
+        partsStream([
+          { type: "text-delta", text: "Worker done." },
+          { type: "finish", finishReason: "stop" },
+        ]),
+      );
+
+    const first = execute(
+      { task: "a" },
+      { toolCallId: "a", messages: [], abortSignal: undefined },
+    );
+
+    // Let the first worker reach its 429 and penalize the shared gate.
+    await settle(50);
+
+    const callsBeforeSecond = streamTextMock.mock.calls.length;
+    const second = execute(
+      { task: "b" },
+      { toolCallId: "b", messages: [], abortSignal: undefined },
+    );
+
+    // Well inside the cooldown: the second worker must still be parked.
+    await settle(50);
+    expect(streamTextMock.mock.calls).toHaveLength(callsBeforeSecond);
+    expect(getSubagentRateLimit("b")?.attempt).toBeNull();
+
+    await Promise.all([first, second]);
+    expect(streamTextMock.mock.calls.length).toBeGreaterThan(callsBeforeSecond);
   });
 
   it("still surfaces a non-rate-limit worker failure to the orchestrator", async () => {

--- a/webui/src/chat/sdk/tests/client/client-subagent.test.ts
+++ b/webui/src/chat/sdk/tests/client/client-subagent.test.ts
@@ -25,9 +25,20 @@ vi.mock(import("#webui/utils/mcp-url"), () => ({
   getMcpUrl: vi.fn(() => "http://localhost:3000/mcp"),
 }));
 
+// Shrink the worker's rate-limit backoff so the retry test doesn't wait seconds.
+vi.mock(import("#webui/lib/rate-limit"), async (importOriginal) => {
+  const actual = await importOriginal();
+
+  return { ...actual, calculateRetryDelay: () => 10 };
+});
+
 import { streamText } from "ai";
 import { ChatSdkClient } from "#webui/chat/sdk/client";
 import { SPAWN_SUBAGENT_TOOL_NAME } from "#webui/chat/sdk/spawn-subagent-tool";
+import {
+  getSubagentRateLimit,
+  resetSubagentRateLimits,
+} from "#webui/chat/sdk/subagent-rate-limit";
 import {
   createConfig,
   mockStreamParts,
@@ -45,6 +56,55 @@ function lastStreamTools(): Record<string, { execute?: unknown }> {
     { tools?: Record<string, { execute?: unknown }> } | undefined;
 
   return call?.tools ?? {};
+}
+
+/**
+ * A stream that rejects the way a provider 429 does, for the worker retry path.
+ * @param error - The error to throw on first iteration
+ * @returns A streamText-shaped result whose fullStream throws
+ */
+function throwingStream(error: unknown): {
+  fullStream: AsyncIterable<Record<string, unknown>>;
+} {
+  return {
+    fullStream: {
+      [Symbol.asyncIterator]: () => ({ next: () => Promise.reject(error) }),
+    },
+  };
+}
+
+/**
+ * A stream that yields the given parts (same shape as mockStreamParts, but
+ * returned rather than installed, so it can be queued with mockReturnValueOnce).
+ * @param parts - Stream parts to emit
+ * @returns A streamText-shaped result
+ */
+function partsStream(parts: Record<string, unknown>[]): {
+  fullStream: AsyncIterable<Record<string, unknown>>;
+} {
+  async function* iterate(): AsyncIterable<Record<string, unknown>> {
+    for (const p of parts) yield p;
+  }
+
+  return { fullStream: iterate() };
+}
+
+/**
+ * Grab the spawn tool the orchestrator injected into its last streamText call.
+ * @returns The spawn tool's execute function
+ */
+function spawnToolExecute(): (
+  args: Record<string, unknown>,
+  opts: { toolCallId: string; messages: []; abortSignal?: AbortSignal },
+) => Promise<string> {
+  const tool = lastStreamTools()[SPAWN_SUBAGENT_TOOL_NAME] as {
+    execute: (
+      args: Record<string, unknown>,
+      opts: { toolCallId: string; messages: []; abortSignal?: AbortSignal },
+    ) => Promise<string>;
+  };
+
+  return tool.execute;
 }
 
 /**
@@ -243,5 +303,72 @@ describe("ChatSdkClient runSubagent (delegation)", () => {
 
     expect(entry?.subagentTranscript).toBeDefined();
     expect(entry?.subagentTranscript?.at(-1)?.content).toBe("Worker done.");
+  });
+});
+
+describe("ChatSdkClient subagent rate-limit handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetSubagentRateLimits();
+  });
+
+  /**
+   * Stand up an orchestrator and hand back its spawn tool's execute.
+   * @returns The spawn tool's execute function
+   */
+  async function orchestratorSpawnTool() {
+    const client = new ChatSdkClient(
+      "key",
+      createConfig({ enabledTools: { [SPAWN_SUBAGENT_TOOL_NAME]: true } }),
+    );
+
+    await client.initialize();
+    await runTurn(client);
+
+    return spawnToolExecute();
+  }
+
+  it("retries a rate-limited worker instead of failing the spawn", async () => {
+    // Workers stream below useChat's executeWithRetry, so without the retry
+    // inside runSubagent a single 429 killed the whole delegated subtask.
+    const execute = await orchestratorSpawnTool();
+
+    streamTextMock
+      .mockReturnValueOnce(
+        throwingStream(
+          Object.assign(new Error("Too Many Requests"), { statusCode: 429 }),
+        ),
+      )
+      .mockReturnValueOnce(
+        partsStream([
+          { type: "text-delta", text: "Worker done." },
+          { type: "finish", finishReason: "stop" },
+        ]),
+      );
+
+    const result = await execute(
+      { task: "add a bassline" },
+      { toolCallId: "t1", messages: [], abortSignal: undefined },
+    );
+
+    expect(result).toBe("Worker done.");
+    // Cleared on the way out, so the card never keeps a stale countdown.
+    expect(getSubagentRateLimit("t1")).toBeNull();
+  });
+
+  it("still surfaces a non-rate-limit worker failure to the orchestrator", async () => {
+    const execute = await orchestratorSpawnTool();
+
+    streamTextMock.mockReturnValueOnce(
+      throwingStream(new Error("MCP connection refused")),
+    );
+
+    await expect(
+      execute(
+        { task: "x" },
+        { toolCallId: "t2", messages: [], abortSignal: undefined },
+      ),
+    ).rejects.toThrow("MCP connection refused");
+    expect(getSubagentRateLimit("t2")).toBeNull();
   });
 });

--- a/webui/src/chat/sdk/tests/client/client-subagent.test.ts
+++ b/webui/src/chat/sdk/tests/client/client-subagent.test.ts
@@ -110,13 +110,23 @@ function spawnToolExecute(): (
 }
 
 /**
- * Wait real wall-clock time and let pending microtasks drain. Real timers (not
- * fake ones) because the code under test interleaves timer waits with many
- * awaits, and advancing fake timers doesn't reliably flush those.
- * @param ms - Milliseconds to wait
+ * Poll until `condition` holds. Real timers (not fake ones) because the code
+ * under test interleaves timer waits with many awaits, and advancing fake timers
+ * doesn't reliably flush those. Waiting on an observable condition rather than a
+ * fixed delay matters here: a fixed wait that proved too short would make the
+ * shared-gate assertions fail as though the gate were per-worker.
+ * @param condition - Checked after each tick
+ * @param timeoutMs - Give up (and let the assertion report the real state) after this
  */
-async function settle(ms: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, ms));
+async function until(
+  condition: () => boolean,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (!condition() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
 }
 
 /**
@@ -398,8 +408,9 @@ describe("ChatSdkClient subagent rate-limit handling", () => {
       { toolCallId: "a", messages: [], abortSignal: undefined },
     );
 
-    // Let the first worker reach its 429 and penalize the shared gate.
-    await settle(50);
+    // The first worker publishing a backoff IS the signal that it took the 429
+    // and penalized the gate — wait for that rather than guessing a delay.
+    await until(() => getSubagentRateLimit("a") != null);
 
     const callsBeforeSecond = streamTextMock.mock.calls.length;
     const second = execute(
@@ -407,10 +418,12 @@ describe("ChatSdkClient subagent rate-limit handling", () => {
       { toolCallId: "b", messages: [], abortSignal: undefined },
     );
 
-    // Well inside the cooldown: the second worker must still be parked.
-    await settle(50);
-    expect(streamTextMock.mock.calls).toHaveLength(callsBeforeSecond);
+    // The second worker parks on the shared window instead of requesting, and
+    // publishes attempt null (waiting on a sibling, not its own retry). Reaching
+    // that state at all proves it consulted the same gate.
+    await until(() => getSubagentRateLimit("b") != null);
     expect(getSubagentRateLimit("b")?.attempt).toBeNull();
+    expect(streamTextMock.mock.calls).toHaveLength(callsBeforeSecond);
 
     await Promise.all([first, second]);
     expect(streamTextMock.mock.calls.length).toBeGreaterThan(callsBeforeSecond);

--- a/webui/src/chat/sdk/tests/formatter.test.ts
+++ b/webui/src/chat/sdk/tests/formatter.test.ts
@@ -70,6 +70,8 @@ describe("formatChatMessages", () => {
     expect(result[0]!.parts).toStrictEqual([
       {
         type: "tool",
+        // Carried through so a running call can be matched to live status.
+        id: "tc1",
         name: "ppal-connect",
         args: {},
         result: '"Connected"',
@@ -144,6 +146,7 @@ describe("formatChatMessages", () => {
     expect(result[0]!.parts).toStrictEqual([
       {
         type: "tool",
+        id: "tc1",
         name: "ppal-connect",
         args: {},
         result: null,

--- a/webui/src/chat/sdk/tests/spawn-subagent-tool.test.ts
+++ b/webui/src/chat/sdk/tests/spawn-subagent-tool.test.ts
@@ -22,6 +22,7 @@ import { createConfig } from "./client-test-helpers";
 type RunWorker = (
   workerConfig: ChatClientConfig,
   task: string,
+  toolCallId: string,
   abortSignal?: AbortSignal,
 ) => Promise<ChatMessage[]>;
 
@@ -228,13 +229,15 @@ describe("createSpawnSubagentTool", () => {
     expect(runWorker.mock.calls[0]?.[1]).toBe("write a bassline");
   });
 
-  it("forwards the abort signal to the worker", async () => {
+  it("forwards the tool-call id and abort signal to the worker", async () => {
     const { tool, runWorker } = setup();
     const controller = new AbortController();
 
     await tool.execute!({ task: "x" }, options(controller.signal));
 
-    expect(runWorker.mock.calls[0]?.[2]).toBe(controller.signal);
+    // The id keys the card's live status, so it must reach the runner.
+    expect(runWorker.mock.calls[0]?.[2]).toBe("tc1");
+    expect(runWorker.mock.calls[0]?.[3]).toBe(controller.signal);
   });
 
   it("increments the shared spawn counter", async () => {

--- a/webui/src/chat/sdk/tests/subagent-rate-limit.test.ts
+++ b/webui/src/chat/sdk/tests/subagent-rate-limit.test.ts
@@ -20,7 +20,6 @@ import {
   resetSubagentRateLimits,
   runSubagentWithRetry,
   setSubagentRateLimit,
-  sleep,
   subscribeToSubagentRateLimits,
 } from "#webui/chat/sdk/subagent-rate-limit";
 import { type ChatMessage } from "#webui/chat/sdk/types";
@@ -256,6 +255,52 @@ describe("runSubagentWithRetry", () => {
     expect(statuses.at(-1)).toBeNull();
   });
 
+  it("reports a wait forced purely by a sibling's backoff as not its own", async () => {
+    // This worker was never rate-limited; it's only holding the shared gate, so
+    // its card must not claim it is retrying.
+    const gate = new RateLimitGate();
+    const statuses: Array<SubagentRateLimitStatus | null> = [];
+
+    gate.penalize(30);
+
+    const { options } = setup(
+      [(h) => h.push({ role: "assistant", content: "Done." })],
+      { gate, onStatus: (status) => statuses.push(status) },
+    );
+
+    await runSubagentWithRetry(options);
+
+    expect(statuses.find((s) => s != null)?.attempt).toBeNull();
+  });
+
+  it("republishes the deadline when a sibling extends the window mid-wait", async () => {
+    // Without this the card counts down to 0 and then sits there for however
+    // much longer the sibling's Retry-After added — the "looks hung" state the
+    // card exists to prevent.
+    const gate = new RateLimitGate();
+    const statuses: Array<SubagentRateLimitStatus | null> = [];
+
+    gate.penalize(40);
+
+    const { options } = setup(
+      [(h) => h.push({ role: "assistant", content: "Done." })],
+      { gate, onStatus: (status) => statuses.push(status) },
+    );
+
+    const run = runSubagentWithRetry(options);
+
+    gate.penalize(120);
+    await run;
+
+    const deadlines = statuses
+      .filter((s) => s != null)
+      .map((s) => s.retryAtMs)
+      .filter((value, index, all) => all.indexOf(value) === index);
+
+    expect(deadlines.length).toBeGreaterThan(1);
+    expect(deadlines.at(-1)).toBeGreaterThan(deadlines[0] as number);
+  });
+
   it("clears the published backoff even when the worker ends up failing", async () => {
     const statuses: Array<SubagentRateLimitStatus | null> = [];
     const { options } = setup(
@@ -329,6 +374,34 @@ describe("RateLimitGate", () => {
     expect(released).toBe(true);
   });
 
+  it("reports the current deadline to a waiter, and again when it moves", async () => {
+    const gate = new RateLimitGate();
+    const deadlines: number[] = [];
+
+    gate.penalize(1000);
+
+    const waiting = gate.wait(undefined, (deadlineMs) =>
+      deadlines.push(deadlineMs),
+    );
+
+    await vi.advanceTimersByTimeAsync(600);
+    gate.penalize(2000);
+    await vi.advanceTimersByTimeAsync(3000);
+    await waiting;
+
+    // Slices re-read the window, so the extension is reported, not swallowed.
+    expect(deadlines.at(-1)).toBeGreaterThan(deadlines[0] as number);
+  });
+
+  it("does not report a deadline when the gate is already open", async () => {
+    const gate = new RateLimitGate();
+    const deadlines: number[] = [];
+
+    await gate.wait(undefined, (deadlineMs) => deadlines.push(deadlineMs));
+
+    expect(deadlines).toStrictEqual([]);
+  });
+
   it("never shortens an existing cooldown", () => {
     const gate = new RateLimitGate();
 
@@ -345,41 +418,6 @@ describe("RateLimitGate", () => {
     await vi.advanceTimersByTimeAsync(1500);
 
     expect(gate.remainingMs).toBe(0);
-  });
-});
-
-describe("sleep", () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("rejects a pending sleep when the signal aborts", async () => {
-    const controller = new AbortController();
-    const pending = sleep(1000, controller.signal);
-
-    controller.abort();
-
-    await expect(pending).rejects.toThrow("Aborted");
-  });
-
-  it("rejects immediately when the signal is already aborted", async () => {
-    const controller = new AbortController();
-
-    controller.abort();
-
-    await expect(sleep(1000, controller.signal)).rejects.toThrow("Aborted");
-  });
-
-  it("resolves normally when the signal never aborts", async () => {
-    const controller = new AbortController();
-    const pending = sleep(1000, controller.signal);
-
-    await vi.advanceTimersByTimeAsync(1000);
-    await expect(pending).resolves.toBeUndefined();
   });
 });
 
@@ -421,6 +459,20 @@ describe("subagent rate-limit status", () => {
     setSubagentRateLimit("tc1", null);
     unsubscribe();
     setSubagentRateLimit("tc1", backoff);
+
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not notify when republishing an unchanged status", () => {
+    // Gate waits republish the same deadline every slice; that must not
+    // re-render every card once a second.
+    const listener = vi.fn();
+    const unsubscribe = subscribeToSubagentRateLimits(listener);
+
+    setSubagentRateLimit("tc1", backoff);
+    setSubagentRateLimit("tc1", { ...backoff });
+    setSubagentRateLimit("tc1", { ...backoff, retryAtMs: 2000 });
+    unsubscribe();
 
     expect(listener).toHaveBeenCalledTimes(2);
   });

--- a/webui/src/chat/sdk/tests/subagent-rate-limit.test.ts
+++ b/webui/src/chat/sdk/tests/subagent-rate-limit.test.ts
@@ -1,0 +1,439 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shrink the backoff so these tests don't sit through real seconds-long waits.
+vi.mock(import("#webui/lib/rate-limit"), async (importOriginal) => {
+  const actual = await importOriginal();
+
+  return { ...actual, calculateRetryDelay: () => 20 };
+});
+
+import {
+  type SubagentRateLimitStatus,
+  type SubagentRetryOptions,
+  RateLimitGate,
+  getSubagentRateLimit,
+  resetSubagentRateLimits,
+  runSubagentWithRetry,
+  setSubagentRateLimit,
+  sleep,
+  subscribeToSubagentRateLimits,
+} from "#webui/chat/sdk/subagent-rate-limit";
+import { type ChatMessage } from "#webui/chat/sdk/types";
+import { MAX_RETRY_ATTEMPTS } from "#webui/lib/rate-limit";
+
+/**
+ * A provider 429 as the AI SDK surfaces it (APICallError uses statusCode).
+ * @returns A rate-limit error
+ */
+function rateLimitError(): Error {
+  return Object.assign(new Error("Too Many Requests"), { statusCode: 429 });
+}
+
+/**
+ * Build retry options over a mutable history, with a runAttempt that records
+ * the messages it was sent and applies each scripted attempt outcome.
+ * @param attempts - Per-attempt behavior: throw the error, or mutate history
+ * @param overrides - Extra option overrides (gate, abortSignal, onStatus)
+ * @returns The options plus the history and the messages runAttempt saw
+ */
+function setup(
+  attempts: Array<(history: ChatMessage[]) => void>,
+  overrides?: Partial<SubagentRetryOptions>,
+) {
+  const history: ChatMessage[] = [];
+  const messages: string[] = [];
+  let index = 0;
+
+  const options: SubagentRetryOptions = {
+    task: "add a bassline",
+    getHistory: () => history,
+    gate: new RateLimitGate(),
+    runAttempt: async (message) => {
+      messages.push(message);
+      // Every attempt echoes the user turn into history first, like sendMessage.
+      history.push({ role: "user", content: message });
+      await Promise.resolve();
+      (attempts[index++] ?? (() => {}))(history);
+    },
+    ...overrides,
+  };
+
+  return { options, history, messages };
+}
+
+describe("runSubagentWithRetry", () => {
+  it("passes the task straight through when nothing goes wrong", async () => {
+    const { options, messages } = setup([
+      (history) => history.push({ role: "assistant", content: "Done." }),
+    ]);
+
+    await runSubagentWithRetry(options);
+
+    expect(messages).toStrictEqual(["add a bassline"]);
+  });
+
+  it("retries a rate-limited worker instead of failing the spawn", async () => {
+    const { options, messages } = setup([
+      () => {
+        throw rateLimitError();
+      },
+      (history) => history.push({ role: "assistant", content: "Done." }),
+    ]);
+
+    await runSubagentWithRetry(options);
+
+    expect(messages).toStrictEqual(["add a bassline", "add a bassline"]);
+  });
+
+  it("restarts cleanly when the failed attempt produced nothing", async () => {
+    // The failed attempt left only its echoed task behind; resending without
+    // dropping it would stack duplicate user turns in the worker's history.
+    const { options, history } = setup([
+      () => {
+        throw rateLimitError();
+      },
+      (h) => h.push({ role: "assistant", content: "Done." }),
+    ]);
+
+    await runSubagentWithRetry(options);
+
+    expect(history.filter((m) => m.role === "user")).toHaveLength(1);
+  });
+
+  it("resumes with continue when the worker already produced text", async () => {
+    const { options, messages, history } = setup([
+      (h) => {
+        h.push({ role: "assistant", content: "Wrote the first half." });
+
+        throw rateLimitError();
+      },
+      (h) => h.push({ role: "assistant", content: "Done." }),
+    ]);
+
+    await runSubagentWithRetry(options);
+
+    expect(messages).toStrictEqual(["add a bassline", "continue"]);
+    expect(history[1]?.content).toBe("Wrote the first half.");
+  });
+
+  it("resumes with continue after a tool call with no text", async () => {
+    // A tool call may already have edited the Live Set, so restarting from
+    // scratch would redo it.
+    const { options, messages } = setup([
+      (h) => {
+        h.push({
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "t1", name: "ppal-create-clip", args: {} }],
+        });
+
+        throw rateLimitError();
+      },
+      (h) => h.push({ role: "assistant", content: "Done." }),
+    ]);
+
+    await runSubagentWithRetry(options);
+
+    expect(messages).toStrictEqual(["add a bassline", "continue"]);
+  });
+
+  it("penalizes the shared gate so sibling workers back off too", async () => {
+    const gate = new RateLimitGate();
+    const { options } = setup(
+      [
+        () => {
+          throw rateLimitError();
+        },
+        (h) => h.push({ role: "assistant", content: "Done." }),
+      ],
+      { gate },
+    );
+
+    const penalized = new Promise<number>((resolve) => {
+      const original = gate.penalize.bind(gate);
+
+      gate.penalize = (delayMs: number) => {
+        original(delayMs);
+        resolve(gate.remainingMs);
+      };
+    });
+
+    await runSubagentWithRetry(options);
+
+    expect(await penalized).toBeGreaterThan(0);
+  });
+
+  it("waits on the shared gate before its first attempt", async () => {
+    // A worker spawned while a sibling is cooling down must not add load.
+    const gate = new RateLimitGate();
+
+    gate.penalize(30);
+
+    const { options, messages } = setup(
+      [(h) => h.push({ role: "assistant", content: "Done." })],
+      { gate },
+    );
+
+    await runSubagentWithRetry(options);
+
+    expect(messages).toHaveLength(1);
+    expect(gate.remainingMs).toBe(0);
+  });
+
+  it("rethrows a non-rate-limit error without retrying", async () => {
+    const { options, messages } = setup([
+      () => {
+        throw new Error("MCP connection refused");
+      },
+    ]);
+
+    await expect(runSubagentWithRetry(options)).rejects.toThrow(
+      "MCP connection refused",
+    );
+    expect(messages).toHaveLength(1);
+  });
+
+  it("stops retrying once the turn is aborted", async () => {
+    const controller = new AbortController();
+    const { options, messages } = setup(
+      [
+        () => {
+          controller.abort();
+
+          throw rateLimitError();
+        },
+      ],
+      { abortSignal: controller.signal },
+    );
+
+    await expect(runSubagentWithRetry(options)).rejects.toThrow(
+      "Too Many Requests",
+    );
+    expect(messages).toHaveLength(1);
+  });
+
+  it("gives the orchestrator an actionable error once the budget runs out", async () => {
+    const alwaysRateLimited = Array.from({ length: MAX_RETRY_ATTEMPTS }, () => {
+      return () => {
+        throw rateLimitError();
+      };
+    });
+    const { options, messages } = setup(alwaysRateLimited);
+
+    await expect(runSubagentWithRetry(options)).rejects.toThrow(
+      `gave up after ${MAX_RETRY_ATTEMPTS} rate-limited attempts`,
+    );
+    expect(messages).toHaveLength(MAX_RETRY_ATTEMPTS);
+  });
+
+  it("publishes the backoff for the card and clears it when done", async () => {
+    const statuses: Array<SubagentRateLimitStatus | null> = [];
+    const { options } = setup(
+      [
+        () => {
+          throw rateLimitError();
+        },
+        (h) => h.push({ role: "assistant", content: "Done." }),
+      ],
+      { onStatus: (status) => statuses.push(status) },
+    );
+
+    await runSubagentWithRetry(options);
+
+    const backoff = statuses.find((s) => s != null);
+
+    expect(backoff).toMatchObject({
+      attempt: 0,
+      maxAttempts: MAX_RETRY_ATTEMPTS,
+    });
+    expect(backoff?.retryAtMs).toBeGreaterThan(0);
+    // Always ends cleared, so a finished card never shows a stale countdown.
+    expect(statuses.at(-1)).toBeNull();
+  });
+
+  it("clears the published backoff even when the worker ends up failing", async () => {
+    const statuses: Array<SubagentRateLimitStatus | null> = [];
+    const { options } = setup(
+      [
+        () => {
+          throw new Error("boom");
+        },
+      ],
+      { onStatus: (status) => statuses.push(status) },
+    );
+
+    await expect(runSubagentWithRetry(options)).rejects.toThrow("boom");
+    expect(statuses.at(-1)).toBeNull();
+  });
+});
+
+describe("RateLimitGate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is open until something is rate-limited", async () => {
+    const gate = new RateLimitGate();
+
+    expect(gate.remainingMs).toBe(0);
+    await expect(gate.wait()).resolves.toBeUndefined();
+  });
+
+  it("parks waiters until the cooldown elapses", async () => {
+    const gate = new RateLimitGate();
+    let released = false;
+
+    gate.penalize(1000);
+
+    const waiting = gate.wait().then(() => {
+      released = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(600);
+    expect(released).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(400);
+    await waiting;
+    expect(released).toBe(true);
+  });
+
+  it("keeps a waiter parked when a sibling extends the window mid-wait", async () => {
+    // The whole point of sharing the gate: worker B's longer Retry-After must
+    // hold worker A too, instead of A waking on its own shorter deadline.
+    const gate = new RateLimitGate();
+    let released = false;
+
+    gate.penalize(1000);
+
+    const waiting = gate.wait().then(() => {
+      released = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(600);
+    gate.penalize(1000);
+
+    await vi.advanceTimersByTimeAsync(400);
+    expect(released).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(600);
+    await waiting;
+    expect(released).toBe(true);
+  });
+
+  it("never shortens an existing cooldown", () => {
+    const gate = new RateLimitGate();
+
+    gate.penalize(5000);
+    gate.penalize(100);
+
+    expect(gate.remainingMs).toBe(5000);
+  });
+
+  it("reports a cooldown that has already expired as open", async () => {
+    const gate = new RateLimitGate();
+
+    gate.penalize(1000);
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(gate.remainingMs).toBe(0);
+  });
+});
+
+describe("sleep", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rejects a pending sleep when the signal aborts", async () => {
+    const controller = new AbortController();
+    const pending = sleep(1000, controller.signal);
+
+    controller.abort();
+
+    await expect(pending).rejects.toThrow("Aborted");
+  });
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    const controller = new AbortController();
+
+    controller.abort();
+
+    await expect(sleep(1000, controller.signal)).rejects.toThrow("Aborted");
+  });
+
+  it("resolves normally when the signal never aborts", async () => {
+    const controller = new AbortController();
+    const pending = sleep(1000, controller.signal);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(pending).resolves.toBeUndefined();
+  });
+});
+
+const backoff = { attempt: 0, maxAttempts: 5, retryAtMs: 1000 };
+
+describe("subagent rate-limit status", () => {
+  afterEach(() => {
+    resetSubagentRateLimits();
+  });
+
+  it("round-trips a status by tool-call id", () => {
+    setSubagentRateLimit("tc1", backoff);
+
+    expect(getSubagentRateLimit("tc1")).toStrictEqual(backoff);
+    expect(getSubagentRateLimit("tc2")).toBeNull();
+  });
+
+  it("clears a status with null", () => {
+    setSubagentRateLimit("tc1", backoff);
+    setSubagentRateLimit("tc1", null);
+
+    expect(getSubagentRateLimit("tc1")).toBeNull();
+  });
+
+  it("keeps parallel workers independent", () => {
+    setSubagentRateLimit("tc1", backoff);
+    setSubagentRateLimit("tc2", { ...backoff, attempt: 2 });
+    setSubagentRateLimit("tc1", null);
+
+    expect(getSubagentRateLimit("tc1")).toBeNull();
+    expect(getSubagentRateLimit("tc2")?.attempt).toBe(2);
+  });
+
+  it("notifies subscribers on set and clear, and stops after unsubscribe", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToSubagentRateLimits(listener);
+
+    setSubagentRateLimit("tc1", backoff);
+    setSubagentRateLimit("tc1", null);
+    unsubscribe();
+    setSubagentRateLimit("tc1", backoff);
+
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not notify when clearing an id that was never set", () => {
+    // Every worker clears its id on finish, so the common path must not
+    // re-render every other card.
+    const listener = vi.fn();
+    const unsubscribe = subscribeToSubagentRateLimits(listener);
+
+    setSubagentRateLimit("never-waited", null);
+    unsubscribe();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/webui/src/components/chat/assistant/AssistantMessage.tsx
+++ b/webui/src/components/chat/assistant/AssistantMessage.tsx
@@ -143,6 +143,7 @@ function renderSinglePart(
           result={part.result}
           isError={part.isError}
           isResponding={isResponding}
+          toolCallId={part.id}
           transcript={renderSubagentTranscript(part.subagentMessages)}
         />
       );

--- a/webui/src/components/chat/assistant/tests/AssistantSubagentCall.test.tsx
+++ b/webui/src/components/chat/assistant/tests/AssistantSubagentCall.test.tsx
@@ -130,6 +130,24 @@ describe("AssistantSubagentCall", () => {
     expect(screen.queryByText(/Rate limited/)).toBeNull();
   });
 
+  it("distinguishes waiting on a sibling's backoff from its own rate limit", async () => {
+    // attempt null = this worker was never rate-limited, it's only holding the
+    // shared gate. Calling that "rate limited" would misreport it.
+    render(<AssistantSubagentCall task="x" result={null} toolCallId="tc1" />);
+
+    await act(() =>
+      setSubagentRateLimit("tc1", {
+        attempt: null,
+        maxAttempts: 5,
+        retryAtMs: Date.now() + 20_000,
+      }),
+    );
+
+    expect(screen.getByText("waiting")).toBeDefined();
+    expect(screen.getByText(/Another subagent hit a rate limit/)).toBeDefined();
+    expect(screen.queryByText("rate limited")).toBeNull();
+  });
+
   it("counts the backoff down while it elapses", async () => {
     vi.useFakeTimers();
 

--- a/webui/src/components/chat/assistant/tests/AssistantSubagentCall.test.tsx
+++ b/webui/src/components/chat/assistant/tests/AssistantSubagentCall.test.tsx
@@ -6,11 +6,19 @@
 /**
  * @vitest-environment happy-dom
  */
-import { render, screen } from "@testing-library/preact";
-import { describe, expect, it } from "vitest";
+import { act, render, screen } from "@testing-library/preact";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  resetSubagentRateLimits,
+  setSubagentRateLimit,
+} from "#webui/chat/sdk/subagent-rate-limit";
 import { AssistantSubagentCall } from "#webui/components/chat/assistant/tool-calls/AssistantSubagentCall";
 
 describe("AssistantSubagentCall", () => {
+  afterEach(() => {
+    resetSubagentRateLimits();
+  });
+
   it("shows a working state while the subagent runs (result null)", () => {
     render(<AssistantSubagentCall task="write a bassline" result={null} />);
 
@@ -66,5 +74,153 @@ describe("AssistantSubagentCall", () => {
     render(<AssistantSubagentCall task="x" result={JSON.stringify("done")} />);
 
     expect(screen.queryByText("↳ subagent transcript")).toBeNull();
+  });
+
+  it("shows the backoff countdown while the worker is rate-limited", async () => {
+    // The card is otherwise frozen on "working…" for the whole backoff, which
+    // can run minutes — indistinguishable from a hung subagent.
+    render(<AssistantSubagentCall task="x" result={null} toolCallId="tc1" />);
+
+    await act(() =>
+      setSubagentRateLimit("tc1", {
+        attempt: 1,
+        maxAttempts: 5,
+        retryAtMs: Date.now() + 20_000,
+      }),
+    );
+
+    expect(screen.getByText("rate limited")).toBeDefined();
+    expect(
+      screen.getByText(/retrying in 2\ds \(attempt 2 of 5\)/),
+    ).toBeDefined();
+  });
+
+  it("drops back to working when the backoff clears", async () => {
+    render(<AssistantSubagentCall task="x" result={null} toolCallId="tc1" />);
+
+    await act(() =>
+      setSubagentRateLimit("tc1", {
+        attempt: 0,
+        maxAttempts: 5,
+        retryAtMs: Date.now() + 5000,
+      }),
+    );
+    await act(() => setSubagentRateLimit("tc1", null));
+
+    expect(screen.getByText("working…")).toBeDefined();
+    expect(screen.queryByText(/Rate limited/)).toBeNull();
+  });
+
+  it("ignores a stale backoff once the call has a result", () => {
+    setSubagentRateLimit("tc1", {
+      attempt: 0,
+      maxAttempts: 5,
+      retryAtMs: Date.now() + 5000,
+    });
+
+    render(
+      <AssistantSubagentCall
+        task="x"
+        result={JSON.stringify("Bassline added.")}
+        toolCallId="tc1"
+      />,
+    );
+
+    expect(screen.getByText("done")).toBeDefined();
+    expect(screen.queryByText(/Rate limited/)).toBeNull();
+  });
+
+  it("counts the backoff down while it elapses", async () => {
+    vi.useFakeTimers();
+
+    try {
+      render(<AssistantSubagentCall task="x" result={null} toolCallId="tc1" />);
+
+      await act(() =>
+        setSubagentRateLimit("tc1", {
+          attempt: 0,
+          maxAttempts: 5,
+          retryAtMs: Date.now() + 10_000,
+        }),
+      );
+      expect(screen.getByText(/retrying in 10s/)).toBeDefined();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      expect(screen.getByText(/retrying in 7s/)).toBeDefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("picks up a backoff that was already in flight before it mounted", () => {
+    setSubagentRateLimit("tc1", {
+      attempt: 0,
+      maxAttempts: 5,
+      retryAtMs: Date.now() + 5000,
+    });
+
+    render(<AssistantSubagentCall task="x" result={null} toolCallId="tc1" />);
+
+    expect(screen.getByText("rate limited")).toBeDefined();
+  });
+
+  it("ignores a sibling worker's backoff", () => {
+    setSubagentRateLimit("tc2", {
+      attempt: 0,
+      maxAttempts: 5,
+      retryAtMs: Date.now() + 5000,
+    });
+
+    render(<AssistantSubagentCall task="x" result={null} toolCallId="tc1" />);
+
+    expect(screen.getByText("working…")).toBeDefined();
+  });
+
+  it("drops the backoff when the call finishes mid-wait", async () => {
+    // The result arriving unsubscribes the card; a status left in the store
+    // (e.g. a sibling's) must not keep showing a countdown on a done card.
+    const { rerender } = render(
+      <AssistantSubagentCall task="x" result={null} toolCallId="tc1" />,
+    );
+
+    await act(() =>
+      setSubagentRateLimit("tc1", {
+        attempt: 0,
+        maxAttempts: 5,
+        retryAtMs: Date.now() + 5000,
+      }),
+    );
+    expect(screen.getByText("rate limited")).toBeDefined();
+
+    rerender(
+      <AssistantSubagentCall
+        task="x"
+        result={JSON.stringify("Bassline added.")}
+        toolCallId="tc1"
+      />,
+    );
+
+    expect(screen.getByText("done")).toBeDefined();
+    expect(screen.queryByText(/Rate limited/)).toBeNull();
+  });
+
+  it("stops listening once unmounted", async () => {
+    const { unmount } = render(
+      <AssistantSubagentCall task="x" result={null} toolCallId="tc1" />,
+    );
+
+    unmount();
+    await act(() =>
+      setSubagentRateLimit("tc1", {
+        attempt: 0,
+        maxAttempts: 5,
+        retryAtMs: Date.now() + 5000,
+      }),
+    );
+
+    expect(screen.queryByText("rate limited")).toBeNull();
   });
 });

--- a/webui/src/components/chat/assistant/tool-calls/AssistantSubagentCall.tsx
+++ b/webui/src/components/chat/assistant/tool-calls/AssistantSubagentCall.tsx
@@ -4,6 +4,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { type ComponentChildren } from "preact";
+import { useEffect, useState } from "preact/hooks";
+import {
+  type SubagentRateLimitStatus,
+  getSubagentRateLimit,
+  subscribeToSubagentRateLimits,
+} from "#webui/chat/sdk/subagent-rate-limit";
 import { DisclosureChevron } from "#webui/components/chat/controls/header/HeaderIcons";
 import { sanitizeMarkdown } from "#webui/lib/utils/sanitize-markdown";
 import { truncateString } from "#webui/lib/utils/truncate-string";
@@ -13,6 +19,8 @@ interface AssistantSubagentCallProps {
   result: string | null;
   isError?: boolean;
   isResponding?: boolean;
+  /** Spawn tool-call id, used to pick up the worker's live rate-limit backoff. */
+  toolCallId?: string;
   /** Rendered worker transcript for the deep-dive tier; omitted when none. */
   transcript?: ComponentChildren;
 }
@@ -30,6 +38,7 @@ const baseClasses =
  * @param {string | null} root0.result - Compact return value, or null while running
  * @param {boolean} [root0.isError] - Whether the subagent call failed
  * @param {boolean} [root0.isResponding] - Whether the assistant is still responding
+ * @param {string} [root0.toolCallId] - Spawn tool-call id for live status lookup
  * @param {ComponentChildren} [root0.transcript] - Rendered worker transcript
  * @returns {JSX.Element} - React component
  */
@@ -38,11 +47,22 @@ export function AssistantSubagentCall({
   result,
   isError,
   isResponding,
+  toolCallId,
   transcript,
 }: AssistantSubagentCallProps) {
   const running = result == null;
   const returnValue = unwrapResult(result);
-  const status = running ? "working…" : isError ? "failed" : "done";
+  // A worker waiting out a 429 is still "running" as far as the tool result is
+  // concerned; without this the card would sit on "working…" through a backoff
+  // that can last minutes.
+  const rateLimit = useSubagentRateLimit(running ? toolCallId : undefined);
+  const status = running
+    ? rateLimit
+      ? "rate limited"
+      : "working…"
+    : isError
+      ? "failed"
+      : "done";
 
   return (
     <details
@@ -57,7 +77,7 @@ export function AssistantSubagentCall({
           {truncateString(task, 80)}
         </span>
         <span
-          className={`ml-auto shrink-0 ${isError ? "text-red-700 dark:text-red-400" : "text-zinc-500"}`}
+          className={`ml-auto shrink-0 ${statusColor(isError, rateLimit != null)}`}
         >
           {status}
         </span>
@@ -74,6 +94,8 @@ export function AssistantSubagentCall({
         />
       )}
 
+      {rateLimit && <RateLimitNotice status={rateLimit} />}
+
       {transcript != null && (
         <details className="disclosure mt-2">
           <summary className="text-zinc-600 dark:text-zinc-400 flex items-center gap-1 list-none [&::-webkit-details-marker]:hidden">
@@ -86,6 +108,91 @@ export function AssistantSubagentCall({
       )}
     </details>
   );
+}
+
+/**
+ * The waiting-it-out line shown while a worker serves a rate-limit backoff, so
+ * a multi-minute wait reads as a countdown rather than a hung subagent.
+ * @param {object} root0 - Component props
+ * @param {SubagentRateLimitStatus} root0.status - The backoff in progress
+ * @returns {JSX.Element} - React component
+ */
+function RateLimitNotice({ status }: { status: SubagentRateLimitStatus }) {
+  const seconds = useSecondsUntil(status.retryAtMs);
+
+  return (
+    <div className="mt-2 text-amber-700 dark:text-amber-400">
+      Rate limited — retrying in {seconds}s (attempt {status.attempt + 1} of{" "}
+      {status.maxAttempts})
+    </div>
+  );
+}
+
+/**
+ * Subscribe a card to its worker's rate-limit backoff. The worker runs below
+ * the orchestrator's stream, so this out-of-band store — not the message
+ * history — is the only thing that can re-render the card while it waits.
+ * @param {string} [toolCallId] - The spawn tool-call id; undefined for a
+ *   finished call or restored history predating ids (then there is no status)
+ * @returns {SubagentRateLimitStatus | null} The backoff, or null when not waiting
+ */
+function useSubagentRateLimit(
+  toolCallId: string | undefined,
+): SubagentRateLimitStatus | null {
+  const [status, setStatus] = useState<SubagentRateLimitStatus | null>(null);
+
+  useEffect(() => {
+    if (toolCallId == null) {
+      setStatus(null);
+
+      return;
+    }
+
+    setStatus(getSubagentRateLimit(toolCallId));
+
+    return subscribeToSubagentRateLimits(() =>
+      setStatus(getSubagentRateLimit(toolCallId)),
+    );
+  }, [toolCallId]);
+
+  return status;
+}
+
+/**
+ * Whole seconds left until a deadline, ticking down twice a second.
+ * @param {number} targetMs - Epoch ms the countdown runs to
+ * @returns {number} Seconds remaining, floored at 0
+ */
+function useSecondsUntil(targetMs: number): number {
+  const [remainingMs, setRemainingMs] = useState(() => targetMs - Date.now());
+
+  useEffect(() => {
+    setRemainingMs(targetMs - Date.now());
+
+    const interval = setInterval(
+      () => setRemainingMs(targetMs - Date.now()),
+      500,
+    );
+
+    return () => clearInterval(interval);
+  }, [targetMs]);
+
+  return Math.max(0, Math.ceil(remainingMs / 1000));
+}
+
+/**
+ * Status-chip color: red for a failed call, amber while rate-limited, muted
+ * otherwise.
+ * @param {boolean} [isError] - Whether the subagent call failed
+ * @param {boolean} [isRateLimited] - Whether the worker is serving a backoff
+ * @returns {string} Tailwind color classes
+ */
+function statusColor(isError?: boolean, isRateLimited?: boolean): string {
+  if (isError) return "text-red-700 dark:text-red-400";
+
+  if (isRateLimited) return "text-amber-700 dark:text-amber-400";
+
+  return "text-zinc-500";
 }
 
 /**

--- a/webui/src/components/chat/assistant/tool-calls/AssistantSubagentCall.tsx
+++ b/webui/src/components/chat/assistant/tool-calls/AssistantSubagentCall.tsx
@@ -56,13 +56,18 @@ export function AssistantSubagentCall({
   // concerned; without this the card would sit on "working…" through a backoff
   // that can last minutes.
   const rateLimit = useSubagentRateLimit(running ? toolCallId : undefined);
-  const status = running
-    ? rateLimit
-      ? "rate limited"
-      : "working…"
-    : isError
-      ? "failed"
-      : "done";
+  // A wait forced by a sibling's backoff (attempt null) is not this worker's own
+  // rate limit — the docs promise that shared pause, so name it distinctly.
+  const waiting = running && rateLimit != null;
+  const status = waiting
+    ? rateLimit.attempt == null
+      ? "waiting"
+      : "rate limited"
+    : running
+      ? "working…"
+      : isError
+        ? "failed"
+        : "done";
 
   return (
     <details
@@ -76,9 +81,7 @@ export function AssistantSubagentCall({
         <span className="truncate min-w-0 text-zinc-600 dark:text-zinc-400">
           {truncateString(task, 80)}
         </span>
-        <span
-          className={`ml-auto shrink-0 ${statusColor(isError, rateLimit != null)}`}
-        >
+        <span className={`ml-auto shrink-0 ${statusColor(isError, waiting)}`}>
           {status}
         </span>
       </summary>
@@ -94,7 +97,7 @@ export function AssistantSubagentCall({
         />
       )}
 
-      {rateLimit && <RateLimitNotice status={rateLimit} />}
+      {waiting && <RateLimitNotice status={rateLimit} />}
 
       {transcript != null && (
         <details className="disclosure mt-2">
@@ -122,8 +125,14 @@ function RateLimitNotice({ status }: { status: SubagentRateLimitStatus }) {
 
   return (
     <div className="mt-2 text-amber-700 dark:text-amber-400">
-      Rate limited — retrying in {seconds}s (attempt {status.attempt + 1} of{" "}
-      {status.maxAttempts})
+      {status.attempt == null ? (
+        <>Another subagent hit a rate limit — starting in {seconds}s</>
+      ) : (
+        <>
+          Rate limited — retrying in {seconds}s (attempt {status.attempt + 1} of{" "}
+          {status.maxAttempts})
+        </>
+      )}
     </div>
   );
 }

--- a/webui/src/hooks/chat/helpers/use-execute-with-retry.ts
+++ b/webui/src/hooks/chat/helpers/use-execute-with-retry.ts
@@ -15,6 +15,7 @@ import {
   MAX_RETRY_ATTEMPTS,
   shouldRetry,
 } from "#webui/lib/rate-limit";
+import { abortableSleep } from "#webui/lib/utils/abortable-sleep";
 import { type UIMessage } from "#webui/types/messages";
 import { handleMessageStream } from "./streaming-helpers";
 
@@ -39,6 +40,11 @@ interface ExecuteWithRetryArgs<TMessage> {
 /**
  * Hook that wraps a streaming chat call with rate-limit-aware retry logic.
  * Owns the retry AbortController and exposes a way to cancel pending retries.
+ *
+ * NOTE: subagent workers stream below this hook (inside the spawn tool's
+ * execute), so they carry their own copy of this strategy in
+ * chat/sdk/subagent-rate-limit.ts. A change to the budget, the delay schedule,
+ * or the resume rule has to be made in both.
  * @param deps - Adapter, autoSave ref, parent abort ref, and state setters
  * @returns executeWithRetry function and abortRetry canceler
  */
@@ -131,24 +137,14 @@ export function useExecuteWithRetry<
             delayMs,
           });
 
-          // Wait before retrying
-          await new Promise<void>((resolve, reject) => {
-            const signal = retryAbortRef.current?.signal;
-            const timer: { id: ReturnType<typeof setTimeout> | null } = {
-              id: null,
-            };
-
-            const onAbort = () => {
-              if (timer.id != null) clearTimeout(timer.id);
-              reject(new Error("Retry cancelled"));
-            };
-
-            timer.id = setTimeout(() => {
-              signal?.removeEventListener("abort", onAbort);
-              resolve();
-            }, delayMs);
-            signal?.addEventListener("abort", onAbort, { once: true });
-          });
+          // Wait before retrying. Rejecting on abort is load-bearing: the
+          // rejection propagates out of executeWithRetry so the canceled turn is
+          // recorded as a failure upstream.
+          await abortableSleep(
+            delayMs,
+            retryAbortRef.current.signal,
+            "Retry cancelled",
+          );
           // Clear the indicator now that the wait is over. If the next attempt
           // also rate-limits, the catch block above will re-set it. Without
           // this, the indicator stays visible during the entire retry response

--- a/webui/src/lib/utils/abortable-sleep.ts
+++ b/webui/src/lib/utils/abortable-sleep.ts
@@ -1,0 +1,43 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Promise-based setTimeout that rejects instead of resolving when the signal
+ * aborts, so a canceled turn unwinds its waiters rather than serving out a
+ * minute-long backoff nobody is waiting for anymore.
+ *
+ * Both rate-limit retry paths wait on this — the main chat's executeWithRetry
+ * and the subagent workers' runSubagentWithRetry — which is why the rejection
+ * message is a parameter: each surfaces its own wording upstream.
+ * @param ms - Delay in milliseconds
+ * @param abortSignal - Signal that cancels the delay
+ * @param abortMessage - Message for the error thrown when the signal aborts
+ */
+export function abortableSleep(
+  ms: number,
+  abortSignal?: AbortSignal,
+  abortMessage = "Aborted",
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (abortSignal?.aborted) {
+      reject(new Error(abortMessage));
+
+      return;
+    }
+
+    const timer: { id: ReturnType<typeof setTimeout> | null } = { id: null };
+
+    const onAbort = () => {
+      if (timer.id != null) clearTimeout(timer.id);
+      reject(new Error(abortMessage));
+    };
+
+    timer.id = setTimeout(() => {
+      abortSignal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/webui/src/lib/utils/tests/abortable-sleep.test.ts
+++ b/webui/src/lib/utils/tests/abortable-sleep.test.ts
@@ -1,0 +1,62 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { abortableSleep } from "#webui/lib/utils/abortable-sleep";
+
+describe("abortableSleep", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves after the delay when the signal never aborts", async () => {
+    const controller = new AbortController();
+    const pending = abortableSleep(1000, controller.signal);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it("resolves after the delay with no signal at all", async () => {
+    const pending = abortableSleep(1000);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it("rejects a pending sleep when the signal aborts", async () => {
+    const controller = new AbortController();
+    const pending = abortableSleep(1000, controller.signal);
+
+    controller.abort();
+
+    await expect(pending).rejects.toThrow("Aborted");
+  });
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    const controller = new AbortController();
+
+    controller.abort();
+
+    await expect(abortableSleep(1000, controller.signal)).rejects.toThrow(
+      "Aborted",
+    );
+  });
+
+  it("uses the caller's rejection message", async () => {
+    // executeWithRetry surfaces "Retry cancelled" into conversation history, so
+    // the message is part of that caller's contract, not an internal detail.
+    const controller = new AbortController();
+    const pending = abortableSleep(1000, controller.signal, "Retry cancelled");
+
+    controller.abort();
+
+    await expect(pending).rejects.toThrow("Retry cancelled");
+  });
+});

--- a/webui/src/types/messages.ts
+++ b/webui/src/types/messages.ts
@@ -31,7 +31,7 @@ export interface UIToolPart {
   type: "tool";
   /**
    * The provider's tool-call id. Carried through so a still-running call can be
-   * matched to out-of-band live status (see subagent-rate-limit-status).
+   * matched to out-of-band live status (see chat/sdk/subagent-rate-limit.ts).
    * Optional because pre-existing persisted history may predate it.
    */
   id?: string;

--- a/webui/src/types/messages.ts
+++ b/webui/src/types/messages.ts
@@ -29,6 +29,12 @@ export interface UIThoughtPart {
 
 export interface UIToolPart {
   type: "tool";
+  /**
+   * The provider's tool-call id. Carried through so a still-running call can be
+   * matched to out-of-band live status (see subagent-rate-limit-status).
+   * Optional because pre-existing persisted history may predate it.
+   */
+  id?: string;
   name: string;
   args: Record<string, unknown>;
   result: string | null;


### PR DESCRIPTION
## Problem

A subagent worker streams inside the spawn tool's `execute()` — below `useChat`'s `executeWithRetry` — and every stream runs with `maxRetries: 0`. So a 429 in a worker rejected straight out as a `tool-error` and killed the delegated subtask with no retry at all, while the orchestrator's own 429s retried normally. With N parallel workers, each one hit the limit independently on its own connection and none of them told the others.

## Changes

- **`runSubagentWithRetry`** wraps each worker run with the same backoff the main chat gets (`detectRateLimit` / `calculateRetryDelay` / `MAX_RETRY_ATTEMPTS` from `lib/rate-limit.ts`). A retry resumes with `"continue"` when the worker already produced text or a tool call (Live may already have been edited); with nothing worth keeping it drops the failed attempt's echoed task so the worker's history doesn't stack duplicate user turns.
- **`RateLimitGate`** is one shared cooldown window per orchestrator client. Every attempt parks on it before requesting, and a 429 penalizes it — so a limit found by one worker backs off its siblings, and the window only ever extends (a longer `Retry-After` mid-wait holds everyone).
- **Exhausting the budget** now throws a message the orchestrator can act on ("wait before delegating again, or do this part of the work yourself") instead of a raw provider 429.
- **The subagent card** shows a `rate limited` status with a countdown instead of freezing on `working…`. Nothing a worker does reaches the orchestrator's `fullStream`, so this goes through an out-of-band per-tool-call store; `UIToolPart` now carries the tool-call id to key it.

Everything lives in `webui/src/chat/sdk/subagent-rate-limit.ts` (kept as one module to stay under the 12-item folder cap, which `hooks/chat` was already at).

## Verification

- `npm run check` — green (coverage 100% functions).
- `npm run check:build`, `npm run ui:test`, `npm run docs:test` — green.
- New tests cover the gate (including a sibling extending the window mid-wait), the retry runner (resume vs. restart, gate penalty, abort, budget exhaustion, status publishing), the status store, the card's rate-limited rendering/countdown, and a client-level run where a worker survives a 429 and still surfaces non-rate-limit failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)