### PR TITLE
fix(lint): lint the files that matched no oxlint override

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -17,7 +17,12 @@
 //
 // The keys-only blocks after them carry `env` per tree — globals are not rules
 // and so have no group to belong to. The blocks after THOSE are the narrow
-// exceptions: a rule turned off for one path, with its reason.
+// exceptions: a rule turned off (or retuned) for one path, with its reason.
+//
+// Every file oxlint lints must resolve to a non-empty rule map. Nothing is
+// hoisted to the top level, so a tree absent from every `files` list is linted
+// with zero rules and reports clean — silently. When adding a tree, add it to
+// the blocks whose rules it agrees with; `dev/Linting.md` has the check.
 //
 // The edits the generator cannot make itself are:
 //
@@ -90,10 +95,14 @@
         "config/**/*.ts",
         "vitest.config.ts",
         "config/**/*.{js,mjs}",
+        "prettier.config.mjs",
+        "evals/**/*.mjs",
         "examples/**/*.{js,mjs}",
         "e2e/docs/**/*.{js,mjs}",
         "e2e/webui/**/*.ts",
         "e2e/docs/**/*.ts",
+        "e2e/ui/**/*.ts",
+        "docs/.vitepress/**/*.{ts,vue}",
         "e2e/mcp/**/*.ts"
       ],
       "jsPlugins": [
@@ -252,6 +261,8 @@
         "config/**/*.ts",
         "vitest.config.ts",
         "config/**/*.{js,mjs}",
+        "prettier.config.mjs",
+        "evals/**/*.mjs",
         "examples/**/*.{js,mjs}",
         "e2e/mcp/**/*.ts"
       ],
@@ -305,6 +316,8 @@
         "config/**/*.ts",
         "vitest.config.ts",
         "config/**/*.{js,mjs}",
+        "prettier.config.mjs",
+        "evals/**/*.mjs",
         "examples/**/*.{js,mjs}"
       ],
       "jsPlugins": [
@@ -364,6 +377,8 @@
         "vitest.config.ts",
         "e2e/webui/**/*.ts",
         "e2e/docs/**/*.ts",
+        "e2e/ui/**/*.ts",
+        "docs/.vitepress/**/*.{ts,vue}",
         "e2e/mcp/**/*.ts"
       ],
       "plugins": ["typescript"],
@@ -514,9 +529,13 @@
         "config/**/*.ts",
         "vitest.config.ts",
         "config/**/*.{js,mjs}",
+        "prettier.config.mjs",
+        "evals/**/*.mjs",
         "e2e/docs/**/*.{js,mjs}",
         "e2e/webui/**/*.ts",
         "e2e/docs/**/*.ts",
+        "e2e/ui/**/*.ts",
+        "docs/.vitepress/**/*.{ts,vue}",
         "e2e/mcp/**/*.ts"
       ],
       "jsPlugins": ["@stylistic/eslint-plugin"],
@@ -566,10 +585,14 @@
         "config/**/*.ts",
         "vitest.config.ts",
         "config/**/*.{js,mjs}",
+        "prettier.config.mjs",
+        "evals/**/*.mjs",
         "examples/**/*.{js,mjs}",
         "e2e/docs/**/*.{js,mjs}",
         "e2e/webui/**/*.ts",
         "e2e/docs/**/*.ts",
+        "e2e/ui/**/*.ts",
+        "docs/.vitepress/**/*.{ts,vue}",
         "e2e/mcp/**/*.ts"
       ],
       "rules": {
@@ -579,10 +602,14 @@
     {
       "files": [
         "config/**/*.{js,mjs}",
+        "prettier.config.mjs",
+        "evals/**/*.mjs",
         "examples/**/*.{js,mjs}",
         "e2e/docs/**/*.{js,mjs}",
         "e2e/webui/**/*.ts",
         "e2e/docs/**/*.ts",
+        "e2e/ui/**/*.ts",
+        "docs/.vitepress/**/*.{ts,vue}",
         "e2e/mcp/**/*.ts"
       ],
       "rules": {
@@ -608,6 +635,8 @@
         "vitest.config.ts",
         "e2e/webui/**/*.ts",
         "e2e/docs/**/*.ts",
+        "e2e/ui/**/*.ts",
+        "docs/.vitepress/**/*.{ts,vue}",
         "e2e/mcp/**/*.ts"
       ],
       "plugins": ["typescript"],
@@ -653,7 +682,14 @@
       }
     },
     {
-      "files": ["config/**/*.{js,mjs}"],
+      "files": ["config/**/*.{js,mjs}", "prettier.config.mjs"],
+      "env": {
+        "es2024": true,
+        "node": true
+      }
+    },
+    {
+      "files": ["evals/**/*.mjs"],
       "env": {
         "es2024": true,
         "node": true
@@ -674,7 +710,12 @@
       }
     },
     {
-      "files": ["e2e/webui/**/*.ts", "e2e/docs/**/*.ts"],
+      "files": [
+        "e2e/webui/**/*.ts",
+        "e2e/docs/**/*.ts",
+        "e2e/ui/**/*.ts",
+        "docs/.vitepress/**/*.{ts,vue}"
+      ],
       "env": {
         "browser": true,
         "node": true
@@ -868,6 +909,8 @@
         "e2e/mcp/**/*.ts",
         "e2e/webui/**/*.ts",
         "e2e/docs/**/*.ts",
+        "e2e/ui/**/*.ts",
+        "docs/.vitepress/**/*.{ts,vue}",
         "webui/**/*.ts",
         "webui/**/*.tsx"
       ],
@@ -919,6 +962,32 @@
       "plugins": ["typescript"],
       "rules": {
         "typescript/no-unnecessary-type-assertion": "off"
+      }
+    },
+    // A Playwright `test.describe` callback is a suite container, not a
+    // function anyone reads top-to-bottom — the same reason `**/*.test.*` gets
+    // 630 rather than 115. Playwright suites are `.spec.ts`, so they miss that
+    // block; per-FILE max-lines still applies at 325.
+    {
+      "files": ["e2e/**/*.spec.ts"],
+      "rules": {
+        "max-lines-per-function": [
+          "error",
+          {
+            "max": 630,
+            "skipBlankLines": true,
+            "skipComments": true
+          }
+        ]
+      }
+    },
+    // The fixture records its own cwd so the transport test can assert what
+    // directory it was spawned in. That is the subject under test, not the
+    // path-resolution mistake the rule exists to catch.
+    {
+      "files": ["evals/chat/agent-cli/tests/agent-cli-fixture.mjs"],
+      "rules": {
+        "no-restricted-properties": "off"
       }
     }
   ]

--- a/dev/Linting.md
+++ b/dev/Linting.md
@@ -61,7 +61,7 @@ tree in it.
 
 Two kinds of block follow the groups: keys-only blocks carrying `env` per tree
 (globals are not rules, so they have no group to belong to), then the narrow
-exceptions — a rule turned off for one path, each with its reason.
+exceptions — a rule turned off or retuned for one path, each with its reason.
 
 All 26 type-aware `@typescript-eslint` rules are native, through
 `oxlint-tsgolint` (a typescript-go checker, stable since 2026-07). Four plugins
@@ -97,11 +97,64 @@ and its rules carry a distinct prefix:
   `RangeError: Line/column pair translates to an out of range offset`. The run
   fails loudly (exit 1), but the stack trace replaces every other JS-plugin
   finding in that file. The SPDX header keeps line 1 occupied everywhere except
-  `examples/**`, which is exempt from headers. Reported positions are one line
-  high throughout, not just at the boundary.
+  `examples/**`, which is exempt from headers, and `docs/.vitepress/**`, which
+  carries none. Reported positions are one line high throughout, not just at the
+  boundary.
 - Bridged rules get no type information (no `parserServices`), so a rule that
   needs types will silently under-report rather than error. This is why
   `sonarjs/assertions-in-tests` had to be dropped entirely.
+
+## Every file must resolve to a non-empty rule map
+
+Nothing is hoisted: the top-level `rules` is empty and `correctness` is off, so
+a tree that appears in no `files` list is linted with **zero rules** and reports
+clean — indistinguishable from passing. That blind spot came over from
+`eslint.config.js` and went unnoticed until it was measured.
+
+The check, the same one used to verify the regrouping:
+
+```bash
+oxlint --debug=files   # every file oxlint lints
+```
+
+Resolve each path against the override `files` globs and assert at least one
+rule is left enabled. Fourteen files failed it: `e2e/ui/**`,
+`docs/.vitepress/**`, `prettier.config.mjs`, and `evals/**/*.mjs`. Every one is
+a tree that was created without being added to `eslint.config.js`, reported
+clean because of it, and came through the migration unchanged.
+
+They were fixed by adding each tree to the blocks whose rules it already agreed
+with — **not** by hoisting the shared set to the top level, which would subject
+them to ~192 rules at once, and not by a new block repeating rules that already
+live elsewhere. Each landed next to its closest existing sibling:
+
+| tree                            | joins                  | why                                                           |
+| ------------------------------- | ---------------------- | ------------------------------------------------------------- |
+| `e2e/ui/**/*.ts`                | `e2e/webui/**/*.ts`    | the stubbed Playwright suite next to the live one             |
+| `docs/.vitepress/**/*.{ts,vue}` | `e2e/webui/**/*.ts`    | plain TS with no tsconfig, so no type-aware rules             |
+| `prettier.config.mjs`           | `config/**/*.{js,mjs}` | a `config/` file living at root only for Prettier's discovery |
+| `evals/**/*.mjs`                | `config/**/*.{js,mjs}` | plain Node ESM, not part of the type-checked `evals/**/*.ts`  |
+
+`prettier.config.mjs` sits beside `config/**/*.{js,mjs}` exactly as
+`vitest.config.ts` already sits beside `config/**/*.ts`.
+
+`.vue` files are linted through their `<script>` block only; `<template>` and
+`<style>` are not covered by any rule here.
+
+Bringing them in cost 17 mechanical fixes (blank lines, one `!!` → `Boolean`)
+and two narrow exceptions, both in `.oxlintrc.json` with their reasons:
+
+- `max-lines-per-function` at 630 for `e2e/**/*.spec.ts`. A Playwright
+  `test.describe` callback is a suite container, the same thing `**/*.test.*`
+  already gets 630 for; Playwright suites are `.spec.ts` so they missed that
+  block. Per-**file** `max-lines` still applies at 325.
+- `no-restricted-properties` off for `agent-cli-fixture.mjs`, which calls
+  `process.cwd()` to record the directory it was spawned in — the subject under
+  test, not the path-resolution mistake the rule catches.
+
+Re-run the check when adding a tree. It is deliberately not a meta test: the
+answer for a new tree is a decision about which rules it agrees with, not a
+default to apply automatically.
 
 ## Where oxlint's option defaults differ from eslint's
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -28,18 +28,21 @@ export default defineConfig({
       .replace(/\.md$/, "")
       .replace(/\/index$/, "")
       .replace(/^index$/, "");
+
     pageData.frontmatter.head ??= [];
     // Respect a page's own canonical (e.g. the /guide/examples redirect stub
     // points at /features/examples); otherwise default to a self-canonical.
     const hasCanonical = pageData.frontmatter.head.some(
       ([tag, attrs]) => tag === "link" && attrs?.rel === "canonical",
     );
+
     if (!hasCanonical) {
       pageData.frontmatter.head.push([
         "link",
         { rel: "canonical", href: `https://producer-pal.org/${path}` },
       ]);
     }
+
     pageData.frontmatter.version = VERSION;
   },
 

--- a/docs/.vitepress/theme/DownloadMarkdown.vue
+++ b/docs/.vitepress/theme/DownloadMarkdown.vue
@@ -8,6 +8,7 @@ const url = computed(() => `/markdown/${page.value.relativePath}`);
 
 const filename = computed(() => {
   const parts = page.value.relativePath.split("/");
+
   return parts[parts.length - 1];
 });
 </script>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -42,16 +42,20 @@ function setupImageZoom() {
 
   document.addEventListener("click", (event) => {
     const target = event.target;
+
     if (
       !(target instanceof HTMLImageElement) ||
       !target.matches(".vp-doc img:not(.no-zoom)")
     ) {
       return;
     }
+
     if (target.classList.contains("zoomed")) {
       close();
+
       return;
     }
+
     close();
     target.classList.add("zoomed");
     backdrop = document.createElement("div");

--- a/e2e/ui/assistant-markdown.spec.ts
+++ b/e2e/ui/assistant-markdown.spec.ts
@@ -58,6 +58,7 @@ test.describe("Assistant markdown sanitization (real browser DOM)", () => {
     const prose = page
       .getByTestId("assistant-message-bubble")
       .locator(".prose");
+
     await expect(prose).toBeVisible();
 
     // Markdown renders to real HTML (the regression that the dompurify 3.4.x
@@ -67,12 +68,14 @@ test.describe("Assistant markdown sanitization (real browser DOM)", () => {
 
     // The safe link is preserved AND hardened to open in a new window.
     const safeLink = prose.getByRole("link", { name: "safe link" });
+
     await expect(safeLink).toHaveAttribute("href", "https://example.com");
     await expect(safeLink).toHaveAttribute("target", "_blank");
     await expect(safeLink).toHaveAttribute("rel", "noopener noreferrer");
 
     // XSS vectors are stripped from the rendered HTML.
     const html = await prose.innerHTML();
+
     expect(html).not.toContain("<script");
     expect(html).not.toContain("javascript:");
     expect(html).not.toContain("onclick");

--- a/e2e/ui/conversation-branching.spec.ts
+++ b/e2e/ui/conversation-branching.spec.ts
@@ -151,8 +151,9 @@ test.describe("Conversation branching (stubbed backend)", () => {
 
     const navFollowsReply = await branchNav.evaluate(
       (nav, bubble) =>
-        !!(
-          bubble.compareDocumentPosition(nav) & Node.DOCUMENT_POSITION_FOLLOWING
+        Boolean(
+          bubble.compareDocumentPosition(nav) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
         ),
       replyHandle,
     );

--- a/e2e/ui/ui-test-helpers.ts
+++ b/e2e/ui/ui-test-helpers.ts
@@ -189,6 +189,7 @@ export async function seedConversations(
           store.createIndex("updatedAt", "updatedAt");
         }
       };
+
       req.onsuccess = () => {
         const db = req.result;
         const tx = db.transaction("conversations", "readwrite");
@@ -201,8 +202,10 @@ export async function seedConversations(
           db.close();
           resolve();
         };
+
         tx.onerror = () => reject(tx.error);
       };
+
       req.onerror = () => reject(req.error);
     });
   }, conversations);
@@ -229,8 +232,10 @@ export async function readConversationsFromDb(
           db.close();
           resolve(getAll.result as SeedConversation[]);
         };
+
         getAll.onerror = () => reject(getAll.error);
       };
+
       req.onerror = () => reject(req.error);
     });
   });


### PR DESCRIPTION
`.oxlintrc.json` has an empty top-level `rules` and `correctness: "off"`, so a file matching none of the override `files` lists was linted with **literally zero rules** — reporting clean because nothing ran.

14 files were in that state: `e2e/ui/**` (9), `docs/.vitepress/**` (3), `prettier.config.mjs`, and `evals/**/*.mjs`. Each is a tree created without being added to `eslint.config.js`; the oxlint migration preserved the gap faithfully.

## Shape

Two alternatives were rejected: hoisting the shared set to the top level (~192 rules at once), and a new block carrying its own baseline (it would repeat rules that already live elsewhere — exactly what the config's regrouping removed). Instead each tree joins the blocks whose rules it already agrees with:

| tree | joins | why |
| --- | --- | --- |
| `e2e/ui/**/*.ts` | `e2e/webui/**/*.ts` | the stubbed Playwright suite beside the live one |
| `docs/.vitepress/**/*.{ts,vue}` | `e2e/webui/**/*.ts` | plain TS with no tsconfig, so no type-aware rules |
| `prettier.config.mjs` | `config/**/*.{js,mjs}` | a `config/` file at root only for Prettier's discovery |
| `evals/**/*.mjs` | `config/**/*.{js,mjs}` | plain Node ESM, not part of the type-checked `evals/**/*.ts` |

`prettier.config.mjs` now sits beside `config/**/*.{js,mjs}` exactly as `vitest.config.ts` already sits beside `config/**/*.ts`.

## Verification

Resolved rule maps diffed across all 1462 linted files, before vs after: no file loses a rule, the 14 gain one, and the only retuned entry is the intended `max-lines-per-function` below. No file resolves to an empty rule map any more.

## Cost

17 mechanical fixes (blank lines, one `!!` → `Boolean`) and two narrow exceptions, each with its reason at the entry:

- **`max-lines-per-function` 630 for `e2e/**/*.spec.ts`** — a Playwright `test.describe` callback is a suite container, the same thing `**/*.test.*` already gets 630 for; Playwright suites are `.spec.ts` so they missed that block. Per-*file* `max-lines` still applies at 325. Worth a look: this also raises the ceiling for the 3 existing `e2e/webui` + `e2e/docs` specs, which pass at 115 today.
- **`no-restricted-properties` off for `agent-cli-fixture.mjs`** — it calls `process.cwd()` to record the directory it was spawned in, which is the subject under test.

`dev/Linting.md` gains a section documenting the invariant and the check. Deliberately not a meta test: the answer for a new tree is a decision about which rules it agrees with, not a default to apply automatically.

`npm run check`, `npm run check:build`, and `npm run ui:test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)