### PR TITLE
fix(chat-ui): keep memory edits typed during a rename

### DIFF
--- a/webui/src/components/context/collection/CollectionScreen.tsx
+++ b/webui/src/components/context/collection/CollectionScreen.tsx
@@ -39,6 +39,14 @@ export interface CollectionEditorRenderArgs<TView> {
   entry: TView | null;
   onSaved: (name: string) => void;
   onDeleted: () => void;
+  /**
+   * Follow this editor's entry to a new slug WITHOUT remounting the editor (a
+   * rename). The live draft — including anything typed during the rename's
+   * round trip — exists only in the mounted instance's state, so remounting
+   * there re-seeds from the server's pre-edit echo and drops it. Editors whose
+   * collection can't rename (custom skills) ignore this.
+   */
+  onRenamed: (name: string) => void;
 }
 
 interface CollectionScreenProps<TView extends DocCollectionEntry, TInput> {
@@ -69,9 +77,10 @@ interface CollectionScreenProps<TView extends DocCollectionEntry, TInput> {
  * Owns the selection state, loading/error gating, and the delete-out-from-under
  * affordance; the caller supplies the domain list + editor and the labels.
  *
- * The editor is keyed by the selection (not the found entry) so its draft
+ * The editor is keyed by a selection epoch (not the found entry) so its draft
  * re-seeds on switch, yet a poll that deletes the entry mid-edit keeps the
- * editor mounted with the user's draft (the banner explains it; Save re-creates).
+ * editor mounted with the user's draft (the banner explains it; Save
+ * re-creates), and so does a rename (see `onRenamed`).
  *
  * @param props - Screen props
  * @returns Screen element
@@ -83,24 +92,25 @@ export function CollectionScreen<TView extends DocCollectionEntry, TInput>(
     props;
   const { description } = props;
   const [selected, setSelected] = useState<Selection>({ mode: "new" });
-  // Bumped by every New press so the create form REMOUNTS on a fresh key, even
-  // when it is already the active pane — otherwise "New" left a half-filled
-  // draft sitting there and looked like it did nothing.
-  const [newEpoch, setNewEpoch] = useState(0);
-  const selectionKey =
-    selected.mode === "edit" ? selected.name : `__new__:${newEpoch}`;
+  // The editor's identity. Bumped by every selection change that lands on a
+  // DIFFERENT draft, so the editor remounts and re-seeds — including a New
+  // press while the create form is already the active pane (otherwise a
+  // half-filled draft sat there and the button looked inert). A RENAME
+  // deliberately does NOT bump it: see the onRenamed doc.
+  const [editorEpoch, setEditorEpoch] = useState(0);
+  const editorKey = `${selected.mode}:${editorEpoch}`;
   // Selecting another entry unmounts the active editor; confirm a discard first
   // if it holds an unsaved new draft (the editor registers the guard).
   const leaveGuard = useLeaveGuardContext();
 
-  // Reset the save indicator whenever the edited entry (or the create form)
-  // changes, so it never carries the previous entry's "Saved" onto the next one
-  // or onto the create form.
+  // Reset the save indicator whenever the editor switches to another draft, so
+  // it never carries the previous entry's "Saved" onto the next one or onto the
+  // create form. A rename keeps the same editor, and with it its own outcome.
   const { resetSaveStatus } = collection;
 
   useEffect(() => {
     resetSaveStatus();
-  }, [selectionKey, resetSaveStatus]);
+  }, [editorKey, resetSaveStatus]);
 
   if (collection.status.kind !== "ready") {
     return (
@@ -123,12 +133,33 @@ export function CollectionScreen<TView extends DocCollectionEntry, TInput>(
     selected.mode === "edit"
       ? (entries.find((entry) => entry.name === selected.name) ?? null)
       : null;
-  const editorKey = selectionKey;
   const deletedExternally = selected.mode === "edit" && activeEntry == null;
+
+  // Point the right pane at another draft, remounting the editor so it re-seeds.
+  // Re-selecting the entry already open is a no-op, so clicking its row again
+  // (or re-saving it under the same slug) keeps the in-progress draft.
+  const selectDraft = (next: Selection): void => {
+    if (
+      next.mode === "edit" &&
+      selected.mode === "edit" &&
+      selected.name === next.name
+    ) {
+      return;
+    }
+
+    setSelected(next);
+    setEditorEpoch((epoch) => epoch + 1);
+  };
+
   const editor = props.renderEditor({
     entry: activeEntry,
-    onSaved: (name) => setSelected({ mode: "edit", name }),
-    onDeleted: () => setSelected({ mode: "new" }),
+    onSaved: (name) => selectDraft({ mode: "edit", name }),
+    onDeleted: () => selectDraft({ mode: "new" }),
+    // No epoch bump: the entry changes slug under the SAME mounted editor.
+    onRenamed: (name) =>
+      setSelected((prev) =>
+        prev.mode === "edit" ? { mode: "edit", name } : prev,
+      ),
   });
 
   // Delete from the list (the row trash). Return to the create form when the
@@ -139,7 +170,7 @@ export function CollectionScreen<TView extends DocCollectionEntry, TInput>(
     const ok = await collection.deleteEntry(name);
 
     if (ok && selected.mode === "edit" && selected.name === name) {
-      setSelected({ mode: "new" });
+      selectDraft({ mode: "new" });
     }
   };
 
@@ -171,7 +202,7 @@ export function CollectionScreen<TView extends DocCollectionEntry, TInput>(
             creating: activeEntry == null,
             onSelect: (name) => {
               if (leaveGuard.confirmLeave())
-                setSelected({ mode: "edit", name });
+                selectDraft({ mode: "edit", name });
             },
             // New always means a BLANK form — including when the create form is
             // already open holding a half-filled draft, which used to be kept
@@ -182,8 +213,7 @@ export function CollectionScreen<TView extends DocCollectionEntry, TInput>(
             // persist on navigate-away instead) just gets the fresh form.
             onNew: () => {
               if (!leaveGuard.confirmLeave()) return;
-              setSelected({ mode: "new" });
-              setNewEpoch((epoch) => epoch + 1);
+              selectDraft({ mode: "new" });
             },
             onDelete: (name) => void handleDeleteEntry(name),
           })}
@@ -192,7 +222,7 @@ export function CollectionScreen<TView extends DocCollectionEntry, TInput>(
           {deletedExternally && (
             <DeletedExternallyBanner
               message={deletedBanner}
-              onDiscard={() => setSelected({ mode: "new" })}
+              onDiscard={() => selectDraft({ mode: "new" })}
             />
           )}
           {cloneElement(editor, { key: editorKey })}

--- a/webui/src/components/context/memory/MemoryEntryEditor.tsx
+++ b/webui/src/components/context/memory/MemoryEntryEditor.tsx
@@ -25,12 +25,20 @@ interface MemoryEntryEditorProps {
   entry: MemoryEntryView | null;
   /** Called after a successful save with the stored entry's slug. */
   onSaved: (name: string) => void;
+  /**
+   * Called after a successful rename with the stored entry's new slug. Distinct
+   * from `onSaved` because it must NOT remount this editor — the live draft is
+   * only here (see {@link CollectionEditorRenderArgs.onRenamed}).
+   */
+  onRenamed: (name: string) => void;
 }
 
 /**
  * Right-pane form for one memory: an editable name (rename in place, or the new
  * draft's slug), a one-line description, and a markdown body. Keyed by the
- * selected entry in the parent so the local draft re-seeds on selection change.
+ * selection in the parent so the local draft re-seeds when another memory is
+ * picked — but NOT by a rename, which keeps this instance (and its draft) alive
+ * while the entry changes slug underneath it (see {@link useMemoryRename}).
  *
  * An existing memory autosaves — there is no Save button; the save state shows
  * in the header (see {@link CollectionScreen}). A new memory is created only by
@@ -43,7 +51,7 @@ interface MemoryEntryEditorProps {
 export function MemoryEntryEditor(
   props: MemoryEntryEditorProps,
 ): preact.JSX.Element {
-  const { collection, entry, onSaved } = props;
+  const { collection, entry, onSaved, onRenamed } = props;
   const isNew = entry == null;
   const [name, setName] = useState(entry?.name ?? "");
   const [description, setDescription] = useState(entry?.description ?? "");
@@ -100,7 +108,7 @@ export function MemoryEntryEditor(
     body,
     requiredError: validation.errors.name,
     noteSaved,
-    onSaved,
+    onRenamed,
   });
 
   const handleSave = async (): Promise<void> => {
@@ -204,10 +212,10 @@ interface MemoryRenameParams {
   body: string;
   /** The client-side required-name error; it takes priority over a rename error. */
   requiredError?: string;
-  /** Advance the autosave baseline for the OLD name after a successful rename. */
+  /** Advance the autosave baseline to the renamed entry's echo. */
   noteSaved: (echoKey: string) => void;
-  /** Navigate to the renamed entry's new slug. */
-  onSaved: (name: string) => void;
+  /** Follow the entry to its new slug, keeping this editor mounted. */
+  onRenamed: (name: string) => void;
 }
 
 /**
@@ -216,9 +224,15 @@ interface MemoryRenameParams {
  * a server-rejected slug) — read fresh from the collection each render, not off
  * the stale rename closure — cleared as soon as the user edits the name. An
  * emptied/unchanged name never renames (an emptied one keeps its required error
- * visible; an unchanged one just normalizes whitespace). On success, the OLD
- * name's draft is marked saved so the navigation's unmount flush can't re-create
- * the old slug; the current draft fields ride along so a dirty body isn't lost.
+ * visible; an unchanged one just normalizes whitespace). The current draft
+ * fields ride along on the write so a dirty body isn't lost.
+ *
+ * On success the editor stays MOUNTED and follows the entry to its new slug
+ * (`onRenamed`): remounting would re-seed the fields from the server's echo,
+ * silently dropping anything typed during the rename's round trip. The name
+ * field adopts the server's slug, and the baseline advances to that echo, so a
+ * draft that did diverge mid-rename is left dirty for the autosave to persist
+ * under the NEW name — and a clean one doesn't re-save.
  * Extracted so the editor body stays within the line limit.
  * @param params - The live draft + collection the rename needs
  * @returns The name field's error and its change/rename handlers
@@ -229,7 +243,7 @@ function useMemoryRename(params: MemoryRenameParams): {
   onRename: (raw: string) => void;
 } {
   const { collection, entry, setName, description, body } = params;
-  const { requiredError, noteSaved, onSaved } = params;
+  const { requiredError, noteSaved, onRenamed } = params;
   const [renameFailed, setRenameFailed] = useState(false);
 
   const nameError =
@@ -264,8 +278,9 @@ function useMemoryRename(params: MemoryRenameParams): {
         }
 
         setRenameFailed(false);
-        noteSaved(memoryEntryKey({ name: entry.name, description, body }));
-        onSaved(renamed.name);
+        setName(renamed.name);
+        noteSaved(memoryEntryKey(renamed));
+        onRenamed(renamed.name);
       });
   };
 

--- a/webui/src/components/context/memory/MemoryScreen.tsx
+++ b/webui/src/components/context/memory/MemoryScreen.tsx
@@ -53,11 +53,12 @@ export function MemoryScreen(props: MemoryScreenProps): preact.JSX.Element {
           onDelete={onDelete}
         />
       )}
-      renderEditor={({ entry, onSaved }) => (
+      renderEditor={({ entry, onSaved, onRenamed }) => (
         <MemoryEntryEditor
           collection={collection}
           entry={entry}
           onSaved={onSaved}
+          onRenamed={onRenamed}
         />
       )}
     />

--- a/webui/src/components/context/memory/tests/MemoryEntryEditor.test.tsx
+++ b/webui/src/components/context/memory/tests/MemoryEntryEditor.test.tsx
@@ -50,11 +50,13 @@ interface EditorProps {
   entry?: MemoryEntryView | null;
   /** The onSaved callback (default: a spy). */
   onSaved?: (name: string) => void;
+  /** The onRenamed callback (default: a spy). */
+  onRenamed?: (name: string) => void;
 }
 
 /**
  * The editor element with test defaults, so render and rerender share one shape.
- * @param props - Overrides for the collection, entry, and onSaved
+ * @param props - Overrides for the collection, entry, and the save callbacks
  * @returns The MemoryEntryEditor element
  */
 function editorElement(props: EditorProps = {}): preact.JSX.Element {
@@ -63,13 +65,14 @@ function editorElement(props: EditorProps = {}): preact.JSX.Element {
       collection={props.collection ?? fakeCollection()}
       entry={props.entry ?? null}
       onSaved={props.onSaved ?? vi.fn()}
+      onRenamed={props.onRenamed ?? vi.fn()}
     />
   );
 }
 
 /**
  * Render the editor with test defaults (idle collection, create mode).
- * @param props - Overrides for the collection, entry, and onSaved
+ * @param props - Overrides for the collection, entry, and the save callbacks
  * @returns The Testing Library render result (for unmount / rerender)
  */
 function renderEditor(props: EditorProps = {}): RenderResult {
@@ -323,25 +326,34 @@ describe("MemoryEntryEditor — rename", () => {
     body: "Composes in C minor.",
   };
 
-  it("renames on blur, carrying the current fields and navigating to the new slug", async () => {
+  it("renames on blur, carrying the current fields and following the new slug", async () => {
     const renameEntry = vi.fn().mockResolvedValue(RENAMED);
     const collection = fakeCollection({ renameEntry });
     const onSaved = vi.fn();
+    const onRenamed = vi.fn();
 
-    renderEditor({ collection, entry: EXISTING, onSaved });
+    renderEditor({ collection, entry: EXISTING, onSaved, onRenamed });
 
-    const nameInput = screen.getByRole("textbox", { name: "Rename" });
+    const nameInput = screen.getByRole("textbox", {
+      name: "Rename",
+    }) as HTMLInputElement;
 
     fireEvent.input(nameInput, { target: { value: "New Slug" } });
     fireEvent.blur(nameInput);
 
+    // onRenamed, NOT onSaved: the parent must follow the new slug WITHOUT
+    // remounting this editor, whose draft is the only copy of anything typed
+    // during the rename's round trip.
     await waitFor(() => {
-      expect(onSaved).toHaveBeenCalledWith("new-slug");
+      expect(onRenamed).toHaveBeenCalledWith("new-slug");
     });
+    expect(onSaved).not.toHaveBeenCalled();
     expect(renameEntry).toHaveBeenCalledWith("prefers-c-minor", "New Slug", {
       description: "default key & genre",
       content: "Composes in C minor.",
     });
+    // The field adopts the server's slugified name (no remount does it for us).
+    expect(nameInput.value).toBe("new-slug");
   });
 
   it("commits the rename on Enter", async () => {

--- a/webui/src/components/context/memory/tests/MemoryScreen-rename.test.tsx
+++ b/webui/src/components/context/memory/tests/MemoryScreen-rename.test.tsx
@@ -1,0 +1,190 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @vitest-environment happy-dom
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
+import { describe, expect, it, vi } from "vitest";
+import { markdownEditorTestMock } from "#webui/components/context/tests/markdown-editor-test-mock";
+import {
+  type Deferred,
+  deferred,
+  installFetchMock,
+  jsonResponse,
+} from "#webui/hooks/context/tests/doc-transport-test-helpers";
+import {
+  type MemoryEntryView,
+  useMemoryCollection,
+} from "#webui/hooks/context/use-memory-collection";
+import { MemoryScreen } from "#webui/components/context/memory/MemoryScreen";
+
+// Stub the CodeMirror body editor for happy-dom; see markdown-editor-test-mock.
+vi.mock(import("#webui/components/context/MarkdownEditor"), () =>
+  markdownEditorTestMock(),
+);
+
+const TAB_SLOT = <div data-testid="tabs">tabs</div>;
+
+const ENTRY: MemoryEntryView = {
+  name: "prefers-c-minor",
+  description: "default key & genre",
+  body: "Composes in C minor.",
+};
+
+/** The server's echo of the rename: the same fields under the new slug. */
+const RENAMED: MemoryEntryView = { ...ENTRY, name: "new-slug" };
+
+const fetchMock = installFetchMock();
+
+/** One captured entry PUT (the autosave/create channel, not the rename one). */
+interface CapturedSave {
+  url: string;
+  body: { description: string; content: string };
+}
+
+/**
+ * The Memory tab wired to the REAL collection hook over the stubbed fetch, so a
+ * rename runs its true round trip: the list commit lands in one microtask and
+ * the caller's navigation in the next. The screen-level fakes elsewhere can't
+ * express that ordering, which is exactly where the dropped-draft bug lived.
+ * @returns The screen element
+ */
+function MemoryScreenHarness(): preact.JSX.Element {
+  const collection = useMemoryCollection();
+
+  return <MemoryScreen collection={collection} tabSlot={TAB_SLOT} />;
+}
+
+/**
+ * Queue the stubbed fetch for one rename round trip: the mount GET lists
+ * `ENTRY`, the rename PUT hangs on a deferred the test resolves, and anything
+ * after that echoes the renamed entry.
+ * @returns The rename PUT's deferred response
+ */
+function routeFetch(): Deferred<Response> {
+  const renamePut = deferred<Response>();
+
+  fetchMock.mockResolvedValueOnce(jsonResponse({ entries: [ENTRY] }));
+  fetchMock.mockReturnValueOnce(renamePut.promise);
+  fetchMock.mockResolvedValue(jsonResponse({ entry: RENAMED }));
+
+  return renamePut;
+}
+
+/**
+ * The entry PUTs the editor issued — the save channel, excluding the rename.
+ * @returns One record per captured write, in dispatch order
+ */
+function entryPuts(): CapturedSave[] {
+  const calls = fetchMock.mock.calls as [string, RequestInit | undefined][];
+
+  return calls
+    .filter(([url, init]) => init?.method === "PUT" && !url.endsWith("/rename"))
+    .map(([url, init]) => ({
+      url,
+      body: JSON.parse(String(init?.body)) as CapturedSave["body"],
+    }));
+}
+
+/**
+ * Open `ENTRY` in the right pane and commit a rename to "New Slug" (which the
+ * server slugifies to `RENAMED`) whose PUT is left in flight.
+ */
+async function startRename(): Promise<void> {
+  fireEvent.click(
+    await screen.findByRole("button", { name: "Edit prefers-c-minor" }),
+  );
+
+  const nameInput = screen.getByRole("textbox", { name: "Rename" });
+
+  fireEvent.input(nameInput, { target: { value: "New Slug" } });
+  fireEvent.blur(nameInput);
+
+  await waitFor(() => {
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).endsWith("/rename")),
+    ).toBe(true);
+  });
+}
+
+/**
+ * The current value of a textbox in the open editor.
+ * @param name - The field's accessible name
+ * @returns The input's value
+ */
+function fieldValue(name: string | RegExp): string {
+  return (screen.getByRole("textbox", { name }) as HTMLInputElement).value;
+}
+
+/**
+ * Wait out the editor's idle autosave: preact defers post-paint effects (the
+ * arming) to a real timeout that happy-dom's rAF never beats, then the debounce
+ * itself runs. Both directions need the same settle, so whether a save fires is
+ * an honest assertion either way.
+ */
+async function settleAutosave(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 1200));
+}
+
+describe("MemoryScreen — editing during an in-flight rename", () => {
+  it("keeps the draft typed while the rename was in flight and saves it under the new slug", async () => {
+    const renamePut = routeFetch();
+
+    render(<MemoryScreenHarness />);
+
+    await startRename();
+
+    // The rename round trip is open — keep typing into the body and the
+    // description (the latter is a controlled input, so a remount that re-seeds
+    // from the server's pre-edit echo is visible in the DOM).
+    fireEvent.input(screen.getByRole("textbox", { name: /Memory/ }), {
+      target: { value: "Composes in C minor and F minor." },
+    });
+    fireEvent.input(screen.getByRole("textbox", { name: /Description/ }), {
+      target: { value: "edited mid-rename" },
+    });
+
+    renamePut.resolve(jsonResponse({ entry: RENAMED }));
+
+    // The list (and the editor) follow the entry to its slugified new name…
+    await screen.findByRole("button", { name: "Edit new-slug" });
+    expect(fieldValue("Rename")).toBe("new-slug");
+    // …carrying the in-flight edits rather than snapping back to the echo.
+    expect(fieldValue(/Description/)).toBe("edited mid-rename");
+
+    // And the carried draft is really persisted — the autosave commits it under
+    // the NEW slug, since the rename's echo left the draft legitimately dirty.
+    await settleAutosave();
+
+    expect(entryPuts()).toStrictEqual([
+      {
+        url: expect.stringContaining("new-slug") as string,
+        body: {
+          description: "edited mid-rename",
+          content: "Composes in C minor and F minor.",
+        },
+      },
+    ]);
+  });
+
+  it("does not re-save an untouched entry after a rename", async () => {
+    const renamePut = routeFetch();
+
+    render(<MemoryScreenHarness />);
+
+    await startRename();
+
+    renamePut.resolve(jsonResponse({ entry: RENAMED }));
+
+    await screen.findByRole("button", { name: "Edit new-slug" });
+
+    // The rename's own echo is the new baseline, so an untouched draft is clean:
+    // following the entry to its new slug must not trigger a redundant write.
+    await settleAutosave();
+
+    expect(entryPuts()).toStrictEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

While a memory's rename PUT is in flight, keystrokes typed into the body/description are silently discarded. The rename commit drops the old slug from the cached list, the editor (keyed by the selected name) remounts under the new slug, and the remounted instance re-seeds from the server's echo — the pre-edit content. The old instance's unmount flush is correctly suppressed (that guard is what stops it resurrecting the old file), so the draft has nowhere to go.

Narrow window — it needs typing during the round trip, sub-second on localhost — but it's silent data loss.

## Fix — carry the live draft across the rename

- **`CollectionScreen`**: the editor is keyed by a monotonic *selection epoch* rather than the entry name. Every identity-changing transition (pick a row, New, delete, create) goes through `selectDraft`, which bumps the epoch; a new `onRenamed` render arg updates the selection *without* bumping it, so the same editor instance stays mounted while the entry changes slug underneath it. `selectDraft` no-ops when re-selecting the entry already open, preserving the previous key-equality behavior.
- **`MemoryEntryEditor`**: on a successful rename the field adopts the server's slugified name, the autosave baseline advances to the rename's **echo**, and `onRenamed` fires. A draft that diverged mid-rename is therefore left legitimately dirty and the ordinary debounced autosave persists it under the new slug; a clean draft matches the echo and doesn't re-save.

Custom skills can't rename, so `CustomSkillsScreen` simply ignores the new arg.

## Verification

New `MemoryScreen-rename.test.tsx` drives `MemoryScreen` against the **real** `useMemoryCollection` over a stubbed fetch — the screen-level fakes can't express the ordering this bug lived in (the list commit lands one microtask before the caller's navigation). It holds the rename PUT open on a deferred, types into the description and body, then asserts the edits are still in the DOM afterward and are PUT under the new slug. A companion test asserts an untouched entry does *not* get a redundant write. Confirmed failing on the pre-fix code and passing after.

`npm run check`, `npm run ui:test`, and `npm run check:build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)