### PR TITLE
Claude Code eval transport + shared agent-CLI seam + fixture-binary test seam

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -50,18 +50,20 @@ scripts/eval [options]
 Models use `provider/model` format, or just the model name if the provider can
 be inferred from the prefix:
 
-| Format                          | Provider   |
-| ------------------------------- | ---------- |
-| `gemini-3-flash-preview`        | google     |
-| `claude-sonnet-4-5`             | anthropic  |
-| `gpt-5-nano`                    | openai     |
-| `google/gemini-3-flash-preview` | google     |
-| `anthropic/claude-sonnet-4-5`   | anthropic  |
-| `codex-code/sol`                | codex-code |
-| `codex-code/terra`              | codex-code |
-| `codex-code/luna`               | codex-code |
-| `openrouter/some-model`         | openrouter |
-| `local/model-name`              | local      |
+| Format                          | Provider    |
+| ------------------------------- | ----------- |
+| `gemini-3-flash-preview`        | google      |
+| `claude-sonnet-4-5`             | anthropic   |
+| `gpt-5-nano`                    | openai      |
+| `google/gemini-3-flash-preview` | google      |
+| `anthropic/claude-sonnet-4-5`   | anthropic   |
+| `codex-code/sol`                | codex-code  |
+| `codex-code/terra`              | codex-code  |
+| `codex-code/luna`               | codex-code  |
+| `claude-code/sonnet`            | claude-code |
+| `claude-code/opus`              | claude-code |
+| `openrouter/some-model`         | openrouter  |
+| `local/model-name`              | local       |
 
 ### Examples
 
@@ -75,6 +77,9 @@ scripts/eval -t connect-to-ableton -m gemini-3-flash-preview -m claude-sonnet-4-
 # Compare Codex subscription models (requires `codex login`)
 scripts/eval -t connect-to-ableton \
   -m codex-code/sol -m codex-code/terra -m codex-code/luna
+
+# Compare subscription CLIs against each other (requires `codex` and `claude`)
+scripts/eval -t connect-to-ableton -m codex-code/terra -m claude-code/sonnet
 
 # Skip Live Set reopening (reuse current MCP connection)
 scripts/eval -t connect-to-ableton -s
@@ -99,6 +104,54 @@ scripts/eval -m local/qwen3-8b -t duplicate --small-model
 The local provider connects to `http://localhost:11434/v1` by default (Ollama).
 Override with `-b` / `--base-url` in the chat CLI, or set `LOCAL_BASE_URL` in
 `.env` for evals.
+
+### Testing subscription CLIs
+
+`claude-code` and `codex-code` are not API providers — they drive an installed
+coding-agent CLI as a subprocess (`claude -p --output-format stream-json`,
+`codex exec --json`), so a run bills the logged-in subscription instead of a
+metered API key. The CLI owns the conversation and the MCP connection; each turn
+is a fresh process that resumes the previous turn's session id.
+
+```bash
+# Requires `claude` on PATH and a logged-in subscription (`claude auth login`)
+scripts/eval -m claude-code/sonnet -t connect-to-ableton
+
+# Requires `codex` on PATH and `codex login`
+scripts/eval -m codex-code/terra -t connect-to-ableton
+```
+
+Both transports strip the vendor's API-key environment variables before
+spawning, so an exported `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` cannot silently
+turn a subscription run into a billed one. Both also run the CLI stripped down
+to Producer Pal: built-in tools off, settings and plugins off, other MCP servers
+ignored, and the eval's system instructions REPLACING the CLI's own agent prompt
+(which is also what keeps the user's memory files out of the run).
+
+Two caveats when comparing a subscription-CLI run against anything else:
+
+- **Token counts are not comparable across transports.** Each vendor defines
+  `input_tokens` differently: Codex reports the total (its `cached_input_tokens`
+  is a subset of it), while Anthropic reports only the uncached portion, with
+  `cache_read_input_tokens` / `cache_creation_input_tokens` alongside. A real
+  `claude-code` turn that processed ~38k tokens prints `tokens: 18` — everything
+  else was a cache read. The mapping deliberately matches the `anthropic` AI SDK
+  path so the two Anthropic routes agree; it does NOT line up with `codex-code`.
+- **Session files outlive the run.** Claude Code keys its on-disk session store
+  by working directory, and each eval session uses a fresh temp directory that
+  `close()` removes. The transcript under `~/.claude/projects/` stays behind,
+  one entry per eval session. (The judge passes `--no-session-persistence` and
+  leaves nothing; turns cannot, since they resume by session id.)
+
+Point `CLAUDE_CODE_BIN` / `CODEX_BIN` at a specific binary when the CLI is not
+on PATH. The transport tests use the same variables to swap in a fixture that
+emits canned JSONL, so `evals/chat/agent-cli/` is testable with neither CLI
+installed.
+
+Adding another CLI is a protocol module implementing `AgentCliTransport` (argv,
+stream parsing, model names) plus one entry in
+`evals/chat/agent-cli/agent-cli-registry.ts`; spawning, session dirs, session-id
+continuity, turn rendering, and judging are already shared.
 
 ### Run environment
 
@@ -170,10 +223,11 @@ Note that a `{ type: "tool_called", tool: "ppal-connect", turn: 0 }` assertion
 passes trivially in a seeded scenario. `connect-to-ableton` is where "does the
 model reach for `ppal-connect`" is actually graded.
 
-The `codex-code` provider is never seeded: the Codex CLI resumes a thread by id
-and owns its own history, so there is nothing to write into and it falls back to
-a real connect turn. Worth remembering when comparing a `codex-code` run against
-any other provider — only one of them paid for that turn.
+The agent-CLI providers (`claude-code`, `codex-code`) are never seeded: the CLI
+resumes a session by id and owns its own history, so there is nothing to write
+into and they fall back to a real connect turn. Worth remembering when comparing
+one of those runs against any other provider — only one of them paid for that
+turn.
 
 ### Scoring
 
@@ -217,9 +271,9 @@ Interactive chat for manual testing and debugging.
 scripts/chat [options] [text...]
 ```
 
-Every provider except `codex-code` is supported: codex-code runs through the
-Codex CLI transport (a spawned `codex exec` subprocess), which only the eval CLI
-drives.
+Every provider except `claude-code` and `codex-code` is supported: those two run
+through an agent-CLI transport (a spawned `claude` / `codex` subprocess), which
+only the eval CLI drives.
 
 ### Options
 
@@ -267,6 +321,10 @@ Set these in `.env` at the project root:
 | `LOCAL_BASE_URL` | Local server URL (default: `http://localhost:11434/v1`) |
 | `MCP_URL`        | MCP server URL (default: `http://localhost:3350/mcp`)   |
 
+The subscription CLIs take no key. `CLAUDE_CODE_BIN` and `CODEX_BIN` override
+which executable is spawned (see
+[Testing subscription CLIs](#testing-subscription-clis)).
+
 ## Prerequisites
 
 - Ableton Live running with the Producer Pal Max for Live device
@@ -275,6 +333,7 @@ Set these in `.env` at the project root:
 - API keys configured for the providers you want to test
 - For local models: Ollama, LM Studio, or another OpenAI-compatible server
   running
+- For `claude-code` / `codex-code`: that CLI installed and logged in
 
 ## Adding scenarios
 

--- a/evals/chat/agent-cli/agent-cli-registry.ts
+++ b/evals/chat/agent-cli/agent-cli-registry.ts
@@ -1,0 +1,52 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Which eval providers are backed by a spawned agent CLI rather than the AI SDK.
+ *
+ * Every place that has to branch on "is this an AI SDK model or a subprocess?"
+ * asks here, so adding a CLI is one entry plus its protocol module.
+ */
+
+import { type EvalProvider } from "#evals/scenarios/types.ts";
+import { CLAUDE_CODE_TRANSPORT } from "../claude-code/claude-code-protocol.ts";
+import { CODEX_CLI_TRANSPORT } from "../codex/codex-cli-protocol.ts";
+import { type AgentCliTransport } from "./agent-cli-transport.ts";
+
+const AGENT_CLI_TRANSPORTS: Partial<Record<EvalProvider, AgentCliTransport>> = {
+  "claude-code": CLAUDE_CODE_TRANSPORT,
+  "codex-code": CODEX_CLI_TRANSPORT,
+};
+
+/**
+ * Look up the agent-CLI transport backing a provider.
+ *
+ * @param provider - The eval provider
+ * @returns Its transport, or undefined when the provider runs through the AI SDK
+ */
+export function getAgentCliTransport(
+  provider: EvalProvider,
+): AgentCliTransport | undefined {
+  return AGENT_CLI_TRANSPORTS[provider];
+}
+
+/**
+ * Require the agent-CLI transport backing a provider.
+ *
+ * @param provider - The eval provider
+ * @returns Its transport
+ * @throws Error when the provider is not backed by an agent CLI
+ */
+export function requireAgentCliTransport(
+  provider: EvalProvider,
+): AgentCliTransport {
+  const transport = AGENT_CLI_TRANSPORTS[provider];
+
+  if (transport == null) {
+    throw new Error(`Provider "${provider}" has no agent CLI transport.`);
+  }
+
+  return transport;
+}

--- a/evals/chat/agent-cli/agent-cli-session.ts
+++ b/evals/chat/agent-cli/agent-cli-session.ts
@@ -10,20 +10,19 @@ import { type EvalSession } from "#evals/scenarios/eval-session.ts";
 import { logTurnStart } from "#evals/scenarios/helpers/eval-session-base.ts";
 import { isQuietMode } from "#evals/scenarios/helpers/output-config.ts";
 import { MCP_URL } from "#evals/shared/mcp-url.ts";
-import { CODEX_CODE_CONFIG } from "#evals/shared/provider-configs.ts";
+import { PROVIDER_CONFIGS } from "#evals/shared/provider-configs.ts";
 import { type TokenUsage } from "#webui/chat/sdk/types.ts";
 import { connectMcp } from "../mcp.ts";
 import { printStepUsage } from "../shared/formatting.ts";
 import { type TurnResult } from "../shared/types.ts";
+import { spawnAgentCli } from "./agent-cli-spawn.ts";
 import {
-  codexCliProtocol,
-  DEFAULT_CODEX_SYSTEM_PROMPT,
-  parseCodexStream,
-} from "./codex-cli-protocol.ts";
-import { spawnCodex } from "./codex-cli.ts";
-import { formatCodexTurn } from "./format-codex-turn.ts";
+  type AgentCliTransport,
+  DEFAULT_AGENT_CLI_SYSTEM_PROMPT,
+} from "./agent-cli-transport.ts";
+import { formatAgentTurn } from "./format-agent-turn.ts";
 
-export interface CodexCliSessionOptions {
+export interface AgentCliSessionOptions {
   instructions?: string;
   mcpUrl?: string;
   model?: string;
@@ -32,39 +31,38 @@ export interface CodexCliSessionOptions {
 }
 
 /**
- * Create a multi-turn Codex session backed by Producer Pal's MCP server.
+ * Create a multi-turn agent-CLI session backed by Producer Pal's MCP server.
+ *
+ * Each turn is a fresh subprocess; continuity comes from replaying the session
+ * id the CLI reported on the previous turn, so the CLI — not this process —
+ * owns the conversation history.
+ *
+ * @param transport - Transport describing the CLI to drive
  * @param options - Model, instructions, and optional MCP URL
  * @returns Eval session compatible with the scenario runner
  */
-export async function createCodexCliSession(
-  options: CodexCliSessionOptions,
+export async function createAgentCliSession(
+  transport: AgentCliTransport,
+  options: AgentCliSessionOptions,
 ): Promise<EvalSession> {
-  const model = options.model ?? CODEX_CODE_CONFIG.defaultModel;
+  const model =
+    options.model ?? PROVIDER_CONFIGS[transport.provider].defaultModel;
   const mcpUrl = options.mcpUrl ?? MCP_URL;
-  const sessionDir = await mkdtemp(join(tmpdir(), "producer-pal-codex-"));
+  const instructions = options.instructions ?? DEFAULT_AGENT_CLI_SYSTEM_PROMPT;
+  const sessionDir = await mkdtemp(join(tmpdir(), transport.tmpPrefix));
   const instructionsFile = join(sessionDir, "instructions.md");
-
-  try {
-    await writeFile(
-      instructionsFile,
-      options.instructions ?? DEFAULT_CODEX_SYSTEM_PROMPT,
-      "utf8",
-    );
-  } catch (error) {
-    await rm(sessionDir, { recursive: true, force: true });
-    throw error;
-  }
 
   let mcpClient: Awaited<ReturnType<typeof connectMcp>>["client"];
 
   try {
+    await writeFile(instructionsFile, instructions, "utf8");
     ({ client: mcpClient } = await connectMcp(mcpUrl));
   } catch (error) {
     await rm(sessionDir, { recursive: true, force: true });
     throw error;
   }
 
-  let threadId: string | undefined;
+  let sessionId: string | undefined;
   let prevUsage: TokenUsage | undefined;
 
   return {
@@ -74,28 +72,29 @@ export async function createCodexCliSession(
       turnNumber: number,
     ): Promise<TurnResult> => {
       logTurnStart(turnNumber, message);
-      const args = codexCliProtocol({
+      const args = transport.buildTurnArgs({
+        instructions,
         instructionsFile,
         mcpUrl,
         model,
-        ...(threadId != null ? { resumeThreadId: threadId } : {}),
+        ...(sessionId != null ? { resumeSessionId: sessionId } : {}),
       });
-      const parsed = parseCodexStream(
-        await spawnCodex(args, message, { cwd: sessionDir }),
+      const parsed = transport.parseStream(
+        await spawnAgentCli(transport, args, message, { cwd: sessionDir }),
       );
 
       // eslint-disable-next-line require-atomic-updates -- turns run sequentially
-      if (parsed.threadId != null) threadId = parsed.threadId;
+      if (parsed.sessionId != null) sessionId = parsed.sessionId;
 
       const usage = options.usage === true ? parsed.usage : undefined;
 
       if (!isQuietMode()) {
-        process.stdout.write(formatCodexTurn(parsed, usage != null));
+        process.stdout.write(formatAgentTurn(parsed, usage != null));
       }
 
       if (usage != null) {
-        // Codex reports usage once per turn (turn.completed), not per step, so
-        // there is one line per turn rather than one per tool round-trip.
+        // These CLIs report usage once per turn, not per step, so there is one
+        // line per turn rather than one per tool round-trip.
         printStepUsage(usage, prevUsage, true);
         prevUsage = usage;
       }

--- a/evals/chat/agent-cli/agent-cli-spawn.ts
+++ b/evals/chat/agent-cli/agent-cli-spawn.ts
@@ -4,32 +4,42 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { parseCodexStream, scrubOpenAiKeys } from "./codex-cli-protocol.ts";
+import {
+  type AgentCliTransport,
+  scrubAgentCliEnv,
+} from "./agent-cli-transport.ts";
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 /** Grace period between SIGTERM and SIGKILL when a turn times out. */
 const SIGKILL_GRACE_MS = 2000;
 
-export interface SpawnCodexOptions {
+export interface SpawnAgentCliOptions {
   cwd: string;
   timeoutMs?: number;
 }
 
 /**
- * Spawn a restricted Codex turn and return its JSONL stdout.
- * @param args - Codex CLI arguments
+ * Spawn one restricted agent-CLI turn and return its JSONL stdout.
+ *
+ * The executable comes from the transport's `binEnvVar` when set, which is both
+ * how a user points at a non-default install and how the tests swap in a
+ * fixture that emits canned JSONL without touching the network.
+ *
+ * @param transport - Transport describing the CLI
+ * @param args - CLI arguments
  * @param prompt - User prompt written to stdin
  * @param options - Working directory and optional timeout
- * @returns Codex JSONL stdout
+ * @returns The CLI's JSONL stdout
  */
-export function spawnCodex(
+export function spawnAgentCli(
+  transport: AgentCliTransport,
   args: string[],
   prompt: string,
-  options: SpawnCodexOptions,
+  options: SpawnAgentCliOptions,
 ): Promise<string> {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const executable = process.env.CODEX_BIN ?? "codex";
-  const env = scrubOpenAiKeys(process.env);
+  const executable = process.env[transport.binEnvVar] ?? transport.bin;
+  const env = scrubAgentCliEnv(process.env, transport.strippedEnvVars);
 
   return new Promise<string>((resolve, reject) => {
     const child: ChildProcessWithoutNullStreams = spawn(executable, args, {
@@ -66,15 +76,17 @@ export function spawnCodex(
     });
     child.on("error", (error) => {
       clearTimers();
-      reject(error);
+      reject(spawnError(transport, executable, error));
     });
     child.on("close", (code) => {
       clearTimers();
 
       if (timedOut) {
-        reject(new Error(`codex CLI timed out after ${timeoutMs / 1000}s`));
+        reject(
+          new Error(`${transport.label} timed out after ${timeoutMs / 1000}s`),
+        );
       } else if (code !== 0) {
-        reject(new Error(codexExitError(code, stdout, stderr)));
+        reject(new Error(exitError(transport, code, stdout, stderr)));
       } else {
         resolve(stdout);
       }
@@ -89,26 +101,53 @@ export function spawnCodex(
 }
 
 /**
- * Build a descriptive error for a non-zero Codex exit. The `turn.failed`/`error`
- * event lands at the END of the JSONL stream, so surface it via parseCodexStream
- * (whose throw carries getErrorMessage's text) and fall back to the stdout tail
- * — a head-truncated slice would drop the actual cause.
+ * Turn a spawn failure into something actionable. A missing CLI arrives as a
+ * bare `spawn <bin> ENOENT`, which names neither the eval provider that asked
+ * for it nor the way to point at a different install.
+ *
+ * @param transport - Transport describing the CLI
+ * @param executable - Executable that failed to spawn
+ * @param error - The spawn error
+ * @returns Error to reject with
+ */
+function spawnError(
+  transport: AgentCliTransport,
+  executable: string,
+  error: Error,
+): Error {
+  if ((error as NodeJS.ErrnoException).code !== "ENOENT") return error;
+
+  return new Error(
+    `${transport.label} executable "${executable}" not found. ` +
+      `Install it, or set ${transport.binEnvVar} to its path.`,
+    { cause: error },
+  );
+}
+
+/**
+ * Build a descriptive error for a non-zero exit. The failure event lands at the
+ * END of the JSONL stream, so surface it via the transport's parser (whose
+ * throw carries the CLI's own message) and fall back to the stdout tail — a
+ * head-truncated slice would drop the actual cause.
+ *
+ * @param transport - Transport describing the CLI
  * @param code - Process exit code
  * @param stdout - Full JSONL stdout
  * @param stderr - Captured stderr
  * @returns Error message describing the failure
  */
-function codexExitError(
+function exitError(
+  transport: AgentCliTransport,
   code: number | null,
   stdout: string,
   stderr: string,
 ): string {
-  const parts = [`codex CLI exited ${code}.`];
+  const parts = [`${transport.label} exited ${code}.`];
 
   let streamError = "";
 
   try {
-    parseCodexStream(stdout);
+    transport.parseStream(stdout);
   } catch (error) {
     streamError = error instanceof Error ? error.message : String(error);
   }

--- a/evals/chat/agent-cli/agent-cli-stream.ts
+++ b/evals/chat/agent-cli/agent-cli-stream.ts
@@ -1,0 +1,154 @@
+// Producer Pal
+// Copyright (C) 2026 Taylor Haun, Adam Murray
+// AI assistance: Codex (OpenAI), Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * The JSONL scaffolding every agent-CLI transport parses through.
+ *
+ * The vendors' event schemas differ, but the shape around them does not: split
+ * stdout into lines, skip whatever isn't JSON, fold each event into an
+ * accumulator, and either throw the CLI's own error or hand back one turn. Only
+ * the fold is per-vendor — that is the callback a transport supplies.
+ */
+
+import { type TokenUsage } from "#webui/chat/sdk/types.ts";
+import { mcpResultText } from "../shared/mcp-result-text.ts";
+import { type ToolCall } from "../shared/types.ts";
+import { type ParsedAgentTurn } from "./agent-cli-transport.ts";
+
+/** The accumulator a transport folds its events into. */
+export interface AgentStreamState {
+  /** Assistant messages in order, joined by the transport's separator. */
+  textParts: string[];
+  toolCalls: ToolCall[];
+  /** Calls awaiting a result, keyed however the transport pairs its events. */
+  openCalls: Map<string, ToolCall>;
+  sessionId?: string;
+  usage?: TokenUsage;
+  /** Set to fail the whole turn; the CLI's own message. */
+  error?: string;
+}
+
+export interface ParseAgentCliStreamOptions {
+  /** CLI name, prefixed to a thrown error. */
+  label: string;
+  /** Separator between assistant messages ("" concatenates, as Codex does). */
+  textSeparator: string;
+  /** Fold one parsed event into the accumulator. */
+  handleEvent: (
+    event: Record<string, unknown>,
+    state: AgentStreamState,
+  ) => void;
+}
+
+/**
+ * Parse one turn of JSONL into the shared eval result shape.
+ *
+ * @param stdout - The CLI's JSONL stdout
+ * @param options - Label, text separator, and the per-vendor event handler
+ * @returns Parsed assistant text, tool calls, session ID, and token usage
+ * @throws Error when the stream reported a failed turn
+ */
+export function parseAgentCliStream(
+  stdout: string,
+  options: ParseAgentCliStreamOptions,
+): ParsedAgentTurn {
+  const state: AgentStreamState = {
+    textParts: [],
+    toolCalls: [],
+    openCalls: new Map(),
+  };
+
+  for (const line of stdout.split("\n")) {
+    const event = parseJsonlLine(line);
+
+    if (event != null) options.handleEvent(event, state);
+  }
+
+  if (state.error != null) {
+    throw new Error(`${options.label} error: ${state.error}`);
+  }
+
+  return {
+    text: state.textParts.join(options.textSeparator),
+    toolCalls: state.toolCalls,
+    ...(state.sessionId != null ? { sessionId: state.sessionId } : {}),
+    ...(state.usage != null ? { usage: state.usage } : {}),
+  };
+}
+
+/**
+ * Parse a JSONL line, ignoring diagnostics written to stdout.
+ *
+ * @param line - One stdout line
+ * @returns Parsed event, or undefined for blank or non-JSON output
+ */
+export function parseJsonlLine(
+  line: string,
+): Record<string, unknown> | undefined {
+  const trimmed = line.trim();
+
+  if (!trimmed) return undefined;
+
+  try {
+    return JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Normalize tool arguments, which arrive as an object or a JSON string.
+ *
+ * @param value - Raw arguments from the stream
+ * @returns Object arguments for the shared tool-call shape
+ */
+export function toToolArguments(value: unknown): Record<string, unknown> {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+
+      if (
+        parsed != null &&
+        typeof parsed === "object" &&
+        !Array.isArray(parsed)
+      ) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return {};
+    }
+  }
+
+  return {};
+}
+
+/**
+ * Serialize an MCP tool result for eval reports.
+ *
+ * Unwrap the first text block so results read like the AI SDK path's — this
+ * string is what the console, the JSON report, and the judge prompt all show.
+ *
+ * @param value - Raw MCP result, its content array, or plain text
+ * @returns String result
+ */
+export function stringifyToolResult(value: unknown): string {
+  if (typeof value === "string") return value;
+
+  return mcpResultText(value) || JSON.stringify(value);
+}
+
+/**
+ * Return a numeric token counter, or zero when absent.
+ *
+ * @param value - Raw counter
+ * @returns Numeric counter
+ */
+export function tokenCount(value: unknown): number {
+  return typeof value === "number" ? value : 0;
+}

--- a/evals/chat/agent-cli/agent-cli-transport.ts
+++ b/evals/chat/agent-cli/agent-cli-transport.ts
@@ -1,0 +1,108 @@
+// Producer Pal
+// Copyright (C) 2026 Taylor Haun, Adam Murray
+// AI assistance: Codex (OpenAI), Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * The contract every agent-CLI eval transport implements.
+ *
+ * These transports drive a coding-agent CLI (Codex, Claude Code, …) as a
+ * subprocess instead of calling a model API: the CLI owns the conversation and
+ * the MCP connection, we hand it a prompt on stdin and read a JSONL event
+ * stream back. That buys subscription auth instead of metered API keys, at the
+ * cost of one CLI-shaped argv and event schema per vendor.
+ *
+ * Everything those two schemas do NOT differ on — spawning, temp session dirs,
+ * carrying a session id across turns, rendering a turn, judging — lives in the
+ * sibling modules here and is shared. A transport is only the vendor-specific
+ * part: argv, stream parsing, and model naming.
+ */
+
+import { type EvalProvider } from "#evals/scenarios/types.ts";
+import { type TokenUsage } from "#webui/chat/sdk/types.ts";
+import { type ToolCall } from "../shared/types.ts";
+
+export const DEFAULT_AGENT_CLI_SYSTEM_PROMPT =
+  "You are Producer Pal, an AI assistant for music production in Ableton Live. " +
+  "Use only the available Producer Pal MCP tools (ppal-*) to inspect or change " +
+  "the Live Set. Do not use shell commands, files, web search, or subagents.";
+
+/** The MCP server name every transport registers Producer Pal under. */
+export const MCP_SERVER_NAME = "producer-pal";
+
+/** Inputs shared by MCP turns and standalone judge calls. */
+export interface AgentCliArgsInput {
+  /** System instructions text, for CLIs that take it on argv. */
+  instructions: string;
+  /** File holding the same text, for CLIs that take a path. */
+  instructionsFile: string;
+  /** Friendly alias or explicit model id. */
+  model: string;
+}
+
+/** Inputs for one turn of an MCP-connected session. */
+export interface AgentCliTurnArgsInput extends AgentCliArgsInput {
+  mcpUrl: string;
+  /** Session id captured from an earlier turn; absent on the first turn. */
+  resumeSessionId?: string;
+}
+
+/** One parsed turn, in the shape the scenario runner grades. */
+export interface ParsedAgentTurn {
+  text: string;
+  toolCalls: ToolCall[];
+  /** The CLI's own conversation id, replayed to resume the next turn. */
+  sessionId?: string;
+  usage?: TokenUsage;
+}
+
+export interface AgentCliTransport {
+  /** Eval provider id this transport backs (`-m <provider>/<model>`). */
+  provider: EvalProvider;
+  /** CLI name, used in error messages. */
+  label: string;
+  /** Executable to spawn. */
+  bin: string;
+  /** Env var overriding `bin` — also the test seam for a fixture binary. */
+  binEnvVar: string;
+  /** mkdtemp prefix for a session's working directory. */
+  tmpPrefix: string;
+  /**
+   * Env vars removed before spawning, so the CLI falls back to the logged-in
+   * subscription instead of billing an API key that happens to be exported.
+   */
+  strippedEnvVars: string[];
+  /** Friendly model names `--list-models` advertises for this provider. */
+  models: string[];
+  /** Model this provider judges with, kept distinct from the one under test. */
+  judgeModel: string;
+  /** Build argv for an initial or resumed MCP turn. Each transport resolves
+   *  its own friendly aliases, so `model` arrives exactly as the user typed. */
+  buildTurnArgs: (input: AgentCliTurnArgsInput) => string[];
+  /** Build argv for an isolated judge call (no MCP, no tools). */
+  buildJudgeArgs: (input: AgentCliArgsInput) => string[];
+  /** Parse one turn's JSONL stdout, throwing on a reported failure. */
+  parseStream: (stdout: string) => ParsedAgentTurn;
+}
+
+/**
+ * Copy an environment without the vars that would redirect a CLI off its
+ * logged-in subscription (and without the undefined values spawn rejects).
+ *
+ * @param env - Parent process environment
+ * @param stripped - Variable names to drop
+ * @returns Environment safe to hand to the CLI
+ */
+export function scrubAgentCliEnv(
+  env: NodeJS.ProcessEnv,
+  stripped: string[],
+): Record<string, string> {
+  const drop = new Set(stripped);
+  const result: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value === "string" && !drop.has(key)) result[key] = value;
+  }
+
+  return result;
+}

--- a/evals/chat/agent-cli/format-agent-turn.ts
+++ b/evals/chat/agent-cli/format-agent-turn.ts
@@ -4,33 +4,34 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
- * Render a parsed Codex turn for the console.
+ * Render a parsed agent-CLI turn for the console.
  *
- * The AI SDK providers print as they stream (evals/chat/stream.ts); the Codex
- * transport only has the finished JSONL, so it renders the whole turn at once
- * with the same shapes — `🔧 tool(args)` / `   ↳ result` lines, then the reply.
+ * The AI SDK providers print as they stream (evals/chat/stream.ts); the
+ * agent-CLI transports only have the finished JSONL, so they render the whole
+ * turn at once with the same shapes — `🔧 tool(args)` / `   ↳ result` lines,
+ * then the reply.
  */
 
 import {
   formatToolCall,
   formatToolResult,
 } from "#evals/chat/shared/formatting.ts";
-import { type ParsedCodexTurn } from "./codex-cli-protocol.ts";
+import { type ParsedAgentTurn } from "./agent-cli-transport.ts";
 
 /**
- * Format one Codex turn's tool calls and reply text for stdout.
+ * Format one turn's tool calls and reply text for stdout.
  *
- * Tool calls come first, then the reply: parseCodexStream concatenates every
- * `agent_message` into one string, so text/tool interleaving is not recoverable
- * (and Codex emits its message last in practice anyway).
+ * Tool calls come first, then the reply: a parsed turn joins every assistant
+ * message into one string, so text/tool interleaving is not recoverable (and
+ * these CLIs emit their closing message last anyway).
  *
  * @param parsed - The parsed turn
  * @param showUsage - Whether a usage line follows (it supplies its own leading
  *   blank line, so the trailing newline is left off)
  * @returns Text to write to stdout, "" when there is nothing to show
  */
-export function formatCodexTurn(
-  parsed: ParsedCodexTurn,
+export function formatAgentTurn(
+  parsed: ParsedAgentTurn,
   showUsage: boolean,
 ): string {
   const parts: string[] = [];

--- a/evals/chat/agent-cli/tests/agent-cli-fixture.mjs
+++ b/evals/chat/agent-cli/tests/agent-cli-fixture.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * A stand-in for `codex` / `claude` in the agent-CLI transport tests.
+ *
+ * `spawnAgentCli` resolves its executable from the transport's `binEnvVar`
+ * (`CODEX_BIN`, `CLAUDE_CODE_BIN`, …), so pointing that at this script exercises
+ * the whole transport — argv, stdin, stream decoding, exit handling, signals —
+ * with no vendor CLI installed and no network.
+ *
+ * Everything it does is driven by `PPAL_FIXTURE_*` environment variables:
+ *
+ * - `PPAL_FIXTURE_STDOUT`     text to write to stdout (usually canned JSONL)
+ * - `PPAL_FIXTURE_SPLIT_AT`   byte offset to flush stdout in two chunks at,
+ *                             so a test can split a multi-byte character
+ * - `PPAL_FIXTURE_STDERR`     text to write to stderr
+ * - `PPAL_FIXTURE_EXIT_CODE`  exit code (default 0)
+ * - `PPAL_FIXTURE_RECORD`     JSONL file to append `{ argv, stdin, cwd }` to,
+ *                             one line per invocation
+ * - `PPAL_FIXTURE_MODE`       `emit` (default), `hang` (never exit on its own),
+ *                             or `ignore-sigterm` (hang AND swallow SIGTERM, so
+ *                             only the SIGKILL escalation ends it)
+ */
+
+import { appendFileSync } from "node:fs";
+
+const HANG_MS = 60_000;
+const CHUNK_GAP_MS = 25;
+
+const mode = process.env.PPAL_FIXTURE_MODE ?? "emit";
+
+if (mode === "ignore-sigterm") {
+  process.on("SIGTERM", () => {});
+}
+
+await main();
+
+/**
+ * Record the invocation, emit the canned streams, then exit as configured.
+ * @returns Nothing
+ */
+async function main() {
+  const stdin = await readStdin();
+  const record = process.env.PPAL_FIXTURE_RECORD;
+
+  if (record) {
+    const line = JSON.stringify({
+      argv: process.argv.slice(2),
+      stdin,
+      cwd: process.cwd(),
+    });
+
+    appendFileSync(record, `${line}\n`, "utf8");
+  }
+
+  const stderr = process.env.PPAL_FIXTURE_STDERR;
+
+  if (stderr) process.stderr.write(stderr);
+
+  await writeStdout();
+
+  if (mode !== "emit") {
+    await delay(HANG_MS);
+  }
+
+  process.exit(Number(process.env.PPAL_FIXTURE_EXIT_CODE ?? "0"));
+}
+
+/**
+ * Write the canned stdout, optionally as two chunks split at a byte offset.
+ * @returns Nothing
+ */
+async function writeStdout() {
+  const out = Buffer.from(process.env.PPAL_FIXTURE_STDOUT ?? "", "utf8");
+  const splitAt = Number(process.env.PPAL_FIXTURE_SPLIT_AT ?? "0");
+
+  if (out.length === 0) return;
+
+  if (splitAt > 0 && splitAt < out.length) {
+    process.stdout.write(out.subarray(0, splitAt));
+    await delay(CHUNK_GAP_MS);
+    process.stdout.write(out.subarray(splitAt));
+
+    return;
+  }
+
+  process.stdout.write(out);
+}
+
+/**
+ * Read the prompt the transport wrote to stdin.
+ * @returns The full stdin text
+ */
+async function readStdin() {
+  let text = "";
+
+  process.stdin.setEncoding("utf8");
+
+  for await (const chunk of process.stdin) text += chunk;
+
+  return text;
+}
+
+/**
+ * Sleep.
+ * @param ms - Milliseconds to wait
+ * @returns A promise resolving after the delay
+ */
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/evals/chat/agent-cli/tests/agent-cli-session.test.ts
+++ b/evals/chat/agent-cli/tests/agent-cli-session.test.ts
@@ -1,0 +1,173 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Multi-turn tests for the agent-CLI session, run against every transport.
+ *
+ * The whole premise of these transports is that the CLI owns the conversation
+ * and we replay its session id to continue — so the id has to survive turn 1
+ * and reach turn 2's argv. Nothing else in the eval suite would notice if it
+ * didn't: a session that silently restarts each turn still produces plausible
+ * output and still scores.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type McpConnection } from "#evals/chat/mcp.ts";
+import { setQuietMode } from "#evals/scenarios/helpers/output-config.ts";
+import { CLAUDE_CODE_TRANSPORT } from "../../claude-code/claude-code-protocol.ts";
+import { CODEX_CLI_TRANSPORT } from "../../codex/codex-cli-protocol.ts";
+import { createAgentCliSession } from "../agent-cli-session.ts";
+import { type AgentCliTransport } from "../agent-cli-transport.ts";
+import {
+  claudeTurnStdout,
+  codexTurnStdout,
+  FIXTURE_BIN,
+  type FixtureInvocation,
+  makeFixtureDir,
+  readInvocations,
+} from "./agent-cli-test-helpers.ts";
+
+// The session opens its own MCP client for state assertions; these tests only
+// care about the subprocess, so stand it in rather than needing a live server.
+const { connectMcpMock, closeMock } = vi.hoisted(() => {
+  const close = vi.fn(async () => {});
+
+  return {
+    closeMock: close,
+    connectMcpMock: vi.fn(async () => ({ client: { close }, transport: {} })),
+  };
+});
+
+vi.mock(import("#evals/chat/mcp.ts"), () => ({
+  connectMcp: connectMcpMock as unknown as (
+    url?: string,
+  ) => Promise<McpConnection>,
+  createMcpTools: vi.fn(),
+}));
+
+const SESSION_ID = "session-abc";
+const MCP_URL = "http://localhost:9999/mcp";
+const INSTRUCTIONS = "You are Producer Pal.";
+
+interface TransportCase {
+  transport: AgentCliTransport;
+  /** Canned stdout for one turn, in this CLI's event schema. */
+  stdout: (sessionId: string, text: string) => string;
+  /** The argv token that marks a resumed turn. */
+  resumeToken: string;
+}
+
+const CASES: TransportCase[] = [
+  {
+    transport: CODEX_CLI_TRANSPORT,
+    stdout: codexTurnStdout,
+    resumeToken: "resume",
+  },
+  {
+    transport: CLAUDE_CODE_TRANSPORT,
+    stdout: claudeTurnStdout,
+    resumeToken: "--resume",
+  },
+];
+
+describe.each(CASES)(
+  "createAgentCliSession — $transport.provider",
+  ({ transport, stdout, resumeToken }) => {
+    let fixture: Awaited<ReturnType<typeof makeFixtureDir>>;
+
+    beforeEach(async () => {
+      setQuietMode(true);
+      fixture = await makeFixtureDir();
+      vi.stubEnv(transport.binEnvVar, FIXTURE_BIN);
+      vi.stubEnv("PPAL_FIXTURE_RECORD", fixture.recordFile);
+      vi.stubEnv("PPAL_FIXTURE_STDOUT", stdout(SESSION_ID, "Connected."));
+    });
+
+    afterEach(async () => {
+      setQuietMode(false);
+      vi.unstubAllEnvs();
+      await fixture.cleanup();
+    });
+
+    /**
+     * Open a session pointed at the fixture binary.
+     *
+     * @returns The session under test
+     */
+    async function openSession(): ReturnType<typeof createAgentCliSession> {
+      return await createAgentCliSession(transport, {
+        instructions: INSTRUCTIONS,
+        mcpUrl: MCP_URL,
+        model: transport.judgeModel,
+      });
+    }
+
+    it("parses a turn into the shared result shape", async () => {
+      const session = await openSession();
+
+      try {
+        const result = await session.sendMessage("Connect to Ableton Live", 1);
+
+        expect(result.text).toBe("Connected.");
+        expect(result.toolCalls).toStrictEqual([
+          { name: "ppal-connect", args: {}, result: "connected" },
+        ]);
+        expect(result.stepUsages).toStrictEqual([
+          { inputTokens: 10, outputTokens: 4 },
+        ]);
+      } finally {
+        await session.close();
+      }
+    });
+
+    it("carries the CLI's session id from the first turn into the second", async () => {
+      const session = await openSession();
+      let invocations: FixtureInvocation[];
+
+      try {
+        await session.sendMessage("Connect to Ableton Live", 1);
+        await session.sendMessage("Make a kick pattern", 2);
+        invocations = readInvocations(fixture.recordFile);
+      } finally {
+        await session.close();
+      }
+
+      const [first, second] = invocations;
+
+      expect(invocations).toHaveLength(2);
+      expect(first?.stdin).toBe("Connect to Ableton Live");
+      expect(first?.argv).not.toContain(SESSION_ID);
+
+      expect(second?.stdin).toBe("Make a kick pattern");
+      expect(second?.argv).toContain(resumeToken);
+      expect(second?.argv).toContain(SESSION_ID);
+    });
+
+    it("runs in a private session dir holding the instructions, and cleans it up", async () => {
+      const session = await openSession();
+      let cwd: string;
+
+      try {
+        await session.sendMessage("Connect to Ableton Live", 1);
+        cwd = readInvocations(fixture.recordFile)[0]?.cwd ?? "";
+
+        expect(readFileSync(join(cwd, "instructions.md"), "utf8")).toBe(
+          INSTRUCTIONS,
+        );
+        // The session's MCP URL reaches the CLI, not just our own MCP client.
+        expect(
+          readInvocations(fixture.recordFile)[0]?.argv.join(" "),
+        ).toContain(MCP_URL);
+      } finally {
+        await session.close();
+      }
+
+      expect(existsSync(cwd)).toBe(false);
+      expect(closeMock).toHaveBeenCalled();
+    });
+  },
+);

--- a/evals/chat/agent-cli/tests/agent-cli-spawn.test.ts
+++ b/evals/chat/agent-cli/tests/agent-cli-spawn.test.ts
@@ -1,0 +1,173 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Subprocess-level tests for the agent-CLI transports.
+ *
+ * These spawn a real child process — the fixture binary, not a vendor CLI — so
+ * the parts a mocked `spawn` would skip (stream decoding across chunk
+ * boundaries, exit codes, signal escalation) are actually exercised.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CODEX_CLI_TRANSPORT } from "../../codex/codex-cli-protocol.ts";
+import { spawnAgentCli } from "../agent-cli-spawn.ts";
+import {
+  codexTurnStdout,
+  FIXTURE_BIN,
+  makeFixtureDir,
+  readInvocations,
+  toJsonl,
+} from "./agent-cli-test-helpers.ts";
+
+/**
+ * Point the transport's bin env var at the fixture, configured by the caller.
+ *
+ * @param env - PPAL_FIXTURE_* variables driving the fixture's behavior
+ */
+function useFixture(env: Record<string, string>): void {
+  vi.stubEnv(CODEX_CLI_TRANSPORT.binEnvVar, FIXTURE_BIN);
+
+  for (const [key, value] of Object.entries(env)) vi.stubEnv(key, value);
+}
+
+describe("spawnAgentCli", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("passes argv and the prompt through, and returns stdout", async () => {
+    const { dir, recordFile, cleanup } = await makeFixtureDir();
+    const stdout = codexTurnStdout("thread-1", "Connected.");
+
+    useFixture({
+      PPAL_FIXTURE_STDOUT: stdout,
+      PPAL_FIXTURE_RECORD: recordFile,
+    });
+
+    try {
+      const result = await spawnAgentCli(
+        CODEX_CLI_TRANSPORT,
+        ["exec", "--model", "gpt-5.6-terra"],
+        "Connect to Ableton Live",
+        { cwd: dir },
+      );
+
+      expect(result).toBe(stdout);
+      expect(readInvocations(recordFile)).toStrictEqual([
+        {
+          argv: ["exec", "--model", "gpt-5.6-terra"],
+          stdin: "Connect to Ableton Live",
+          cwd: dir,
+        },
+      ]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("decodes a multi-byte character split across two stdout chunks", async () => {
+    const { dir, cleanup } = await makeFixtureDir();
+    // "café" — the é is two bytes, so flushing between them hands the parent a
+    // partial code point. Without a streaming decoder it arrives as U+FFFD and
+    // the JSON line no longer parses.
+    const stdout = codexTurnStdout("thread-1", "Café ✅");
+    const splitAt =
+      Buffer.byteLength(stdout.slice(0, stdout.indexOf("é")), "utf8") + 1;
+
+    useFixture({
+      PPAL_FIXTURE_STDOUT: stdout,
+      PPAL_FIXTURE_SPLIT_AT: String(splitAt),
+    });
+
+    try {
+      const raw = await spawnAgentCli(CODEX_CLI_TRANSPORT, [], "hi", {
+        cwd: dir,
+      });
+
+      expect(raw).toBe(stdout);
+      expect(CODEX_CLI_TRANSPORT.parseStream(raw).text).toBe("Café ✅");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("names the missing executable and its env var", async () => {
+    const { dir, cleanup } = await makeFixtureDir();
+
+    vi.stubEnv(
+      CODEX_CLI_TRANSPORT.binEnvVar,
+      "/nonexistent/producer-pal-codex",
+    );
+
+    try {
+      await expect(
+        spawnAgentCli(CODEX_CLI_TRANSPORT, [], "hi", { cwd: dir }),
+      ).rejects.toThrow(
+        /codex CLI executable "\/nonexistent\/producer-pal-codex" not found.*CODEX_BIN/s,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("surfaces the CLI's own error from the end of a failed stream", async () => {
+    const { dir, cleanup } = await makeFixtureDir();
+
+    useFixture({
+      PPAL_FIXTURE_STDOUT: toJsonl([
+        { type: "item.completed", item: { type: "agent_message", text: "hm" } },
+        { type: "turn.failed", error: { message: "MCP server unavailable" } },
+      ]),
+      PPAL_FIXTURE_EXIT_CODE: "1",
+    });
+
+    try {
+      await expect(
+        spawnAgentCli(CODEX_CLI_TRANSPORT, [], "hi", { cwd: dir }),
+      ).rejects.toThrow(/codex CLI exited 1.*MCP server unavailable/s);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("falls back to the stdout tail and stderr when the stream reports nothing", async () => {
+    const { dir, cleanup } = await makeFixtureDir();
+
+    useFixture({
+      PPAL_FIXTURE_STDOUT: "not json at all\n",
+      PPAL_FIXTURE_STDERR: "error: not logged in\n",
+      PPAL_FIXTURE_EXIT_CODE: "2",
+    });
+
+    try {
+      await expect(
+        spawnAgentCli(CODEX_CLI_TRANSPORT, [], "hi", { cwd: dir }),
+      ).rejects.toThrow(
+        /codex CLI exited 2.*stdout: not json at all.*stderr: error: not logged in/s,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("times out and escalates past a swallowed SIGTERM", async () => {
+    const { dir, cleanup } = await makeFixtureDir();
+
+    // The fixture installs a no-op SIGTERM handler and never exits on its own,
+    // so only the SIGKILL escalation can end it. If that were dropped, this
+    // promise would never settle.
+    useFixture({ PPAL_FIXTURE_MODE: "ignore-sigterm" });
+
+    try {
+      await expect(
+        spawnAgentCli(CODEX_CLI_TRANSPORT, [], "hi", {
+          cwd: dir,
+          timeoutMs: 50,
+        }),
+      ).rejects.toThrow("codex CLI timed out after 0.05s");
+    } finally {
+      await cleanup();
+    }
+  }, 15_000);
+});

--- a/evals/chat/agent-cli/tests/agent-cli-test-helpers.ts
+++ b/evals/chat/agent-cli/tests/agent-cli-test-helpers.ts
@@ -1,0 +1,162 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Shared plumbing for the agent-CLI transport tests: the fixture binary's path,
+ * a temp working directory per test, and canned JSONL in each CLI's schema.
+ */
+
+import { readFileSync } from "node:fs";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** The stand-in binary `*_BIN` is pointed at. See agent-cli-fixture.mjs. */
+export const FIXTURE_BIN = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "agent-cli-fixture.mjs",
+);
+
+/**
+ * Make a temp directory for one test to spawn in and record into.
+ *
+ * @returns The directory, a record-file path inside it, and a cleanup callback
+ */
+export async function makeFixtureDir(): Promise<{
+  dir: string;
+  recordFile: string;
+  cleanup: () => Promise<void>;
+}> {
+  // Resolved, because macOS hands out /var/… paths that the child reports back
+  // as /private/var/… once it is the process cwd.
+  const dir = await realpath(
+    await mkdtemp(join(tmpdir(), "producer-pal-agent-cli-test-")),
+  );
+
+  return {
+    dir,
+    recordFile: join(dir, "invocations.jsonl"),
+    cleanup: async () => await rm(dir, { recursive: true, force: true }),
+  };
+}
+
+/** One recorded fixture invocation. */
+export interface FixtureInvocation {
+  argv: string[];
+  stdin: string;
+  cwd: string;
+}
+
+/**
+ * Read every invocation the fixture appended, in call order.
+ *
+ * @param recordFile - Path the fixture was told to record to
+ * @returns The recorded invocations
+ */
+export function readInvocations(recordFile: string): FixtureInvocation[] {
+  return readFileSync(recordFile, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as FixtureInvocation);
+}
+
+/**
+ * Serialize events as the JSONL these CLIs stream on stdout.
+ *
+ * @param events - Events to emit, in order
+ * @returns Newline-delimited JSON
+ */
+export function toJsonl(events: unknown[]): string {
+  return events.map((event) => JSON.stringify(event)).join("\n") + "\n";
+}
+
+/**
+ * Build a one-tool Codex turn: thread id, an MCP call, a reply, and usage.
+ *
+ * @param threadId - Thread id the turn reports
+ * @param text - The assistant's reply
+ * @returns Codex JSONL stdout
+ */
+export function codexTurnStdout(threadId: string, text: string): string {
+  return toJsonl([
+    { type: "thread.started", thread_id: threadId },
+    {
+      type: "item.completed",
+      item: {
+        id: "call-1",
+        type: "mcp_tool_call",
+        server: "producer-pal",
+        tool: "ppal-connect",
+        arguments: {},
+        status: "completed",
+        result: { content: [{ type: "text", text: "connected" }] },
+      },
+    },
+    { type: "item.completed", item: { type: "agent_message", text } },
+    {
+      type: "turn.completed",
+      usage: { input_tokens: 10, output_tokens: 4 },
+    },
+  ]);
+}
+
+/**
+ * Build a one-tool Claude Code turn in the same shape as codexTurnStdout.
+ *
+ * @param sessionId - Session id the turn reports
+ * @param text - The assistant's reply
+ * @returns Claude Code JSONL stdout
+ */
+export function claudeTurnStdout(sessionId: string, text: string): string {
+  return toJsonl([
+    {
+      type: "system",
+      subtype: "init",
+      session_id: sessionId,
+      mcp_servers: [{ name: "producer-pal", status: "connected" }],
+    },
+    {
+      type: "assistant",
+      session_id: sessionId,
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_1",
+            name: "mcp__producer-pal__ppal-connect",
+            input: {},
+          },
+        ],
+      },
+    },
+    {
+      type: "user",
+      session_id: sessionId,
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_1",
+            content: [{ type: "text", text: "connected" }],
+          },
+        ],
+      },
+    },
+    {
+      type: "assistant",
+      session_id: sessionId,
+      message: { content: [{ type: "text", text }] },
+    },
+    {
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: text,
+      session_id: sessionId,
+      usage: { input_tokens: 10, output_tokens: 4 },
+    },
+  ]);
+}

--- a/evals/chat/agent-cli/tests/format-agent-turn.test.ts
+++ b/evals/chat/agent-cli/tests/format-agent-turn.test.ts
@@ -5,9 +5,9 @@
 
 import { describe, expect, it } from "vitest";
 
-import { formatCodexTurn } from "./format-codex-turn.ts";
+import { formatAgentTurn } from "../format-agent-turn.ts";
 
-describe("formatCodexTurn", () => {
+describe("formatAgentTurn", () => {
   const turn = {
     text: "Added a kick pattern.",
     toolCalls: [
@@ -17,7 +17,7 @@ describe("formatCodexTurn", () => {
   };
 
   it("renders tool calls, results, and the reply", () => {
-    const output = formatCodexTurn(turn, false);
+    const output = formatAgentTurn(turn, false);
 
     expect(output).toBe(
       "🔧 ppal-connect({})\n" +
@@ -30,11 +30,11 @@ describe("formatCodexTurn", () => {
   });
 
   it("drops the trailing newline when a usage line follows", () => {
-    expect(formatCodexTurn(turn, true)).toMatch(/Added a kick pattern\.$/);
+    expect(formatAgentTurn(turn, true)).toMatch(/Added a kick pattern\.$/);
   });
 
   it("omits the result line for a call that never reported one", () => {
-    const output = formatCodexTurn(
+    const output = formatAgentTurn(
       { text: "", toolCalls: [{ name: "ppal-connect", args: {} }] },
       false,
     );
@@ -44,11 +44,11 @@ describe("formatCodexTurn", () => {
 
   it("renders reply-only turns without a leading blank line", () => {
     expect(
-      formatCodexTurn({ text: "No tools needed.", toolCalls: [] }, false),
+      formatAgentTurn({ text: "No tools needed.", toolCalls: [] }, false),
     ).toBe("No tools needed.\n");
   });
 
   it("returns nothing for an empty turn", () => {
-    expect(formatCodexTurn({ text: "", toolCalls: [] }, false)).toBe("");
+    expect(formatAgentTurn({ text: "", toolCalls: [] }, false)).toBe("");
   });
 });

--- a/evals/chat/claude-code/claude-code-protocol.test.ts
+++ b/evals/chat/claude-code/claude-code-protocol.test.ts
@@ -1,0 +1,353 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+
+import {
+  claudeCodeJudgeArgs,
+  claudeCodeTurnArgs,
+  parseClaudeCodeStream,
+} from "./claude-code-protocol.ts";
+
+/**
+ * Assert every isolation flag survives on one argv. `evals/**` is excluded from
+ * coverage, so these assertions are the only guard against a dropped flag.
+ *
+ * @param args - Claude Code CLI arguments to check
+ */
+function expectRestrictions(args: string[]): void {
+  const flat = args.join(" ");
+
+  expect(flat).toContain("--output-format stream-json");
+  expect(args).toContain("-p");
+  // stream-json in print mode is rejected without it.
+  expect(args).toContain("--verbose");
+  expect(args).toContain("--disable-slash-commands");
+  expect(args).toContain("--strict-mcp-config");
+  // Built-in tools off and settings sources off — both take an empty value.
+  expect(args[args.indexOf("--tools") + 1]).toBe("");
+  expect(args[args.indexOf("--setting-sources") + 1]).toBe("");
+  // `--tools <tools...>` is variadic, so whatever follows its empty value must
+  // be another flag or the CLI swallows it as a tool name. (`--setting-sources`
+  // takes a single value and needs no such guard.)
+  expect(args[args.indexOf("--tools") + 2]).toMatch(/^--/);
+}
+
+/**
+ * Read the `--mcp-config` payload off an argv.
+ *
+ * @param args - Claude Code CLI arguments
+ * @returns The parsed MCP configuration
+ */
+function mcpConfig(args: string[]): { mcpServers: Record<string, unknown> } {
+  return JSON.parse(args[args.indexOf("--mcp-config") + 1] ?? "") as {
+    mcpServers: Record<string, unknown>;
+  };
+}
+
+/**
+ * Serialize events as the JSONL Claude Code streams on stdout.
+ *
+ * @param events - Events to emit, in order
+ * @returns Newline-delimited JSON
+ */
+function jsonl(events: unknown[]): string {
+  return events.map((event) => JSON.stringify(event)).join("\n");
+}
+
+describe("claudeCodeTurnArgs", () => {
+  const input = {
+    instructions: "You are Producer Pal.",
+    instructionsFile: "/tmp/instructions.md",
+    mcpUrl: "http://localhost:3350/mcp",
+    model: "sonnet",
+  };
+
+  it("builds a restricted initial MCP turn", () => {
+    const args = claudeCodeTurnArgs(input);
+
+    expectRestrictions(args);
+    expect(args).toStrictEqual(expect.arrayContaining(["--model", "sonnet"]));
+    // Instructions go inline: --system-prompt REPLACES Claude Code's own
+    // coding-agent prompt, and with it the memory injected into that prompt.
+    expect(args[args.indexOf("--system-prompt") + 1]).toBe(input.instructions);
+    expect(mcpConfig(args).mcpServers).toStrictEqual({
+      "producer-pal": { type: "http", url: input.mcpUrl },
+    });
+    expect(args[args.indexOf("--allowedTools") + 1]).toBe("mcp__producer-pal");
+    expect(args).not.toContain("--resume");
+  });
+
+  it("resumes by session id while keeping every restriction", () => {
+    const args = claudeCodeTurnArgs({
+      ...input,
+      resumeSessionId: "session-123",
+    });
+
+    expectRestrictions(args);
+    expect(args.slice(-2)).toStrictEqual(["--resume", "session-123"]);
+    expect(mcpConfig(args).mcpServers).toHaveProperty("producer-pal");
+  });
+});
+
+describe("claudeCodeJudgeArgs", () => {
+  it("runs without MCP or session persistence", () => {
+    const args = claudeCodeJudgeArgs({
+      instructions: "You are a judge.",
+      instructionsFile: "/tmp/judge.md",
+      model: "haiku",
+    });
+
+    expectRestrictions(args);
+    expect(args).toStrictEqual(expect.arrayContaining(["--model", "haiku"]));
+    expect(mcpConfig(args).mcpServers).toStrictEqual({});
+    expect(args).toContain("--no-session-persistence");
+  });
+});
+
+describe("parseClaudeCodeStream", () => {
+  it("collects text, MCP calls, results, session id and usage", () => {
+    const stdout = jsonl([
+      "not json — a startup warning",
+      {
+        type: "system",
+        subtype: "init",
+        session_id: "session-abc",
+        mcp_servers: [{ name: "producer-pal", status: "connected" }],
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "thinking", thinking: "internal, not part of the reply" },
+            { type: "text", text: "Connecting." },
+            {
+              type: "tool_use",
+              id: "toolu_1",
+              name: "mcp__producer-pal__ppal-connect",
+              input: { greeting: "hi" },
+            },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_1",
+              content: [
+                { type: "text", text: "connected" },
+                { type: "text", text: "…skills…" },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Ready when you are." }] },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "Ready when you are.",
+        session_id: "session-abc",
+        usage: {
+          input_tokens: 25,
+          output_tokens: 424,
+          cache_read_input_tokens: 15243,
+          cache_creation_input_tokens: 7895,
+        },
+      },
+    ]);
+    const parsed = parseClaudeCodeStream(stdout);
+
+    // Separate assistant messages, so a blank line rather than a run-on.
+    expect(parsed.text).toBe("Connecting.\n\nReady when you are.");
+    expect(parsed.sessionId).toBe("session-abc");
+    // The `mcp__<server>__` namespace is stripped so tool-call assertions match
+    // what every other transport records.
+    expect(parsed.toolCalls).toStrictEqual([
+      {
+        name: "ppal-connect",
+        args: { greeting: "hi" },
+        result: "connected",
+      },
+    ]);
+    expect(parsed.usage).toStrictEqual({
+      inputTokens: 25,
+      outputTokens: 424,
+      cacheReadTokens: 15243,
+      cacheWriteTokens: 7895,
+    });
+  });
+
+  it("records a failed tool result without failing the whole turn", () => {
+    const stdout = jsonl([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_1",
+              name: "mcp__producer-pal__ppal-create-clip",
+              input: {},
+            },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_1",
+              content: "no track at index 9",
+              is_error: true,
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(parseClaudeCodeStream(stdout).toolCalls[0]?.result).toBe(
+      "ERROR: no track at index 9",
+    );
+  });
+
+  it("falls back to JSON for a result carrying no text block", () => {
+    const stdout = jsonl([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_1",
+              name: "mcp__producer-pal__ppal-read-clip",
+              input: {},
+            },
+          ],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_1",
+              content: [{ type: "image", data: "…" }],
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(parseClaudeCodeStream(stdout).toolCalls[0]?.result).toBe(
+      JSON.stringify([{ type: "image", data: "…" }]),
+    );
+  });
+
+  it("throws when the Producer Pal MCP server did not connect", () => {
+    // Claude Code has no `required=true`; without this the turn would run with
+    // no tools at all and grade as a model that simply refused to use them.
+    const stdout = jsonl([
+      {
+        type: "system",
+        subtype: "init",
+        session_id: "session-abc",
+        mcp_servers: [{ name: "producer-pal", status: "failed" }],
+      },
+      { type: "result", subtype: "success", is_error: false, result: "hi" },
+    ]);
+
+    expect(() => parseClaudeCodeStream(stdout)).toThrow(
+      /MCP server "producer-pal" is failed/,
+    );
+  });
+
+  it("throws on a failed result event", () => {
+    const stdout = jsonl([
+      {
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        result: "rate limit reached",
+        terminal_reason: "error",
+        session_id: "session-abc",
+      },
+    ]);
+
+    // The specific subtype wins over the coarser terminal_reason ("error").
+    expect(() => parseClaudeCodeStream(stdout)).toThrow(
+      /error_during_execution: rate limit reached/,
+    );
+  });
+
+  it("falls back to terminal_reason when subtype is the misleading 'success'", () => {
+    // The most common real failure — the API being unreachable — still reports
+    // `subtype: "success"` next to `is_error: true`, which would otherwise read
+    // "claude CLI error: success:".
+    const stdout = jsonl([
+      {
+        type: "result",
+        subtype: "success",
+        is_error: true,
+        result: "API Error: Unable to connect to API (ConnectionRefused)",
+        terminal_reason: "api_error",
+        session_id: "session-abc",
+      },
+    ]);
+
+    expect(() => parseClaudeCodeStream(stdout)).toThrow(
+      /api_error: API Error: Unable to connect/,
+    );
+    expect(() => parseClaudeCodeStream(stdout)).not.toThrow(/success:/);
+  });
+
+  it("throws when the permission layer denied the tool calls", () => {
+    // Sibling of the dead-MCP case with the same silent outcome: if the
+    // --allowedTools rule stops matching, every call comes back denied and the
+    // run grades as a model that tried and failed.
+    const stdout = jsonl([
+      {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "I was unable to use the tools.",
+        session_id: "session-abc",
+        permission_denials: [
+          { tool_name: "mcp__producer-pal__ppal-connect" },
+          { tool_name: "mcp__producer-pal__ppal-connect" },
+        ],
+      },
+    ]);
+
+    expect(() => parseClaudeCodeStream(stdout)).toThrow(
+      /2 tool call\(s\) denied.*mcp__producer-pal__ppal-connect.*--allowedTools/s,
+    );
+  });
+
+  it("does not treat an empty permission_denials list as a failure", () => {
+    const stdout = jsonl([
+      {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "done",
+        session_id: "session-abc",
+        permission_denials: [],
+      },
+    ]);
+
+    expect(parseClaudeCodeStream(stdout).text).toBe("");
+  });
+});

--- a/evals/chat/claude-code/claude-code-protocol.ts
+++ b/evals/chat/claude-code/claude-code-protocol.ts
@@ -1,0 +1,365 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Claude Code's half of the agent-CLI transport contract:
+ * `claude -p --output-format stream-json` argv, and the JSONL event schema it
+ * streams back.
+ *
+ * Isolation is by subtraction rather than a sandbox flag: `--tools ""` removes
+ * every built-in tool (so only Producer Pal's MCP tools remain),
+ * `--setting-sources ""` drops user/project/local settings and plugins,
+ * `--disable-slash-commands` drops skills, `--strict-mcp-config` ignores MCP
+ * servers configured anywhere else, and `--system-prompt` REPLACES Claude
+ * Code's coding-agent prompt (and the memory injected into it) with the eval's
+ * instructions. What survives is a plain Producer Pal assistant.
+ */
+
+import { type TokenUsage } from "#webui/chat/sdk/types.ts";
+import {
+  type AgentStreamState,
+  parseAgentCliStream,
+  stringifyToolResult,
+  tokenCount,
+  toToolArguments,
+} from "../agent-cli/agent-cli-stream.ts";
+import {
+  type AgentCliArgsInput,
+  type AgentCliTransport,
+  type AgentCliTurnArgsInput,
+  MCP_SERVER_NAME,
+  type ParsedAgentTurn,
+} from "../agent-cli/agent-cli-transport.ts";
+import { type ToolCall } from "../shared/types.ts";
+
+/** Aliases the CLI resolves itself; explicit model ids also pass through. */
+export const CLAUDE_CODE_MODELS = ["fable", "haiku", "opus", "sonnet"];
+
+/** Tools from our MCP server arrive namespaced; strip it back to `ppal-*`. */
+const MCP_TOOL_PREFIX = `mcp__${MCP_SERVER_NAME}__`;
+
+export const CLAUDE_CODE_TRANSPORT: AgentCliTransport = {
+  provider: "claude-code",
+  label: "claude CLI",
+  bin: "claude",
+  binEnvVar: "CLAUDE_CODE_BIN",
+  tmpPrefix: "producer-pal-claude-code-",
+  // Claude Code prefers an exported API key over the logged-in subscription,
+  // and the Bedrock/Vertex switches would route the turn to a third party.
+  strippedEnvVars: [
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+  ],
+  models: CLAUDE_CODE_MODELS,
+  judgeModel: "haiku",
+  buildTurnArgs: claudeCodeTurnArgs,
+  buildJudgeArgs: claudeCodeJudgeArgs,
+  parseStream: parseClaudeCodeStream,
+};
+
+/**
+ * Build arguments for an initial or resumed Claude Code eval turn.
+ * @param input - Model, instructions, MCP URL, and optional session ID
+ * @returns Claude Code CLI arguments
+ */
+export function claudeCodeTurnArgs(input: AgentCliTurnArgsInput): string[] {
+  const mcpConfig = {
+    mcpServers: { [MCP_SERVER_NAME]: { type: "http", url: input.mcpUrl } },
+  };
+
+  return [
+    ...buildRestrictedArgs(input),
+    "--strict-mcp-config",
+    "--mcp-config",
+    JSON.stringify(mcpConfig),
+    // Pre-approve the whole server: -p mode cannot prompt, and an unapproved
+    // MCP call would come back denied rather than failing the run.
+    "--allowedTools",
+    `mcp__${MCP_SERVER_NAME}`,
+    ...(input.resumeSessionId != null
+      ? ["--resume", input.resumeSessionId]
+      : []),
+  ];
+}
+
+/**
+ * Build arguments for an isolated Claude Code judge call.
+ * @param input - Model and instructions for the judge
+ * @returns Claude Code CLI arguments
+ */
+export function claudeCodeJudgeArgs(input: AgentCliArgsInput): string[] {
+  return [
+    ...buildRestrictedArgs(input),
+    "--strict-mcp-config",
+    "--mcp-config",
+    JSON.stringify({ mcpServers: {} }),
+    // The judge is one shot and never resumes, so keep it out of the CLI's
+    // on-disk session history.
+    "--no-session-persistence",
+  ];
+}
+
+/**
+ * Parse one Claude Code JSONL turn into the shared eval result shape.
+ * @param stdout - Claude Code JSONL stdout
+ * @returns Parsed assistant text, MCP calls, session ID, and token usage
+ */
+export function parseClaudeCodeStream(stdout: string): ParsedAgentTurn {
+  return parseAgentCliStream(stdout, {
+    label: "claude CLI",
+    // Assistant messages arrive as separate events; a blank line between them
+    // keeps a pre-tool aside from running into the closing reply.
+    textSeparator: "\n\n",
+    handleEvent,
+  });
+}
+
+/**
+ * Build the arguments shared by MCP turns and judge calls.
+ *
+ * `--tools ""` must be followed by another flag: it is variadic
+ * (`--tools <tools...>`), so a bare value after it would be swallowed as a tool
+ * name. `--setting-sources <sources>` takes a single comma-separated value and
+ * has no such hazard; it is last-but-one only for readability.
+ *
+ * @param input - Model and instructions
+ * @returns Restricted Claude Code CLI arguments
+ */
+function buildRestrictedArgs(input: AgentCliArgsInput): string[] {
+  return [
+    "-p",
+    "--output-format",
+    "stream-json",
+    // stream-json output is rejected in print mode without it.
+    "--verbose",
+    "--model",
+    input.model,
+    "--system-prompt",
+    input.instructions,
+    "--setting-sources",
+    "",
+    "--disable-slash-commands",
+    "--tools",
+    "",
+  ];
+}
+
+/**
+ * Apply a Claude Code stream event to the current turn accumulator.
+ * @param event - Parsed Claude Code event
+ * @param state - Mutable turn accumulator
+ */
+function handleEvent(
+  event: Record<string, unknown>,
+  state: AgentStreamState,
+): void {
+  if (typeof event.session_id === "string") state.sessionId = event.session_id;
+
+  if (event.type === "system" && event.subtype === "init") {
+    state.error ??= mcpConnectionError(event.mcp_servers);
+  } else if (event.type === "assistant") {
+    for (const block of messageContent(event))
+      handleAssistantBlock(block, state);
+  } else if (event.type === "user") {
+    for (const block of messageContent(event)) handleToolResult(block, state);
+  } else if (event.type === "result") {
+    state.usage = mapClaudeUsage(event.usage);
+    state.error ??= permissionDenialError(event.permission_denials);
+    state.error ??= resultError(event);
+  }
+}
+
+/**
+ * Read a message event's content blocks.
+ * @param event - An `assistant` or `user` event
+ * @returns The content blocks, or an empty list for an unexpected shape
+ */
+function messageContent(
+  event: Record<string, unknown>,
+): Record<string, unknown>[] {
+  const message = event.message as { content?: unknown } | undefined;
+  const content = message?.content;
+
+  if (!Array.isArray(content)) return [];
+
+  return content.filter(
+    (block): block is Record<string, unknown> =>
+      block != null && typeof block === "object",
+  );
+}
+
+/**
+ * Collect assistant text and tool calls, skipping thinking blocks.
+ * @param block - One assistant content block
+ * @param state - Mutable turn accumulator
+ */
+function handleAssistantBlock(
+  block: Record<string, unknown>,
+  state: AgentStreamState,
+): void {
+  if (block.type === "text" && typeof block.text === "string") {
+    if (block.text !== "") state.textParts.push(block.text);
+  } else if (block.type === "tool_use" && typeof block.name === "string") {
+    const call: ToolCall = {
+      name: stripMcpPrefix(block.name),
+      args: toToolArguments(block.input),
+    };
+
+    state.toolCalls.push(call);
+
+    if (typeof block.id === "string") state.openCalls.set(block.id, call);
+  }
+}
+
+/**
+ * Attach a tool result to the call that produced it.
+ * @param block - One user content block
+ * @param state - Mutable turn accumulator
+ */
+function handleToolResult(
+  block: Record<string, unknown>,
+  state: AgentStreamState,
+): void {
+  if (block.type !== "tool_result" || typeof block.tool_use_id !== "string") {
+    return;
+  }
+
+  const call = state.openCalls.get(block.tool_use_id);
+
+  if (call == null) return;
+
+  const text = stringifyToolResult(block.content);
+
+  call.result = block.is_error === true ? `ERROR: ${text}` : text;
+  state.openCalls.delete(block.tool_use_id);
+}
+
+/**
+ * Report an MCP server that failed to come up.
+ *
+ * Claude Code has no equivalent of Codex's `required=true` — it runs the turn
+ * anyway, with no Producer Pal tools, and the run silently grades a model that
+ * never had them. So treat a non-connected server as a failed turn.
+ *
+ * @param value - The init event's `mcp_servers` list
+ * @returns Error message, or undefined when every configured server connected
+ */
+function mcpConnectionError(value: unknown): string | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  for (const item of value as unknown[]) {
+    const entry = (item ?? {}) as { name?: unknown; status?: unknown };
+
+    if (entry.status !== "connected") {
+      return (
+        `MCP server "${String(entry.name)}" is ${String(entry.status)}. ` +
+        `Is Ableton Live running with the Producer Pal device?`
+      );
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Report tool calls the permission layer refused.
+ *
+ * The sibling of a dead MCP server, with the same silent outcome: if the
+ * `--allowedTools` rule stops matching (renamed server, changed rule syntax),
+ * the model calls its tools and every call comes back denied — which grades as
+ * a model that tried and failed rather than a broken harness.
+ *
+ * ANY denial fails the turn, which is right only because `--tools ""` leaves
+ * nothing but our MCP server to deny. Revisit if built-ins are ever re-enabled:
+ * a denied `Bash` attempt would then be a model mistake, not a broken harness.
+ *
+ * @param value - The result event's `permission_denials` list
+ * @returns Error message, or undefined when nothing was denied
+ */
+function permissionDenialError(value: unknown): string | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+
+  const names = (value as unknown[])
+    .map((item) => ((item ?? {}) as { tool_name?: unknown }).tool_name)
+    .map((name) => (typeof name === "string" ? name : "unknown"));
+
+  return (
+    `${names.length} tool call(s) denied by the permission layer: ` +
+    `${[...new Set(names)].join(", ")}. Does --allowedTools still match?`
+  );
+}
+
+/**
+ * Extract a failure from the terminating `result` event.
+ *
+ * `subtype` is the specific label and is used whenever it says anything — but
+ * the most common real failure, the API being unreachable, reports
+ * `subtype: "success"` alongside `is_error: true`, which would read
+ * "claude CLI error: success:". Fall back to `terminal_reason` there.
+ *
+ * @param event - The result event
+ * @returns Error message, or undefined for a successful turn
+ */
+function resultError(event: Record<string, unknown>): string | undefined {
+  if (event.is_error !== true && event.subtype === "success") return undefined;
+
+  const detail =
+    typeof event.result === "string" && event.result !== ""
+      ? event.result
+      : "no detail reported";
+  const specific =
+    event.subtype !== "success" ? firstString(event.subtype) : undefined;
+  const reason =
+    specific ?? firstString(event.terminal_reason, event.api_error_status);
+
+  return reason == null ? detail : `${reason}: ${detail}`;
+}
+
+/**
+ * Return the first value that is a non-empty string.
+ * @param values - Candidate values from the event
+ * @returns The first usable string, or undefined
+ */
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value !== "") return value;
+  }
+
+  return undefined;
+}
+
+/**
+ * Strip our MCP namespace so tool names match every other transport's.
+ * @param name - Tool name as Claude Code reports it
+ * @returns Bare `ppal-*` name where applicable
+ */
+function stripMcpPrefix(name: string): string {
+  return name.startsWith(MCP_TOOL_PREFIX)
+    ? name.slice(MCP_TOOL_PREFIX.length)
+    : name;
+}
+
+/**
+ * Map Claude Code token counters to the shared usage shape.
+ * @param value - Raw result usage
+ * @returns Shared token usage or undefined
+ */
+function mapClaudeUsage(value: unknown): TokenUsage | undefined {
+  if (value == null || typeof value !== "object") return undefined;
+  const usage = value as Record<string, unknown>;
+  const result: TokenUsage = {
+    inputTokens: tokenCount(usage.input_tokens),
+    outputTokens: tokenCount(usage.output_tokens),
+  };
+  const cacheRead = tokenCount(usage.cache_read_input_tokens);
+  const cacheWrite = tokenCount(usage.cache_creation_input_tokens);
+
+  if (cacheRead > 0) result.cacheReadTokens = cacheRead;
+  if (cacheWrite > 0) result.cacheWriteTokens = cacheWrite;
+
+  return result;
+}

--- a/evals/chat/codex/codex-cli-protocol.test.ts
+++ b/evals/chat/codex/codex-cli-protocol.test.ts
@@ -5,12 +5,13 @@
 
 import { describe, expect, it } from "vitest";
 
+import { scrubAgentCliEnv } from "../agent-cli/agent-cli-transport.ts";
 import {
-  codexCliProtocol,
+  CODEX_CLI_TRANSPORT,
   codexJudgeArgs,
+  codexTurnArgs,
   parseCodexStream,
   resolveCodexModel,
-  scrubOpenAiKeys,
 } from "./codex-cli-protocol.ts";
 
 /**
@@ -31,15 +32,16 @@ function expectRestrictions(args: string[]): void {
   expect(args).toContain('sandbox_mode="read-only"');
 }
 
-describe("codexCliProtocol", () => {
+describe("codexTurnArgs", () => {
   const input = {
+    instructions: "You are Producer Pal.",
     instructionsFile: "/tmp/instructions.md",
     mcpUrl: "http://localhost:3350/mcp",
     model: "terra",
   };
 
   it("builds a restricted initial MCP turn", () => {
-    const args = codexCliProtocol(input);
+    const args = codexTurnArgs(input);
 
     expect(args.slice(0, 3)).toStrictEqual(["exec", "--sandbox", "read-only"]);
     expect(args).toStrictEqual(
@@ -54,7 +56,7 @@ describe("codexCliProtocol", () => {
   });
 
   it("pins resumed turns to every restriction through config", () => {
-    const args = codexCliProtocol({ ...input, resumeThreadId: "thread-123" });
+    const args = codexTurnArgs({ ...input, resumeSessionId: "thread-123" });
 
     expect(args.slice(0, 2)).toStrictEqual(["exec", "resume"]);
     expect(args).not.toContain("--sandbox");
@@ -65,7 +67,11 @@ describe("codexCliProtocol", () => {
 
 describe("codexJudgeArgs", () => {
   it("runs ephemerally without MCP configuration", () => {
-    const args = codexJudgeArgs("luna", "/tmp/judge.md");
+    const args = codexJudgeArgs({
+      instructions: "You are a judge.",
+      instructionsFile: "/tmp/judge.md",
+      model: "luna",
+    });
 
     expect(args).toContain("--ephemeral");
     expect(args).toStrictEqual(
@@ -85,22 +91,25 @@ describe("resolveCodexModel", () => {
   });
 });
 
-describe("scrubOpenAiKeys", () => {
+describe("scrubAgentCliEnv", () => {
   it("forces Codex subscription auth while preserving other variables", () => {
-    const env = scrubOpenAiKeys({
-      CODEX_API_KEY: "codex-secret",
-      OPENAI_API_KEY: "api-secret",
-      OPENAI_KEY: "eval-secret",
-      PATH: "/usr/bin",
-      EMPTY: undefined,
-    });
+    const env = scrubAgentCliEnv(
+      {
+        CODEX_API_KEY: "codex-secret",
+        OPENAI_API_KEY: "api-secret",
+        OPENAI_KEY: "eval-secret",
+        PATH: "/usr/bin",
+        EMPTY: undefined,
+      },
+      CODEX_CLI_TRANSPORT.strippedEnvVars,
+    );
 
     expect(env).toStrictEqual({ PATH: "/usr/bin" });
   });
 });
 
 describe("parseCodexStream", () => {
-  it("collects text, MCP calls, results, thread id and usage", () => {
+  it("collects text, MCP calls, results, session id and usage", () => {
     const stdout = [
       { type: "thread.started", thread_id: "thread-abc" },
       {
@@ -145,7 +154,7 @@ describe("parseCodexStream", () => {
     const parsed = parseCodexStream(stdout);
 
     expect(parsed.text).toBe("Connected.");
-    expect(parsed.threadId).toBe("thread-abc");
+    expect(parsed.sessionId).toBe("thread-abc");
     // The MCP envelope is unwrapped to its text block, matching what the AI SDK
     // path records — this string reaches the console, reports, and judge prompt.
     expect(parsed.toolCalls).toStrictEqual([

--- a/evals/chat/codex/codex-cli-protocol.ts
+++ b/evals/chat/codex/codex-cli-protocol.ts
@@ -3,9 +3,26 @@
 // AI assistance: Codex (OpenAI), Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+/**
+ * The Codex CLI's half of the agent-CLI transport contract: `codex exec --json`
+ * argv, and the JSONL event schema it streams back.
+ */
+
 import { type TokenUsage } from "#webui/chat/sdk/types.ts";
-import { mcpResultText } from "../shared/mcp-result-text.ts";
-import { type ToolCall } from "../shared/types.ts";
+import {
+  type AgentStreamState,
+  parseAgentCliStream,
+  stringifyToolResult,
+  tokenCount,
+  toToolArguments,
+} from "../agent-cli/agent-cli-stream.ts";
+import {
+  type AgentCliArgsInput,
+  type AgentCliTransport,
+  type AgentCliTurnArgsInput,
+  MCP_SERVER_NAME,
+  type ParsedAgentTurn,
+} from "../agent-cli/agent-cli-transport.ts";
 
 export const CODEX_MODEL_ALIASES: Record<string, string> = {
   luna: "gpt-5.6-luna",
@@ -13,28 +30,40 @@ export const CODEX_MODEL_ALIASES: Record<string, string> = {
   terra: "gpt-5.6-terra",
 };
 
-export const DEFAULT_CODEX_SYSTEM_PROMPT =
-  "You are Producer Pal, an AI assistant for music production in Ableton Live. " +
-  "Use only the available Producer Pal MCP tools (ppal-*) to inspect or change " +
-  "the Live Set. Do not use shell commands, files, web search, or subagents.";
-
-export interface CodexSessionArgsInput {
-  instructionsFile: string;
-  mcpUrl: string;
-  model: string;
-  resumeThreadId?: string;
-}
+export const CODEX_CLI_TRANSPORT: AgentCliTransport = {
+  provider: "codex-code",
+  label: "codex CLI",
+  bin: "codex",
+  binEnvVar: "CODEX_BIN",
+  tmpPrefix: "producer-pal-codex-",
+  strippedEnvVars: ["CODEX_API_KEY", "OPENAI_API_KEY", "OPENAI_KEY"],
+  // Fixed alias set (no models endpoint); read from the aliases so a listing
+  // can't advertise a name the CLI can't resolve.
+  models: Object.keys(CODEX_MODEL_ALIASES).sort(),
+  judgeModel: "luna",
+  buildTurnArgs: codexTurnArgs,
+  buildJudgeArgs: codexJudgeArgs,
+  parseStream: parseCodexStream,
+};
 
 /**
  * Build arguments for an initial or resumed Codex eval turn.
- * @param input - Model, instructions, MCP URL, and optional thread ID
+ * @param input - Model, instructions, MCP URL, and optional session ID
  * @returns Codex CLI arguments
  */
-export function codexCliProtocol(input: CodexSessionArgsInput): string[] {
-  const common = buildCommonArgs(input);
+export function codexTurnArgs(input: AgentCliTurnArgsInput): string[] {
+  const common = [
+    ...buildRestrictedArgs(input),
+    "-c",
+    `mcp_servers.${MCP_SERVER_NAME}.url=${JSON.stringify(input.mcpUrl)}`,
+    "-c",
+    `mcp_servers.${MCP_SERVER_NAME}.required=true`,
+    "-c",
+    `mcp_servers.${MCP_SERVER_NAME}.default_tools_approval_mode="approve"`,
+  ];
 
-  if (input.resumeThreadId != null) {
-    return ["exec", "resume", ...common, input.resumeThreadId, "-"];
+  if (input.resumeSessionId != null) {
+    return ["exec", "resume", ...common, input.resumeSessionId, "-"];
   }
 
   return ["exec", "--sandbox", "read-only", ...common, "-"];
@@ -42,20 +71,16 @@ export function codexCliProtocol(input: CodexSessionArgsInput): string[] {
 
 /**
  * Build arguments for an isolated Codex judge call.
- * @param model - Friendly alias or explicit model ID
- * @param instructionsFile - Absolute path to judge instructions
+ * @param input - Model and instructions for the judge
  * @returns Codex CLI arguments
  */
-export function codexJudgeArgs(
-  model: string,
-  instructionsFile: string,
-): string[] {
+export function codexJudgeArgs(input: AgentCliArgsInput): string[] {
   return [
     "exec",
     "--sandbox",
     "read-only",
     "--ephemeral",
-    ...buildRestrictedArgs(model, instructionsFile),
+    ...buildRestrictedArgs(input),
     "-",
   ];
 }
@@ -70,95 +95,25 @@ export function resolveCodexModel(model: string): string {
 }
 
 /**
- * Remove OpenAI API keys so Codex uses the logged-in subscription.
- * @param env - Parent process environment
- * @returns Environment without OpenAI API keys or undefined values
- */
-export function scrubOpenAiKeys(
-  env: NodeJS.ProcessEnv,
-): Record<string, string> {
-  const stripped = new Set(["CODEX_API_KEY", "OPENAI_API_KEY", "OPENAI_KEY"]);
-  const result: Record<string, string> = {};
-
-  for (const [key, value] of Object.entries(env)) {
-    if (typeof value === "string" && !stripped.has(key)) result[key] = value;
-  }
-
-  return result;
-}
-
-export interface ParsedCodexTurn {
-  text: string;
-  toolCalls: ToolCall[];
-  threadId?: string;
-  usage?: TokenUsage;
-}
-
-/**
  * Parse one Codex JSONL turn into the shared eval result shape.
  * @param stdout - Codex JSONL stdout
- * @returns Parsed assistant text, MCP calls, thread ID, and token usage
+ * @returns Parsed assistant text, MCP calls, session ID, and token usage
  */
-export function parseCodexStream(stdout: string): ParsedCodexTurn {
-  const state: CodexStreamState = {
-    text: "",
-    toolCalls: [],
-    openCalls: new Map(),
-  };
-
-  for (const line of stdout.split("\n")) {
-    const event = parseLine(line);
-
-    if (event != null) handleEvent(event, state);
-  }
-
-  if (state.error != null) throw new Error(`codex CLI error: ${state.error}`);
-
-  return {
-    text: state.text,
-    toolCalls: state.toolCalls,
-    ...(state.threadId != null ? { threadId: state.threadId } : {}),
-    ...(state.usage != null ? { usage: state.usage } : {}),
-  };
-}
-
-interface CodexStreamState {
-  text: string;
-  toolCalls: ToolCall[];
-  /** In-flight MCP calls awaiting completion, keyed by callKey(). */
-  openCalls: Map<string, ToolCall>;
-  threadId?: string;
-  usage?: TokenUsage;
-  error?: string;
-}
-
-/**
- * Build restrictions and the Producer Pal MCP configuration.
- * @param input - Model, instructions, and MCP session options
- * @returns CLI arguments shared by initial and resumed turns
- */
-function buildCommonArgs(input: CodexSessionArgsInput): string[] {
-  return [
-    ...buildRestrictedArgs(input.model, input.instructionsFile),
-    "-c",
-    `mcp_servers.producer-pal.url=${JSON.stringify(input.mcpUrl)}`,
-    "-c",
-    "mcp_servers.producer-pal.required=true",
-    "-c",
-    'mcp_servers.producer-pal.default_tools_approval_mode="approve"',
-  ];
+export function parseCodexStream(stdout: string): ParsedAgentTurn {
+  return parseAgentCliStream(stdout, {
+    label: "codex CLI",
+    // Codex emits its message as one `agent_message` item, so parts concatenate.
+    textSeparator: "",
+    handleEvent,
+  });
 }
 
 /**
  * Build arguments shared by MCP turns and judge calls.
- * @param model - Friendly alias or explicit model ID
- * @param instructionsFile - Absolute path to base instructions
+ * @param input - Model and instructions
  * @returns Restricted Codex CLI arguments
  */
-function buildRestrictedArgs(
-  model: string,
-  instructionsFile: string,
-): string[] {
+function buildRestrictedArgs(input: AgentCliArgsInput): string[] {
   return [
     "--json",
     "--skip-git-repo-check",
@@ -171,7 +126,7 @@ function buildRestrictedArgs(
     "--disable",
     "multi_agent",
     "--model",
-    resolveCodexModel(model),
+    resolveCodexModel(input.model),
     "-c",
     'approval_policy="never"',
     "-c",
@@ -179,25 +134,8 @@ function buildRestrictedArgs(
     "-c",
     'sandbox_mode="read-only"',
     "-c",
-    `model_instructions_file=${JSON.stringify(instructionsFile)}`,
+    `model_instructions_file=${JSON.stringify(input.instructionsFile)}`,
   ];
-}
-
-/**
- * Parse a JSONL line, ignoring diagnostics written to stdout.
- * @param line - One stdout line
- * @returns Parsed event or undefined for non-JSON output
- */
-function parseLine(line: string): Record<string, unknown> | undefined {
-  const trimmed = line.trim();
-
-  if (!trimmed) return undefined;
-
-  try {
-    return JSON.parse(trimmed) as Record<string, unknown>;
-  } catch {
-    return undefined;
-  }
 }
 
 /**
@@ -207,10 +145,10 @@ function parseLine(line: string): Record<string, unknown> | undefined {
  */
 function handleEvent(
   event: Record<string, unknown>,
-  state: CodexStreamState,
+  state: AgentStreamState,
 ): void {
   if (event.type === "thread.started" && typeof event.thread_id === "string") {
-    state.threadId = event.thread_id;
+    state.sessionId = event.thread_id;
   } else if (event.type === "turn.completed") {
     state.usage = mapCodexUsage(event.usage);
   } else if (event.type === "turn.failed" || event.type === "error") {
@@ -225,12 +163,12 @@ function handleEvent(
  * @param itemValue - Event item payload
  * @param state - Mutable turn accumulator
  */
-function handleItem(itemValue: unknown, state: CodexStreamState): void {
+function handleItem(itemValue: unknown, state: AgentStreamState): void {
   if (itemValue == null || typeof itemValue !== "object") return;
   const item = itemValue as Record<string, unknown>;
 
   if (item.type === "agent_message" && typeof item.text === "string") {
-    state.text += item.text;
+    state.textParts.push(item.text);
   } else if (item.type === "mcp_tool_call") {
     collectMcpCall(item, state);
   }
@@ -243,7 +181,7 @@ function handleItem(itemValue: unknown, state: CodexStreamState): void {
  */
 function collectMcpCall(
   item: Record<string, unknown>,
-  state: CodexStreamState,
+  state: AgentStreamState,
 ): void {
   const key = callKey(item);
 
@@ -253,18 +191,18 @@ function collectMcpCall(
 
   if (call == null) {
     if (typeof item.tool !== "string") return;
-    call = { name: item.tool, args: toArguments(item.arguments) };
+    call = { name: item.tool, args: toToolArguments(item.arguments) };
     state.toolCalls.push(call);
     state.openCalls.set(key, call);
   } else {
     // `item.started` can carry empty `arguments`, with the real ones only on
     // completion — so let a non-empty payload replace what landed first.
-    const args = toArguments(item.arguments);
+    const args = toToolArguments(item.arguments);
 
     if (Object.keys(args).length > 0) call.args = args;
   }
 
-  if (item.result != null) call.result = stringifyResult(item.result);
+  if (item.result != null) call.result = stringifyToolResult(item.result);
 
   if (item.status === "failed") {
     const message = getErrorMessage(item);
@@ -305,35 +243,6 @@ function isFinishedCall(item: Record<string, unknown>): boolean {
 }
 
 /**
- * Normalize object or JSON-string tool arguments.
- * @param value - Raw Codex arguments
- * @returns Object arguments for the shared tool-call shape
- */
-function toArguments(value: unknown): Record<string, unknown> {
-  if (value != null && typeof value === "object" && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
-  }
-
-  if (typeof value === "string") {
-    try {
-      const parsed = JSON.parse(value) as unknown;
-
-      if (
-        parsed != null &&
-        typeof parsed === "object" &&
-        !Array.isArray(parsed)
-      ) {
-        return parsed as Record<string, unknown>;
-      }
-    } catch {
-      return {};
-    }
-  }
-
-  return {};
-}
-
-/**
  * Map Codex token counters to the shared usage shape.
  * @param value - Raw turn usage
  * @returns Shared token usage or undefined
@@ -341,44 +250,19 @@ function toArguments(value: unknown): Record<string, unknown> {
 function mapCodexUsage(value: unknown): TokenUsage | undefined {
   if (value == null || typeof value !== "object") return undefined;
   const usage = value as Record<string, unknown>;
-  const inputTokens = numberValue(usage.input_tokens);
-  const outputTokens = numberValue(usage.output_tokens);
+  const inputTokens = tokenCount(usage.input_tokens);
+  const outputTokens = tokenCount(usage.output_tokens);
   const result: TokenUsage = {
     inputTokens,
     outputTokens,
   };
-  const cached = numberValue(usage.cached_input_tokens);
-  const reasoning = numberValue(usage.reasoning_output_tokens);
+  const cached = tokenCount(usage.cached_input_tokens);
+  const reasoning = tokenCount(usage.reasoning_output_tokens);
 
   if (cached > 0) result.cacheReadTokens = cached;
   if (reasoning > 0) result.reasoningTokens = reasoning;
 
   return result;
-}
-
-/**
- * Return a numeric counter or zero when absent.
- * @param value - Raw counter
- * @returns Numeric counter
- */
-function numberValue(value: unknown): number {
-  return typeof value === "number" ? value : 0;
-}
-
-/**
- * Serialize a Codex MCP result for eval reports.
- *
- * Codex reports the whole MCP envelope (`{ content: [...] }`); unwrap its first
- * text block so results read like the AI SDK path's. This string is what the
- * console, the JSON report, and the judge prompt all show.
- *
- * @param value - Raw MCP result
- * @returns String result
- */
-function stringifyResult(value: unknown): string {
-  if (typeof value === "string") return value;
-
-  return mcpResultText(value) || JSON.stringify(value);
 }
 
 /**

--- a/evals/chat/index.ts
+++ b/evals/chat/index.ts
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { Command } from "commander";
+import { getAgentCliTransport } from "#evals/chat/agent-cli/agent-cli-registry.ts";
 import { listModels } from "#evals/shared/list-models.ts";
 import {
   LIST_MODELS_HINT,
@@ -111,13 +112,13 @@ program
 
     const { provider, model } = spec;
 
-    // codex-code runs through the Codex CLI transport (a spawned subprocess),
-    // not the AI SDK this CLI streams from. Without this the provider factory
-    // throws past commander's handler as a raw stack trace.
-    if (provider === "codex-code") {
+    // The agent-CLI providers run through a spawned subprocess, not the AI SDK
+    // this CLI streams from. Without this the provider factory throws past
+    // commander's handler as a raw stack trace.
+    if (getAgentCliTransport(provider) != null) {
       program.error(
-        `Provider "codex-code" is only supported by the eval CLI, which drives ` +
-          `the Codex CLI transport instead of the AI SDK. ` +
+        `Provider "${provider}" is only supported by the eval CLI, which drives ` +
+          `a spawned agent CLI instead of the AI SDK. ` +
           `Try: scripts/eval -m ${provider}/${model} -t <scenario>`,
       );
 

--- a/evals/chat/provider.ts
+++ b/evals/chat/provider.ts
@@ -79,9 +79,10 @@ export function createProviderModel(
       }).chatModel(model);
     }
 
+    case "claude-code":
     case "codex-code":
       throw new Error(
-        "codex-code uses the Codex CLI transport, not the AI SDK provider.",
+        `${provider} uses a spawned agent CLI transport, not the AI SDK provider.`,
       );
 
     default: {

--- a/evals/chat/thinking.ts
+++ b/evals/chat/thinking.ts
@@ -72,6 +72,8 @@ export function buildProviderOptions(
       return buildOpenRouterThinking(level);
     case "local":
       return undefined;
+    // The agent CLIs carry their own reasoning configuration.
+    case "claude-code":
     case "codex-code":
       return undefined;
 

--- a/evals/scenarios/eval-session.ts
+++ b/evals/scenarios/eval-session.ts
@@ -9,13 +9,15 @@
 
 import { type Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { type ModelMessage, stepCountIs, streamText } from "ai";
-import { createCodexCliSession } from "#evals/chat/codex/codex-cli-session.ts";
+import { getAgentCliTransport } from "#evals/chat/agent-cli/agent-cli-registry.ts";
+import { createAgentCliSession } from "#evals/chat/agent-cli/agent-cli-session.ts";
 import { createMcpTools } from "#evals/chat/mcp.ts";
 import { createProviderModel } from "#evals/chat/provider.ts";
 import { printStepUsage } from "#evals/chat/shared/formatting.ts";
 import { processCliStream } from "#evals/chat/stream.ts";
 import {
   ANTHROPIC_CONFIG,
+  CLAUDE_CODE_CONFIG,
   CODEX_CODE_CONFIG,
   GEMINI_CONFIG,
   OPENAI_CONFIG,
@@ -42,6 +44,8 @@ export function getDefaultModel(provider: EvalProvider): string {
   switch (provider) {
     case "anthropic":
       return ANTHROPIC_CONFIG.defaultModel;
+    case "claude-code":
+      return CLAUDE_CODE_CONFIG.defaultModel;
     case "codex-code":
       return CODEX_CODE_CONFIG.defaultModel;
     case "google":
@@ -74,8 +78,8 @@ export interface EvalSession {
   /** Close the session */
   close: () => Promise<void>;
   /** Append a pre-built turn to history without calling the model. Absent on
-   *  transports that own their conversation state (the Codex CLI resumes a
-   *  thread by id, so there is no history array to write into) — callers must
+   *  transports that own their conversation state (the agent CLIs resume a
+   *  session by id, so there is no history array to write into) — callers must
    *  fall back to a real `sendMessage` turn when this is undefined. */
   seedTurn?: (turn: SeededTurn) => void;
 }
@@ -96,8 +100,10 @@ interface EvalSessionOptions {
 export async function createEvalSession(
   options: EvalSessionOptions,
 ): Promise<EvalSession> {
-  if (options.provider === "codex-code") {
-    return await createCodexCliSession({
+  const agentCli = getAgentCliTransport(options.provider);
+
+  if (agentCli != null) {
+    return await createAgentCliSession(agentCli, {
       ...(options.model != null ? { model: options.model } : {}),
       ...(options.instructions != null
         ? { instructions: options.instructions }

--- a/evals/scenarios/helpers/judge/agent-cli-judge.ts
+++ b/evals/scenarios/helpers/judge/agent-cli-judge.ts
@@ -6,28 +6,26 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  codexJudgeArgs,
-  parseCodexStream,
-} from "#evals/chat/codex/codex-cli-protocol.ts";
-import { spawnCodex } from "#evals/chat/codex/codex-cli.ts";
+import { spawnAgentCli } from "#evals/chat/agent-cli/agent-cli-spawn.ts";
+import { type AgentCliTransport } from "#evals/chat/agent-cli/agent-cli-transport.ts";
 import {
   finishJudgeOutput,
   printJudgeChunk,
   printJudgeHeader,
 } from "./judge-output.ts";
 
-export const CODEX_CODE_JUDGE_MODEL = "luna";
-
 /**
- * Run an isolated Codex subscription model as the LLM judge.
+ * Run an isolated agent-CLI subscription model as the LLM judge.
+ *
+ * @param transport - Transport describing the CLI to drive
  * @param prompt - Evaluation prompt
  * @param systemPrompt - Judge instructions
- * @param judgeModel - Resolved model alias or ID (see CODEX_CODE_JUDGE_MODEL)
+ * @param judgeModel - Friendly alias or explicit model ID
  * @param criteria - Criteria shown in console output
  * @returns Raw judge response
  */
-export async function callCodexCliJudge(
+export async function callAgentCliJudge(
+  transport: AgentCliTransport,
   prompt: string,
   systemPrompt: string,
   judgeModel: string,
@@ -36,16 +34,19 @@ export async function callCodexCliJudge(
   const workingDir = await mkdtemp(join(tmpdir(), "producer-pal-judge-"));
   const instructionsFile = join(workingDir, "instructions.md");
 
-  printJudgeHeader("codex-code", judgeModel, criteria);
+  printJudgeHeader(transport.provider, judgeModel, criteria);
 
   try {
     await writeFile(instructionsFile, systemPrompt, "utf8");
-    const stdout = await spawnCodex(
-      codexJudgeArgs(judgeModel, instructionsFile),
-      prompt,
-      { cwd: workingDir },
-    );
-    const text = parseCodexStream(stdout).text.trim();
+    const args = transport.buildJudgeArgs({
+      instructions: systemPrompt,
+      instructionsFile,
+      model: judgeModel,
+    });
+    const stdout = await spawnAgentCli(transport, args, prompt, {
+      cwd: workingDir,
+    });
+    const text = transport.parseStream(stdout).text.trim();
 
     printJudgeChunk(text);
     finishJudgeOutput();

--- a/evals/scenarios/helpers/judge/judge.ts
+++ b/evals/scenarios/helpers/judge/judge.ts
@@ -8,13 +8,11 @@
  */
 
 import { streamText } from "ai";
+import { getAgentCliTransport } from "#evals/chat/agent-cli/agent-cli-registry.ts";
 import { createProviderModel } from "#evals/chat/provider.ts";
 import { getDefaultModel } from "#evals/scenarios/eval-session.ts";
 import { type EvalProvider } from "#evals/scenarios/types.ts";
-import {
-  callCodexCliJudge,
-  CODEX_CODE_JUDGE_MODEL,
-} from "./codex-cli-judge.ts";
+import { callAgentCliJudge } from "./agent-cli-judge.ts";
 import {
   finishJudgeOutput,
   printJudgeChunk,
@@ -39,13 +37,21 @@ export async function callJudge(
   model: string | undefined,
   criteria: string,
 ): Promise<string> {
-  if (provider === "codex-code") {
+  const agentCli = getAgentCliTransport(provider);
+
+  if (agentCli != null) {
     // Isolated judge model, distinct from the model under test, to avoid
     // self-grading. Must resolve before the generic default below, which would
-    // otherwise pick the codex session default (the model being evaluated).
-    const judgeModel = model ?? CODEX_CODE_JUDGE_MODEL;
+    // otherwise pick the CLI session default (the model being evaluated).
+    const judgeModel = model ?? agentCli.judgeModel;
 
-    return await callCodexCliJudge(prompt, systemPrompt, judgeModel, criteria);
+    return await callAgentCliJudge(
+      agentCli,
+      prompt,
+      systemPrompt,
+      judgeModel,
+      criteria,
+    );
   }
 
   const judgeModel = model ?? getDefaultModel(provider);

--- a/evals/scenarios/types.ts
+++ b/evals/scenarios/types.ts
@@ -19,7 +19,13 @@ export type { TurnResult, ToolCall } from "#evals/chat/shared/types.ts";
 export type { ConfigOptions };
 
 export type EvalProvider =
-  "anthropic" | "codex-code" | "google" | "local" | "openai" | "openrouter";
+  | "anthropic"
+  | "claude-code"
+  | "codex-code"
+  | "google"
+  | "local"
+  | "openai"
+  | "openrouter";
 
 /**
  * A test scenario that runs against Ableton Live

--- a/evals/shared/list-models.ts
+++ b/evals/shared/list-models.ts
@@ -11,7 +11,7 @@
  * or an eval run.
  */
 
-import { CODEX_MODEL_ALIASES } from "#evals/chat/codex/codex-cli-protocol.ts";
+import { requireAgentCliTransport } from "#evals/chat/agent-cli/agent-cli-registry.ts";
 import { type EvalProvider } from "#evals/scenarios/types.ts";
 import {
   PROVIDERS,
@@ -173,10 +173,11 @@ async function fetchModelsForProvider(
         },
       );
 
+    case "claude-code":
     case "codex-code":
-      // Fixed alias set (no models endpoint); read from the transport so the
-      // listing can't advertise an alias the CLI can't resolve.
-      return Object.keys(CODEX_MODEL_ALIASES).sort();
+      // Fixed name set (no models endpoint); read from the transport so the
+      // listing can't advertise a name the CLI can't resolve.
+      return requireAgentCliTransport(provider).models;
 
     case "google":
       return await fetchGoogleModels();

--- a/evals/shared/parse-model-arg.test.ts
+++ b/evals/shared/parse-model-arg.test.ts
@@ -1,0 +1,57 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { parseModelArg } from "./parse-model-arg.ts";
+
+describe("parseModelArg", () => {
+  it("splits an explicit provider/model on the first slash only", () => {
+    expect(parseModelArg("claude-code/sonnet")).toStrictEqual({
+      provider: "claude-code",
+      model: "sonnet",
+    });
+    expect(
+      parseModelArg("openrouter/anthropic/claude-haiku-4.5"),
+    ).toStrictEqual({
+      provider: "openrouter",
+      model: "anthropic/claude-haiku-4.5",
+    });
+  });
+
+  it("infers the provider from a model prefix", () => {
+    expect(parseModelArg("claude-sonnet-4-5")).toStrictEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+    });
+    expect(parseModelArg("gpt-5-nano").provider).toBe("openai");
+    expect(parseModelArg("gemini-3-flash-preview").provider).toBe("google");
+  });
+
+  it("rejects a bare provider name rather than inferring from its prefix", () => {
+    // `claude-code` is both a provider name and a `claude-` prefix match.
+    // Inference used to win, quietly routing someone who asked for the
+    // subscription CLI to the metered Anthropic API — where the only symptom
+    // was "API key for Anthropic is not set". Every provider must fail the
+    // same way its sibling `codex-code` does.
+    for (const provider of [
+      "claude-code",
+      "codex-code",
+      "anthropic",
+      "local",
+    ]) {
+      expect(() => parseModelArg(provider)).toThrow(
+        `Provider-only not allowed: "${provider}"`,
+      );
+    }
+  });
+
+  it("rejects an unknown prefix and a provider with no model", () => {
+    expect(() => parseModelArg("mystery-model")).toThrow(
+      /Unknown model prefix/,
+    );
+    expect(() => parseModelArg("nope/x")).toThrow(/Unknown provider: nope/);
+    expect(() => parseModelArg("claude-code/")).toThrow(/Missing model after/);
+  });
+});

--- a/evals/shared/parse-model-arg.ts
+++ b/evals/shared/parse-model-arg.ts
@@ -59,6 +59,14 @@ export function parseModelArg(arg: string): ModelSpec {
  * @throws Error if provider-only input or unknown prefix
  */
 function inferProviderFromModel(model: string): ModelSpec {
+  // Provider-only FIRST, before prefix inference: `claude-code` is both a
+  // provider name and a `claude-` prefix match, and inferring would silently
+  // route it to the metered Anthropic API — the exact thing someone reaching
+  // for the subscription CLI is trying to avoid.
+  if (PROVIDERS.includes(model as EvalProvider)) {
+    throw new Error(`Provider-only not allowed: "${model}". Specify a model.`);
+  }
+
   if (model.startsWith("claude-")) {
     return { provider: "anthropic", model };
   }
@@ -69,11 +77,6 @@ function inferProviderFromModel(model: string): ModelSpec {
 
   if (model.startsWith("gemini-")) {
     return { provider: "google", model };
-  }
-
-  // Check if it's a provider-only input (error)
-  if (PROVIDERS.includes(model as EvalProvider)) {
-    throw new Error(`Provider-only not allowed: "${model}". Specify a model.`);
   }
 
   throw new Error(

--- a/evals/shared/provider-configs.ts
+++ b/evals/shared/provider-configs.ts
@@ -28,6 +28,14 @@ export const ANTHROPIC_CONFIG: ProviderConfig = {
   defaultModel: "claude-sonnet-4-5-20250929",
 };
 
+/** Claude Code CLI subscription provider configuration */
+export const CLAUDE_CODE_CONFIG: ProviderConfig = {
+  apiKeyEnvVar: "",
+  providerName: "Claude Code CLI",
+  defaultModel: "sonnet",
+  apiKeyOptional: true,
+};
+
 /** Codex CLI subscription provider configuration */
 export const CODEX_CODE_CONFIG: ProviderConfig = {
   apiKeyEnvVar: "",
@@ -86,6 +94,7 @@ export function validateApiKey(config: ProviderConfig): string {
 /** All provider configs keyed by provider id (registry order) */
 export const PROVIDER_CONFIGS: Record<EvalProvider, ProviderConfig> = {
   anthropic: ANTHROPIC_CONFIG,
+  "claude-code": CLAUDE_CODE_CONFIG,
   "codex-code": CODEX_CODE_CONFIG,
   google: GEMINI_CONFIG,
   local: LOCAL_CONFIG,


### PR DESCRIPTION
Adds a `claude-code` eval transport, extracts the shared agent-CLI seam it needed, and gives that seam a real test harness.

Two commits, one per concern — **merge, don't squash**, so both survive in history.

### `feat(evals)`: Claude Code transport behind a shared agent-CLI seam

Claude Code is a documented Producer Pal install target with zero eval coverage today. `-m claude-code/sonnet` now drives the installed `claude` CLI as a subprocess, billing the logged-in subscription rather than a metered API key.

The Codex-shaped protocol module fused argv construction, JSONL parsing, and usage mapping; the session module next to it was already ~90% generic. Split along that line before copying the vendor-shaped file a second time:

| | |
|---|---|
| `evals/chat/agent-cli/` | spawn, session dirs, session-id continuity, turn rendering, JSONL scaffolding, judge |
| `evals/chat/<vendor>/` | argv, event schema, model naming |

Adding a CLI is now an `AgentCliTransport` value plus one registry entry. Every "AI SDK or subprocess?" branch — session factory, judge, provider factory, model listing, chat-CLI rejection — asks the registry instead of string-matching one provider id.

Claude Code specifics worth knowing:

- **Isolation is by subtraction, not a sandbox flag.** `--tools ""` drops every built-in tool, `--setting-sources ""` drops settings and plugins, `--disable-slash-commands` drops skills, `--strict-mcp-config` ignores MCP servers configured elsewhere, and `--system-prompt` replaces the coding-agent prompt (and the memory injected into it) with the eval's instructions. `--tools` and `--setting-sources` are variadic, so the empty value must be followed by another flag — a test pins that.
- **No equivalent of Codex's `mcp_servers.*.required=true`.** Claude Code runs the turn anyway with no tools, which would grade as a model that simply declined to use them. A non-connected server in the init event now fails the turn.
- **Tool names arrive namespaced** (`mcp__producer-pal__ppal-connect`); the prefix is stripped so tool-call assertions match every other transport.

Verified against the real CLI: MCP tool call, `--resume` continuity across turns, and an isolated judge call.

### `test(evals)`: fixture-binary seam

The subprocess, the multi-turn session state, and the judge had no tests — and CI would never have said so, since `evals/**` is in both the coverage include and exclude lists in `vitest.config.ts` (exclude wins), so eval tests run but are never measured.

`spawnAgentCli` already resolves its executable from the transport's `binEnvVar`. Pointing that at a fixture script that emits canned JSONL makes the whole transport testable with no vendor CLI and no network — a real child process, so the parts a mocked `spawn` would skip are actually exercised: a multi-byte character flushed across two stdout chunks, ENOENT, the timeout escalating past a swallowed SIGTERM to SIGKILL, non-zero-exit error construction, argv/prompt plumbing, and the private per-session working directory.

The session tests run against **every** transport, pinning the session-id handoff from turn 1's stream into turn 2's argv. That handoff is the entire multi-turn premise, and nothing else would catch it breaking: a session that silently restarts each turn still produces plausible output and still scores.

ENOENT previously surfaced as a bare `spawn codex ENOENT`, naming neither the provider that wanted it nor the env var that overrides it. It now says both.

### Notes

- `evals/` duplication went **down**: 0.38% → 0.34%, despite a second protocol module landing.
- No behavior change for existing providers; `codex-code` builds the same argv it did before.
- Gemini CLI (the third transport) is deliberately not in this PR — its non-interactive JSON streaming and multi-turn resume story need their own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)