### PR TITLE
Low-severity review findings: intent records, prose corrections, and a briefing-URL fix

### DIFF
--- a/dev/Chat-UI.md
+++ b/dev/Chat-UI.md
@@ -294,10 +294,19 @@ through this single code path via provider-specific model factories in
 
 **Locked Settings:**
 
-Provider, model, and thinking level are locked per conversation. When a
-conversation is saved, these settings are stored on the `ConversationRecord`.
-When restored, they're passed as `ConversationLockedSettings` to prevent
-settings changes from affecting the active conversation.
+Provider, model, thinking level, small-model mode, the resolved system
+instruction, and notation are locked per conversation. When a conversation is
+saved, these settings are stored on the `ConversationRecord`. When restored,
+they're passed as `ConversationLockedSettings` to prevent settings changes from
+affecting the active conversation.
+
+Notation is hard-locked rather than re-read per init: it decides how clip notes
+are PARSED, so a transcript written in one notation must keep being read in it.
+
+The toolset (`enabledTools`) rides on the same record but is **recorded, not
+enforced** — continuing a restored conversation reconnects with whatever is
+enabled now, since a tool the user just turned on to keep working has to be
+reachable. It is kept so the settings notice can say the toolset moved.
 
 Per-message overrides (`MessageOverrides`) can still override thinking for
 individual messages. When used, the overridden value is stamped on the assistant

--- a/dev/decisions/0014-subagent-resume-from-transcript.md
+++ b/dev/decisions/0014-subagent-resume-from-transcript.md
@@ -42,7 +42,8 @@ spawns workers under whatever "Default subagent" preset is selected now
 Worker identity is a 1-based index, persisted beside the transcript and surfaced
 to the model as a `[subagent N]` label on each result. The orchestrator
 addresses a worker by that number (`resumeFrom`). Implemented in
-`webui/src/chat/sdk/subagent-session.ts` and `spawn-subagent-tool.ts`.
+`webui/src/chat/sdk/subagent/subagent-session.ts` and `spawn-subagent-tool.ts`
+beside it.
 
 ## Alternatives rejected
 

--- a/docs/guide/customizing-skills.md
+++ b/docs/guide/customizing-skills.md
@@ -61,11 +61,12 @@ a whole area you never use:
 ::: warning Fragment names changed in 2.0.1
 
 The `core-*` fragments (`core-transforms`, `core-devices`,
-`core-context-standard`, …) were re-cut into the list above. If you customized
-one, its file in `~/.producer-pal/skills/` is no longer used — Producer Pal
-warns about it in the Skills **Preview** view and the Max window. Copy your
-changes into whichever new fragment now covers that material and delete the old
-file.
+`core-context-standard`, …) were re-cut into the list above, and
+`midi-json-standard` / `midi-json-basic` were folded into a single `midi-json`.
+If you customized any of them, its file in `~/.producer-pal/skills/` is no
+longer used — Producer Pal warns about it in the Skills **Preview** view and the
+Max window. Copy your changes into whichever new fragment now covers that
+material and delete the old file.
 
 :::
 

--- a/e2e/ui/ui-test-helpers.ts
+++ b/e2e/ui/ui-test-helpers.ts
@@ -115,7 +115,7 @@ export async function installStubs(page: Page): Promise<void> {
     }),
   );
 
-  // Custom system prompt read (the chat mounts useSystemPromptMemory) — empty
+  // Custom system prompt read (the chat mounts useSystemPrompt) — empty
   // means "use the built-in instruction", the default state under test.
   await page.route("**/system-prompt", (route) =>
     route.fulfill({

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -151,6 +151,18 @@ export const DISABLED_TOOLS_HEADER = "x-producer-pal-disabled-tools";
  * anything the request's header withholds. An absent or empty header leaves the
  * configured set untouched.
  *
+ * NOTHING IS RESERVED HERE, and that is deliberate — `ppal-connect` included.
+ * `validateTools` (create-mcp-server.ts) does require it, which looks like an
+ * inconsistency worth "fixing"; it is not. The two guard different things:
+ * `validateTools` guards the server's GLOBAL config, where dropping the entry
+ * point would leave an external MCP client with no way in. This guards ONE
+ * request's subtraction, and a subagent worker withholds `ppal-connect` on
+ * purpose — its briefing replaces the connect call, and withholding the tool is
+ * also what makes the server drop the connect/context skills fragments so the
+ * briefing stays short (see WORKER_WITHHELD_TOOLS in subagent-briefing.ts).
+ * Reserving the name here would hand every worker `ppal-connect` back and
+ * re-inflate every briefing.
+ *
  * @param headerValue - The request's header value, or undefined when absent
  * @param configuredTools - The server's global `config.tools`
  * @returns The tools to register and to gate skills fragments on

--- a/src/tools/core/context-helpers.ts
+++ b/src/tools/core/context-helpers.ts
@@ -169,6 +169,13 @@ export async function handleWriteGlobalContext(
     // The guard compares against the CURRENT document, which lives on the Node
     // side — one extra round-trip on the (rare) write path, and the freshest
     // possible baseline: the copy injected at connect may be stale.
+    //
+    // Read-then-write is check-then-act, so a webui PUT or a second MCP session
+    // can land between the two RPCs and be overwritten. Accepted, not overlooked:
+    // there is no transactional isolation across the V8→Node boundary to close
+    // it with, and the only alternative — guarding against the stale connect-time
+    // copy — trades a narrow race for a guard that is wrong whenever the document
+    // changed during the session. A fresh baseline is the point.
     const existing = await handleReadGlobalContext();
     const warning = clobberWarning("global", existing.content, content);
 

--- a/webui/src/chat/sdk/subagent/subagent-briefing.ts
+++ b/webui/src/chat/sdk/subagent/subagent-briefing.ts
@@ -51,7 +51,7 @@ export async function fetchSubagentBriefing(
   config: ChatClientConfig,
 ): Promise<string | null> {
   try {
-    const response = await fetch(getSubagentBriefingUrl(), {
+    const response = await fetch(getSubagentBriefingUrl(config.mcpUrl), {
       headers: perRequestHeaders(
         config.smallModelMode,
         config.enabledTools,

--- a/webui/src/components/settings/PresetsTab.tsx
+++ b/webui/src/components/settings/PresetsTab.tsx
@@ -24,9 +24,11 @@ export function PresetsTab({ settings }: PresetsTabProps) {
     <div className="space-y-4">
       <p className="text-sm text-zinc-500 dark:text-zinc-300">
         A preset saves and recalls a full chat setup — provider, model,
-        thinking, small-model mode, and the enabled toolset — in one click. Set
-        those up on the Connection and Tools tabs, then save them here as a
-        named preset. API keys and appearance preferences are never included.
+        thinking, small-model mode, notation, and the enabled toolset — in one
+        click. Set those up on the Connection and Tools tabs, then save them
+        here as a named preset. Loading a preset that saved a notation also
+        changes the device's notation. API keys and appearance preferences are
+        never included.
       </p>
       <PresetControls settings={settings} />
     </div>

--- a/webui/src/components/tests/App-context-mocks.tsx
+++ b/webui/src/components/tests/App-context-mocks.tsx
@@ -20,7 +20,7 @@ import { type UseDocReturn } from "#webui/hooks/context/use-doc";
 
 /**
  * Ready useSystemPrompt value so App tests don't fetch /system-prompt.
- * @returns A stable, no-op doc-memory hook return in the "ready" state
+ * @returns A stable, no-op use-doc hook return in the "ready" state
  */
 export function systemPromptDocMock(): UseDocReturn {
   return {

--- a/webui/src/utils/mcp-url.ts
+++ b/webui/src/utils/mcp-url.ts
@@ -141,10 +141,15 @@ export function getSkillsPreviewUrl(
  * worker starts with: skills, the Live Set, and the user's context layers). The
  * caller's profile rides on request headers, not query params, so there is
  * nothing to interpolate here.
+ *
+ * The briefing lives beside the MCP endpoint on the same server, so it follows
+ * the same base: pass a client config's `mcpUrl` override and the briefing is
+ * fetched from that server, exactly as its MCP requests would be.
+ * @param {string} [mcpUrl] - A client config's MCP URL override, if it set one
  * @returns {string} The subagent-briefing endpoint URL
  */
-export function getSubagentBriefingUrl(): string {
-  return getMcpUrl().replace(/\/mcp$/, "/subagent-briefing");
+export function getSubagentBriefingUrl(mcpUrl?: string): string {
+  return (mcpUrl ?? getMcpUrl()).replace(/\/mcp$/, "/subagent-briefing");
 }
 
 /**

--- a/webui/src/utils/tests/mcp-url.test.ts
+++ b/webui/src/utils/tests/mcp-url.test.ts
@@ -109,6 +109,18 @@ describe("getSubagentBriefingUrl", () => {
       "http://localhost:3350/subagent-briefing",
     );
   });
+
+  // The briefing lives beside the MCP endpoint, so a config that points its MCP
+  // requests at another server must fetch its briefing from that server too —
+  // otherwise a worker is briefed by one Producer Pal and calls tools on another.
+  it("follows a config's mcpUrl override instead of the page origin", () => {
+    vi.stubGlobal("window", {
+      location: { hostname: "localhost", port: "3350", protocol: "http:" },
+    });
+    expect(getSubagentBriefingUrl("http://otherhost:9000/mcp")).toBe(
+      "http://otherhost:9000/subagent-briefing",
+    );
+  });
 });
 
 describe("detectCorsBlock", () => {


### PR DESCRIPTION
Closes out the low-severity tier of the `main...dev` adversarial review. Three logical groups, landing **one commit at a time** so each gets its own green CI run. Intended for a **regular merge** (not squash) so the three messages stay separate in history.

### 1. `docs(server)` — record two deliberate omissions that read as bugs
Comments only, no behavior.

- **L2 was a wrong finding.** It proposed giving `resolveEnabledTools` a `ppal-connect` reserved-name guard to match `validateTools`. Subagent workers withhold `ppal-connect` *on purpose* (`WORKER_WITHHELD_TOOLS`) — the briefing replaces the connect call, and withholding the tool is what makes the server drop the connect/context skills fragments so briefings stay short. Implementing it would have handed every worker `ppal-connect` back and re-inflated every briefing. The asymmetry (global config vs. per-request subtraction) is now recorded.
- **L12 is working as designed.** `handleWriteGlobalContext`'s read-then-write is check-then-act, but there is no transactional isolation across the V8→Node boundary, and the alternative — guarding against the stale connect-time copy — is wrong whenever the document changed in-session. Accepted to keep clobber guarding; now recorded.

### 2. `docs` — correct five places where prose drifted from the code
Five stale facts (L5–L9). The code is right in every case. Highest-value is the Presets tab, which omitted **notation** from what a preset captures — it's the one captured field with a side effect outside the browser (it changes the device notation), and the guide already carries a warning callout about exactly that.

Also: `ConversationLockedSettings` locks six fields, not three, and separately *records* the toolset without enforcing it. Plus an ADR path, a retired-slot omission, and the last two memory→context rename leftovers — a repo-wide grep for the old identifiers now returns nothing.

### 3. `fix(webui)` — fetch a worker's briefing from its own MCP server
The only behavior change, and it is latent: nothing in the app sets `ChatClientConfig.mcpUrl` today (only a client test does). `client.ts` honors that override; the briefing fetch didn't, so a config pointing elsewhere would brief a worker from one server while it called tools on another. Fixed rather than commented because the field carries no doc scoping the briefing out, and there was no evidence the omission was deliberate.

### Not in this PR
- **L3** (basic driver inlines update-clip guidance outside the include graph) — real, but the inlining is deliberate per its docstring and carving a fragment adds a user-overridable slot plus a retirement path. Ticketed for a focused session.
- **L11**, **L13** — ticketed.
- **L4** — nothing to fix. **L14**, **L15** — maintainer handling.

### Verification
`npm run check` 10,579 passed / 0 failed, functions 100% · `npm run ui:test` 15 passed · `npm run check:build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)