### PR TITLE
feat(skills): omit skills fragments for tools that are disabled

### DIFF
--- a/dev/Architecture.md
+++ b/dev/Architecture.md
@@ -253,6 +253,26 @@ This is why the built-in skills blob — historically assembled in the V8
 picture: the override files are only readable from Node, so `buildSkills` runs
 where the filesystem lives and the result is injected into `ppal-connect`.
 
+### Per-request assembly
+
+`POST /mcp` builds a fresh `createMcpServer` per request, so two settings can
+vary per caller rather than per device. Both ride an HTTP header (see
+`src/shared/config.ts`), and both fall back to the global config when absent, so
+external MCP clients are unaffected:
+
+- `SMALL_MODEL_MODE_HEADER` — shrinks tool schemas and selects the `basic`
+  skills driver.
+- `DISABLED_TOOLS_HEADER` — a comma-separated **subtraction** from
+  `config.tools`. It withholds those tools from registration _and_ drops the
+  skills fragments that teach them (`src/skills/fragment-tool-gates.ts`), so a
+  caller never pays for guidance about a tool it can't call.
+
+The subtraction shape is what the webui can actually send: its `enabledTools` is
+a sparse map (absent = enabled), and the header must be set when the transport
+is built — before `listTools` could reveal the catalog a whitelist would need.
+Together these are what lets one server serve a full-strength orchestrator and
+several narrowly-scoped subagent workers concurrently.
+
 ## Build System
 
 Four separate bundles built with rollup.js (MCP server, V8, Portal) and Vite

--- a/docs/guide/chat-ui.md
+++ b/docs/guide/chat-ui.md
@@ -389,6 +389,12 @@ For state-of-the-art cloud providers (Gemini, OpenAI, etc), you generally want
 to keep everything enabled to make full use of Producer Pal's capabilities. If
 you want to prevent the AI from using a specific tool, you can disable it here.
 
+Disabling a tool also drops the part of the
+[Producer Pal Skills](/guide/customizing-skills) that teaches it — turn off
+library search and the AI stops being told how to search a library it can't
+reach. The saving is therefore bigger than the tool's own schema, and you don't
+have to trim skills by hand to match your toolset.
+
 Consult [the Features page](/features) for more info on what each tool does.
 
 <img src="/img/producer-pal-chat-settings-tools.png" alt="Tools settings" width="500"/>

--- a/docs/guide/customizing-skills.md
+++ b/docs/guide/customizing-skills.md
@@ -115,6 +115,17 @@ few rules:
 
 ## Trimming skills you don't need
 
+::: tip Disabling a tool already trims its skills
+
+Fragments are cut along tool lines, so turning a tool off drops the fragment
+that teaches it — automatically, wherever you turned it off: the Tools tab in
+the [Chat UI](/guide/chat-ui#tools) (per preset, and per subagent), or the tool
+list an external MCP client is configured with. Switch off library search and
+the library guide is gone from that conversation's skills. Reach for the manual
+trimming below for areas you want dropped while keeping the tool.
+
+:::
+
 If you never use a whole area of Producer Pal, remove its guidance: override the
 **Full skills (standard)** fragment and delete the include line for that area.
 Everything you keep continues to track the built-ins.
@@ -148,7 +159,9 @@ If you do delete a line something else needs, Producer Pal says so — the Skill
 ::: tip Check the result
 
 After editing, use the Skills tab's **Preview** view to see the assembled
-document, and start a new conversation for the change to take effect.
+document, and start a new conversation for the change to take effect. The
+preview shows what an external MCP client receives; a chat whose preset disables
+tools gets a shorter document still.
 
 :::
 

--- a/src/mcp-server/create-express-app.ts
+++ b/src/mcp-server/create-express-app.ts
@@ -5,16 +5,13 @@
 
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { ErrorCode } from "@modelcontextprotocol/sdk/types.js";
-import express, {
-  type Request,
-  type Response,
-  type NextFunction,
-  type Express,
-} from "express";
+import express, { type Request, type Response, type Express } from "express";
 import Max from "max-api";
 import chatUiHtml from "virtual:chat-ui-html";
 import {
+  DISABLED_TOOLS_HEADER,
   SMALL_MODEL_MODE_HEADER,
+  resolveEnabledTools,
   resolveSmallModelMode,
 } from "#src/shared/config.ts";
 import { errorMessage } from "#src/shared/error-utils.ts";
@@ -31,11 +28,9 @@ import {
 } from "./create-mcp-server.ts";
 import { type WrappedCallLiveApi } from "./helpers/connect/connect-append.ts";
 import { enrichConnect } from "./helpers/connect/enrich-connect.ts";
+import { corsMiddleware } from "./helpers/http/cors-middleware.ts";
 import { requestBody } from "./helpers/http/request-body.ts";
-import {
-  isLocalOrigin,
-  rejectCrossOriginWrite,
-} from "./helpers/http/request-origin.ts";
+import { rejectCrossOriginWrite } from "./helpers/http/request-origin.ts";
 import { registerProjectContextBackupNodeRoutes } from "./helpers/project-context-backup/project-context-backup-node-routes.ts";
 import { callLiveApi } from "./max-api-adapter.ts";
 import * as console from "./node-for-max-logger.ts";
@@ -164,26 +159,33 @@ function applyLiveApiEnabled(next: boolean): void {
 /**
  * Enrich ppal-connect Node-side with the skills, context, memory, and next-step
  * blocks (see enrich-connect.ts for the block order and why it matters).
- * config.projectContext is the per-Live Set context blob. smallModelMode arrives
- * through a getter (not config directly) so a POST /mcp request can supply its
- * own per-request value for the skills variant — the same value that shrinks its
- * tool schemas — while REST routes keep reading the live global.
+ * config.projectContext is the per-Live Set context blob. smallModelMode and the
+ * toolset arrive through getters (not config directly) so a POST /mcp request
+ * can supply its own per-request values — the same values that shrink its tool
+ * schemas and its registered tools — while REST routes keep reading the live
+ * globals.
  *
  * @param getSmallModelMode - Reads the small-model mode for this wrapper's calls
+ * @param getTools - Reads the toolset skills fragments are gated on
  * @returns A callLiveApi whose ppal-connect results carry every block
  */
 function buildEnrichedCall(
   getSmallModelMode: () => boolean,
+  getTools: () => readonly string[],
 ): WrappedCallLiveApi {
   return enrichConnect(callLiveApi, () => ({
     notation: config.notation,
     smallModelMode: getSmallModelMode(),
     projectContext: config.projectContext,
+    tools: getTools(),
   }));
 }
 
 // REST routes read the live global; POST /mcp builds its own per-request wrapper.
-const callLiveApiEnriched = buildEnrichedCall(() => config.smallModelMode);
+const callLiveApiEnriched = buildEnrichedCall(
+  () => config.smallModelMode,
+  () => config.tools,
+);
 
 interface JsonRpcError {
   jsonrpc: string;
@@ -229,50 +231,9 @@ function setNoStore(res: Response): void {
 export function createExpressApp(): Express {
   const app = express();
 
-  // CORS: by default reflect only localhost origins, so a browser page you
-  // serve locally (a dev server, the MCP Inspector, your own tool on another
-  // port) can call the API, while pages from the internet stay blocked. The
-  // Origin header is browser-set and can't be forged by page JS, so an internet
-  // page always carries its real domain and gets no header. Non-browser clients
-  // (curl, scripts, Max) ignore CORS entirely and are unaffected either way.
-  // Set ENABLE_REMOTE_CORS to widen this to any origin ("*") — needed only for
-  // browser dev tooling served from a non-localhost origin (a remote Inspector,
-  // LAN). Specify it manually on the CLI before a build; it is never baked into
-  // an npm script.
-  app.use((req: Request, res: Response, next: NextFunction): void => {
-    const origin = req.get("Origin");
-    let allowOrigin: string | null = null;
-
-    if (process.env.ENABLE_REMOTE_CORS === "true") {
-      allowOrigin = "*";
-    } else if (origin != null && isLocalOrigin(origin)) {
-      allowOrigin = origin;
-    }
-
-    if (allowOrigin != null) {
-      res.setHeader("Access-Control-Allow-Origin", allowOrigin);
-
-      // Reflected origins vary per request, so caches must key on Origin.
-      if (allowOrigin !== "*") {
-        res.setHeader("Vary", "Origin");
-      }
-
-      res.setHeader(
-        "Access-Control-Allow-Methods",
-        "GET, POST, OPTIONS, DELETE",
-      );
-      res.setHeader("Access-Control-Allow-Headers", "*");
-
-      // Answer the preflight for an allowed origin.
-      if (req.method === "OPTIONS") {
-        res.status(200).end();
-
-        return;
-      }
-    }
-
-    next();
-  });
+  // Localhost-only CORS by default; ENABLE_REMOTE_CORS widens it (see the
+  // middleware for the reasoning).
+  app.use(corsMiddleware);
 
   // Tool arguments with large MIDI note arrays or bar|beat transforms can
   // exceed Express's 100 KB default.
@@ -305,13 +266,25 @@ export function createExpressApp(): Express {
         config.smallModelMode,
       );
 
+      // Per-request tool subsetting: the chat and each subagent worker withhold
+      // the tools their preset turned off, so this caller neither registers
+      // those schemas nor receives the skills fragments that teach them. A
+      // subtraction from the global whitelist — absent ⇒ the global unchanged.
+      const requestTools = resolveEnabledTools(
+        req.get(DISABLED_TOOLS_HEADER),
+        config.tools,
+      );
+
       const server = createMcpServer(
-        buildEnrichedCall(() => requestSmallModelMode),
+        buildEnrichedCall(
+          () => requestSmallModelMode,
+          () => requestTools,
+        ),
         {
           smallModelMode: requestSmallModelMode,
           notation: config.notation,
           liveApiEnabled: config.liveApiEnabled,
-          tools: config.tools,
+          tools: requestTools,
         },
       );
       const transport = new StreamableHTTPServerTransport({
@@ -387,7 +360,7 @@ export function createExpressApp(): Express {
   registerCustomSkillsCollectionRoutes(app);
   registerSystemPromptRoutes(app);
   registerSkillOverridesRoutes(app);
-  registerSkillsPreviewRoute(app);
+  registerSkillsPreviewRoute(app, () => config.tools);
 
   registerVoiceTokenRoute(app);
   registerGeminiVoiceTokenRoute(app);

--- a/src/mcp-server/helpers/connect/enrich-connect.ts
+++ b/src/mcp-server/helpers/connect/enrich-connect.ts
@@ -20,6 +20,12 @@ export interface ConnectEnrichmentConfig {
   smallModelMode: boolean;
   /** This Live Set's context blob, held by the Max device (config, not fs). */
   projectContext: string;
+  /**
+   * The tools this caller can call — the global whitelist, or one request's
+   * narrowed set. Skills fragments teaching only tools that are off are dropped.
+   * Omitted ⇒ no gating (every fragment ships).
+   */
+  tools?: readonly string[];
 }
 
 /**
@@ -50,6 +56,7 @@ export function enrichConnect(
           withSkills(inner, () => ({
             notation: getConfig().notation,
             smallModelMode: getConfig().smallModelMode,
+            tools: getConfig().tools,
           })),
           () => getConfig().projectContext,
         ),

--- a/src/mcp-server/helpers/http/cors-middleware.ts
+++ b/src/mcp-server/helpers/http/cors-middleware.ts
@@ -1,0 +1,62 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray, Eike Haß
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type Request, type Response, type NextFunction } from "express";
+import { isLocalOrigin } from "./request-origin.ts";
+
+/**
+ * CORS middleware for the MCP server.
+ *
+ * By default it reflects only localhost origins, so a browser page you serve
+ * locally (a dev server, the MCP Inspector, your own tool on another port) can
+ * call the API, while pages from the internet stay blocked. The Origin header is
+ * browser-set and can't be forged by page JS, so an internet page always carries
+ * its real domain and gets no header. Non-browser clients (curl, scripts, Max)
+ * ignore CORS entirely and are unaffected either way.
+ *
+ * Set ENABLE_REMOTE_CORS to widen this to any origin ("*") — needed only for
+ * browser dev tooling served from a non-localhost origin (a remote Inspector,
+ * LAN). Specify it manually on the CLI before a build; it is never baked into an
+ * npm script.
+ *
+ * @param req - Express request
+ * @param res - Express response
+ * @param next - Next middleware in the chain
+ */
+export function corsMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const origin = req.get("Origin");
+  let allowOrigin: string | null = null;
+
+  if (process.env.ENABLE_REMOTE_CORS === "true") {
+    allowOrigin = "*";
+  } else if (origin != null && isLocalOrigin(origin)) {
+    allowOrigin = origin;
+  }
+
+  if (allowOrigin != null) {
+    res.setHeader("Access-Control-Allow-Origin", allowOrigin);
+
+    // Reflected origins vary per request, so caches must key on Origin.
+    if (allowOrigin !== "*") {
+      res.setHeader("Vary", "Origin");
+    }
+
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS, DELETE");
+    res.setHeader("Access-Control-Allow-Headers", "*");
+
+    // Answer the preflight for an allowed origin.
+    if (req.method === "OPTIONS") {
+      res.status(200).end();
+
+      return;
+    }
+  }
+
+  next();
+}

--- a/src/mcp-server/routes/skills-preview-route.ts
+++ b/src/mcp-server/routes/skills-preview-route.ts
@@ -30,9 +30,18 @@ import { readSkillOverrides } from "../helpers/skill-overrides-store.ts";
  * truncated blob. Read-only, so it is not origin-gated (unlike the override
  * writes) — it exposes nothing a GET /skill-overrides didn't already.
  *
+ * The preview reflects the DEVICE's tool whitelist, so a fragment whose tools
+ * are all switched off shows as gone here too — this is the blob an external MCP
+ * client receives. It cannot reflect the chat's per-preset tool toggles: those
+ * are client-side, ride a per-request header, and differ per conversation.
+ *
  * @param app - Express application
+ * @param getTools - Reads the device's tool whitelist; omit for no tool gating
  */
-export function registerSkillsPreviewRoute(app: Express): void {
+export function registerSkillsPreviewRoute(
+  app: Express,
+  getTools?: () => readonly string[],
+): void {
   app.get("/skills-preview", (req: Request, res: Response): void => {
     // Overrides can change on the device/filesystem between calls — never cache.
     res.set("Cache-Control", "no-store");
@@ -55,7 +64,7 @@ export function registerSkillsPreviewRoute(app: Express): void {
     // silently truncated blob.
     const warnings: string[] = [];
     const skills = buildSkills(
-      { notation, smallModelMode },
+      { notation, smallModelMode, tools: getTools?.() },
       readSkillOverrides(),
       (message) => warnings.push(message),
     );

--- a/src/mcp-server/tests/express-app/create-express-app-small-model-header.test.ts
+++ b/src/mcp-server/tests/express-app/create-express-app-small-model-header.test.ts
@@ -3,43 +3,23 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import Max from "max-api";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { SMALL_MODEL_MODE_HEADER } from "#src/shared/config.ts";
-import { MAX_ERROR_DELIMITER } from "#src/shared/mcp-response-utils.ts";
 import { setupExpressAppServer } from "../express-app-test-helpers.ts";
-
-type MockMax = typeof Max & {
-  defaultMcpResponseHandler:
-    ((requestId: string, ...chunks: string[]) => void) | null;
-};
-const mockMax = Max as MockMax;
+import {
+  connectSkillsBlock,
+  connectWithHeaders,
+  SKILLS_HEADER,
+} from "./mcp-header-test-helpers.ts";
 
 /**
- * Connect an MCP client to the server with (or without) the small-model-mode
- * header. The transport carries the header on every request the client makes.
+ * Headers for a given small-model-mode value, or none when it is omitted.
  *
- * @param serverUrl - The running server's /mcp URL
  * @param header - Value for the small-model-mode header, or undefined to omit it
- * @returns A connected client and its transport (close the transport when done)
+ * @returns The request headers to send
  */
-async function connectWithHeader(
-  serverUrl: string,
-  header: string | undefined,
-): Promise<{ client: Client; transport: StreamableHTTPClientTransport }> {
-  const client = new Client({ name: "test-client", version: "1.0.0" });
-  const transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
-    requestInit:
-      header == null
-        ? undefined
-        : { headers: { [SMALL_MODEL_MODE_HEADER]: header } },
-  });
-
-  await client.connect(transport);
-
-  return { client, transport };
+function headers(header: string | undefined): Record<string, string> {
+  return header == null ? {} : { [SMALL_MODEL_MODE_HEADER]: header };
 }
 
 /**
@@ -56,60 +36,16 @@ async function createTrackHasCount(
   serverUrl: string,
   header: string | undefined,
 ): Promise<boolean> {
-  const { client, transport } = await connectWithHeader(serverUrl, header);
+  const { client, transport } = await connectWithHeaders(
+    serverUrl,
+    headers(header),
+  );
 
   try {
     const { tools } = await client.listTools();
     const createTrack = tools.find((t) => t.name === "ppal-create-track");
 
     return createTrack?.inputSchema.properties?.count != null;
-  } finally {
-    await transport.close();
-  }
-}
-
-/**
- * Call ppal-connect with a header and return the injected skills block — the
- * text block starting with the skills heading, which enrich-connect appends
- * Node-side and which varies (basic vs standard) by small-model mode. This is
- * the second consumer the header drives. Max is mocked to return a bare success
- * so the connect handler resolves and enrichment runs.
- *
- * @param serverUrl - The running server's /mcp URL
- * @param header - Value for the small-model-mode header, or undefined to omit it
- * @returns The injected skills block text, or "" when none was found
- */
-async function connectSkillsBlock(
-  serverUrl: string,
-  header: string | undefined,
-): Promise<string> {
-  Max.outlet = vi.fn((message: string, requestId: string) => {
-    if (message === "mcp_request") {
-      setTimeout(() => {
-        mockMax.defaultMcpResponseHandler!(
-          requestId,
-          JSON.stringify({ content: [{ type: "text", text: "{}" }] }),
-          MAX_ERROR_DELIMITER,
-        );
-      }, 1);
-    }
-
-    return Promise.resolve();
-  }) as typeof Max.outlet;
-
-  const { client, transport } = await connectWithHeader(serverUrl, header);
-
-  try {
-    const result = await client.callTool({
-      name: "ppal-connect",
-      arguments: {},
-    });
-    const content = result.content as Array<{ type: string; text?: string }>;
-
-    return (
-      content.find((c) => c.text?.startsWith("# Producer Pal Skills"))?.text ??
-      ""
-    );
   } finally {
     await transport.close();
   }
@@ -147,12 +83,18 @@ describe("POST /mcp per-request small-model-mode header", () => {
 
   describe("skills variant", () => {
     it("serves a different skills variant per-request driven by the header", async () => {
-      const basic = await connectSkillsBlock(appState.serverUrl, "true");
-      const standard = await connectSkillsBlock(appState.serverUrl, "false");
+      const basic = await connectSkillsBlock(
+        appState.serverUrl,
+        headers("true"),
+      );
+      const standard = await connectSkillsBlock(
+        appState.serverUrl,
+        headers("false"),
+      );
 
       // Both connect requests inject a skills block...
-      expect(basic.startsWith("# Producer Pal Skills")).toBe(true);
-      expect(standard.startsWith("# Producer Pal Skills")).toBe(true);
+      expect(basic.startsWith(SKILLS_HEADER)).toBe(true);
+      expect(standard.startsWith(SKILLS_HEADER)).toBe(true);
       // ...but the small-model (basic) variant differs from the standard one,
       // proving the per-request header — not just the global — selects it.
       expect(basic).not.toBe(standard);

--- a/src/mcp-server/tests/express-app/create-express-app-tool-gating.test.ts
+++ b/src/mcp-server/tests/express-app/create-express-app-tool-gating.test.ts
@@ -1,0 +1,141 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { DISABLED_TOOLS_HEADER } from "#src/shared/config.ts";
+import { setupExpressAppServer } from "../express-app-test-helpers.ts";
+import {
+  connectSkillsBlock,
+  listToolNames,
+  SKILLS_HEADER,
+} from "./mcp-header-test-helpers.ts";
+
+/** The section heading the ppal-library fragment owns. */
+const LIBRARY_SECTION = "## Finding Library Content";
+
+/**
+ * Headers withholding the given tools, or none when the list is empty.
+ *
+ * @param disabled - Tool names this request withholds
+ * @returns The request headers to send
+ */
+function headers(...disabled: string[]): Record<string, string> {
+  return disabled.length === 0
+    ? {}
+    : { [DISABLED_TOOLS_HEADER]: disabled.join(",") };
+}
+
+// The harness leaves the global config.tools at its default (every tool).
+const appState = setupExpressAppServer();
+
+describe("POST /mcp per-request disabled-tools header", () => {
+  describe("tool registration", () => {
+    it("withholds the named tools from this request", async () => {
+      const names = await listToolNames(
+        appState.serverUrl,
+        headers("ppal-library", "ppal-playback"),
+      );
+
+      expect(names).not.toContain("ppal-library");
+      expect(names).not.toContain("ppal-playback");
+      expect(names).toContain("ppal-connect");
+    });
+
+    it("serves the full toolset when the header is absent", async () => {
+      // Proves an external MCP client that sends no header is unaffected.
+      expect(await listToolNames(appState.serverUrl, headers())).toContain(
+        "ppal-library",
+      );
+    });
+
+    it("ignores a name the server doesn't offer", async () => {
+      const names = await listToolNames(
+        appState.serverUrl,
+        headers("spawn_subagent"),
+      );
+
+      expect(names).toContain("ppal-connect");
+    });
+
+    it("does not leak one request's toolset onto the next", async () => {
+      await listToolNames(appState.serverUrl, headers("ppal-library"));
+
+      expect(await listToolNames(appState.serverUrl, headers())).toContain(
+        "ppal-library",
+      );
+    });
+  });
+
+  describe("skills gating", () => {
+    it("omits the skills fragment for a tool this request withheld", async () => {
+      const gated = await connectSkillsBlock(
+        appState.serverUrl,
+        headers("ppal-library"),
+      );
+
+      expect(gated.startsWith(SKILLS_HEADER)).toBe(true);
+      expect(gated).not.toContain(LIBRARY_SECTION);
+      // Only that fragment goes — the rest of the document is intact.
+      expect(gated).toContain("## Devices & Instruments");
+    });
+
+    it("keeps every fragment when the header is absent", async () => {
+      const full = await connectSkillsBlock(appState.serverUrl, headers());
+
+      expect(full).toContain(LIBRARY_SECTION);
+    });
+
+    it("shrinks the blob in proportion to what was withheld", async () => {
+      const full = await connectSkillsBlock(appState.serverUrl, headers());
+      const narrow = await connectSkillsBlock(
+        appState.serverUrl,
+        headers(
+          "ppal-library",
+          "ppal-read-device",
+          "ppal-create-device",
+          "ppal-update-device",
+        ),
+      );
+
+      expect(narrow).not.toContain(LIBRARY_SECTION);
+      expect(narrow).not.toContain("## Devices & Instruments");
+      expect(narrow).not.toContain("### Specialized Device Controls");
+      expect(narrow.length).toBeLessThan(full.length);
+    });
+  });
+});
+
+describe("GET /skills-preview tool gating", () => {
+  /**
+   * Fetch the assembled preview blob.
+   *
+   * @returns The `skills` field of the preview response
+   */
+  async function fetchPreview(): Promise<string> {
+    const response = await fetch(`${appState.baseUrl}/skills-preview`);
+    const body = (await response.json()) as { skills: string };
+
+    return body.skills;
+  }
+
+  it("reflects the device tool whitelist, not just the built-in manifest", async () => {
+    // What the preview promises is the blob an external MCP client receives, so
+    // a tool switched off on the device has to show as gone here too.
+    expect(await fetchPreview()).toContain(LIBRARY_SECTION);
+
+    const configResponse = await fetch(appState.configUrl);
+    const full = (await configResponse.json()) as { tools: string[] };
+
+    try {
+      await appState.postConfig({
+        tools: full.tools.filter((name) => name !== "ppal-library"),
+      });
+
+      expect(await fetchPreview()).not.toContain(LIBRARY_SECTION);
+    } finally {
+      await appState.postConfig({ tools: full.tools });
+    }
+  });
+});

--- a/src/mcp-server/tests/express-app/mcp-header-test-helpers.ts
+++ b/src/mcp-server/tests/express-app/mcp-header-test-helpers.ts
@@ -1,0 +1,115 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Shared harness for the POST /mcp per-request header suites (small-model mode,
+// disabled tools). Both headers ride the same transport and drive the same two
+// consumers — the registered tools/schemas a client lists, and the skills block
+// enrich-connect appends to ppal-connect — so the plumbing lives here once.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import Max from "max-api";
+import { vi } from "vitest";
+import { MAX_ERROR_DELIMITER } from "#src/shared/mcp-response-utils.ts";
+
+type MockMax = typeof Max & {
+  defaultMcpResponseHandler:
+    ((requestId: string, ...chunks: string[]) => void) | null;
+};
+
+const mockMax = Max as MockMax;
+
+/** Prefix identifying the skills block among a connect result's text blocks. */
+export const SKILLS_HEADER = "# Producer Pal Skills";
+
+/**
+ * Connect an MCP client carrying the given headers. The transport applies them
+ * to every request the client makes; pass `{}` to send none.
+ *
+ * @param serverUrl - The running server's /mcp URL
+ * @param headers - Request headers to send, or `{}` for a bare client
+ * @returns A connected client and its transport (close the transport when done)
+ */
+export async function connectWithHeaders(
+  serverUrl: string,
+  headers: Record<string, string>,
+): Promise<{ client: Client; transport: StreamableHTTPClientTransport }> {
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  const transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
+    requestInit:
+      Object.keys(headers).length === 0
+        ? undefined
+        : { headers: { ...headers } },
+  });
+
+  await client.connect(transport);
+
+  return { client, transport };
+}
+
+/**
+ * The tool names a client sees with the given headers.
+ *
+ * @param serverUrl - The running server's /mcp URL
+ * @param headers - Request headers to send
+ * @returns The listed tool names
+ */
+export async function listToolNames(
+  serverUrl: string,
+  headers: Record<string, string>,
+): Promise<string[]> {
+  const { client, transport } = await connectWithHeaders(serverUrl, headers);
+
+  try {
+    const { tools } = await client.listTools();
+
+    return tools.map((tool) => tool.name);
+  } finally {
+    await transport.close();
+  }
+}
+
+/**
+ * Call ppal-connect with the given headers and return the injected skills block
+ * — the text block starting with the skills heading, which enrich-connect
+ * appends Node-side. Max is mocked to return a bare success so the connect
+ * handler resolves and enrichment runs.
+ *
+ * @param serverUrl - The running server's /mcp URL
+ * @param headers - Request headers to send
+ * @returns The injected skills block text, or "" when none was found
+ */
+export async function connectSkillsBlock(
+  serverUrl: string,
+  headers: Record<string, string>,
+): Promise<string> {
+  Max.outlet = vi.fn((message: string, requestId: string) => {
+    if (message === "mcp_request") {
+      setTimeout(() => {
+        mockMax.defaultMcpResponseHandler?.(
+          requestId,
+          JSON.stringify({ content: [{ type: "text", text: "{}" }] }),
+          MAX_ERROR_DELIMITER,
+        );
+      }, 1);
+    }
+
+    return Promise.resolve();
+  }) as typeof Max.outlet;
+
+  const { client, transport } = await connectWithHeaders(serverUrl, headers);
+
+  try {
+    const result = await client.callTool({
+      name: "ppal-connect",
+      arguments: {},
+    });
+    const content = result.content as Array<{ type: string; text?: string }>;
+
+    return content.find((c) => c.text?.startsWith(SKILLS_HEADER))?.text ?? "";
+  } finally {
+    await transport.close();
+  }
+}

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -118,3 +118,49 @@ export function resolveSmallModelMode(
 
   return fallback;
 }
+
+// --- Per-request tool subsetting (MCP transport) ---
+
+/**
+ * HTTP header that narrows one request's toolset: a comma-separated list of
+ * tools to withhold from the server's configured set.
+ *
+ * A SUBTRACTION rather than a whitelist, for two reasons. The client-side
+ * toggles it carries are themselves a sparse map where absent means enabled, and
+ * the header has to be set when the transport is built — before `listTools`
+ * could tell the caller what the full catalog even is. Subtracting needs no
+ * catalog: a name the server doesn't know is simply a no-op, and a tool added in
+ * a later release stays enabled by default.
+ *
+ * It drives BOTH tool registration (the caller's `listTools` shrinks, so it
+ * isn't paying for schemas it disabled) and the skills variant — a fragment
+ * teaching only withheld tools is dropped from the ppal-connect blob. Absent ⇒
+ * the server's global `config.tools`, so external MCP clients are unaffected;
+ * same contract as {@link SMALL_MODEL_MODE_HEADER}.
+ */
+export const DISABLED_TOOLS_HEADER = "x-producer-pal-disabled-tools";
+
+/**
+ * Resolve the tools available to one request: the server's configured set minus
+ * anything the request's header withholds. An absent or empty header leaves the
+ * configured set untouched.
+ *
+ * @param headerValue - The request's header value, or undefined when absent
+ * @param configuredTools - The server's global `config.tools`
+ * @returns The tools to register and to gate skills fragments on
+ */
+export function resolveEnabledTools(
+  headerValue: string | undefined,
+  configuredTools: readonly string[],
+): string[] {
+  const disabled = new Set(
+    (headerValue ?? "")
+      .split(",")
+      .map((name) => name.trim())
+      .filter((name) => name !== ""),
+  );
+
+  if (disabled.size === 0) return [...configuredTools];
+
+  return configuredTools.filter((name) => !disabled.has(name));
+}

--- a/src/shared/tests/config.test.ts
+++ b/src/shared/tests/config.test.ts
@@ -6,10 +6,12 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   BUILD_SHA,
+  DISABLED_TOOLS_HEADER,
   MIN_LIVE_VERSION,
   SAME_TIME_EPSILON,
   SMALL_MODEL_MODE_HEADER,
   VERSION,
+  resolveEnabledTools,
   resolveSmallModelMode,
 } from "#src/shared/config.ts";
 
@@ -74,5 +76,57 @@ describe("resolveSmallModelMode", () => {
     expect(resolveSmallModelMode("1", true)).toBe(true);
     expect(resolveSmallModelMode("yes", false)).toBe(false);
     expect(resolveSmallModelMode("", true)).toBe(true);
+  });
+});
+
+describe("resolveEnabledTools", () => {
+  const CONFIGURED = ["ppal-connect", "ppal-read-clip", "ppal-library"];
+
+  it("is a lowercase header name (HTTP headers are matched case-insensitively)", () => {
+    expect(DISABLED_TOOLS_HEADER).toBe(DISABLED_TOOLS_HEADER.toLowerCase());
+  });
+
+  it("returns the configured set when the header is absent or empty", () => {
+    expect(resolveEnabledTools(undefined, CONFIGURED)).toStrictEqual(
+      CONFIGURED,
+    );
+    expect(resolveEnabledTools("", CONFIGURED)).toStrictEqual(CONFIGURED);
+    expect(resolveEnabledTools(" , ", CONFIGURED)).toStrictEqual(CONFIGURED);
+  });
+
+  it("copies rather than aliasing the configured set", () => {
+    // The caller holds the live config.tools array; a request must not be able
+    // to hand a mutable reference to it around.
+    expect(resolveEnabledTools(undefined, CONFIGURED)).not.toBe(CONFIGURED);
+  });
+
+  it("subtracts the named tools", () => {
+    expect(resolveEnabledTools("ppal-library", CONFIGURED)).toStrictEqual([
+      "ppal-connect",
+      "ppal-read-clip",
+    ]);
+    expect(
+      resolveEnabledTools("ppal-library,ppal-read-clip", CONFIGURED),
+    ).toStrictEqual(["ppal-connect"]);
+  });
+
+  it("tolerates whitespace and stray separators", () => {
+    expect(
+      resolveEnabledTools(" ppal-library , , ppal-read-clip ", CONFIGURED),
+    ).toStrictEqual(["ppal-connect"]);
+  });
+
+  it("ignores names the server doesn't offer", () => {
+    // A subtraction needs no catalog: an unknown name — a client-side tool, or
+    // one from a newer build — is a no-op rather than an error.
+    expect(
+      resolveEnabledTools("spawn_subagent,ppal-nonesuch", CONFIGURED),
+    ).toStrictEqual(CONFIGURED);
+  });
+
+  it("can empty the toolset entirely", () => {
+    expect(resolveEnabledTools(CONFIGURED.join(","), CONFIGURED)).toStrictEqual(
+      [],
+    );
   });
 });

--- a/src/skills/build-skills.ts
+++ b/src/skills/build-skills.ts
@@ -8,6 +8,7 @@ import {
   builtinFragments,
   resolveFragmentAlias,
 } from "#src/skills/builtin-fragments.ts";
+import { gatedOutFragments } from "#src/skills/fragment-tool-gates.ts";
 import { resolveIncludes } from "#src/skills/include-resolver.ts";
 import {
   isSkillSlotName,
@@ -21,6 +22,12 @@ export interface BuildSkillsOptions {
   notation?: Notation;
   /** Whether small-model mode is active (selects the basic driver). */
   smallModelMode?: boolean;
+  /**
+   * The tools this caller can actually call. Fragments teaching only disabled
+   * tools are dropped (see fragment-tool-gates.ts). Omit when the toolset isn't
+   * known — every fragment then ships, which is the safe direction.
+   */
+  tools?: readonly string[];
 }
 
 /**
@@ -38,9 +45,17 @@ export type SkillOverrides = Record<string, string>;
  * directives in that driver. Each fragment resolves to the user's override when
  * present, else the release built-in.
  *
+ * A fragment whose tools are all disabled resolves to an EMPTY body rather than
+ * being skipped, matching how a release build handles `code-transforms`: the
+ * driver's include line stays valid, so an unknown fragment keeps meaning a
+ * stale reference worth warning about. Gating is applied AFTER the override
+ * lookup — a customized `library.md` is just as dead as the built-in when the
+ * library tool is off.
+ *
  * @param options - Runtime context ({@link BuildSkillsOptions}).
  * @param options.notation - The global notation setting (defaults to bar|beat).
  * @param options.smallModelMode - Whether small-model mode is active.
+ * @param options.tools - The tools available to this caller (omit for no gating).
  * @param overrides - Per-fragment user overrides (empty by default).
  * @param onWarn - Sink for non-fatal assembly warnings (unknown fragments,
  *   refused nesting, unsafe refs, overrides keyed to a retired slot name).
@@ -53,12 +68,14 @@ export function buildSkills(
   {
     notation = DEFAULT_NOTATION,
     smallModelMode = false,
+    tools,
   }: BuildSkillsOptions = {},
   overrides: SkillOverrides = {},
   onWarn?: (message: string) => void,
 ): string {
   const builtIns = builtinFragments();
   const root = smallModelMode ? "basic" : "standard";
+  const gatedOut = gatedOutFragments(tools);
 
   warnRetiredOverrides(overrides, onWarn);
 
@@ -67,6 +84,8 @@ export function buildSkills(
     notation,
     lookup: (name) => {
       const key = resolveFragmentAlias(name);
+
+      if (gatedOut.has(key)) return "";
 
       return overrides[key] ?? builtIns[key] ?? null;
     },

--- a/src/skills/fragment-tool-gates.ts
+++ b/src/skills/fragment-tool-gates.ts
@@ -1,0 +1,134 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Which tools each skills fragment teaches. Disabling a tool used to leave its
+// guidance in the blob — a user who turned ppal-library off still paid ~750
+// tokens learning to search a library the model could not reach. This table is
+// what lets assembly drop that.
+//
+// The rule runs in ONE direction only. Tool disabled ⇒ drop its fragments: safe,
+// automatic, no judgment. The converse (tool enabled ⇒ include its fragments) is
+// merely a heuristic — anything that can edit a clip would otherwise be handed
+// every waveform and ratchet — so it is preset-authoring guidance, not runtime
+// logic, and does not live here.
+//
+// Gates are ANY-OF: a fragment ships when at least one of its tools is live.
+// Most fragments serve two or three (the notation head serves five), so a single
+// owning tool per fragment was never the shape of this.
+//
+// The table is keyed by FRAGMENT name rather than declared on SkillSlotDef
+// because a gate is a runtime concern while a slot is an authoring one, and the
+// two sets differ: `code-transforms` is a real fragment with no override slot.
+// A test asserts every fragment has an entry, so adding one forces the decision.
+
+// The two clip writers, named because three separate gates reach for them.
+const CREATE_CLIP = "ppal-create-clip";
+const UPDATE_CLIP = "ppal-update-clip";
+
+/**
+ * Tools that carry clip `notes` in either direction — the three read tools all
+ * have a `notes` include, and create/update-clip take notes as input. Any one of
+ * them makes the notation head load-bearing.
+ */
+const NOTE_TOOLS = [
+  "ppal-read-clip",
+  CREATE_CLIP,
+  UPDATE_CLIP,
+  "ppal-read-track",
+  "ppal-read-scene",
+] as const;
+
+/** The tools whose schemas accept `transforms` / `preTransforms`. */
+const TRANSFORM_TOOLS = [CREATE_CLIP, UPDATE_CLIP, "ppal-duplicate"] as const;
+
+/** The three device tools; the path grammar and build recipes serve all of them. */
+const DEVICE_TOOLS = [
+  "ppal-read-device",
+  "ppal-create-device",
+  "ppal-update-device",
+] as const;
+
+/**
+ * A fragment's condition for shipping: the tools it teaches (any-of), or one of
+ * two reasons no toolset can decide it.
+ *
+ * - `"always"` — needed regardless of toolset. `time-and-values` defines the
+ *   units every other fragment's numbers are in; `working-with-live` is
+ *   music-making judgment that outlives any one tool.
+ * - `"conversation-only"` — maps to no tool at all, because its subject is what
+ *   to TELL someone when a tool won't do. Tool gating can never drop it; the
+ *   audience gating that should (a subagent worker has no user to explain
+ *   anything to) is a separate axis this table doesn't model yet.
+ */
+export type FragmentGate = readonly string[] | "always" | "conversation-only";
+
+/**
+ * Fragment name → the condition under which it ships. Drivers are absent: they
+ * are the roots being assembled, not sections of the assembly.
+ */
+export const FRAGMENT_GATES: Record<string, FragmentGate> = {
+  "time-and-values": "always",
+  "working-with-live": "always",
+  "getting-help": "conversation-only",
+
+  "transforms-core": TRANSFORM_TOOLS,
+  "transforms-expressions": TRANSFORM_TOOLS,
+  "transforms-generative": TRANSFORM_TOOLS,
+  "code-transforms": TRANSFORM_TOOLS,
+
+  library: ["ppal-library"],
+  devices: DEVICE_TOOLS,
+  // Reading a Drift or an EQ Eight benefits from the pseudo-param names as much
+  // as writing one does, so this is not update-device alone. It stays a strict
+  // subset of the devices gate — see the requires-subset test.
+  "specialized-devices": ["ppal-read-device", "ppal-update-device"],
+  // Moving clips is update-clip; take lanes are create-clip and duplicate.
+  arrangement: [UPDATE_CLIP, "ppal-duplicate", CREATE_CLIP],
+
+  "context-standard": ["ppal-context"],
+  "context-basic": ["ppal-context"],
+
+  "barbeat-standard": NOTE_TOOLS,
+  "barbeat-basic": NOTE_TOOLS,
+  "stark-standard": NOTE_TOOLS,
+  "stark-basic": NOTE_TOOLS,
+  "midi-json": NOTE_TOOLS,
+};
+
+/**
+ * The fragments to drop for a given toolset: those whose every tool is off.
+ *
+ * No transitive close over {@link SkillSlotDef.requires} happens here, and none
+ * is needed — a dependent's gate is required to be a SUBSET of the gate of what
+ * it requires (enforced by test), so a kept fragment's prerequisites are kept
+ * too. That is what keeps gating from reintroducing the vocabulary-without-
+ * grammar failure `requires` exists to catch, and it does it statically, where
+ * the mistake would actually be made (editing this table) rather than at
+ * assembly time in a loop no real toolset could reach.
+ *
+ * @param enabledTools - The tools available to this caller; omit for no gating
+ *   (every fragment ships, which is what a caller that doesn't know its toolset
+ *   should get)
+ * @returns Names of the fragments to omit
+ */
+export function gatedOutFragments(
+  enabledTools?: readonly string[],
+): ReadonlySet<string> {
+  const dropped = new Set<string>();
+
+  if (enabledTools == null) return dropped;
+
+  const live = new Set(enabledTools);
+
+  for (const [name, gate] of Object.entries(FRAGMENT_GATES)) {
+    if (typeof gate === "string") continue;
+
+    if (!gate.some((tool) => live.has(tool))) {
+      dropped.add(name);
+    }
+  }
+
+  return dropped;
+}

--- a/src/skills/tests/build-skills.test.ts
+++ b/src/skills/tests/build-skills.test.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { TOOL_NAMES } from "#src/mcp-server/create-mcp-server.ts";
 import { NOTATIONS } from "#src/shared/notation.ts";
 import { buildSkills } from "#src/skills/build-skills.ts";
 import { standardDriver } from "#src/skills/drivers.ts";
@@ -381,6 +382,89 @@ describe("buildSkills - overrides", () => {
 
     expect(result).toBe("MY INTRO\n\nMY OWN NOTATION GUIDE");
     expect(result).not.toContain("## Time & Note Values");
+  });
+});
+
+describe("buildSkills - tool gating", () => {
+  const ALL_TOOLS = [...TOOL_NAMES];
+
+  it("ships everything when the toolset is not supplied", () => {
+    expect(buildSkills({ notation: "barbeat" })).toBe(
+      buildSkills({ notation: "barbeat", tools: ALL_TOOLS }),
+    );
+  });
+
+  it("drops a section whose every tool is off, and says nothing about it", () => {
+    // Disabling a tool is a setting, not a broken document — no warning.
+    const warnings: string[] = [];
+    const result = buildSkills(
+      {
+        notation: "barbeat",
+        tools: ALL_TOOLS.filter((name) => name !== "ppal-library"),
+      },
+      {},
+      (message) => warnings.push(message),
+    );
+
+    expect(result).not.toContain("## Finding Library Content");
+    expect(result).toContain("## Devices & Instruments");
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("drops a user's override of a gated fragment too", () => {
+    // The override slot is named for the fragment's subject, so a customized
+    // library guide is exactly as dead as the built-in when the tool is off.
+    const result = buildSkills(
+      {
+        notation: "barbeat",
+        tools: ALL_TOOLS.filter((name) => name !== "ppal-library"),
+      },
+      { library: "MY LIBRARY NOTES" },
+    );
+
+    expect(result).not.toContain("MY LIBRARY NOTES");
+  });
+
+  it("drops a dependent together with what it requires, never alone", () => {
+    const warnings: string[] = [];
+    const result = buildSkills(
+      {
+        notation: "barbeat",
+        tools: ALL_TOOLS.filter((name) => !name.endsWith("-device")),
+      },
+      {},
+      (message) => warnings.push(message),
+    );
+
+    expect(result).not.toContain("## Devices & Instruments");
+    expect(result).not.toContain("### Specialized Device Controls");
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("cuts the blob down to the conversational core for a minimal toolset", () => {
+    const full = buildSkills({ notation: "barbeat", tools: ALL_TOOLS });
+    const minimal = buildSkills({
+      notation: "barbeat",
+      tools: ["ppal-connect", "ppal-playback", "ppal-select"],
+    });
+
+    expect(minimal).toContain("## Time & Note Values");
+    expect(minimal).toContain("## Working with Ableton Live");
+    expect(minimal).toContain("## Getting Help");
+    expect(minimal).not.toContain("## Positions & Meter"); // bar|beat head
+    expect(minimal).not.toContain("## Transforms");
+    expect(minimal).not.toContain("## Context & Memory");
+    expect(minimal.length).toBeLessThan(full.length / 2);
+  });
+
+  it("gates the small-model document the same way", () => {
+    const result = buildSkills({
+      smallModelMode: true,
+      tools: ALL_TOOLS.filter((name) => name !== "ppal-context"),
+    });
+
+    expect(result).toContain(HEADER);
+    expect(result).not.toContain("## Context");
   });
 });
 

--- a/src/skills/tests/fragment-tool-gates.test.ts
+++ b/src/skills/tests/fragment-tool-gates.test.ts
@@ -1,0 +1,131 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { TOOL_NAMES } from "#src/mcp-server/create-mcp-server.ts";
+import { builtinFragments } from "#src/skills/builtin-fragments.ts";
+import {
+  FRAGMENT_GATES,
+  gatedOutFragments,
+} from "#src/skills/fragment-tool-gates.ts";
+import { SKILL_SLOT_NAMES, SKILL_SLOTS } from "#src/skills/skill-slots.ts";
+
+// The driver roots are what gets assembled, not sections of the assembly, so
+// they carry no gate.
+const DRIVERS = new Set(["standard", "basic"]);
+
+const ALL_TOOLS = [...TOOL_NAMES, "ppal-live-api"];
+
+/**
+ * The tools a fragment's gate names, or null when it ships unconditionally.
+ *
+ * @param name - Fragment name
+ * @returns The gate's tool list, or null for an "always"/"conversation-only" gate
+ */
+function gateTools(name: string): readonly string[] | null {
+  const gate = FRAGMENT_GATES[name];
+
+  return gate == null || typeof gate === "string" ? null : gate;
+}
+
+describe("FRAGMENT_GATES", () => {
+  it("declares a gate for every fragment", () => {
+    // Forces the decision when a fragment is added: no entry would silently mean
+    // "always ships", which is exactly the waste this table exists to remove.
+    const fragments = Object.keys(builtinFragments()).filter(
+      (name) => !DRIVERS.has(name),
+    );
+
+    for (const name of fragments) {
+      expect(FRAGMENT_GATES[name], `${name} has no gate`).toBeDefined();
+    }
+  });
+
+  it("names only real tools", () => {
+    for (const [name, gate] of Object.entries(FRAGMENT_GATES)) {
+      if (typeof gate === "string") continue;
+
+      expect(gate.length, `${name} gates on nothing`).toBeGreaterThan(0);
+
+      for (const tool of gate) {
+        expect(ALL_TOOLS, `${name} gates on unknown ${tool}`).toContain(tool);
+      }
+    }
+  });
+
+  it("gates a dependent no more widely than what it requires", () => {
+    // THE invariant that lets gating skip a transitive close: if X requires Y,
+    // every toolset that keeps X must keep Y. Violate it and gating reintroduces
+    // the vocabulary-without-grammar failure `requires` exists to catch — the
+    // model holding ratchet() and the waveforms with no transform syntax.
+    for (const name of SKILL_SLOT_NAMES) {
+      const gate = gateTools(name);
+
+      if (gate == null) continue;
+
+      for (const required of SKILL_SLOTS[name].requires ?? []) {
+        const requiredGate = gateTools(required);
+
+        if (requiredGate == null) continue;
+
+        for (const tool of gate) {
+          expect(
+            requiredGate,
+            `${tool} keeps ${name} but drops ${required}`,
+          ).toContain(tool);
+        }
+      }
+    }
+  });
+});
+
+describe("gatedOutFragments", () => {
+  it("drops nothing when the toolset is unknown", () => {
+    expect(gatedOutFragments().size).toBe(0);
+  });
+
+  it("drops nothing when every tool is enabled", () => {
+    expect(gatedOutFragments(ALL_TOOLS).size).toBe(0);
+  });
+
+  it("keeps a fragment when ANY of its tools is enabled", () => {
+    // devices gates on read/create/update-device; one is enough.
+    expect(gatedOutFragments(["ppal-create-device"])).not.toContain("devices");
+    expect(gatedOutFragments(["ppal-read-device"])).not.toContain("devices");
+  });
+
+  it("drops a fragment only when all of its tools are off", () => {
+    const dropped = gatedOutFragments(["ppal-connect", "ppal-library"]);
+
+    expect(dropped).toContain("devices");
+    expect(dropped).toContain("transforms-core");
+    expect(dropped).toContain("arrangement");
+    expect(dropped).not.toContain("library");
+  });
+
+  it("never drops the always-on or conversation-only fragments", () => {
+    const dropped = gatedOutFragments(["ppal-connect"]);
+
+    expect(dropped).not.toContain("time-and-values");
+    expect(dropped).not.toContain("working-with-live");
+    expect(dropped).not.toContain("getting-help");
+  });
+
+  it("drops the notation heads only when nothing reads or writes notes", () => {
+    expect(gatedOutFragments(["ppal-read-track"])).not.toContain(
+      "barbeat-standard",
+    );
+    expect(gatedOutFragments(["ppal-playback"])).toContain("barbeat-standard");
+  });
+
+  it("drops specialized-devices while keeping devices for a build-only toolset", () => {
+    // create-device builds a rack; the per-device pseudo-param catalog is for
+    // reading and updating them.
+    const dropped = gatedOutFragments(["ppal-create-device"]);
+
+    expect(dropped).toContain("specialized-devices");
+    expect(dropped).not.toContain("devices");
+  });
+});

--- a/webui/src/chat/helpers/mcp-client-helpers.ts
+++ b/webui/src/chat/helpers/mcp-client-helpers.ts
@@ -7,7 +7,10 @@
  */
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { SMALL_MODEL_MODE_HEADER } from "#src/shared/config";
+import {
+  DISABLED_TOOLS_HEADER,
+  SMALL_MODEL_MODE_HEADER,
+} from "#src/shared/config";
 
 const MCP_CLIENT_NAME = "producer-pal-chat-ui";
 const MCP_CLIENT_VERSION = "1.0.0";
@@ -28,23 +31,39 @@ export interface McpToolDefinition {
  * subagent worker) independent of the global default. Omit it — as the voice
  * paths do — to send no header and let the server fall back to the global.
  *
+ * `enabledTools` likewise rides along as a header, listing only what this caller
+ * turned OFF: the server then neither registers those tools nor sends the skills
+ * fragments that teach them. The settings connection (which needs the full
+ * catalog to draw the toggles) passes neither argument and sends no headers.
+ *
  * @param mcpUrl - URL of the MCP server
  * @param smallModelMode - Per-request small-model mode; omit to use the global
+ * @param enabledTools - Map of tool name to enabled state (absent = enabled);
+ *   omit to leave the server's toolset untouched
  * @returns Connected MCP client
  */
 export async function createConnectedMcpClient(
   mcpUrl: string,
   smallModelMode?: boolean,
+  enabledTools?: Record<string, boolean>,
 ): Promise<Client> {
+  const headers: Record<string, string> = {};
+
+  if (smallModelMode != null) {
+    headers[SMALL_MODEL_MODE_HEADER] = String(smallModelMode);
+  }
+
+  const disabled = disabledToolNames(enabledTools);
+
+  if (disabled !== "") {
+    headers[DISABLED_TOOLS_HEADER] = disabled;
+  }
+
   const transport = new StreamableHTTPClientTransport(
     new URL(mcpUrl),
-    smallModelMode == null
+    Object.keys(headers).length === 0
       ? undefined
-      : {
-          requestInit: {
-            headers: { [SMALL_MODEL_MODE_HEADER]: String(smallModelMode) },
-          },
-        },
+      : { requestInit: { headers } },
   );
   const client = new Client({
     name: MCP_CLIENT_NAME,
@@ -57,7 +76,28 @@ export async function createConnectedMcpClient(
 }
 
 /**
+ * The comma-separated tool names to withhold, from the sparse enabled map.
+ * Only explicit `false` entries count — an absent tool is enabled, which is what
+ * keeps a tool added in a later release on by default.
+ *
+ * @param enabledTools - Map of tool name to enabled state
+ * @returns Comma-separated disabled tool names, or "" when none are disabled
+ */
+function disabledToolNames(enabledTools?: Record<string, boolean>): string {
+  if (!enabledTools) return "";
+
+  return Object.keys(enabledTools)
+    .filter((name) => enabledTools[name] === false)
+    .join(",");
+}
+
+/**
  * Filters MCP tools based on enabled/disabled configuration.
+ *
+ * Kept even though {@link createConnectedMcpClient} now withholds the same tools
+ * server-side: this is what decides the toolset when no header applies (the
+ * voice paths), and it covers names the server's whitelist never had.
+ *
  * @param tools - Array of MCP tool definitions
  * @param enabledTools - Map of tool names to enabled state (undefined = enabled)
  * @returns Filtered array of tools

--- a/webui/src/chat/helpers/tests/mcp-client-helpers.test.ts
+++ b/webui/src/chat/helpers/tests/mcp-client-helpers.test.ts
@@ -5,7 +5,10 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { SMALL_MODEL_MODE_HEADER } from "#src/shared/config";
+import {
+  DISABLED_TOOLS_HEADER,
+  SMALL_MODEL_MODE_HEADER,
+} from "#src/shared/config";
 import {
   createConnectedMcpClient,
   filterEnabledTools,
@@ -98,5 +101,39 @@ describe("createConnectedMcpClient", () => {
     expect(
       mockTransport.mock.calls[0]?.[1]?.requestInit?.headers,
     ).toStrictEqual({ [SMALL_MODEL_MODE_HEADER]: "false" });
+  });
+
+  it("lists only the explicitly disabled tools in the disabled-tools header", async () => {
+    await createConnectedMcpClient("http://localhost:3000/mcp", undefined, {
+      "tool-a": true,
+      "tool-b": false,
+      "tool-c": false,
+    });
+
+    expect(
+      mockTransport.mock.calls[0]?.[1]?.requestInit?.headers,
+    ).toStrictEqual({ [DISABLED_TOOLS_HEADER]: "tool-b,tool-c" });
+  });
+
+  it("sends both headers when both apply", async () => {
+    await createConnectedMcpClient("http://localhost:3000/mcp", true, {
+      "tool-b": false,
+    });
+
+    expect(
+      mockTransport.mock.calls[0]?.[1]?.requestInit?.headers,
+    ).toStrictEqual({
+      [SMALL_MODEL_MODE_HEADER]: "true",
+      [DISABLED_TOOLS_HEADER]: "tool-b",
+    });
+  });
+
+  it("sends no disabled-tools header when nothing is disabled", async () => {
+    // An all-enabled map must leave the server's toolset alone, not send "".
+    await createConnectedMcpClient("http://localhost:3000/mcp", undefined, {
+      "tool-a": true,
+    });
+
+    expect(mockTransport.mock.calls[0]?.[1]).toBeUndefined();
   });
 });

--- a/webui/src/chat/sdk/mcp-tools.ts
+++ b/webui/src/chat/sdk/mcp-tools.ts
@@ -21,7 +21,10 @@ export interface McpTools {
  * Creates AI SDK-compatible tools from an MCP server connection.
  * Each tool's execute function delegates to mcpClient.callTool().
  * @param mcpUrl - URL of the MCP server
- * @param enabledTools - Map of tool names to enabled state
+ * @param enabledTools - Map of tool names to enabled state. Sent to the server
+ *   as the disabled-tools header (so it withholds those tools AND their skills
+ *   fragments) and applied again to the returned list, which also drops names
+ *   the server doesn't know about.
  * @param smallModelMode - Per-request small-model mode carried on every MCP
  *   request (shrinks tool schemas + selects the basic skills variant); omit for
  *   the global default
@@ -32,7 +35,11 @@ export async function createMcpTools(
   enabledTools?: Record<string, boolean>,
   smallModelMode?: boolean,
 ): Promise<McpTools> {
-  const mcpClient = await createConnectedMcpClient(mcpUrl, smallModelMode);
+  const mcpClient = await createConnectedMcpClient(
+    mcpUrl,
+    smallModelMode,
+    enabledTools,
+  );
   const toolsResult = await mcpClient.listTools();
   const filtered = filterEnabledTools(toolsResult.tools, enabledTools);
 

--- a/webui/src/chat/sdk/tests/mcp-tools.test.ts
+++ b/webui/src/chat/sdk/tests/mcp-tools.test.ts
@@ -61,6 +61,7 @@ describe("createMcpTools", () => {
     expect(createConnectedMcpClient).toHaveBeenCalledWith(
       "http://custom:9000/mcp",
       undefined,
+      undefined,
     );
   });
 
@@ -70,6 +71,7 @@ describe("createMcpTools", () => {
     expect(createConnectedMcpClient).toHaveBeenCalledWith(
       "http://localhost:3000/mcp",
       true,
+      undefined,
     );
   });
 
@@ -79,6 +81,18 @@ describe("createMcpTools", () => {
     await createMcpTools("http://localhost:3000/mcp", enabledTools);
 
     expect(filterEnabledTools).toHaveBeenCalledWith(mockTools, enabledTools);
+  });
+
+  it("forwards enabledTools to the MCP client so the server withholds them too", async () => {
+    const enabledTools = { "ppal-read": false };
+
+    await createMcpTools("http://localhost:3000/mcp", enabledTools, false);
+
+    expect(createConnectedMcpClient).toHaveBeenCalledWith(
+      "http://localhost:3000/mcp",
+      false,
+      enabledTools,
+    );
   });
 
   it("sets tool descriptions", async () => {


### PR DESCRIPTION
Disabling a tool used to leave its guidance in the skills blob. Fragments are now gated on the active toolset, server-side.

## Fragment → tool map

Gates are **any-of**: a fragment ships when at least one of its tools is live.

| Fragment | Kept if any of… |
|---|---|
| `{notation}-*` | read-clip, create-clip, update-clip, read-track, read-scene |
| `time-and-values` | *always* |
| `working-with-live` | *always* |
| `transforms-*`, `code-transforms` | create-clip, update-clip, duplicate |
| `library` | library |
| `devices` | read/create/update-device |
| `specialized-devices` | read-device, update-device |
| `arrangement` | update-clip, duplicate, create-clip |
| `context-*` | context |
| `getting-help` | *conversation-only* |

A test asserts every fragment has an entry, so adding one forces the decision.

## Why no transitive close over `requires`

A dependent's gate must be a **subset** of the gate of what it requires — enforced by test rather than walked at assembly time. A kept fragment's prerequisites are therefore kept with it, so gating can't reintroduce the vocabulary-without-grammar failure `requires` exists to catch, and the check lands where the mistake would actually be made (editing the gate table).

## Per-request header

`x-producer-pal-disabled-tools` follows the small-model-mode pattern in the same `POST /mcp` handler. It is a **subtraction** from `config.tools`, not a whitelist: the webui's `enabledTools` is a sparse map, and the header must be set when the transport is built — before `listTools` could reveal the catalog a whitelist would need. Absent ⇒ the global, so external MCP clients are unaffected. It drives tool registration as well as skills.

## Effect

Measured against the full standard document:

| Toolset | Skills |
|---|---|
| full | ~10,600 tok |
| no library | −7% |
| no device tools | −16% |
| clip-writing worker | −30% |
| read-only | −67% |
| playback only | −88% |

## Also

- CORS middleware extracted from `create-express-app.ts` (line cap)
- shared connect helpers extracted so the two header suites don't clone them
- Skills **Preview** now reflects the device tool whitelist

🤖 Generated with [Claude Code](https://claude.com/claude-code)