### PR TITLE
Context and memory: write guards, save ordering, and blank New form

### DIFF
--- a/dev/Memory-System.md
+++ b/dev/Memory-System.md
@@ -52,8 +52,8 @@ than scope-specific verbs:
 
 | Scope     | Storage                                       | Actions                                                                                         |
 | --------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `project` | one blob, held by the Max device (no `fs`)    | `read`, `write` (replace)                                                                       |
-| `global`  | one pinned blob, `~/.producer-pal/context.md` | `read`, `write` (replace)                                                                       |
+| `project` | one blob, held by the Max device (no `fs`)    | `read`, `write` (replace, guarded)                                                              |
+| `global`  | one pinned blob, `~/.producer-pal/context.md` | `read`, `write` (replace, guarded)                                                              |
 | `memory`  | indexed collection, `~/.producer-pal/memory/` | `read` (entry by `name`, or the index if no `name`), `write` (upsert `name`), `delete` (`name`) |
 
 `scope` defaults to `project`; `action` defaults to `read`. `read` on `memory`
@@ -368,7 +368,30 @@ the whole thing:
 - **Non-empty document** — say what you'd add and wait for a yes. Once they
   agree (or asked in the first place), write immediately; don't ask twice, and
   don't fall back to memory as a way of avoiding the question.
-- Carry the existing content forward, or the write erases it.
+- Carry the existing content forward. A write that doesn't is now refused rather
+  than applied — see the clobber guard below.
+
+**The clobber guard** (`clobberWarning` in `context-helpers.ts`). Instructions
+are not a mechanism, so the destructive case is also blocked in code: a
+`project`/`global` write whose content keeps NONE of the existing document is
+skipped, and the model gets a `WARNING:` block plus the current document back,
+so it can re-send a merged write. `force: true` overrides it — declared in
+`context.def.ts` in every mode (a guard whose escape hatch is invisible to the
+tier that hits it would deadlock the write) but deliberately absent from the
+skills, so the model meets it in the warning rather than reaching for it.
+
+Detection is line containment, both sides normalized (list marker stripped,
+whitespace collapsed, trailing punctuation dropped) so an ordinary reformat
+survives, and only lines of ≥ 8 non-whitespace characters may vouch for a write
+— otherwise a `---` rule or a table row would satisfy it for free. The guard is
+inert on an empty document, on a blank write (the documented clear), and on a
+document with nothing substantive to test.
+
+It applies to the TOOL path only. The webui/REST editors write through their own
+routes, so the user may select-all-and-replace their own document freely; this
+guards an LLM discarding content it never meant to touch, not the user's
+editing. Automation that legitimately replaces a whole document through the tool
+(the e2e round-trip, the eval seed/restore) passes `force`.
 
 **Managing memory** (the assistant's own layer):
 

--- a/e2e/mcp/workflow/ppal-context.test.ts
+++ b/e2e/mcp/workflow/ppal-context.test.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
@@ -24,11 +25,18 @@ const ctx = setupMcpTestContext({ once: true });
 async function callProjectContextTool(
   action: "read" | "write",
   content?: string,
+  force?: boolean,
 ): Promise<unknown> {
-  const args: { action: string; content?: string } = { action };
+  const args: { action: string; content?: string; force?: boolean } = {
+    action,
+  };
 
   if (content !== undefined) {
     args.content = content;
+  }
+
+  if (force !== undefined) {
+    args.force = force;
   }
 
   return ctx.client!.callTool({ name: "ppal-context", arguments: args });
@@ -63,8 +71,10 @@ describe("ppal-context (project scope)", () => {
 
     await setConfig({ projectContext: INITIAL_CONTENT });
 
+    // A total replacement of a non-empty document needs `force` — see the
+    // clobber-guard test below.
     const writeResult = parseToolResult<ContentResult>(
-      await callProjectContextTool("write", UPDATED_CONTENT),
+      await callProjectContextTool("write", UPDATED_CONTENT, true),
     );
 
     expect(writeResult.content).toBe(UPDATED_CONTENT);
@@ -74,6 +84,26 @@ describe("ppal-context (project scope)", () => {
     );
 
     expect(verifyResult.content).toBe(UPDATED_CONTENT);
+  });
+
+  it("skips an unforced write that keeps none of the existing document", async () => {
+    const INITIAL_CONTENT = "- Genre: deep house.\n- Drop at bar 33.";
+
+    await setConfig({ projectContext: INITIAL_CONTENT });
+
+    const response = extractToolResultText(
+      await callProjectContextTool("write", "- Key: A minor."),
+    );
+
+    // The warning rides along as a WARNING: block on the same result.
+    expect(response).toContain("scope:project write SKIPPED");
+    expect(response).toContain("force:true");
+
+    const verifyResult = parseToolResult<ContentResult>(
+      await callProjectContextTool("read"),
+    );
+
+    expect(verifyResult.content).toBe(INITIAL_CONTENT);
   });
 
   it("requires content for write action", async () => {
@@ -94,6 +124,7 @@ async function callContextTool(args: {
   content?: string;
   name?: string;
   description?: string;
+  force?: boolean;
 }): Promise<unknown> {
   return ctx.client!.callTool({ name: "ppal-context", arguments: args });
 }
@@ -111,11 +142,15 @@ describe("ppal-context (global scope)", () => {
     try {
       const testContent = `e2e global context ${randomUUID()}`;
 
+      // `force` because this replaces whatever the developer already had — the
+      // clobber guard (see the project-scope test above) would otherwise skip
+      // both this write and the restore below.
       const written = parseToolResult<ContentResult>(
         await callContextTool({
           action: "write",
           scope: "global",
           content: testContent,
+          force: true,
         }),
       );
 
@@ -131,6 +166,7 @@ describe("ppal-context (global scope)", () => {
         action: "write",
         scope: "global",
         content: original,
+        force: true,
       });
     }
 

--- a/evals/scenarios/defs/context/context-scenario-helpers.ts
+++ b/evals/scenarios/defs/context/context-scenario-helpers.ts
@@ -128,10 +128,15 @@ export function seedContext(seed: {
       // "whatever this developer happens to have". Global context is injected on
       // every connect and instructs behavior directly, so inheriting the real
       // one makes results depend on the machine the eval ran on.
+      // `force` on both the seed and the restore below: these REPLACE the
+      // document wholesale, which is exactly what the tool's clobber guard
+      // skips for a model. Setup/teardown are the deliberate case it exists to
+      // let through.
       await callContext(mcpClient, {
         action: "write",
         scope: "global",
         content: seed.global ?? "",
+        force: true,
       });
 
       for (const memory of memories) {
@@ -171,6 +176,7 @@ export function seedContext(seed: {
           action: "write",
           scope: "global",
           content: originalGlobal,
+          force: true,
         });
       }
 

--- a/evals/scenarios/defs/context/context-write-layers.ts
+++ b/evals/scenarios/defs/context/context-write-layers.ts
@@ -39,6 +39,7 @@ import {
   REQUIRES_MEMORY,
   TOOL_CONNECT,
   assertContextWrite,
+  assertNoContextWrite,
   assertNoUnconfirmedWrite,
   seedContext,
 } from "./context-scenario-helpers.ts";
@@ -81,6 +82,17 @@ export const contextWriteLayerProject: EvalScenario = {
     // hiding the fact that it still chose the right layer.
     assertContextWrite({ scope: "project", turn: "any" }),
 
+    // One scope, not both. A fact copied into the other user-owned layer (the
+    // small-model tier's "layer smear") burns context on every turn — both
+    // layers are always injected — and goes stale the moment one is updated.
+    //
+    // Deliberately NOT `count: 1`. These scenarios seed a non-empty document,
+    // so the tool's clobber guard is live: a model that restructures the seed
+    // prose enough to trip it re-sends a merged write, which is the guard
+    // working — two writes, one document, right layer. Counting writes would
+    // score that as a failure.
+    assertNoContextWrite({ scope: "global", turn: "any" }),
+
     // A write REPLACES the user's whole document — it must be offered, not
     // assumed.
     assertNoUnconfirmedWrite(1),
@@ -122,6 +134,12 @@ export const contextWriteLayerGlobal: EvalScenario = {
     // "everything I make, not just this track" is the tell for global over
     // project. Turn-agnostic; the confirm check below is the separate signal.
     assertContextWrite({ scope: "global", turn: "any" }),
+
+    // The observed small-model failure: it saved the universal preference to
+    // global (right) and ALSO copied it into project (wrong). See the project
+    // scenario's note on why a duplicated fact is worse than it looks — and on
+    // why the write is not counted.
+    assertNoContextWrite({ scope: "project", turn: "any" }),
 
     assertNoUnconfirmedWrite(1),
 

--- a/src/skills/core/core-context.ts
+++ b/src/skills/core/core-context.ts
@@ -50,7 +50,23 @@ Managing memory:
  * The Context section of the basic (small-model) core. Deliberately minimal:
  * small-model mode's ppal-context is blobs-only (no memory scope), so this
  * covers the project/global documents and nothing else.
+ *
+ * Two rules here are a deliberate token spend in the tier that can least afford
+ * it, because both defects they fix are invisible to the tool schema:
+ *  - **Exactly one scope.** Small models wrote an always-applies preference to
+ *    global AND copied it into project. A duplicated fact burns context on every
+ *    turn (both layers are always injected) and goes stale as soon as one side
+ *    is updated.
+ *  - **Confirm before replacing.** The standard tier's confirm rule was never
+ *    mirrored here, so small models wrote the user's own document unasked. It is
+ *    a consent bug rather than data loss (they do carry existing content
+ *    forward — see the context-write-preserves-* evals), and the tool-side
+ *    clobber guard covers the destructive case regardless of tier.
+ *
+ * Both are stated WITH their release condition (write on agreement; fill an
+ * empty document freely) — a bare prohibition here makes the model refuse to
+ * write even when asked, which is the failure the standard tier hit first.
  */
 export const coreContextBasic = `## Context
 
-\`ppal-context\` scope:project stores facts about THIS Live Set; scope:global stores who the user is across all projects (style, preferences, goals). Both are single documents — read the same scope before writing (write replaces the whole document). Write each note so a future assistant with none of this chat can use it: the whole structure, not one isolated detail.`;
+\`ppal-context\` scope:project stores facts about THIS Live Set; scope:global stores who the user is across all projects (style, preferences, goals). Both are single documents — read the same scope before writing (write replaces the whole document). Put a fact in exactly ONE scope, never both. These documents are the user's: when the scope already has content, say what you'd add and write it once they agree or ask — an empty one you can just fill in, then say what you saved. Write each note so a future assistant with none of this chat can use it: the whole structure, not one isolated detail.`;

--- a/src/tools/core/context-helpers.ts
+++ b/src/tools/core/context-helpers.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { requestNode } from "#src/live-api-adapter/node-request-v8-protocol.ts";
+import * as console from "#src/shared/v8-max-console.ts";
 
 export interface ContentResult {
   content: string;
@@ -24,16 +25,30 @@ export function handleReadProjectContext(
  * Handle write action for the project context blob.
  * @param content - Project context content to write
  * @param context - The context object
+ * @param force - Replace the document even when the write keeps none of it
  * @returns Content result with the updated project context
  */
 export function handleWriteProjectContext(
   content: string | undefined,
   context: Partial<ToolContext> = {},
+  force = false,
 ): ContentResult {
   // "" is a valid clear; only an omitted content param is rejected so an
   // accidental write can't silently wipe the context.
   if (content == null) {
     throw new Error("Content required for write action");
+  }
+
+  const existing = context.projectContext?.content ?? "";
+
+  if (!force) {
+    const warning = clobberWarning("project", existing, content);
+
+    if (warning != null) {
+      console.warn(warning);
+
+      return { content: existing };
+    }
   }
 
   const projectContext = context.projectContext;
@@ -139,16 +154,126 @@ export async function handleReadMemoryIndex(): Promise<ContentResult> {
  * an accidental write can't silently wipe it.
  *
  * @param content - Global context content to write ("" clears it)
+ * @param force - Replace the document even when the write keeps none of it
  * @returns Content result with the stored content
  */
 export async function handleWriteGlobalContext(
   content: string | undefined,
+  force = false,
 ): Promise<ContentResult> {
   if (content == null) {
     throw new Error("Content required for write action");
   }
 
+  if (!force) {
+    // The guard compares against the CURRENT document, which lives on the Node
+    // side — one extra round-trip on the (rare) write path, and the freshest
+    // possible baseline: the copy injected at connect may be stale.
+    const existing = await handleReadGlobalContext();
+    const warning = clobberWarning("global", existing.content, content);
+
+    if (warning != null) {
+      console.warn(warning);
+
+      return existing;
+    }
+  }
+
   return await callNodeContentRoute("globalContext.write", { content });
+}
+
+/**
+ * Guard the unrecoverable failure mode in the user-owned context layers: an
+ * `action:write` REPLACES the whole document, so a model that sends only its new
+ * fact destroys everything the user accumulated. (A memory entry is replaced the
+ * same way, but it holds one fact under a name the model must reuse deliberately
+ * — a far smaller blast radius, and not guarded here.) When the incoming content
+ * keeps NONE of what's there, that is far likelier a mistake than an intent — so
+ * the write is skipped and this warning is relayed to the model (ADR-0009
+ * warn-and-skip), which can re-send with the content merged or pass `force`.
+ *
+ * Deliberately line containment, not a similarity score: cheap, explainable, and
+ * with no threshold to argue about. Both sides are normalized first (list marker
+ * stripped, internal whitespace collapsed, trailing punctuation dropped) so an
+ * ordinary reformat — prose rewrapped into bullets, a re-indent — still counts
+ * as surviving; headings are ignored for the same reason. One surviving line is
+ * enough to read as an edit rather than a replacement.
+ *
+ * Only SUBSTANTIVE lines can vouch for a write. Without that floor, a `---`
+ * rule, a `|` table row, or any short line that happens to appear in the new
+ * content would satisfy the guard for free, leaving a document with a horizontal
+ * rule effectively unguarded. A document with nothing substantive in it has
+ * nothing distinctive to test, so the guard stays out of the way there.
+ *
+ * Inert in the two cases where nothing can be lost: an empty existing document,
+ * and a blank incoming write (the documented explicit clear, which the webui's
+ * "empty the file" path also uses).
+ *
+ * @param scope - The layer being written (project | global), for the message
+ * @param existing - The document as it stands
+ * @param incoming - The content the model wants to write
+ * @returns The warning to relay, or null when the write may proceed
+ */
+export function clobberWarning(
+  scope: string,
+  existing: string,
+  incoming: string,
+): string | null {
+  if (incoming.trim() === "") return null;
+
+  const lines = existing
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("#"));
+
+  if (lines.length === 0) return null;
+
+  // Compared line-by-line rather than against the whole blob, so a match can't
+  // straddle two lines of the incoming content.
+  const incomingLines = incoming.split("\n").map(normalizeForContainment);
+  const checkable = lines
+    .map(normalizeForContainment)
+    .filter((line) => line.replaceAll(/\s/g, "").length >= MIN_SURVIVING_CHARS);
+
+  if (checkable.length === 0) return null;
+
+  if (checkable.some((line) => incomingLines.some((l) => l.includes(line)))) {
+    return null;
+  }
+
+  return (
+    `scope:${scope} write SKIPPED — nothing was written. Your content kept ` +
+    `none of the existing document (${lines.length} line(s) would be lost, ` +
+    `starting with "${lines[0]}"). The result above is the document as it ` +
+    `stands: re-send the write with that content plus your addition. If the ` +
+    `user really asked to replace the whole thing, pass force:true — ask them ` +
+    `first if you haven't.`
+  );
+}
+
+/**
+ * Shortest line that may vouch for a write (non-whitespace chars, after
+ * normalization). Long enough that structural boilerplate — `---`, `| --- |`,
+ * a fence, a one-word list item — can't stand in for the user's content.
+ */
+const MIN_SURVIVING_CHARS = 8;
+
+/**
+ * Reduce a line to what containment should ignore differences in: leading list
+ * marker or blockquote, indentation and repeated spaces, trailing punctuation.
+ * The needle is normalized the same way as the haystack lines, so re-bulleting a
+ * prose line or adding a period still reads as the same content.
+ *
+ * @param line - One raw line of either document
+ * @returns The line reduced to its comparable text
+ */
+function normalizeForContainment(line: string): string {
+  return line
+    .trim()
+    .replace(/^(?:[-*+>]|\d+[.)])\s+/, "")
+    .replaceAll(/\s+/g, " ")
+    .replace(/[.,;:!?]+$/, "")
+    .trim();
 }
 
 /**

--- a/src/tools/core/context.def.ts
+++ b/src/tools/core/context.def.ts
@@ -96,5 +96,20 @@ export const toolDefContext = defineTool("ppal-context", {
         "when it's relevant. Required on a memory write.",
       smallModel: null,
     }),
+
+    // The escape hatch for the clobber guard (context-helpers.ts's
+    // clobberWarning), and deliberately NOT taught in the skills: the model
+    // learns of it from the warning, at the moment it is relevant, so it never
+    // reaches for it casually. Declared in EVERY mode — including small-model,
+    // where it costs a few tokens — because a guard whose only way out is hidden
+    // from the tier that hits it would deadlock the write, which is worse than
+    // the clobber it prevents.
+    force: z
+      .boolean()
+      .optional()
+      .describe(
+        "Only when a write was skipped for dropping the whole document: " +
+          "true replaces it anyway.",
+      ),
   },
 });

--- a/src/tools/core/context.ts
+++ b/src/tools/core/context.ts
@@ -21,6 +21,7 @@ interface ContextArgs {
   scope?: string;
   name?: string;
   description?: string;
+  force?: boolean;
 }
 
 /**
@@ -42,11 +43,12 @@ interface ContextArgs {
  * @param args.scope - Which context to target (project | global | memory; default project)
  * @param args.name - Memory entry name (read/write/delete, memory scope)
  * @param args.description - One-line recall hook (memory write)
+ * @param args.force - Replace a project/global document the write keeps none of
  * @param toolContext - The context object
  * @returns Content result
  */
 export async function context(
-  { action, content, scope, name, description }: ContextArgs = {},
+  { action, content, scope, name, description, force }: ContextArgs = {},
   toolContext: Partial<ToolContext> = {},
 ): Promise<ContentResult> {
   if (scope === "memory") {
@@ -71,7 +73,7 @@ export async function context(
       case "read":
         return await handleReadGlobalContext();
       case "write":
-        return await handleWriteGlobalContext(content);
+        return await handleWriteGlobalContext(content, force);
       default:
         throw new Error(`Unknown action for scope:global: ${action}`);
     }
@@ -81,7 +83,7 @@ export async function context(
     case "read":
       return handleReadProjectContext(toolContext);
     case "write":
-      return handleWriteProjectContext(content, toolContext);
+      return handleWriteProjectContext(content, toolContext, force);
     default:
       throw new Error(`Unknown action for scope:project: ${action}`);
   }

--- a/src/tools/core/tests/context-def.test.ts
+++ b/src/tools/core/tests/context-def.test.ts
@@ -75,6 +75,7 @@ describe("ppal-context modal config — default (large-model) mode", () => {
       "content",
       "name",
       "description",
+      "force",
     ]);
     expect(enumOptions(shape.action as unknown as ZodType)).toStrictEqual([
       "read",
@@ -117,7 +118,21 @@ describe("ppal-context modal config — small-model mode", () => {
     const config = registerContext({ smallModelMode: true });
     const shape = getShape(config);
 
-    expect(Object.keys(shape)).toStrictEqual(["action", "scope", "content"]);
+    expect(Object.keys(shape)).toStrictEqual([
+      "action",
+      "scope",
+      "content",
+      "force",
+    ]);
+  });
+
+  // Small models preserve content anyway, so the guard rarely fires for them —
+  // but if it does, hiding its escape hatch would deadlock the write.
+  it("keeps force reachable so the clobber guard can't deadlock a write", () => {
+    const config = registerContext({ smallModelMode: true });
+    const shape = getShape(config);
+
+    expect(shape.force?.description).toContain("true replaces it anyway");
   });
 
   it("overrides the content description to drop the memory-entry clause", () => {

--- a/src/tools/core/tests/context-global.test.ts
+++ b/src/tools/core/tests/context-global.test.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as v8Console from "#src/shared/v8-max-console.ts";
 import { context } from "../context.ts";
 
 vi.mock(import("#src/live-api-adapter/node-request-v8-protocol.ts"), () => ({
@@ -98,14 +99,95 @@ describe("context - global scope", () => {
     });
 
     it("throws when the node route reports failure", async () => {
-      vi.mocked(protocolMock.requestNode).mockResolvedValue({
-        success: false,
-        error: "permission denied",
-      });
+      // The clobber guard reads the current document first, so the write's
+      // failure is the SECOND response here.
+      vi.mocked(protocolMock.requestNode)
+        .mockResolvedValueOnce({ success: true, result: { content: "" } })
+        .mockResolvedValue({ success: false, error: "permission denied" });
 
       await expect(
         context({ action: "write", scope: "global", content: "x" }),
       ).rejects.toThrow("globalContext.write failed: permission denied");
+    });
+  });
+
+  // Same guard as the project scope (see context-project.test.ts); here the
+  // baseline comes from a globalContext.read round-trip rather than the
+  // in-memory blob.
+  describe("write action - clobber guard", () => {
+    const EXISTING = "# How I work\n\n- Call me Adam.\n- Stock devices only.";
+
+    /**
+     * Answer globalContext.read with EXISTING and echo whatever a write stores.
+     * @returns Nothing; installs the mock implementation
+     */
+    function mockGlobalStore(): void {
+      vi.mocked(protocolMock.requestNode).mockImplementation(
+        async (route: string, args?: object) =>
+          route === "globalContext.read"
+            ? { success: true, result: { content: EXISTING } }
+            : {
+                success: true,
+                result: { content: (args as { content: string }).content },
+              },
+      );
+    }
+
+    it("skips the write and warns when the new content keeps none of the document", async () => {
+      const warnSpy = vi.spyOn(v8Console, "warn");
+
+      mockGlobalStore();
+
+      const result = await context({
+        action: "write",
+        scope: "global",
+        content: "- Prefers 90 BPM.",
+      });
+
+      expect(result).toStrictEqual({ content: EXISTING });
+      expect(protocolMock.requestNode).not.toHaveBeenCalledWith(
+        "globalContext.write",
+        expect.anything(),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("scope:global write SKIPPED"),
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("writes when force is true, without reading first", async () => {
+      mockGlobalStore();
+
+      const result = await context({
+        action: "write",
+        scope: "global",
+        content: "- Prefers 90 BPM.",
+        force: true,
+      });
+
+      expect(result).toStrictEqual({ content: "- Prefers 90 BPM." });
+      expect(protocolMock.requestNode).toHaveBeenCalledExactlyOnceWith(
+        "globalContext.write",
+        { content: "- Prefers 90 BPM." },
+      );
+    });
+
+    it("allows the normal append case", async () => {
+      mockGlobalStore();
+      const merged = `${EXISTING}\n- Prefers 90 BPM.`;
+
+      const result = await context({
+        action: "write",
+        scope: "global",
+        content: merged,
+      });
+
+      expect(result).toStrictEqual({ content: merged });
+      expect(protocolMock.requestNode).toHaveBeenCalledWith(
+        "globalContext.write",
+        { content: merged },
+      );
     });
   });
 

--- a/src/tools/core/tests/context-project.test.ts
+++ b/src/tools/core/tests/context-project.test.ts
@@ -3,7 +3,8 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as v8Console from "#src/shared/v8-max-console.ts";
 import { context } from "../context.ts";
 
 describe("context - project scope (default)", () => {
@@ -54,14 +55,16 @@ describe("context - project scope (default)", () => {
       expect(outlet).toHaveBeenCalledWith(0, "update_project_context", "");
     });
 
+    // A total replacement of a NON-EMPTY document now needs `force` — see the
+    // clobber-guard block below.
     it.each([
-      ["updates content when project context is present", ""],
-      ["overwrites existing content", "old content"],
-    ])("%s", async (_, initialContent) => {
+      ["updates content when project context is present", "", false],
+      ["overwrites existing content when forced", "old content", true],
+    ])("%s", async (_, initialContent, force) => {
       if (initialContent) toolContext.projectContext!.content = initialContent;
 
       const result = await context(
-        { action: "write", content: "new content" },
+        { action: "write", content: "new content", force },
         toolContext,
       );
 
@@ -79,6 +82,188 @@ describe("context - project scope (default)", () => {
 
       expect(result).toStrictEqual({ content: "fresh" });
       expect(outlet).toHaveBeenCalledWith(0, "update_project_context", "fresh");
+    });
+  });
+
+  // The unrecoverable failure mode for the user-owned layers: a write REPLACES
+  // the document, so content that keeps none of it destroys everything the user
+  // accumulated.
+  describe("write action - clobber guard", () => {
+    const EXISTING = ["# Notes", "- Genre: deep house.", "- Drop at bar 33."]
+      .join("\n")
+      .concat("\n");
+
+    it("skips the write and warns when the new content keeps none of the document", async () => {
+      const warnSpy = vi.spyOn(v8Console, "warn");
+
+      toolContext.projectContext!.content = EXISTING;
+
+      const result = await context(
+        { action: "write", content: "- Key: A minor." },
+        toolContext,
+      );
+
+      // No-op: the document stands, and the result hands the model exactly what
+      // it needs to re-send a merged write.
+      expect(toolContext.projectContext!.content).toBe(EXISTING);
+      expect(result).toStrictEqual({ content: EXISTING });
+      // outlet 1 DOES fire — that's how console.warn reaches the LLM. Only the
+      // project-context update on outlet 0 must not.
+      expect(outlet).not.toHaveBeenCalledWith(
+        0,
+        "update_project_context",
+        expect.anything(),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("scope:project write SKIPPED"),
+      );
+      // Names the escape hatch, since the skills deliberately don't.
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("force:true"),
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("writes when force is true", async () => {
+      toolContext.projectContext!.content = EXISTING;
+
+      const result = await context(
+        { action: "write", content: "- Key: A minor.", force: true },
+        toolContext,
+      );
+
+      expect(toolContext.projectContext!.content).toBe("- Key: A minor.");
+      expect(result).toStrictEqual({ content: "- Key: A minor." });
+      expect(outlet).toHaveBeenCalledWith(
+        0,
+        "update_project_context",
+        "- Key: A minor.",
+      );
+    });
+
+    it("is inert when the document is empty (nothing to destroy)", async () => {
+      const result = await context(
+        { action: "write", content: "- Key: A minor." },
+        toolContext,
+      );
+
+      expect(result).toStrictEqual({ content: "- Key: A minor." });
+      expect(outlet).toHaveBeenCalledWith(
+        0,
+        "update_project_context",
+        "- Key: A minor.",
+      );
+    });
+
+    it("allows the normal append case (one existing line survives verbatim)", async () => {
+      toolContext.projectContext!.content = EXISTING;
+      const merged = `${EXISTING}- Key: A minor.`;
+
+      const result = await context(
+        { action: "write", content: merged },
+        toolContext,
+      );
+
+      expect(result).toStrictEqual({ content: merged });
+      expect(outlet).toHaveBeenCalledWith(0, "update_project_context", merged);
+    });
+
+    it("allows a restructuring rewrite that drops only headings", async () => {
+      toolContext.projectContext!.content = EXISTING;
+      const rewritten =
+        "## Track notes\n- Genre: deep house.\n- Drop at bar 33.";
+
+      const result = await context(
+        { action: "write", content: rewritten },
+        toolContext,
+      );
+
+      expect(result).toStrictEqual({ content: rewritten });
+      expect(outlet).toHaveBeenCalledWith(
+        0,
+        "update_project_context",
+        rewritten,
+      );
+    });
+
+    // Both sides are normalized before the containment test, so an ordinary
+    // reformat still counts as surviving — without it, this guard would fire on
+    // the everyday rewrite and teach models to reach for force.
+    it.each([
+      ["prose re-bulleted", "- Genre: deep house.\n- Drop at bar 33."],
+      ["re-indented", "  Genre: deep house.\n\t- Drop at bar 33."],
+      ["trailing punctuation added", "Genre: deep house!\n- Drop at bar 33."],
+      ["numbered instead of dashed", "1. Genre: deep house\n2. Drop at bar 33"],
+    ])(
+      "allows a reformat that keeps the content (%s)",
+      async (_, rewritten) => {
+        toolContext.projectContext!.content =
+          "Genre: deep house.\nDrop at bar 33.";
+
+        const result = await context(
+          { action: "write", content: rewritten },
+          toolContext,
+        );
+
+        expect(result).toStrictEqual({ content: rewritten });
+        expect(outlet).toHaveBeenCalledWith(
+          0,
+          "update_project_context",
+          rewritten,
+        );
+      },
+    );
+
+    // Structural boilerplate must not vouch for a write: it appears in almost
+    // any markdown, so a document containing one would otherwise be unguarded.
+    it("still fires when only a horizontal rule survives", async () => {
+      const warnSpy = vi.spyOn(v8Console, "warn");
+      const existing = "---\n\nGenre: deep house.\nDrop at bar 33.";
+
+      toolContext.projectContext!.content = existing;
+
+      const result = await context(
+        { action: "write", content: "---\n\nKey: A minor." },
+        toolContext,
+      );
+
+      expect(result).toStrictEqual({ content: existing });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("scope:project write SKIPPED"),
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    // Nothing distinctive enough to test containment on — the guard has no
+    // opinion rather than blocking every write to such a document.
+    it("stays out of the way when no line is substantive", async () => {
+      toolContext.projectContext!.content = "---\n- 124\n- A min";
+
+      const result = await context(
+        { action: "write", content: "- Key: A minor." },
+        toolContext,
+      );
+
+      expect(result).toStrictEqual({ content: "- Key: A minor." });
+      expect(outlet).toHaveBeenCalledWith(
+        0,
+        "update_project_context",
+        "- Key: A minor.",
+      );
+    });
+
+    it("still allows an empty write to clear a non-empty document", async () => {
+      toolContext.projectContext!.content = EXISTING;
+
+      const result = await context(
+        { action: "write", content: "" },
+        toolContext,
+      );
+
+      expect(result).toStrictEqual({ content: "" });
+      expect(outlet).toHaveBeenCalledWith(0, "update_project_context", "");
     });
   });
 

--- a/webui/src/components/context/collection/CollectionScreen.tsx
+++ b/webui/src/components/context/collection/CollectionScreen.tsx
@@ -83,7 +83,12 @@ export function CollectionScreen<TView extends DocCollectionEntry, TInput>(
     props;
   const { description } = props;
   const [selected, setSelected] = useState<Selection>({ mode: "new" });
-  const selectionKey = selected.mode === "edit" ? selected.name : "__new__";
+  // Bumped by every New press so the create form REMOUNTS on a fresh key, even
+  // when it is already the active pane — otherwise "New" left a half-filled
+  // draft sitting there and looked like it did nothing.
+  const [newEpoch, setNewEpoch] = useState(0);
+  const selectionKey =
+    selected.mode === "edit" ? selected.name : `__new__:${newEpoch}`;
   // Selecting another entry unmounts the active editor; confirm a discard first
   // if it holds an unsaved new draft (the editor registers the guard).
   const leaveGuard = useLeaveGuardContext();
@@ -118,7 +123,7 @@ export function CollectionScreen<TView extends DocCollectionEntry, TInput>(
     selected.mode === "edit"
       ? (entries.find((entry) => entry.name === selected.name) ?? null)
       : null;
-  const editorKey = selected.mode === "edit" ? selected.name : "__new__";
+  const editorKey = selectionKey;
   const deletedExternally = selected.mode === "edit" && activeEntry == null;
   const editor = props.renderEditor({
     entry: activeEntry,
@@ -168,14 +173,17 @@ export function CollectionScreen<TView extends DocCollectionEntry, TInput>(
               if (leaveGuard.confirmLeave())
                 setSelected({ mode: "edit", name });
             },
-            // From the create form, New keeps it mounted (same key), so a dirty
-            // draft isn't abandoned — no guard. But from an entry (including one
-            // deleted out from under us, whose kept draft is a dirty NEW entry)
-            // New unmounts the editor, so confirm a discard first like onSelect.
+            // New always means a BLANK form — including when the create form is
+            // already open holding a half-filled draft, which used to be kept
+            // (the button appeared to do nothing). The editor's own discard
+            // confirm gates it, exactly as onSelect does: memory registers one
+            // for a dirty new draft, so the user is asked before losing it. An
+            // editor that registers nothing (custom skills, whose new drafts
+            // persist on navigate-away instead) just gets the fresh form.
             onNew: () => {
-              if (selected.mode === "edit" && !leaveGuard.confirmLeave())
-                return;
+              if (!leaveGuard.confirmLeave()) return;
               setSelected({ mode: "new" });
+              setNewEpoch((epoch) => epoch + 1);
             },
             onDelete: (name) => void handleDeleteEntry(name),
           })}

--- a/webui/src/components/context/memory/tests/MemoryScreen.test.tsx
+++ b/webui/src/components/context/memory/tests/MemoryScreen.test.tsx
@@ -503,4 +503,52 @@ describe("MemoryScreen — new-draft discard guard", () => {
     expect(window.confirm).not.toHaveBeenCalled();
     expect(screen.getByRole("textbox", { name: "Rename" })).toBeTruthy();
   });
+
+  // New means a BLANK form even when the create form is the pane already open:
+  // it used to keep the half-filled draft, so the button looked inert.
+  it("clears a half-filled new draft once the discard is confirmed", () => {
+    stubConfirm(true);
+    renderGuardedReady();
+
+    typeNewName("half-typed");
+    clickNewMemory();
+
+    expect(window.confirm).toHaveBeenCalledOnce();
+    expect(nameFieldValue()).toBe("");
+  });
+
+  it("keeps the half-filled new draft when the discard is cancelled", () => {
+    stubConfirm(false);
+    renderGuardedReady();
+
+    typeNewName("half-typed");
+    clickNewMemory();
+
+    expect(window.confirm).toHaveBeenCalledOnce();
+    expect(nameFieldValue()).toBe("half-typed");
+  });
+
+  it("does not confirm when New is pressed on an already-blank form", () => {
+    stubConfirm();
+    renderGuardedReady();
+
+    clickNewMemory();
+
+    expect(window.confirm).not.toHaveBeenCalled();
+    expect(nameFieldValue()).toBe("");
+  });
 });
+
+/** Click the left pane's "New memory" button. */
+function clickNewMemory(): void {
+  fireEvent.click(screen.getByRole("button", { name: "New memory" }));
+}
+
+/**
+ * The create form's Name field value.
+ * @returns The current text in the Name input
+ */
+function nameFieldValue(): string {
+  return (screen.getByRole("textbox", { name: /Name/ }) as HTMLInputElement)
+    .value;
+}

--- a/webui/src/hooks/context/tests/doc-transport-test-helpers.ts
+++ b/webui/src/hooks/context/tests/doc-transport-test-helpers.ts
@@ -209,6 +209,8 @@ export function describeDocTransport(spec: DocTransportSpec): void {
       expect(result.current.saveError).toContain(spec.writeError);
     });
 
+    registerSaveOrderingTests(fetchMock, renderReady);
+
     it("save() echoes empty string when the PUT omits content", async () => {
       const result = await renderReady("x");
 
@@ -224,4 +226,110 @@ export function describeDocTransport(spec: DocTransportSpec): void {
       });
     });
   });
+}
+
+/**
+ * Register the save-vs-save ordering tests inside the caller's describe block.
+ * Two saves of the same doc can overlap (a debounced flush, then a blur or a
+ * further keystroke before the first echo lands), and whichever echo arrives
+ * LAST would otherwise win — reverting the editor to content the user has
+ * already typed past. Split out of {@link describeDocTransport} to keep that
+ * function within the per-function line limit.
+ * @param fetchMock - The suite's fetch mock, queued in issue order
+ * @param renderReady - Renders the hook past its mount GET
+ */
+function registerSaveOrderingTests(
+  fetchMock: ReturnType<typeof vi.fn>,
+  renderReady: (content?: string) => Promise<{ current: UseDocReturn }>,
+): void {
+  // Both ordering tests race the same two saves; only the first write's echo
+  // (a stored document, or a failure) differs.
+  const raceSaves = async (
+    result: { current: UseDocReturn },
+    firstEcho: Response,
+  ): Promise<boolean | undefined> => {
+    const [firstOk] = await raceTwoWrites(
+      fetchMock,
+      { dispatch: () => result.current.save("one"), echo: firstEcho },
+      {
+        dispatch: () => result.current.save("two"),
+        echo: jsonResponse({ content: "two" }),
+      },
+    );
+
+    return firstOk as boolean | undefined;
+  };
+
+  it("keeps the newest save's content when an older save's echo lands last", async () => {
+    const result = await renderReady();
+
+    await raceSaves(result, jsonResponse({ content: "one" }));
+
+    expect(result.current.status).toStrictEqual({
+      kind: "ready",
+      content: "two",
+    });
+    expect(result.current.saveStatus).toBe("saved");
+  });
+
+  it("does not let a superseded save's failure paint an error over the newest save", async () => {
+    const result = await renderReady();
+
+    const firstOk = await raceSaves(
+      result,
+      new Response("nope", { status: 500, statusText: "Server Error" }),
+    );
+
+    // The caller still learns its own write failed (so it can retry) — only the
+    // shared UI state belongs to the newest save.
+    expect(firstOk).toBe(false);
+    expect(result.current.saveStatus).toBe("saved");
+    expect(result.current.saveError).toBeNull();
+  });
+}
+
+/** One write in a {@link raceTwoWrites} pair: how to dispatch it, and its echo. */
+export interface RacedWrite {
+  /** Dispatch the write (the hook call under test). */
+  dispatch: () => Promise<unknown>;
+  /** The response its request eventually resolves with. */
+  echo: Response;
+}
+
+/**
+ * Run two writes concurrently and settle the SECOND one FIRST, so the first
+ * write's echo lands last — the out-of-order landing every write-ordering guard
+ * in these hooks exists for. Shared by the document, entry-collection, and
+ * slot-collection suites, which differ only in which hook call they dispatch.
+ * @param fetchMock - The suite's fetch mock, queued in dispatch order
+ * @param first - The write dispatched first, whose echo resolves last
+ * @param second - The write dispatched second, whose echo resolves first
+ * @returns Both writes' resolved values, in dispatch order
+ */
+export async function raceTwoWrites(
+  fetchMock: ReturnType<typeof vi.fn>,
+  first: RacedWrite,
+  second: RacedWrite,
+): Promise<[unknown, unknown]> {
+  const firstRequest = deferred<Response>();
+  const secondRequest = deferred<Response>();
+
+  fetchMock.mockReturnValueOnce(firstRequest.promise);
+  fetchMock.mockReturnValueOnce(secondRequest.promise);
+
+  let firstResult: unknown;
+  let secondResult: unknown;
+
+  await act(async () => {
+    const firstPending = first.dispatch();
+    const secondPending = second.dispatch();
+
+    secondRequest.resolve(second.echo);
+    secondResult = await secondPending;
+
+    firstRequest.resolve(first.echo);
+    firstResult = await firstPending;
+  });
+
+  return [firstResult, secondResult];
 }

--- a/webui/src/hooks/context/tests/use-context-editor-state.test.ts
+++ b/webui/src/hooks/context/tests/use-context-editor-state.test.ts
@@ -157,6 +157,33 @@ async function drainMicrotasks(turns = 3): Promise<void> {
 }
 
 /**
+ * Fire Clear (its confirm already stubbed) and prove it is still blocked on an
+ * in-flight save: the clear POST must not go out until every save it was
+ * ordered behind has settled.
+ * @param result - The rendered hook's result handle
+ * @param clear - The clear spy, asserted not to have fired yet
+ * @returns The pending handleClear promise, for the test to await later
+ */
+async function startBlockedClear(
+  result: RenderedEditor["result"],
+  clear: ReturnType<typeof vi.fn>,
+): Promise<{ pending: Promise<boolean> }> {
+  let clearPromise: Promise<boolean> | null = null;
+
+  await act(() => {
+    clearPromise = result.current.handleClear();
+  });
+
+  // Allow microtasks to run; clear must still be waiting on the in-flight save.
+  await drainMicrotasks();
+  expect(clear).not.toHaveBeenCalled();
+
+  // Wrapped, not returned bare: an async function returning a promise awaits it,
+  // which would hang here — the whole point is that this one is still pending.
+  return { pending: clearPromise as unknown as Promise<boolean> };
+}
+
+/**
  * Stub `window.confirm` to return the given answer.
  * @param answer - What confirm() should return (accept vs cancel)
  * @returns The confirm spy, for asserting whether/how it was called
@@ -325,19 +352,69 @@ describe("useContextEditorState", () => {
       expect(clear).not.toHaveBeenCalled();
 
       // Fire Clear. Promise stays pending until we resolve the save below.
-      let clearPromise: Promise<boolean> | null = null;
-
-      await act(() => {
-        clearPromise = result.current.handleClear();
-      });
-      // Allow microtasks to run; clear must still be blocked on the in-flight save.
-      await drainMicrotasks();
-      expect(clear).not.toHaveBeenCalled();
+      const { pending: clearPromise } = await startBlockedClear(result, clear);
 
       // Release the in-flight save's response; clear should then proceed.
       await act(async () => {
         resolveSave(true);
         await clearPromise;
+      });
+      expect(clear).toHaveBeenCalledTimes(1);
+    });
+
+    it("handleClear awaits EVERY in-flight save, not just the newest", async () => {
+      // Two saves overlap (a debounced flush, then another before the first
+      // echo lands). Tracking only the newest would stop awaiting the older
+      // one, whose POST could then land after clear's and resurrect content.
+      const resolvers: Array<(saved: boolean) => void> = [];
+      const save = vi
+        .fn()
+        .mockImplementation(
+          () => new Promise<boolean>((resolve) => resolvers.push(resolve)),
+        );
+      const clear = vi.fn().mockResolvedValue(true);
+      const { result } = renderReadyEditor({ save, clear });
+
+      stubConfirm(true);
+
+      await typeDraft(result, "draft one");
+      await flushDebounceWindow();
+      await typeDraft(result, "draft two");
+      await flushDebounceWindow();
+      expect(save).toHaveBeenCalledTimes(2);
+
+      const { pending: clearPromise } = await startBlockedClear(result, clear);
+
+      // Release only the NEWER save: the older one is still on the wire.
+      await act(async () => {
+        resolvers[1]?.(true);
+      });
+      await drainMicrotasks();
+      expect(clear).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolvers[0]?.(true);
+        await clearPromise;
+      });
+      expect(clear).toHaveBeenCalledTimes(1);
+    });
+
+    it("is not wedged by a save that rejects instead of resolving false", async () => {
+      // save() resolves false on failure today; if that ever changed, a rejected
+      // promise left in the in-flight set would make every later clear/import
+      // await a rejecting Promise.all.
+      const save = vi.fn().mockRejectedValue(new Error("network down"));
+      const clear = vi.fn().mockResolvedValue(true);
+      const { result } = renderReadyEditor({ save, clear });
+
+      stubConfirm(true);
+
+      await typeDraft(result, "draft");
+      await flushDebounceWindow(2);
+      expect(save).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await expect(result.current.handleClear()).resolves.toBe(true);
       });
       expect(clear).toHaveBeenCalledTimes(1);
     });

--- a/webui/src/hooks/context/tests/use-memory-collection.test.ts
+++ b/webui/src/hooks/context/tests/use-memory-collection.test.ts
@@ -17,6 +17,8 @@ import {
   deferred,
   installFetchMock,
   jsonResponse,
+  type RacedWrite,
+  raceTwoWrites,
   renderAndWait,
 } from "./doc-transport-test-helpers";
 
@@ -121,6 +123,34 @@ async function saveResolvingAfterReset(
     put.resolve(late);
     await saving;
   });
+}
+
+/**
+ * Save one entry's body through the collection hook.
+ * @param result - The rendered hook's `result` handle
+ * @param name - The entry to save
+ * @param content - The body to store
+ * @returns The saved entry, or null on failure
+ */
+function saveBody(
+  result: HookResult,
+  name: string,
+  content: string,
+): Promise<MemoryEntryView | null> {
+  return result.current.saveEntry(name, { ...SAMPLE_INPUT, content });
+}
+
+/**
+ * The older, slower write the same-entry race tests dispatch first: a save of
+ * "prefers-c-minor" whose echo lands last and must not be committed.
+ * @param result - The rendered hook's `result` handle
+ * @returns The raced write descriptor
+ */
+function slowSaveOfSampleEntry(result: HookResult): RacedWrite {
+  return {
+    dispatch: () => saveBody(result, "prefers-c-minor", "OLD"),
+    echo: jsonResponse({ entry: rawEntry({ body: "OLD" }) }),
+  };
 }
 
 describe("useMemoryCollection", () => {
@@ -474,6 +504,59 @@ describe("useMemoryCollection", () => {
     await waitFor(() => {
       expect(readyEntries(result)[0]?.body).toBe("v2");
     });
+  });
+
+  it("drops an older save's echo for the same entry when a newer save has landed", async () => {
+    // Two overlapping saves of one entry (a debounced autosave, then the
+    // unmount flush or an explicit Save). The FIRST echo is slow and lands
+    // last, which would merge superseded content back into the list.
+    const result = await mountReady([rawEntry({ body: "loaded" })]);
+
+    await raceTwoWrites(fetchMock, slowSaveOfSampleEntry(result), {
+      dispatch: () => saveBody(result, "prefers-c-minor", "NEW"),
+      echo: jsonResponse({ entry: rawEntry({ body: "NEW" }) }),
+    });
+
+    expect(readyEntries(result)[0]?.body).toBe("NEW");
+  });
+
+  it("does not let a save of one entry discard another entry's echo", async () => {
+    // Ordering is per entry: a collection-wide newest-write-wins rule would
+    // drop this first entry's merge just because a second entry was saved after.
+    const result = await mountReady([
+      rawEntry({ body: "loaded" }),
+      rawEntry({ name: "loose-drums", body: "loaded" }),
+    ]);
+
+    await raceTwoWrites(
+      fetchMock,
+      {
+        dispatch: () => saveBody(result, "prefers-c-minor", "A"),
+        echo: jsonResponse({ entry: rawEntry({ body: "A" }) }),
+      },
+      {
+        dispatch: () => saveBody(result, "loose-drums", "B"),
+        echo: jsonResponse({
+          entry: rawEntry({ name: "loose-drums", body: "B" }),
+        }),
+      },
+    );
+
+    expect(readyEntries(result).map((entry) => entry.body)).toStrictEqual([
+      "A",
+      "B",
+    ]);
+  });
+
+  it("keeps a delete that a slower save of the same entry would resurrect", async () => {
+    const result = await mountReady([rawEntry({ body: "loaded" })]);
+
+    await raceTwoWrites(fetchMock, slowSaveOfSampleEntry(result), {
+      dispatch: () => result.current.deleteEntry("prefers-c-minor"),
+      echo: jsonResponse({}),
+    });
+
+    expect(readyEntries(result)).toStrictEqual([]);
   });
 
   it("drops a refresh that a concurrent save superseded", async () => {

--- a/webui/src/hooks/context/tests/use-skill-overrides.test.ts
+++ b/webui/src/hooks/context/tests/use-skill-overrides.test.ts
@@ -13,6 +13,7 @@ import {
   deferred,
   installFetchMock,
   jsonResponse,
+  raceTwoWrites,
   renderAndWait,
 } from "./doc-transport-test-helpers";
 
@@ -38,6 +39,25 @@ function rawSlot(over: Record<string, unknown> = {}): Record<string, unknown> {
   };
 }
 
+/** A rendered hook's `result` handle. */
+type HookResult = { current: ReturnType<typeof useSkillOverrides> };
+
+/**
+ * One slot's current override, asserting the collection is ready first.
+ * @param result - The rendered hook's `result` handle
+ * @param index - Position in the slot list
+ * @returns That slot's override body
+ */
+function overrideOf(result: HookResult, index: number): string | undefined {
+  const { status } = result.current;
+
+  if (status.kind !== "ready") {
+    throw new Error(`expected ready, got ${status.kind}`);
+  }
+
+  return status.slots[index]?.override;
+}
+
 describe("useSkillOverrides", () => {
   const fetchMock = installFetchMock();
 
@@ -45,7 +65,7 @@ describe("useSkillOverrides", () => {
   // Most tests only need the mount to succeed before exercising a write.
   async function renderReady(
     slots: Array<Record<string, unknown>> = [rawSlot()],
-  ): Promise<{ current: ReturnType<typeof useSkillOverrides> }> {
+  ): Promise<HookResult> {
     fetchMock.mockResolvedValueOnce(jsonResponse({ slots }));
 
     return await renderAndWait(useSkillOverrides, "ready");
@@ -277,6 +297,52 @@ describe("useSkillOverrides", () => {
 
       expect(status.kind === "ready" && status.slots[0]?.override).toBe("v2");
     });
+  });
+
+  it("drops an older save's echo for the same slot when a newer save has landed", async () => {
+    // The slot editor autosaves (debounce flush, then a blur flush behind it),
+    // so two writes of one slot overlap. An older echo landing last would put
+    // `override` back and raise a spurious "changed outside the editor" banner
+    // whose Reload adopts the superseded content.
+    const result = await renderReady([rawSlot({ override: "loaded" })]);
+
+    await raceTwoWrites(
+      fetchMock,
+      {
+        dispatch: () => result.current.saveSlot("barbeat-standard", "OLD"),
+        echo: jsonResponse({ slot: rawSlot({ override: "OLD" }) }),
+      },
+      {
+        dispatch: () => result.current.saveSlot("barbeat-standard", "NEW"),
+        echo: jsonResponse({ slot: rawSlot({ override: "NEW" }) }),
+      },
+    );
+
+    expect(overrideOf(result, 0)).toBe("NEW");
+  });
+
+  it("does not let a save of one slot discard another slot's echo", async () => {
+    // Ordering is per slot: newest-write-wins across the whole collection would
+    // drop this first slot's merge just because a second slot was saved after.
+    const result = await renderReady([
+      rawSlot({ override: "loaded" }),
+      rawSlot({ name: "stark", override: "loaded" }),
+    ]);
+
+    await raceTwoWrites(
+      fetchMock,
+      {
+        dispatch: () => result.current.saveSlot("barbeat-standard", "A"),
+        echo: jsonResponse({ slot: rawSlot({ override: "A" }) }),
+      },
+      {
+        dispatch: () => result.current.saveSlot("stark", "B"),
+        echo: jsonResponse({ slot: rawSlot({ name: "stark", override: "B" }) }),
+      },
+    );
+
+    expect(overrideOf(result, 0)).toBe("A");
+    expect(overrideOf(result, 1)).toBe("B");
   });
 
   it("drops a refresh that a concurrent save superseded", async () => {

--- a/webui/src/hooks/context/use-context-editor-state.ts
+++ b/webui/src/hooks/context/use-context-editor-state.ts
@@ -26,6 +26,19 @@ function clearTimer(ref: TimerRef): void {
   }
 }
 
+/**
+ * Every save POST currently in flight, as one promise to await before the
+ * caller's own write goes out — or null when the editor is idle, so clear/import
+ * reach their POST without an extra microtask hop (the single-promise ref this
+ * replaced had that same fast path). Promise.all walks the set synchronously, so
+ * the saves that settle (and remove themselves) afterward are still awaited.
+ * @param saves - The live set of in-flight save promises
+ * @returns A promise for all current saves, or null when there are none
+ */
+function pendingSaves(saves: Set<Promise<boolean>>): Promise<unknown> | null {
+  return saves.size === 0 ? null : Promise.all(saves);
+}
+
 export interface UseContextEditorStateReturn {
   /**
    * Bumped on Clear / Reload-from-server to remount the uncontrolled
@@ -102,9 +115,13 @@ export function useContextEditorState(
   const lastSavedRef = useRef<string | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Tracks the most recent in-flight save() promise so handleClear can await
-  // it (prevents a stale draft POST from landing after clear's POST).
-  const inFlightSaveRef = useRef<Promise<boolean> | null>(null);
+  // Every in-flight save() promise, so handleClear/handleImport can await them
+  // ALL before dispatching their own write (prevents a stale draft POST from
+  // landing after theirs). A set rather than one ref: saves can overlap (a
+  // debounce flush, then a blur flush before the first echo lands), and keeping
+  // only the newest would silently stop awaiting the earlier one — the very
+  // write-ordering hazard this is here to close.
+  const inFlightSavesRef = useRef<Set<Promise<boolean>>>(new Set());
   const memoryRef = useRef(memory);
   // False once the hook has unmounted, so the unmount flush's save promise
   // can't schedule a retry or setState after teardown (a persistent failure
@@ -208,14 +225,16 @@ export function useContextEditorState(
     lastSavedRef.current = value;
     // Track the in-flight save so handleClear can await it before dispatching
     // clear (orders the writes on the wire — clear already accepts the
-    // round-trip latency).
-    const savePromise = current.save(value);
+    // round-trip latency). Tracked as a promise that SETTLES rather than the
+    // raw one: a rejection would otherwise leave the entry in the set forever
+    // and wedge every later clear/import on a rejecting Promise.all. save()
+    // resolves false rather than throwing today — this keeps that from being
+    // load-bearing, and routes an unexpected throw into the retry path below.
+    const savePromise = current.save(value).catch(() => false);
 
-    inFlightSaveRef.current = savePromise;
+    inFlightSavesRef.current.add(savePromise);
     void savePromise.then((saved) => {
-      if (inFlightSaveRef.current === savePromise) {
-        inFlightSaveRef.current = null;
-      }
+      inFlightSavesRef.current.delete(savePromise);
 
       // The hook unmounted mid-save: don't touch state or reschedule. The
       // flush already went out (best-effort); retrying after teardown would
@@ -289,12 +308,12 @@ export function useContextEditorState(
     clearTimer(debounceTimerRef);
     clearTimer(retryTimerRef);
 
-    // Wait for any in-flight save POST to complete before clear's POST goes
-    // out. Without this, the older draft's POST could land AFTER clear's
+    // Wait for every in-flight save POST to complete before clear's POST goes
+    // out. Without this, an older draft's POST could land AFTER clear's
     // POST and resurrect the cleared content. (The fetch promise resolves
     // only after the server has responded, so awaiting it orders the writes
     // server-side.)
-    const pending = inFlightSaveRef.current;
+    const pending = pendingSaves(inFlightSavesRef.current);
 
     if (pending != null) await pending;
 
@@ -353,9 +372,9 @@ export function useContextEditorState(
       clearTimer(debounceTimerRef);
       clearTimer(retryTimerRef);
 
-      // Order the import POST after any in-flight save so a stale draft POST
+      // Order the import POST after every in-flight save so a stale draft POST
       // can't land after it and resurrect the old content (see handleClear).
-      const pending = inFlightSaveRef.current;
+      const pending = pendingSaves(inFlightSavesRef.current);
 
       if (pending != null) await pending;
 

--- a/webui/src/hooks/context/use-doc-collection.ts
+++ b/webui/src/hooks/context/use-doc-collection.ts
@@ -22,6 +22,7 @@ import {
   type SaveStatus,
   useRefreshOnFocusAndPoll,
   useSaveRefreshGuard,
+  useWriteOrdering,
 } from "./use-doc";
 
 const AUTOSAVE_DEBOUNCE_MS = 800;
@@ -123,7 +124,12 @@ export function useDocCollection<TView extends DocCollectionEntry, TInput>(
   // shared "saved"/"error" indicator onto the now-active entry (the list merge
   // still applies — only the status indicator is entry-scoped).
   const saveGenerationRef = useRef(0);
-  const { beginSave, endSave, guardRefresh } = useSaveRefreshGuard();
+  // Per-ENTRY write ordering, distinct from saveGenerationRef (which scopes the
+  // status indicator to the selected entry): a slow earlier save landing after a
+  // newer one must not revert that entry in the cached list.
+  const { claim } = useWriteOrdering();
+  const { beginSave, endSave, guardRefresh, isUnmounted } =
+    useSaveRefreshGuard();
 
   const refresh = useCallback(
     (): Promise<void> =>
@@ -138,15 +144,22 @@ export function useDocCollection<TView extends DocCollectionEntry, TInput>(
 
   // Shared save lifecycle for the mutators: mark saving, run `op`, commit its
   // result (a setStatus) on success, record the error on failure, and always
-  // clear the in-flight guard. Resolves `op`'s result, or null on failure — so
+  // clear the in-flight guard. `names` are the entries the mutation targets —
+  // its result is committed only while it is still the newest write for all of
+  // them (see useWriteOrdering). Resolves `op`'s result, or null on failure — so
   // saveEntry/renameEntry return the entry (or null) and deleteEntry maps the
   // void result to a boolean.
   const mutate = useCallback(
     async <T>(
       op: () => Promise<T>,
       commit: (result: T) => void,
+      names: string[],
     ): Promise<T | null> => {
       const generation = saveGenerationRef.current;
+      // Ordering is per entry, NOT newest-write-wins: beginSave's own predicate
+      // would let a save of entry B discard entry A's echo. Only its
+      // unmounted half applies here.
+      const superseded = claim(...names);
 
       beginSave();
       setSaveStatus("saving");
@@ -155,11 +168,15 @@ export function useDocCollection<TView extends DocCollectionEntry, TInput>(
       try {
         const result = await op();
 
-        commit(result);
+        if (isUnmounted()) return result;
+        if (!superseded()) commit(result);
+
         if (saveGenerationRef.current === generation) setSaveStatus("saved");
 
         return result;
       } catch (error: unknown) {
+        if (isUnmounted()) return null;
+
         if (saveGenerationRef.current === generation) {
           setSaveError(errorMessage(error));
           setSaveStatus("error");
@@ -170,7 +187,7 @@ export function useDocCollection<TView extends DocCollectionEntry, TInput>(
         endSave();
       }
     },
-    [beginSave, endSave],
+    [beginSave, endSave, claim, isUnmounted],
   );
 
   const saveEntry = useCallback(
@@ -178,6 +195,7 @@ export function useDocCollection<TView extends DocCollectionEntry, TInput>(
       mutate(
         () => putEntry<TView, TInput>(entryUrl(name), input, createOnly, label),
         (entry) => setStatus((prev) => mergeEntry(prev, entry)),
+        [name],
       ),
     [mutate, entryUrl, label],
   );
@@ -196,6 +214,8 @@ export function useDocCollection<TView extends DocCollectionEntry, TInput>(
         // re-adds it; the list re-sorts by name, so order is irrelevant).
         (entry) =>
           setStatus((prev) => mergeEntry(removeEntry(prev, oldName), entry)),
+        // A rename touches both slugs, so a later write to EITHER supersedes it.
+        [oldName, newName],
       ),
     [mutate, entryUrl, label],
   );
@@ -207,6 +227,7 @@ export function useDocCollection<TView extends DocCollectionEntry, TInput>(
       const result = await mutate(
         () => deleteEntryRequest(entryUrl(name), label),
         () => setStatus((prev) => removeEntry(prev, name)),
+        [name],
       );
 
       return result !== null;

--- a/webui/src/hooks/context/use-doc.ts
+++ b/webui/src/hooks/context/use-doc.ts
@@ -91,12 +91,21 @@ export function useDoc(
 
   const save = useCallback(
     async (content: string): Promise<boolean> => {
-      beginSave();
+      // Two saves can overlap (a debounced flush, then a blur or another
+      // keystroke's flush before the first echo lands). Whichever echo arrives
+      // LAST would otherwise win the state, so an older save landing late would
+      // revert the editor to superseded content: commit only while this save is
+      // still the newest one issued. The outcome is still reported truthfully —
+      // it's the state commit that is superseded, not the write.
+      const discardSave = beginSave();
+
       setSaveStatus("saving");
       setSaveError(null);
 
       try {
         const stored = await write(content);
+
+        if (discardSave()) return true;
 
         setStatus({ kind: "ready", content: stored.content });
         setDrift(stored.drift);
@@ -104,6 +113,8 @@ export function useDoc(
 
         return true;
       } catch (error: unknown) {
+        if (discardSave()) return false;
+
         setSaveError(errorMessage(error));
         setSaveStatus("error");
 
@@ -139,10 +150,17 @@ export function useDoc(
 
 /** Save/refresh race coordination primitives (see {@link useSaveRefreshGuard}). */
 export interface SaveRefreshGuard {
-  /** Mark a save started (before its write begins). */
-  beginSave: () => void;
+  /** Mark a save started (before its write begins). The returned predicate
+   *  reports whether THIS save's result should be DISCARDED — a newer save was
+   *  issued after it (whose echo is the one the UI must keep), or the component
+   *  unmounted while it was in flight. */
+  beginSave: () => () => boolean;
   /** Mark a save finished (in the write's finally). */
   endSave: () => void;
+  /** True once the component has unmounted — the half of `beginSave`'s
+   *  predicate a collection hook wants on its own, since ordering there is per
+   *  entry ({@link useWriteOrdering}) rather than newest-write-wins. */
+  isUnmounted: () => boolean;
   /** Snapshot the guard at a refresh's start; the returned predicate reports
    *  whether the refresh's result should be DISCARDED — because a save overlapped
    *  its round-trip (the save's echo should win) or the component unmounted while
@@ -160,6 +178,11 @@ export interface SaveRefreshGuard {
  * overlapped the round-trip. The same predicate also reports true once the
  * component has unmounted, so a late-resolving fetch can't setState on a dead
  * component (matching the AbortController guard the preview/config hooks use).
+ *
+ * The same generation counter orders saves against EACH OTHER: `beginSave`
+ * returns a predicate that reports whether its own save has since been
+ * superseded, so an older write's echo landing last can't revert the UI to
+ * content the user has already typed past.
  * @returns The save-bracketing and refresh-guard helpers
  */
 export function useSaveRefreshGuard(): SaveRefreshGuard {
@@ -174,9 +197,12 @@ export function useSaveRefreshGuard(): SaveRefreshGuard {
     [],
   );
 
-  const beginSave = useCallback((): void => {
+  const beginSave = useCallback((): (() => boolean) => {
     saveCountRef.current++;
-    saveGenRef.current++;
+    const generation = ++saveGenRef.current;
+
+    return (): boolean =>
+      !mountedRef.current || saveGenRef.current !== generation;
   }, []);
 
   const endSave = useCallback((): void => {
@@ -193,7 +219,47 @@ export function useSaveRefreshGuard(): SaveRefreshGuard {
       saveGenRef.current !== genAtStart;
   }, []);
 
-  return { beginSave, endSave, guardRefresh };
+  const isUnmounted = useCallback((): boolean => !mountedRef.current, []);
+
+  return { beginSave, endSave, guardRefresh, isUnmounted };
+}
+
+/** Per-target write ordering (see {@link useWriteOrdering}). */
+export interface WriteOrdering {
+  /**
+   * Stamp the targets a write is about to touch. The returned predicate reports
+   * whether this write has since been SUPERSEDED — a later write claimed one of
+   * the same targets — so its result must not be committed.
+   */
+  claim: (...names: string[]) => () => boolean;
+}
+
+/**
+ * Order writes against each other WITHIN a collection, where "newest write
+ * wins" (what {@link useSaveRefreshGuard}'s generation counter gives a single
+ * document) is too coarse: saving entry B must not discard entry A's echo.
+ * Each write stamps the names it touches with a monotonic sequence number, and
+ * a stamp overwritten by a later write invalidates the earlier one's commit —
+ * so two overlapping saves of ONE entry resolve to the newest, and a delete
+ * beats a slower save it was issued after, while unrelated entries never
+ * interfere. Shared by the entry collections (`useDocCollection`) and the skill
+ * slots (`useSkillOverrides`).
+ * @returns The claim helper
+ */
+export function useWriteOrdering(): WriteOrdering {
+  const sequenceRef = useRef(0);
+  const latestRef = useRef<Map<string, number>>(new Map());
+
+  const claim = useCallback((...names: string[]): (() => boolean) => {
+    const sequence = ++sequenceRef.current;
+
+    for (const name of names) latestRef.current.set(name, sequence);
+
+    return (): boolean =>
+      names.some((name) => latestRef.current.get(name) !== sequence);
+  }, []);
+
+  return { claim };
 }
 
 /**

--- a/webui/src/hooks/context/use-skill-overrides.ts
+++ b/webui/src/hooks/context/use-skill-overrides.ts
@@ -14,6 +14,7 @@ import {
   type SaveStatus,
   useRefreshOnFocusAndPoll,
   useSaveRefreshGuard,
+  useWriteOrdering,
 } from "./use-doc";
 
 /** One overridable skills fragment, as the editor needs it. */
@@ -77,10 +78,14 @@ export function useSkillOverrides(): UseSkillOverridesReturn {
   // shared "saved"/"error" indicator onto the now-active slot (the list merge
   // still applies — only the status indicator is slot-scoped).
   const saveGenerationRef = useRef(0);
+  // Per-SLOT write ordering, so two overlapping saves of one slot resolve to
+  // the newest (see writeSlot) while unrelated slots never interfere.
   // Same refresh-vs-save coordination as useDoc (a focus/poll read can
   // resolve older slot data than a concurrent save's echo and, landing last,
   // clobber it), just over the slot collection instead of one document.
-  const { beginSave, endSave, guardRefresh } = useSaveRefreshGuard();
+  const { claim } = useWriteOrdering();
+  const { beginSave, endSave, guardRefresh, isUnmounted } =
+    useSaveRefreshGuard();
 
   const refresh = useCallback(
     (): Promise<void> =>
@@ -94,8 +99,19 @@ export function useSkillOverrides(): UseSkillOverridesReturn {
   );
 
   const writeSlot = useCallback(
-    async (write: () => Promise<SkillSlotView>): Promise<boolean> => {
+    async (
+      name: string,
+      write: () => Promise<SkillSlotView>,
+    ): Promise<boolean> => {
       const generation = saveGenerationRef.current;
+      // Slots autosave through useContextEditorState (a debounce flush, then a
+      // blur flush right behind it), so two writes of ONE slot overlap and the
+      // older echo can land last. Merging it would put `override` back, flip the
+      // status SkillSlotScreen memoizes off this list, and raise a spurious
+      // "updated outside the editor" banner whose Reload adopts the superseded
+      // content. Ordering is per slot, so a write to another slot never
+      // interferes.
+      const superseded = claim(name);
 
       beginSave();
       setSaveStatus("saving");
@@ -104,11 +120,15 @@ export function useSkillOverrides(): UseSkillOverridesReturn {
       try {
         const updated = await write();
 
-        setStatus((prev) => mergeSlot(prev, updated));
+        if (isUnmounted()) return true;
+        if (!superseded()) setStatus((prev) => mergeSlot(prev, updated));
+
         if (saveGenerationRef.current === generation) setSaveStatus("saved");
 
         return true;
       } catch (error: unknown) {
+        if (isUnmounted()) return false;
+
         if (saveGenerationRef.current === generation) {
           setSaveError(errorMessage(error));
           setSaveStatus("error");
@@ -119,17 +139,17 @@ export function useSkillOverrides(): UseSkillOverridesReturn {
         endSave();
       }
     },
-    [beginSave, endSave],
+    [beginSave, endSave, claim, isUnmounted],
   );
 
   const saveSlot = useCallback(
     (name: string, content: string): Promise<boolean> =>
-      writeSlot(() => putSlot(name, content)),
+      writeSlot(name, () => putSlot(name, content)),
     [writeSlot],
   );
 
   const resetSlot = useCallback(
-    (name: string): Promise<boolean> => writeSlot(() => deleteSlot(name)),
+    (name: string): Promise<boolean> => writeSlot(name, () => deleteSlot(name)),
     [writeSlot],
   );
 


### PR DESCRIPTION
Four independent fixes in the context/memory write path, one commit each — please **merge, don't squash**, so each ticket keeps its own commit.

**1. Skip a project/global write that discards the whole document**
`ppal-context action:write` replaces the document, so a model that sends only its new fact destroys everything the user accumulated. A write whose content keeps none of the existing document is now skipped and warned about (warn-and-skip), with the current document returned so the model can re-send a merged write. `force:true` is the escape hatch — in the schema, deliberately not in the skills. Detection normalizes both sides (list marker, whitespace, trailing punctuation) so an ordinary reformat survives, and only lines of ≥ 8 non-whitespace characters may vouch for a write, so a `---` rule or table row can't satisfy it for free. Tool path only; the REST/webui editors are untouched. `dev/Memory-System.md` documents it as built.

**2. Basic-tier skills: confirm rule + one scope per fact**
Small models had no confirm rule at all (it was added to the standard tier only) and duplicated an always-applies fact into both user-owned layers. Both rules are stated with their release condition so the wording can't over-correct into refusing to write. The layer scenarios now assert the other user-owned layer stays untouched — deliberately without a write count, which would score the clobber guard's own re-send as a failure.

**3. Order overlapping saves in the context editors**
Only save-vs-refresh was guarded. Two saves of the same doc had no ordering guard, so a slow first echo landing last reverted the UI to content already typed past. Fixed at all four sites, in two shapes: newest-write-wins for the single document, and per-target ordering for the two collections (entries and skill slots) — where a collection-wide rule would wrongly discard entry A's echo because entry B was saved after. The editor state also awaits every in-flight save (it tracked only the newest, silently un-guarding clear/import).

**4. New starts a blank entry form**
Pressing New with the create form already open kept the half-filled draft, so the button looked inert. It now remounts fresh, with the existing leave guard confirming the discard.

Not yet run (both need Ableton): the `ppal-context` MCP e2e suite, and the context eval set under `--small-model` for the skills change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)