### PR TITLE
fix(webui): settle the idle autosave before renaming a memory

### DIFF
--- a/webui/src/components/context/collection/CollectionScreen.tsx
+++ b/webui/src/components/context/collection/CollectionScreen.tsx
@@ -133,6 +133,13 @@ export function CollectionScreen<TView extends DocCollectionEntry, TInput>(
     selected.mode === "edit"
       ? (entries.find((entry) => entry.name === selected.name) ?? null)
       : null;
+  // A rename resolves this to null for ONE render: the collection hook's commit
+  // drops the old slug before the caller's `.then` moves `selected` to the new
+  // one. That is not a paintable flicker — both updates are microtasks in the
+  // same task, and a browser can only paint between tasks, so the banner below
+  // is added and removed within one checkpoint (guarded by MemoryScreen-rename's
+  // next-task assertion). Keep those two updates in the same task: an `await`
+  // on I/O between them would make this transient banner genuinely visible.
   const deletedExternally = selected.mode === "edit" && activeEntry == null;
 
   // Point the right pane at another draft, remounting the editor so it re-seeds.

--- a/webui/src/components/context/memory/MemoryEntryEditor.tsx
+++ b/webui/src/components/context/memory/MemoryEntryEditor.tsx
@@ -71,7 +71,7 @@ export function MemoryEntryEditor(
   const doSave = (): Promise<MemoryEntryView | null> =>
     collection.saveEntry(targetName, { description, content: body }, isNew);
 
-  const { noteSaved, externalUpdate, adoptExternal } =
+  const { noteSaved, externalUpdate, adoptExternal, settlePendingSave } =
     useCollectionEntryAutosave({
       canSave,
       draftKey: memoryEntryKey({ name: targetName, description, body }),
@@ -108,6 +108,7 @@ export function MemoryEntryEditor(
     body,
     requiredError: validation.errors.name,
     noteSaved,
+    settlePendingSave,
     onRenamed,
   });
 
@@ -214,6 +215,8 @@ interface MemoryRenameParams {
   requiredError?: string;
   /** Advance the autosave baseline to the renamed entry's echo. */
   noteSaved: (echoKey: string) => void;
+  /** Settle the idle autosave (which targets the OLD slug) before renaming. */
+  settlePendingSave: () => Promise<void>;
   /** Follow the entry to its new slug, keeping this editor mounted. */
   onRenamed: (name: string) => void;
 }
@@ -233,6 +236,11 @@ interface MemoryRenameParams {
  * field adopts the server's slug, and the baseline advances to that echo, so a
  * draft that did diverge mid-rename is left dirty for the autosave to persist
  * under the NEW name — and a clean one doesn't re-save.
+ *
+ * The idle autosave is settled BEFORE the rename is dispatched
+ * ({@link CollectionEntryAutosaveReturn.settlePendingSave}): both writes target
+ * the current slug, and a save still racing the rename can re-create the entry
+ * the rename just moved away from.
  * Extracted so the editor body stays within the line limit.
  * @param params - The live draft + collection the rename needs
  * @returns The name field's error and its change/rename handlers
@@ -243,7 +251,7 @@ function useMemoryRename(params: MemoryRenameParams): {
   onRename: (raw: string) => void;
 } {
   const { collection, entry, setName, description, body } = params;
-  const { requiredError, noteSaved, onRenamed } = params;
+  const { requiredError, noteSaved, settlePendingSave, onRenamed } = params;
   const [renameFailed, setRenameFailed] = useState(false);
 
   const nameError =
@@ -257,6 +265,28 @@ function useMemoryRename(params: MemoryRenameParams): {
   };
 
   // Commit a rename on blur / Enter; see the hook's doc for the full contract.
+  const commitRename = async (oldName: string, to: string): Promise<void> => {
+    // Never leave an autosave of the OLD slug racing the rename.
+    await settlePendingSave();
+
+    const renamed = await collection.renameEntry(oldName, to, {
+      description,
+      content: body,
+    });
+
+    if (renamed == null) {
+      setRenameFailed(true);
+      setName(oldName);
+
+      return;
+    }
+
+    setRenameFailed(false);
+    setName(renamed.name);
+    noteSaved(memoryEntryKey(renamed));
+    onRenamed(renamed.name);
+  };
+
   const onRename = (raw: string): void => {
     if (entry == null) return;
     const trimmed = raw.trim();
@@ -267,21 +297,7 @@ function useMemoryRename(params: MemoryRenameParams): {
       return;
     }
 
-    void collection
-      .renameEntry(entry.name, trimmed, { description, content: body })
-      .then((renamed) => {
-        if (renamed == null) {
-          setRenameFailed(true);
-          setName(entry.name);
-
-          return;
-        }
-
-        setRenameFailed(false);
-        setName(renamed.name);
-        noteSaved(memoryEntryKey(renamed));
-        onRenamed(renamed.name);
-      });
+    void commitRename(entry.name, trimmed);
   };
 
   return { nameError, onNameChange, onRename };

--- a/webui/src/components/context/memory/tests/MemoryScreen-rename.test.tsx
+++ b/webui/src/components/context/memory/tests/MemoryScreen-rename.test.tsx
@@ -7,7 +7,7 @@
  * @vitest-environment happy-dom
  */
 import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, type Mock, vi } from "vitest";
 import { markdownEditorTestMock } from "#webui/components/context/tests/markdown-editor-test-mock";
 import {
   type Deferred,
@@ -56,6 +56,79 @@ function MemoryScreenHarness(): preact.JSX.Element {
   const collection = useMemoryCollection();
 
   return <MemoryScreen collection={collection} tabSlot={TAB_SLOT} />;
+}
+
+/** A write the fake server has received but not yet applied. */
+interface PendingWrite {
+  /** The request URL (the rename channel ends in `/rename`). */
+  url: string;
+  /** Apply this write to the store and answer its request. */
+  land: () => void;
+}
+
+/**
+ * The suite's fetch mock under fetch's own signature — `installFetchMock`
+ * returns the untyped `vi.fn()`, whose implementations are void-returning.
+ */
+type FetchMock = Mock<(url: string, init?: RequestInit) => Promise<Response>>;
+
+/**
+ * A fake memory server holding every write until the test lands it, so the
+ * ordering of two racing writes is the test's to choose rather than the mock's.
+ * Its store is the "files on disk" the assertions read.
+ * @returns The store and the queue of unlanded writes
+ */
+function fakeServer(): {
+  store: Map<string, MemoryEntryView>;
+  pending: PendingWrite[];
+} {
+  const store = new Map<string, MemoryEntryView>([[ENTRY.name, ENTRY]]);
+  const pending: PendingWrite[] = [];
+
+  (fetchMock as unknown as FetchMock).mockImplementation((rawUrl, init) => {
+    const url = String(rawUrl);
+
+    if ((init?.method ?? "GET") === "GET") {
+      return Promise.resolve(jsonResponse({ entries: [...store.values()] }));
+    }
+
+    const body = JSON.parse(String(init?.body)) as {
+      description: string;
+      content: string;
+      newName?: string;
+    };
+    const isRename = url.endsWith("/rename");
+    const slug =
+      url
+        .replace(/\/rename$/, "")
+        .split("/")
+        .pop() ?? "";
+    // The server slugifies a rename's target; a plain save writes its URL slug.
+    const target = isRename
+      ? (body.newName ?? "").trim().toLowerCase().replaceAll(/\W+/g, "-")
+      : slug;
+    const entry: MemoryEntryView = {
+      name: target,
+      description: body.description,
+      body: body.content,
+    };
+    const response = deferred<Response>();
+
+    pending.push({
+      url,
+      land: () => {
+        // A rename writes the new slug and drops the old one; a save is an
+        // upsert, which is exactly why a stale one re-creates a moved entry.
+        if (isRename) store.delete(slug);
+        store.set(target, entry);
+        response.resolve(jsonResponse({ entry }));
+      },
+    });
+
+    return response.promise;
+  });
+
+  return { store, pending };
 }
 
 /**
@@ -186,5 +259,84 @@ describe("MemoryScreen — editing during an in-flight rename", () => {
     await settleAutosave();
 
     expect(entryPuts()).toStrictEqual([]);
+  });
+
+  it("never leaves the deleted-externally banner paintable", async () => {
+    const renamePut = routeFetch();
+
+    render(<MemoryScreenHarness />);
+
+    await startRename();
+
+    // Dropping the old slug from the list and moving the selection to the new
+    // one are two separate state updates, so the entry momentarily resolves to
+    // null and CollectionScreen's deleted-externally banner mounts. Both are
+    // microtasks in the same task, and a browser paints only BETWEEN tasks — so
+    // sample at the first macrotask boundary after the rename lands: the banner
+    // must already be gone. An `await` on I/O inserted between those updates
+    // would split the task and make the banner genuinely visible.
+    renamePut.resolve(jsonResponse({ entry: RENAMED }));
+
+    const bannerAtNextTask = await new Promise<boolean>((resolve) => {
+      setTimeout(
+        () =>
+          resolve(
+            String(document.body.textContent).includes(
+              "deleted outside the editor",
+            ),
+          ),
+        0,
+      );
+    });
+
+    expect(bannerAtNextTask).toBe(false);
+    await screen.findByRole("button", { name: "Edit new-slug" });
+  });
+});
+
+describe("MemoryScreen — renaming with an autosave of the old slug in flight", () => {
+  it("waits for the in-flight save to land before renaming, so it can't re-create the old slug", async () => {
+    const { store, pending } = fakeServer();
+
+    render(<MemoryScreenHarness />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Edit prefers-c-minor" }),
+    );
+
+    // Typing arms the idle autosave, which is keyed to the entry's CURRENT
+    // slug. Let it fire: its PUT to `prefers-c-minor` is now in flight.
+    fireEvent.input(screen.getByRole("textbox", { name: /Memory/ }), {
+      target: { value: "Composes in C minor and F minor." },
+    });
+
+    await waitFor(() => {
+      expect(pending).toHaveLength(1);
+    });
+    expect(pending[0]?.url).toContain("prefers-c-minor");
+
+    // Rename while that save is still open. Dispatching now would leave two
+    // writes racing for one file, and the server landing the rename first would
+    // let the save re-create the entry the rename just moved away from.
+    const nameInput = screen.getByRole("textbox", { name: "Rename" });
+
+    fireEvent.input(nameInput, { target: { value: "New Slug" } });
+    fireEvent.blur(nameInput);
+    await settleAutosave();
+
+    expect(pending).toHaveLength(1);
+
+    // Once the save lands, the rename goes out — against a settled old slug.
+    pending[0]?.land();
+
+    await waitFor(() => {
+      expect(pending).toHaveLength(2);
+    });
+    expect(pending[1]?.url).toContain("/rename");
+
+    pending[1]?.land();
+
+    await screen.findByRole("button", { name: "Edit new-slug" });
+    expect([...store.keys()]).toStrictEqual(["new-slug"]);
   });
 });

--- a/webui/src/hooks/context/use-doc-collection.ts
+++ b/webui/src/hooks/context/use-doc-collection.ts
@@ -269,6 +269,16 @@ export interface CollectionEntryAutosaveReturn {
    * so reading it off the same ref is safe here.
    */
   adoptExternal: () => void;
+  /**
+   * Settle the idle autosave before a write that MOVES this entry (a rename):
+   * cancel the armed debounce, and resolve once any already-dispatched save has
+   * landed. Both target the entry's CURRENT slug, so a rename issued on top of
+   * one leaves two writes racing for the same file — and if the rename lands
+   * first, the save re-creates the entry it just moved away from (a duplicate
+   * under the old name). Cancelling loses nothing: the rename carries the same
+   * live draft to the new slug.
+   */
+  settlePendingSave: () => Promise<void>;
 }
 
 /**
@@ -304,6 +314,9 @@ export function useCollectionEntryAutosave(
   const deletedExternallyRef = useRef(false);
   const lastSavedRef = useRef<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The persist currently in flight, so a rename can wait it out (see
+  // settlePendingSave); null whenever no save is outstanding.
+  const inFlightRef = useRef<Promise<void> | null>(null);
   const mountedRef = useRef(true);
   const seededRef = useRef(false);
   const [externalUpdate, setExternalUpdate] = useState(false);
@@ -356,11 +369,15 @@ export function useCollectionEntryAutosave(
     const previous = lastSavedRef.current;
 
     lastSavedRef.current = key;
-    void persistRef.current().then((echoKey) => {
+
+    const pending = persistRef.current().then((echoKey) => {
+      if (inFlightRef.current === pending) inFlightRef.current = null;
       if (!mountedRef.current || lastSavedRef.current !== key) return;
 
       lastSavedRef.current = echoKey ?? previous;
     });
+
+    inFlightRef.current = pending;
   }, []);
 
   // Seed the baseline once (an unedited existing entry must not re-save on
@@ -441,7 +458,15 @@ export function useCollectionEntryAutosave(
     setExternalUpdate(false);
   }, []);
 
-  return { noteSaved, externalUpdate, adoptExternal };
+  // Cancel the armed debounce (the rename carries the same draft onward), then
+  // wait out a save already dispatched — it can only be resolved by letting it
+  // land, since the request is gone. See the interface doc for why.
+  const settlePendingSave = useCallback(async (): Promise<void> => {
+    clearTimer(timerRef);
+    await inFlightRef.current;
+  }, []);
+
+  return { noteSaved, externalUpdate, adoptExternal, settlePendingSave };
 }
 
 // --- Helpers below main export ---


### PR DESCRIPTION
Investigates the two narrow rename/autosave races raised in the v2.0.0 release review of the memory editor. One was real and is fixed; the other is not observable and is documented + guarded instead.

## 1. Rename vs. stale-slug autosave — REAL, fixed

**Reproduced.** Typing in a memory's body arms the 800ms debounced autosave keyed to the entry's **current** slug. Renaming before that write lands leaves two requests racing for the same file. Client state is fine (the per-entry write-ordering guard drops the superseded commit) — the damage is server-side: `saveEntry` is an upsert, so if the server handles the rename first, the stale save **re-creates the entry the rename just moved away from**. The user ends up with a duplicate memory under the old name, surfacing on the next 5s list poll.

The concurrency is reached by ordinary use — type, pause ~800ms, rename — no artificial timing. A regression test drives exactly that and fails on `dev`.

**Fix:** the rename settles the autosave before dispatching. A new `settlePendingSave()` on `useCollectionEntryAutosave` cancels an armed debounce and waits out a save already in flight. Cancelling loses nothing: the rename carries the same live draft to the new slug. Rename failure still leaves the draft dirty, so the body edit is re-armed and persisted under the old name.

## 2. One-frame "deleted externally" flicker — NOT observable, no change

The transient is real — a `MutationObserver` probe confirms the amber banner node is added to the DOM and removed again during a rename. But the collection commit and the selection follow-up are microtasks in the **same task**, and a browser paints only *between* tasks: sampling the DOM at the first macrotask boundary after the rename lands shows the banner already gone. The ticket's "slow render path / DevTools profiling" theory doesn't apply — render slowness doesn't split a microtask checkpoint.

So the ordering is left alone. Instead `CollectionScreen` documents why the transient is safe, and a next-task assertion guards the invariant: inserting an `await` on I/O between those two updates would split the task and make the banner genuinely visible, and the test would catch it.

## Testing

- `npm run check` green (10433 tests, functions 100%, branches 98.02%)
- `npm run check:build` green
- `npm run ui:test` green (15 Playwright specs)
- New regression test verified red on `dev`, green with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)