### PR TITLE
Split bar|beat's authoring syntax into a gated -write sibling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ docs/.vitepress/cache
 # Eval results (generated JSON)
 evals/results
 
+# Skills snapshots (npm run skills:snapshot — a scratch artifact for comparing
+# two states of the fragment carve, not a committed baseline)
+dev/skills-snapshots
+
 # Playwright Test Results
 test-results
 test-reports

--- a/dev/Development-Tools.md
+++ b/dev/Development-Tools.md
@@ -18,6 +18,26 @@ scripts/chat --list-models openai     # list one provider's models
 scripts/chat -m claude-sonnet-4-5     # start a chat
 ```
 
+## Skills Snapshots
+
+`npm run skills:snapshot` writes the assembled skills blob for every (toolset
+profile × depth × notation) to `dev/skills-snapshots/` (gitignored) and prints a
+report: the size of every combination, and which tools keep each fragment.
+
+To see what a fragment reorganization actually did to each caller's
+instructions:
+
+```bash
+npm run skills:snapshot -- --out /tmp/skills-before   # before your edits
+npm run skills:snapshot -- --diff /tmp/skills-before  # after
+```
+
+`--diff` prints per-blob size deltas, then the line-level diff.
+
+Profiles live in `scripts/skills/toolset-profiles.ts` — add one when a new use
+case matters. The point is to check a carve cheaply, before spending an eval
+run.
+
 ## CLI Tool
 
 **Purpose:** Direct MCP server interaction for end-to-end testing. Claude Code

--- a/dev/decisions/0016-notation-head-gating-granularity.md
+++ b/dev/decisions/0016-notation-head-gating-granularity.md
@@ -1,6 +1,6 @@
 # ADR-0016: One fragment per notation is the tool-gating floor
 
-- **Status:** Accepted
+- **Status:** Superseded by [ADR-0019](0019-notation-head-read-write-split.md)
 - **Date logged:** 2026-07-29
 
 ## Context

--- a/dev/decisions/0019-notation-head-read-write-split.md
+++ b/dev/decisions/0019-notation-head-read-write-split.md
@@ -1,0 +1,85 @@
+# ADR-0019: A notation head may split off a `-write` sibling
+
+- **Status:** Accepted
+- **Date logged:** 2026-07-30
+- **Supersedes:** [ADR-0016](0016-notation-head-gating-granularity.md)
+
+## Context
+
+ADR-0016 made one fragment per notation per depth the tool-gating floor, so a
+read-only caller pays for the authoring guide it cannot use. It was explicit
+that the gate table was not the blocker — a `-write` fragment gated on the two
+clip writers is a handful of lines — and that the override contract was:
+splitting `barbeat-standard` while keeping the name duplicates the authoring
+sections for anyone carrying an override of it, with nothing able to detect
+that. Its revisit trigger was an override-migration answer.
+
+The answer turned out not to be a mechanism. Adam's call: **nobody has
+customized skills yet**, so there is no install base to migrate. That removes
+the only thing standing in the way, and the window where a split is free is now.
+
+The measured case for taking it: `barbeat-serializer.ts` emits only
+`v/n/p pitch(es) bar|beat` with comma-merged beat lists and `±n` offsets. It
+never emits a repeat pattern, a pattern bracket, a bar copy, or a `v0`, so a
+read-only caller provably never encounters that syntax. The carve moved 5,275 of
+the head's 8,954 chars — **59%** — behind the writers' gate.
+
+## Decision
+
+A notation head MAY spin its authoring syntax out into a `-write` sibling
+fragment, gated on `NOTE_WRITE_TOOLS` (`ppal-create-clip`, `ppal-update-clip`).
+The base head keeps both its name and its meaning: the format, minus what only a
+writer can use.
+
+That last part is the load-bearing bit. Because the base name survives, the
+standard driver's `@include "./{notation}-standard.md"` line never changes, no
+slot is retired, no alias is added, and each notation opts in separately. The
+`-read` / `-write` symmetry considered first would have renamed the base ref,
+which forces an alias for every notation that _isn't_ split — real complexity
+bought for nothing.
+
+Only `barbeat-standard` is split. `stark-standard` and `midi-json` register an
+EMPTY `-write` fragment so the notation-templated ref resolves, the same
+present-but-empty shape `code-transforms` uses in a release build.
+
+## Consequences
+
+- A read-only worker's bar|beat guidance drops from ~8,950 to ~3,680 chars.
+- `barbeat-standard-write` `requires` `barbeat-standard`, and
+  `NOTE_WRITE_TOOLS ⊂ NOTE_TOOLS`, so the requires-subset invariant holds and
+  gating still needs no transitive close.
+- Two lines had to be **rewritten rather than moved**, and they are where a
+  regression would surface first: the meter paragraph in `## Positions & Meter`
+  (its "use a repeat pattern instead" prescription moved to the write half; the
+  meter FACT stayed, since reading positions in 6/8 needs it), and the
+  comma-list bullet (its "or repeat pattern" clause moved, restated by the write
+  half's lead-in). Leaving either mention behind is the `transforms-core`
+  failure mode — vocabulary whose grammar is gone.
+- If someone _does_ turn out to have a `barbeat-standard.md` override, their
+  copy of the authoring sections ships alongside the built-in write fragment.
+  The only signal is the existing ⚠ "default changed since you forked" badge in
+  the Skills editor. Accepted on the no-install-base call.
+- `transforms-core` gates on `[create-clip, update-clip, duplicate]` and
+  mentions `v0` in `notes` strings and "generate with repeats/bar-copies". A
+  caller with read tools + `ppal-duplicate` but no clip writer now keeps those
+  mentions while the write half drops. Left alone deliberately: trimming
+  mentions in `transforms-core` is exactly what cost a `drum-transforms` eval
+  turn before.
+- Extending the carve to `barbeat-basic` (`## Generate notes`, 642 of 1,445
+  chars) and to stark costs no new decision — add the body, add the slot.
+  stark's head is composed from shared string consts, so it means restructuring
+  that composition rather than moving sections. midi-json is symmetric enough
+  that splitting it would buy nothing.
+
+## Alternatives rejected
+
+- **Keep the coarse `NOTE_TOOLS` gate** (ADR-0016's position) — correct only
+  while an override-migration answer was required. It no longer is.
+- **`-read` / `-write` symmetry** — renames the driver's notation ref, forcing
+  alias entries folding `stark-standard-read` → `stark-standard` and
+  `midi-json-standard-read` → `midi-json`, plus a retired slot name, to buy
+  nothing a user can see.
+- **Sentence-level trimming inside the `v` / `n` / `p` bullets** — would harvest
+  a few hundred more chars, but each cut is a judgment call with nothing to
+  catch a mis-sort. The seam runs by whole bullet and section; ambiguous lines
+  stay on the read side, where both audiences get them.

--- a/dev/decisions/README.md
+++ b/dev/decisions/README.md
@@ -81,6 +81,7 @@ What this enables, costs, or commits us to. Note any revisit triggers.
 | [0013](0013-config-override-gate.md)               | Config-override env vars are opt-in (gated), not opt-out              |
 | [0014](0014-subagent-resume-from-transcript.md)    | A subagent resumes from its recorded transcript, not a live session   |
 | [0015](0015-project-context-param-rename.md)       | Rename the project-context device parameter in 2.1.0, while it's free |
-| [0016](0016-notation-head-gating-granularity.md)   | One fragment per notation is the tool-gating floor                    |
+| [0016](0016-notation-head-gating-granularity.md)   | One fragment per notation is the tool-gating floor (superseded)       |
 | [0017](0017-oxlint-category-baseline.md)           | oxlint runs on categories, with an opt-out list                       |
 | [0018](0018-tolerated-but-untaught-syntax.md)      | Accept the syntax models already write, without teaching it           |
+| [0019](0019-notation-head-read-write-split.md)     | A notation head may split off a `-write` sibling                      |

--- a/docs/guide/customizing-skills.md
+++ b/docs/guide/customizing-skills.md
@@ -56,6 +56,7 @@ a whole area you never use:
 | `context-standard` / `context-basic` | [Context & Memory](/guide/context) — the project, global, and memory layers                       |
 | `getting-help`                       | What to tell you when a request is outside Producer Pal's reach                                   |
 | `barbeat-standard` / `barbeat-basic` | The bar\|beat note notation guide (default notation)                                              |
+| `barbeat-standard-write`             | The bar\|beat syntax used only to _write_ notes — repeats, brackets, bar copying, examples        |
 | `stark-standard` / `stark-basic`     | The stark note notation guide                                                                     |
 | `midi-json`                          | The midi-json note notation guide                                                                 |
 
@@ -138,8 +139,10 @@ Fragments are cut along tool lines, so turning a tool off drops the fragment
 that teaches it — automatically, wherever you turned it off: the Tools tab in
 the [Chat UI](/guide/chat-ui#tools) (per preset, and per subagent), or the tool
 list an external MCP client is configured with. Switch off library search and
-the library guide is gone from that conversation's skills. Reach for the manual
-trimming below for areas you want dropped while keeping the tool.
+the library guide is gone from that conversation's skills. Direction counts too:
+a conversation that can read clips but not create or update them keeps the
+bar\|beat note format and drops the syntax used only to write notes. Reach for
+the manual trimming below for areas you want dropped while keeping the tool.
 
 :::
 
@@ -158,6 +161,7 @@ override you wrote for it — check the box again and it comes back.
 | Build or tweak instruments with the AI                  | `devices` **and** `specialized-devices`                                              |
 | Work in the Arrangement view with the AI                | `arrangement`                                                                        |
 | Use project/global context or memory                    | `context-standard`                                                                   |
+| Ask for new MIDI notes, but still want them read back   | `barbeat-standard-write` (bar\|beat only — the other notations aren't split)         |
 | Write or edit MIDI notes at all                         | the notation guide for your notation (e.g. `barbeat-standard`)                       |
 
 The same trims by hand: override the **Full skills (standard)** fragment and
@@ -172,8 +176,9 @@ A few fragments teach a vocabulary whose syntax lives elsewhere. The transforms
 guides all build on `transforms-core` — keeping `transforms-generative` without
 it leaves the AI knowing `ratchet()` and the waveforms but not the shape of a
 transform, which is worse than dropping all three. `specialized-devices` sits
-inside `devices` the same way. That's why the rows above are ordered
-most-specific-first and say which fragments travel together.
+inside `devices` the same way, and so does `barbeat-standard-write` inside
+`barbeat-standard`. That's why the rows above are ordered most-specific-first
+and say which fragments travel together.
 
 If you do drop a fragment something else needs, Producer Pal says so — the
 Skills **Preview** view shows a warning, and so does the Max window.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "duplication:evals": "printf 'Evals ' && jscpd -s --no-colors -c config/.jscpd-evals.json",
     "duplication:e2e": "printf 'E2E ' && jscpd -s --no-colors -c config/.jscpd-e2e.json",
     "duplication:verbose": "jscpd -c config/.jscpd.json && jscpd -c config/.jscpd-tests.json && jscpd -c config/.jscpd-scripts.json && jscpd -c config/.jscpd-evals.json && jscpd -c config/.jscpd-e2e.json",
+    "skills:snapshot": "node scripts/skills/snapshot-skills.ts",
     "loc": "node scripts/stats/loc.ts",
     "test:stats": "node scripts/stats/test-stats.ts",
     "e2e:stats": "node scripts/stats/e2e-stats.ts",

--- a/scripts/probes/verify-live-db-readonly.ts
+++ b/scripts/probes/verify-live-db-readonly.ts
@@ -10,7 +10,7 @@
  * staleness signals, and any errors.
  *
  * Usage:
- *   node scripts/verify-live-db-readonly.ts [--duration=<seconds>]
+ *   node scripts/probes/verify-live-db-readonly.ts [--duration=<seconds>]
  *
  * Run once with Live closed for a baseline, then again with Live open
  * (use `scripts/open-live-set` to launch a known-safe test project).

--- a/scripts/probes/voice-token-probe.ts
+++ b/scripts/probes/voice-token-probe.ts
@@ -18,8 +18,8 @@
  * configurations.
  *
  * Usage:
- *   node scripts/voice-token-probe.ts            # all scenarios, 3 turns each
- *   node scripts/voice-token-probe.ts --turns 2  # fewer turns (cheaper)
+ *   node scripts/probes/voice-token-probe.ts            # all scenarios, 3 turns each
+ *   node scripts/probes/voice-token-probe.ts --turns 2  # fewer turns (cheaper)
  *
  * Requires OPENAI_KEY in .env (see .env.example).
  */

--- a/scripts/skills/markdown-table.test.ts
+++ b/scripts/skills/markdown-table.test.ts
@@ -1,0 +1,68 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { markdownTable } from "./markdown-table.ts";
+
+describe("markdownTable", () => {
+  it("pads every cell to its column's widest value", () => {
+    const table = markdownTable(
+      ["Fragment", "Chars"],
+      [
+        ["library", "3005"],
+        ["specialized-devices", "3004"],
+      ],
+    );
+
+    expect(table.split("\n")).toStrictEqual([
+      "| Fragment            | Chars |",
+      "| ------------------- | ----- |",
+      "| library             | 3005  |",
+      "| specialized-devices | 3004  |",
+    ]);
+  });
+
+  it("carries alignment into the separator and the padding", () => {
+    const table = markdownTable(
+      ["left", "right", "mid"],
+      [["a", "b", "c"]],
+      ["left", "right", "center"],
+    );
+
+    expect(table.split("\n")).toStrictEqual([
+      "| left | right | mid |",
+      "| ---- | ----: | :-: |",
+      "| a    |     b |  c  |",
+    ]);
+  });
+
+  it("keeps rows aligned when cells hold the report's ✓/– marks", () => {
+    // The gate matrix is mostly these two; a miscount here misaligns every row.
+    const lines = markdownTable(
+      ["Fragment", "all"],
+      [
+        ["library", "✓"],
+        ["devices", "–"],
+      ],
+      ["left", "center"],
+    ).split("\n");
+
+    expect(new Set(lines.map((line) => line.length))).toStrictEqual(
+      new Set([lines[0]?.length]),
+    );
+  });
+
+  it("holds a column open wide enough for its separator", () => {
+    const table = markdownTable(["a"], [["b"]]);
+
+    expect(table).toBe("| a   |\n| --- |\n| b   |");
+  });
+
+  it("fills in for a row with missing trailing cells", () => {
+    const table = markdownTable(["a", "b"], [["only"]]);
+
+    expect(table.split("\n").at(-1)).toBe("| only |     |");
+  });
+});

--- a/scripts/skills/markdown-table.ts
+++ b/scripts/skills/markdown-table.ts
@@ -1,0 +1,78 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/** Column alignment in the rendered table. */
+export type ColumnAlign = "left" | "right" | "center";
+
+/**
+ * Render a padded markdown table. Padded rather than minimal because the skills
+ * report is read as raw text in an editor as often as rendered.
+ *
+ * @param headers - Column headings
+ * @param rows - Cell text, one array per row
+ * @param aligns - Per-column alignment (defaults to left)
+ * @returns The table markdown, no trailing newline
+ */
+export function markdownTable(
+  headers: readonly string[],
+  rows: readonly (readonly string[])[],
+  aligns: readonly ColumnAlign[] = [],
+): string {
+  // Cell text is BMP-only (the ✓/– marks included), so UTF-16 length is the
+  // display width. A dashed separator needs room for its alignment colons.
+  const widths = headers.map((header, column) =>
+    Math.max(
+      header.length,
+      ...rows.map((row) => (row[column] ?? "").length),
+      3,
+    ),
+  );
+  const align = (column: number): ColumnAlign => aligns[column] ?? "left";
+  // Driven by the column widths, not by the row: a row with fewer cells than
+  // there are headers still has to emit every column, or it stops being a table.
+  const line = (cells: readonly string[]): string =>
+    `| ${widths.map((size, column) => pad(cells[column] ?? "", size, align(column))).join(" | ")} |`;
+
+  return [
+    line(headers),
+    `| ${widths.map((w, column) => separator(w, align(column))).join(" | ")} |`,
+    ...rows.map(line),
+  ].join("\n");
+}
+
+// --- Helpers below main export ---
+
+/**
+ * Pad a cell to a column width.
+ *
+ * @param text - Cell text
+ * @param size - Column width
+ * @param align - Column alignment
+ * @returns The padded cell
+ */
+function pad(text: string, size: number, align: ColumnAlign): string {
+  const slack = Math.max(0, size - text.length);
+
+  if (align === "right") return " ".repeat(slack) + text;
+  if (align === "left") return text + " ".repeat(slack);
+
+  const left = Math.floor(slack / 2);
+
+  return " ".repeat(left) + text + " ".repeat(slack - left);
+}
+
+/**
+ * Build one column's dashed separator, carrying its alignment.
+ *
+ * @param size - Column width
+ * @param align - Column alignment
+ * @returns The separator cell
+ */
+function separator(size: number, align: ColumnAlign): string {
+  if (align === "right") return "-".repeat(size - 1) + ":";
+  if (align === "center") return ":" + "-".repeat(size - 2) + ":";
+
+  return "-".repeat(size);
+}

--- a/scripts/skills/skills-corpus.ts
+++ b/scripts/skills/skills-corpus.ts
@@ -1,0 +1,210 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Builds the skills snapshot corpus: one assembled blob per (toolset profile x
+// depth x notation), plus the README that summarizes them.
+//
+// A snapshot file is the blob and NOTHING else — no header, no timestamp — so a
+// reorganization's git diff is pure content movement. The path carries the
+// combination.
+
+import { NOTATIONS, type Notation } from "#src/shared/notation.ts";
+import { buildSkills } from "#src/skills/build-skills.ts";
+import { builtinFragments } from "#src/skills/builtin-fragments.ts";
+import {
+  fragmentGate,
+  gatedOutFragments,
+} from "#src/skills/fragment-tool-gates.ts";
+import {
+  assertKnownTools,
+  TOOLSET_PROFILES,
+  type ToolsetProfile,
+} from "./toolset-profiles.ts";
+import { markdownTable } from "./markdown-table.ts";
+
+/** One file in the corpus, at a path relative to the corpus root. */
+export interface SnapshotFile {
+  path: string;
+  content: string;
+}
+
+/** The two driver depths, in the order the report lists them. */
+const DEPTHS = [
+  { name: "standard", smallModelMode: false },
+  { name: "basic", smallModelMode: true },
+] as const;
+
+/**
+ * Build every file in the corpus: the assembled blobs and the README.
+ *
+ * `code-transforms` is forced OFF regardless of the shell's `ENABLE_CODE_EXEC`,
+ * so a debug environment can't rewrite the corpus with content no release build
+ * ships. Snapshots are the chat audience; the subagent delta is a column in the
+ * report instead of 24 more near-identical files.
+ *
+ * @returns Every corpus file, path relative to the corpus root
+ */
+export function buildCorpus(): SnapshotFile[] {
+  assertKnownTools();
+  process.env.ENABLE_CODE_EXEC = "false";
+
+  const blobs = TOOLSET_PROFILES.flatMap((profile) =>
+    DEPTHS.flatMap((depth) =>
+      NOTATIONS.map((notation) => ({
+        path: `${profile.name}/${depth.name}-${notation}.md`,
+        content: assemble(profile, depth.smallModelMode, notation, "chat"),
+      })),
+    ),
+  );
+
+  return [{ path: "README.md", content: buildReadme() }, ...blobs];
+}
+
+// --- Helpers below main export ---
+
+/**
+ * Assemble one blob.
+ *
+ * @param profile - The toolset profile
+ * @param smallModelMode - Whether to use the basic driver
+ * @param notation - The note format
+ * @param audience - Who the blob is for
+ * @returns The assembled skills string
+ */
+function assemble(
+  profile: ToolsetProfile,
+  smallModelMode: boolean,
+  notation: Notation,
+  audience: "chat" | "subagent",
+): string {
+  return buildSkills({
+    notation,
+    smallModelMode,
+    tools: profile.tools,
+    audience,
+  });
+}
+
+/**
+ * Build the corpus README: what it is, how to regenerate it, and the two tables
+ * that answer "how big is each combination" and "which tools keep each fragment".
+ *
+ * @returns The README markdown
+ */
+function buildReadme(): string {
+  return [
+    "# Skills snapshots",
+    "",
+    "Generated and gitignored. Each file under a profile directory is the exact blob",
+    "`ppal-connect` returns for that combination — nothing else, so a diff between two",
+    "runs is pure content movement.",
+    "",
+    "To see what a reorganization did:",
+    "",
+    "```bash",
+    "npm run skills:snapshot -- --out /tmp/skills-before   # before your edits",
+    "npm run skills:snapshot -- --diff /tmp/skills-before  # after",
+    "```",
+    "",
+    "Assembled with `code-transforms` off (release behavior) and the `chat` audience.",
+    "Rough token cost is chars / 4.",
+    "",
+    "## Toolset profiles",
+    "",
+    ...TOOLSET_PROFILES.map((p) => `- **${p.name}** — ${p.description}`),
+    "",
+    "## Combination sizes",
+    "",
+    "`subagent` drops the conversation-only fragments; every other axis is identical.",
+    "",
+    comboTable(),
+    "",
+    "## Fragments",
+    "",
+    "A fragment is dropped when NONE of its tools is enabled. That's the only",
+    "direction the gate runs: notation heads and the `-basic` variants also depend on",
+    "the notation and the depth, so ✓ means the gate keeps it, not that every",
+    "combination includes it.",
+    "",
+    fragmentTable(),
+    "",
+  ].join("\n");
+}
+
+/**
+ * The combination-size table: one row per (profile x depth x notation), with the
+ * chat and subagent character counts.
+ *
+ * @returns A markdown table
+ */
+function comboTable(): string {
+  const rows = TOOLSET_PROFILES.flatMap((profile) =>
+    DEPTHS.flatMap((depth) =>
+      NOTATIONS.map((notation) => [
+        profile.name,
+        depth.name,
+        notation,
+        String(
+          assemble(profile, depth.smallModelMode, notation, "chat").length,
+        ),
+        String(
+          assemble(profile, depth.smallModelMode, notation, "subagent").length,
+        ),
+      ]),
+    ),
+  );
+
+  return markdownTable(
+    ["Profile", "Depth", "Notation", "chat", "subagent"],
+    rows,
+    ["left", "left", "left", "right", "right"],
+  );
+}
+
+/**
+ * The fragment table: size, which profiles' gates keep it, and the gate itself.
+ *
+ * @returns A markdown table
+ */
+function fragmentTable(): string {
+  const fragments = builtinFragments(false);
+  const droppedByProfile = TOOLSET_PROFILES.map((profile) =>
+    gatedOutFragments(profile.tools),
+  );
+
+  const rows = Object.entries(fragments).map(([name, body]) => [
+    name,
+    String(body.length),
+    ...droppedByProfile.map((dropped) => (dropped.has(name) ? "–" : "✓")),
+    describeGate(name),
+  ]);
+
+  return markdownTable(
+    [
+      "Fragment",
+      "Chars",
+      ...TOOLSET_PROFILES.map((profile) => profile.name),
+      "Ships when",
+    ],
+    rows,
+    ["left", "right", ...TOOLSET_PROFILES.map(() => "center" as const), "left"],
+  );
+}
+
+/**
+ * Render a fragment's gate for the report.
+ *
+ * @param name - Fragment name
+ * @returns The gate as display text
+ */
+function describeGate(name: string): string {
+  const gate = fragmentGate(name);
+
+  if (gate == null) return "_driver root_";
+  if (gate === "always") return "always";
+  if (gate === "conversation-only") return "chat audience only";
+
+  return gate.join(", ");
+}

--- a/scripts/skills/snapshot-helpers.test.ts
+++ b/scripts/skills/snapshot-helpers.test.ts
@@ -1,0 +1,121 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  compareCorpora,
+  formatChanges,
+  parseArgs,
+} from "./snapshot-helpers.ts";
+
+const DEFAULT_DIR = "/repo/dev/skills-snapshots";
+
+describe("parseArgs", () => {
+  it("defaults the output directory and asks for no comparison", () => {
+    expect(parseArgs([], DEFAULT_DIR)).toStrictEqual({
+      outDir: DEFAULT_DIR,
+      diffDir: null,
+    });
+  });
+
+  it("resolves both directories against the invocation directory", () => {
+    const args = parseArgs(["--out", "a", "--diff", "b"], DEFAULT_DIR);
+
+    expect(args.outDir).toBe(path.resolve("a"));
+    expect(args.diffDir).toBe(path.resolve("b"));
+  });
+
+  it("rejects --flag=value, which would silently write to the default", () => {
+    // The default output directory is ERASED before writing, so falling back to
+    // it on a typo is how a user loses the baseline they meant to keep.
+    expect(() => parseArgs(["--out=/tmp/x"], DEFAULT_DIR)).toThrow(
+      /unknown argument/,
+    );
+  });
+
+  it("rejects an unknown flag", () => {
+    expect(() => parseArgs(["--check"], DEFAULT_DIR)).toThrow(
+      /unknown argument "--check"/,
+    );
+  });
+
+  it("rejects a flag with no value, or with another flag as its value", () => {
+    expect(() => parseArgs(["--diff"], DEFAULT_DIR)).toThrow(
+      /--diff needs a directory/,
+    );
+    expect(() => parseArgs(["--diff", "--out", "x"], DEFAULT_DIR)).toThrow(
+      /--diff needs a directory/,
+    );
+  });
+
+  it("refuses to diff against the directory it is about to erase", () => {
+    // Otherwise: delete the baseline, regenerate it, diff it against itself, and
+    // report "No blob changed" — a confident false negative.
+    expect(() => parseArgs(["--diff", DEFAULT_DIR], DEFAULT_DIR)).toThrow(
+      /would erase it/,
+    );
+    expect(() =>
+      parseArgs(["--out", "same", "--diff", "same"], DEFAULT_DIR),
+    ).toThrow(/would erase it/);
+  });
+});
+
+describe("compareCorpora", () => {
+  it("finds no change between identical corpora", () => {
+    const corpus = new Map([["a.md", "x"]]);
+
+    expect(compareCorpora(corpus, new Map(corpus))).toStrictEqual([]);
+  });
+
+  it("catches an edit that keeps the length", () => {
+    // A renamed heading or a reordered list is exactly what a re-carve produces;
+    // comparing sizes alone would call this "no change".
+    const changes = compareCorpora(
+      new Map([["a.md", "Producer Pal"]]),
+      new Map([["a.md", "PRODUCER PAL"]]),
+    );
+
+    expect(changes).toStrictEqual([
+      { kind: "changed", file: "a.md", was: 12, now: 12 },
+    ]);
+  });
+
+  it("reports added and removed files", () => {
+    const changes = compareCorpora(
+      new Map([["gone.md", "x"]]),
+      new Map([["new.md", "yy"]]),
+    );
+
+    expect(changes).toStrictEqual([
+      { kind: "added", file: "new.md", now: 2 },
+      { kind: "removed", file: "gone.md" },
+    ]);
+  });
+});
+
+describe("formatChanges", () => {
+  it("says so when nothing changed", () => {
+    expect(formatChanges([])).toBe("No blob changed.");
+  });
+
+  it("shows a signed delta, and names a same-size edit as one", () => {
+    const lines = formatChanges([
+      { kind: "changed", file: "grew.md", was: 100, now: 113 },
+      { kind: "changed", file: "shrank.md", was: 100, now: 90 },
+      { kind: "changed", file: "moved.md", was: 100, now: 100 },
+      { kind: "added", file: "new.md", now: 5 },
+      { kind: "removed", file: "gone.md" },
+    ]).split("\n");
+
+    expect(lines).toStrictEqual([
+      "  ~ grew.md 100 → 113 (+13)",
+      "  ~ shrank.md 100 → 90 (-10)",
+      "  ~ moved.md (same size, different text)",
+      "  + new.md (5)",
+      "  - gone.md",
+    ]);
+  });
+});

--- a/scripts/skills/snapshot-helpers.ts
+++ b/scripts/skills/snapshot-helpers.ts
@@ -1,0 +1,147 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Argument parsing and corpus comparison for snapshot-skills.ts, split out so
+// both are unit-testable — the script's destructive step (it removes the output
+// directory before writing) means a misread argument deletes the wrong thing.
+
+import path from "node:path";
+
+/** The output directory, and the corpus to compare it against. */
+export interface SnapshotArgs {
+  outDir: string;
+  diffDir: string | null;
+}
+
+/** How one file differs between two corpora. */
+export interface CorpusChange {
+  kind: "added" | "removed" | "changed";
+  file: string;
+  /** Character counts, on a change. */
+  was?: number;
+  now?: number;
+}
+
+/** The marker the generated README opens with, used to recognize a corpus. */
+export const CORPUS_MARKER = "# Skills snapshots";
+
+const FLAGS = new Set(["--out", "--diff"]);
+
+/**
+ * Parse `--out DIR` / `--diff DIR`. Strict on purpose: an unrecognized argument
+ * throws rather than falling back to the default output directory, because that
+ * default gets ERASED before writing — a typo'd `--out=/tmp/x` would otherwise
+ * silently delete the baseline the user was trying to keep.
+ *
+ * @param argv - Arguments after the script name
+ * @param defaultDir - Where to write when `--out` is absent
+ * @returns The resolved output and comparison directories
+ * @throws When an argument is unknown, malformed, or missing its value
+ */
+export function parseArgs(
+  argv: readonly string[],
+  defaultDir: string,
+): SnapshotArgs {
+  const values = new Map<string, string>();
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index] as string;
+
+    if (!FLAGS.has(arg)) {
+      throw new Error(
+        `unknown argument "${arg}" (expected --out DIR or --diff DIR; note the value is a separate argument, not --out=DIR)`,
+      );
+    }
+
+    const value = argv[++index];
+
+    if (value == null || value.startsWith("--")) {
+      throw new Error(`${arg} needs a directory`);
+    }
+
+    // Resolved against the invocation directory, which is what a user typing a
+    // relative path means.
+    values.set(arg, path.resolve(value));
+  }
+
+  const outDir = values.get("--out") ?? defaultDir;
+  const diffDir = values.get("--diff") ?? null;
+
+  if (diffDir != null && diffDir === outDir) {
+    throw new Error(
+      `--diff ${diffDir} is the directory being written; the comparison would erase it and then report no change. Pass a different --out, or diff against a copy.`,
+    );
+  }
+
+  return { outDir, diffDir };
+}
+
+/**
+ * Compare two corpora by CONTENT, not size. An edit that keeps a blob's length
+ * (a renamed heading, a reordered list) is exactly the kind a fragment re-carve
+ * produces, and a size-only comparison would call it "no change".
+ *
+ * @param before - Previous corpus, relative path → contents
+ * @param after - Corpus just written, relative path → contents
+ * @returns Every difference, added/changed first, then removed
+ */
+export function compareCorpora(
+  before: ReadonlyMap<string, string>,
+  after: ReadonlyMap<string, string>,
+): CorpusChange[] {
+  const changes: CorpusChange[] = [];
+
+  for (const [file, content] of after) {
+    const was = before.get(file);
+
+    if (was == null) changes.push({ kind: "added", file, now: content.length });
+    else if (was !== content) {
+      changes.push({
+        kind: "changed",
+        file,
+        was: was.length,
+        now: content.length,
+      });
+    }
+  }
+
+  for (const file of before.keys()) {
+    if (!after.has(file)) changes.push({ kind: "removed", file });
+  }
+
+  return changes;
+}
+
+/**
+ * Render the comparison for the terminal.
+ *
+ * @param changes - The differences ({@link compareCorpora})
+ * @returns One line per change, or a single "nothing changed" line
+ */
+export function formatChanges(changes: readonly CorpusChange[]): string {
+  if (changes.length === 0) return "No blob changed.";
+
+  return changes.map(formatChange).join("\n");
+}
+
+// --- Helpers below main export ---
+
+/**
+ * Render one change. A changed blob shows its size delta, and says so explicitly
+ * when the content moved without the length moving.
+ *
+ * @param change - The difference to render
+ * @returns The display line
+ */
+function formatChange(change: CorpusChange): string {
+  if (change.kind === "added") return `  + ${change.file} (${change.now})`;
+  if (change.kind === "removed") return `  - ${change.file}`;
+
+  const delta = (change.now ?? 0) - (change.was ?? 0);
+
+  if (delta === 0) return `  ~ ${change.file} (same size, different text)`;
+
+  return `  ~ ${change.file} ${change.was} → ${change.now} (${delta > 0 ? "+" : ""}${delta})`;
+}

--- a/scripts/skills/snapshot-skills.ts
+++ b/scripts/skills/snapshot-skills.ts
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Writes the skills snapshot corpus — the assembled blob for every (toolset
+// profile x depth x notation) — and compares two of them. Output is gitignored:
+// it's a scratch artifact for iterating on the fragment carve, not a committed
+// baseline.
+//
+//   npm run skills:snapshot                 write dev/skills-snapshots, print the report
+//   npm run skills:snapshot -- --out DIR    write somewhere else (keep a "before")
+//   npm run skills:snapshot -- --diff DIR   write, then show what changed vs DIR
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildCorpus, type SnapshotFile } from "./skills-corpus.ts";
+import {
+  compareCorpora,
+  CORPUS_MARKER,
+  formatChanges,
+  parseArgs,
+} from "./snapshot-helpers.ts";
+
+const PROJECT_ROOT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const DEFAULT_DIR = path.join(PROJECT_ROOT, "dev/skills-snapshots");
+
+await main();
+
+/**
+ * Generate the corpus, print the report, and diff against a previous run when
+ * `--diff` names one.
+ */
+async function main(): Promise<void> {
+  const args = parseOrExit();
+  const corpus = buildCorpus();
+
+  await write(corpus, args.outDir);
+  console.log(readmeOf(corpus));
+  console.log(`Wrote ${corpus.length} files to ${label(args.outDir)}/\n`);
+
+  if (args.diffDir != null) await diff(args.diffDir, args.outDir);
+}
+
+// --- Helpers below main export ---
+
+/**
+ * Parse the command line, reporting a usage error rather than a stack trace.
+ *
+ * @returns The parsed arguments
+ */
+function parseOrExit(): ReturnType<typeof parseArgs> {
+  try {
+    return parseArgs(process.argv.slice(2), DEFAULT_DIR);
+  } catch (error: unknown) {
+    console.error(`skills:snapshot: ${(error as Error).message}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Name a directory for display: repo-relative when it's inside the repo, else
+ * absolute (a `--out /tmp/...` shouldn't print as a pile of `../`).
+ *
+ * @param dir - Absolute directory path
+ * @returns The path to show
+ */
+function label(dir: string): string {
+  const relative = path.relative(PROJECT_ROOT, dir);
+
+  return relative.startsWith("..") ? dir : relative || ".";
+}
+
+/**
+ * The README's text, which doubles as the terminal report.
+ *
+ * @param corpus - The generated files
+ * @returns The report markdown
+ */
+function readmeOf(corpus: SnapshotFile[]): string {
+  return corpus.find((file) => file.path === "README.md")?.content ?? "";
+}
+
+/**
+ * Write the corpus, replacing whatever is there. The directory is removed first
+ * so a profile or notation that no longer exists doesn't leave a stale file
+ * behind looking current — which is why {@link assertSafeTarget} runs before it.
+ *
+ * @param corpus - The files to write
+ * @param outDir - Absolute path to write them under
+ */
+async function write(corpus: SnapshotFile[], outDir: string): Promise<void> {
+  await assertSafeTarget(outDir);
+  await fs.rm(outDir, { recursive: true, force: true });
+
+  for (const file of corpus) {
+    const target = path.join(outDir, file.path);
+
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, file.content, "utf-8");
+  }
+}
+
+/**
+ * Refuse to erase a directory that isn't ours. `--out` takes an arbitrary path
+ * and the write is a recursive delete, so `--out ~/Documents` has to be a usage
+ * error rather than a data loss. Absent or empty is fine; anything else must
+ * carry a corpus README.
+ *
+ * @param outDir - The directory about to be removed and rewritten
+ */
+async function assertSafeTarget(outDir: string): Promise<void> {
+  const entries = await readDirNames(outDir);
+
+  if (entries == null || entries.length === 0) return;
+
+  const readme = await readFileOrNull(path.join(outDir, "README.md"));
+
+  if (readme?.startsWith(CORPUS_MARKER)) return;
+
+  console.error(
+    `skills:snapshot: refusing to erase ${outDir} — it is not empty and holds no snapshot corpus. Pick an empty or nonexistent directory.`,
+  );
+  process.exit(1);
+}
+
+/**
+ * Compare a previous run against the one just written: a content-level summary
+ * first, then the line-level diff from `diff -ru`, which prints exactly what a
+ * reviewer wants to read.
+ *
+ * @param oldDir - The previous corpus
+ * @param newDir - The corpus just written
+ */
+async function diff(oldDir: string, newDir: string): Promise<void> {
+  if (!(await isDirectory(oldDir))) {
+    console.error(`skills:snapshot: ${oldDir} is not a directory to compare.`);
+    process.exit(1);
+  }
+
+  console.log(`# Changes vs ${label(oldDir)}\n`);
+  console.log(
+    formatChanges(
+      compareCorpora(await readCorpus(oldDir), await readCorpus(newDir)),
+    ),
+  );
+
+  printUnifiedDiff(oldDir, newDir);
+}
+
+/**
+ * Print the line-level diff, or say why there isn't one. Silence here would read
+ * as "nothing changed" right after a summary that said otherwise, so a missing
+ * `diff` binary or a truncated pipe has to announce itself.
+ *
+ * @param oldDir - The previous corpus
+ * @param newDir - The corpus just written
+ */
+function printUnifiedDiff(oldDir: string, newDir: string): void {
+  const result = spawnSync("diff", ["-ru", oldDir, newDir], {
+    encoding: "utf-8",
+    maxBuffer: 256 * 1024 * 1024,
+  });
+
+  if (result.stdout) console.log(`\n${result.stdout}`);
+
+  if (result.error != null) {
+    console.error(
+      `\nskills:snapshot: could not run \`diff\` (${result.error.message}). The summary above still holds; compare the directories yourself for line-level detail.`,
+    );
+  }
+}
+
+/**
+ * Read every blob in a corpus directory. README.md is excluded — it only
+ * restates the numbers, so a change there is never news.
+ *
+ * @param dir - Corpus directory
+ * @returns Relative path → contents
+ */
+async function readCorpus(dir: string): Promise<Map<string, string>> {
+  const entries = await fs.readdir(dir, {
+    recursive: true,
+    withFileTypes: true,
+  });
+  const found = new Map<string, string>();
+
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+
+    const full = path.join(entry.parentPath, entry.name);
+    const relative = path.relative(dir, full);
+
+    if (relative === "README.md") continue;
+
+    found.set(relative, await fs.readFile(full, "utf-8"));
+  }
+
+  return found;
+}
+
+/**
+ * List a directory's entries, treating absence as a value.
+ *
+ * @param dir - Absolute directory path
+ * @returns Entry names, or null when the path doesn't exist or isn't a directory
+ */
+async function readDirNames(dir: string): Promise<string[] | null> {
+  try {
+    return await fs.readdir(dir);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read a file, treating absence as a value.
+ *
+ * @param target - Absolute path
+ * @returns The contents, or null when it can't be read
+ */
+async function readFileOrNull(target: string): Promise<string | null> {
+  try {
+    return await fs.readFile(target, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a path is an existing directory.
+ *
+ * @param target - Absolute path
+ * @returns True only for a directory
+ */
+async function isDirectory(target: string): Promise<boolean> {
+  try {
+    const stats = await fs.stat(target);
+
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/scripts/skills/toolset-profiles.ts
+++ b/scripts/skills/toolset-profiles.ts
@@ -1,0 +1,97 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// The named toolsets the skills snapshot corpus is generated for. Each one is a
+// USE CASE the fragment carve is supposed to serve, not a sample of the 2^21
+// toolsets a user could actually assemble — the point is to see what a read-only
+// worker or a clip author receives, and to notice when a reorganization changes
+// it.
+//
+// Tool lists are written out rather than derived from a prefix, so a profile
+// states a decision instead of drifting the day a tool is added. `assertKnownTools`
+// catches the other side of that: a renamed tool would otherwise silently widen a
+// profile's snapshot.
+
+import { TOOL_NAMES } from "#src/mcp-server/create-mcp-server.ts";
+
+/** A named toolset the corpus is generated for. */
+export interface ToolsetProfile {
+  /** Directory name in the corpus and column head in the report. */
+  name: string;
+  /** The caller this stands in for, one line. */
+  description: string;
+  /** The tools that caller can call. */
+  tools: readonly string[];
+}
+
+const CONNECT = "ppal-connect";
+const READ_CLIP = "ppal-read-clip";
+const READ_TRACK = "ppal-read-track";
+
+export const TOOLSET_PROFILES: readonly ToolsetProfile[] = [
+  {
+    name: "all",
+    description: "Every tool — the ungated baseline the chat gets by default.",
+    tools: TOOL_NAMES,
+  },
+  {
+    name: "read-only",
+    description:
+      "A caller that can look but not touch: the narrow subagent worker gating exists to serve.",
+    tools: [
+      CONNECT,
+      "ppal-read-live-set",
+      READ_TRACK,
+      "ppal-read-scene",
+      READ_CLIP,
+      "ppal-read-device",
+    ],
+  },
+  {
+    name: "clip-write",
+    description: "A clip author: reads a clip's context, writes notes back.",
+    tools: [
+      CONNECT,
+      READ_TRACK,
+      READ_CLIP,
+      "ppal-create-clip",
+      "ppal-update-clip",
+    ],
+  },
+  {
+    name: "device-work",
+    description:
+      "A sound designer: builds and tweaks devices, writes no notes.",
+    tools: [
+      CONNECT,
+      READ_TRACK,
+      "ppal-read-device",
+      "ppal-create-device",
+      "ppal-update-device",
+    ],
+  },
+];
+
+/**
+ * Fail loudly when a profile names a tool the server doesn't register. A rename
+ * would otherwise drop that tool from the profile silently, widening every
+ * snapshot it gates — the exact drift the explicit lists exist to prevent.
+ *
+ * @throws When any profile names an unknown tool
+ */
+export function assertKnownTools(): void {
+  const known = new Set(TOOL_NAMES);
+  const unknown = TOOLSET_PROFILES.flatMap((profile) =>
+    profile.tools
+      .filter((tool) => !known.has(tool))
+      .map((tool) => `${profile.name}: ${tool}`),
+  );
+
+  if (unknown.length > 0) {
+    throw new Error(
+      `toolset profiles name tools the server doesn't register:\n  ${unknown.join("\n  ")}`,
+    );
+  }
+}

--- a/src/mcp-server/helpers/skill-overrides-store.ts
+++ b/src/mcp-server/helpers/skill-overrides-store.ts
@@ -24,6 +24,10 @@
 
 import { type SkillOverrides } from "#src/skills/build-skills.ts";
 import {
+  fragmentGate,
+  type FragmentGate,
+} from "#src/skills/fragment-tool-gates.ts";
+import {
   isDisableableSkillSlot,
   SKILL_SLOT_NAMES,
   SKILL_SLOTS,
@@ -88,6 +92,13 @@ export interface SkillSlotState {
   enabled: boolean;
   /** Whether the editor may offer an off switch (false for the drivers). */
   canDisable: boolean;
+  /**
+   * The tools (any-of) that keep this fragment, or `"always"` /
+   * `"conversation-only"`; null for the drivers. Sent so the editor can state
+   * the rule — a fragment's conditional behavior was only ever described in its
+   * prose description, which drifts.
+   */
+  gate: FragmentGate | null;
   /** Whether the built-in changed since this override was forked. */
   drifted: boolean;
   /** Fork-time provenance (null when there is no override). */
@@ -170,6 +181,7 @@ export function readSkillSlotState(name: SkillSlotName): SkillSlotState {
     override,
     enabled: isEnabled(data),
     canDisable: isDisableableSkillSlot(name),
+    gate: fragmentGate(name),
     drifted: isDrifted(provenance, BUILT_IN_HASHES[name]),
     provenance,
   };

--- a/src/mcp-server/routes/skills-preview-route.ts
+++ b/src/mcp-server/routes/skills-preview-route.ts
@@ -14,7 +14,7 @@
 
 import { type Express, type Request, type Response } from "express";
 import { DEFAULT_NOTATION, isNotation } from "#src/shared/notation.ts";
-import { buildSkills } from "#src/skills/build-skills.ts";
+import { assembleSkills } from "#src/skills/build-skills.ts";
 import { resolveFragmentAlias } from "#src/skills/builtin-fragments.ts";
 import { readSkillOverrides } from "../helpers/skill-overrides-store.ts";
 
@@ -24,11 +24,12 @@ import { readSkillOverrides } from "../helpers/skill-overrides-store.ts";
  * (`"true"` enables basic/small-model skills) select the combination. The
  * response carries the assembled blob, the two slot names the COMBINATION picks
  * (the driver and the notation head — every other fragment is named by the
- * driver's own manifest, which the user can read in the editor), and any
- * assembly `warnings` (unknown fragments, refused nesting, unsafe refs in a user
- * override) so the editor can flag a broken override instead of showing a
- * truncated blob. Read-only, so it is not origin-gated (unlike the override
- * writes) — it exposes nothing a GET /skill-overrides didn't already.
+ * driver's own manifest, which the user can read in the editor), the fragments
+ * the toolset `dropped`, and any assembly `warnings` (unknown fragments, refused
+ * nesting, unsafe refs in a user override) so the editor can flag a broken
+ * override instead of showing a truncated blob. Read-only, so it is not
+ * origin-gated (unlike the override writes) — it exposes nothing a GET
+ * /skill-overrides didn't already.
  *
  * The preview reflects the DEVICE's tool whitelist, so a fragment whose tools
  * are all switched off shows as gone here too — this is the blob an external MCP
@@ -63,12 +64,20 @@ export function registerSkillsPreviewRoute(
     // refs) so the editor can surface a broken override instead of showing a
     // silently truncated blob.
     const warnings: string[] = [];
-    const skills = buildSkills(
+    const { skills, dropped } = assembleSkills(
       { notation, smallModelMode, tools: getTools?.() },
       readSkillOverrides(),
       (message) => warnings.push(message),
     );
 
-    res.json({ notation, smallModelMode, head, driver, skills, warnings });
+    res.json({
+      notation,
+      smallModelMode,
+      head,
+      driver,
+      skills,
+      dropped,
+      warnings,
+    });
   });
 }

--- a/src/mcp-server/tests/skill-overrides/skill-overrides-route.test.ts
+++ b/src/mcp-server/tests/skill-overrides/skill-overrides-route.test.ts
@@ -35,6 +35,7 @@ interface SlotState {
   override: string;
   enabled: boolean;
   canDisable: boolean;
+  gate: readonly string[] | string | null;
   drifted: boolean;
   provenance: { producerPalVersion: string; builtInHash: string } | null;
 }
@@ -54,6 +55,24 @@ describe("skill-overrides route", () => {
       expect(slot.enabled).toBe(true);
       expect(slot.provenance).toBeNull();
     }
+  });
+
+  it("GET carries each slot's tool gate, so the editor can state the rule", async () => {
+    // The editor renders this verbatim; a field-name or shape change here would
+    // otherwise only surface as the gate note quietly vanishing.
+    const res = await fetch(base);
+    const { slots } = (await res.json()) as { slots: SlotState[] };
+    // Read through the slot, not a defaulted lookup: a driver's gate is
+    // legitimately null, so a `?? fallback` would hide a missing slot AND a
+    // correct null behind the same value.
+    const gateOf = (name: string): SlotState["gate"] | undefined =>
+      slots.find((slot) => slot.name === name)?.gate;
+
+    expect(gateOf("library")).toStrictEqual(["ppal-library"]);
+    expect(gateOf("time-and-values")).toBe("always");
+    expect(gateOf("getting-help")).toBe("conversation-only");
+    // The drivers are the document, not a section of it.
+    expect(gateOf("standard")).toBeNull();
   });
 
   it("PUT saves an override with provenance; GET reflects it", async () => {

--- a/src/mcp-server/tests/skill-overrides/skills-preview-route.test.ts
+++ b/src/mcp-server/tests/skill-overrides/skills-preview-route.test.ts
@@ -42,6 +42,7 @@ interface PreviewBody {
   head: string;
   driver: string;
   skills: string;
+  dropped: string[];
   warnings: string[];
 }
 
@@ -137,5 +138,48 @@ describe("skills-preview route", () => {
     expect(body.warnings.some((w) => w.includes("unknown fragment"))).toBe(
       true,
     );
+  });
+
+  it("drops nothing when the device gates no tools", async () => {
+    const body = await getPreview("notation=barbeat");
+
+    expect(body.dropped).toStrictEqual([]);
+  });
+});
+
+describe("skills-preview route - tool gating", () => {
+  let gatedServer: MarkdownRouteServer;
+  let gatedBase = "";
+
+  beforeAll(async () => {
+    gatedServer = await startMarkdownRouteServer((app) => {
+      // A read-only toolset: no library, no context, no clip writers.
+      registerSkillsPreviewRoute(app, () => [
+        "ppal-connect",
+        "ppal-read-clip",
+        "ppal-read-track",
+      ]);
+    });
+    gatedBase = `${gatedServer.baseUrl}/skills-preview`;
+  });
+
+  afterAll(async () => {
+    await gatedServer.close();
+  });
+
+  it("names the fragments the device's toolset left out", async () => {
+    const res = await fetch(`${gatedBase}?notation=barbeat`);
+    const body = (await res.json()) as PreviewBody;
+
+    expect(body.dropped).toContain("library");
+    expect(body.dropped).toContain("context-standard");
+    expect(body.dropped).toContain("barbeat-standard-write");
+    // Kept: read-clip alone is enough for the notation head and arrangement.
+    expect(body.dropped).not.toContain("barbeat-standard");
+    expect(body.dropped).not.toContain("arrangement");
+    // Empty in a release build either way, so reporting it as a loss is noise.
+    expect(body.dropped).not.toContain("code-transforms");
+    // Every name is one the user can find in the fragment editor.
+    expect(body.skills).not.toContain("## Finding Library Content");
   });
 });

--- a/src/skills/build-skills.ts
+++ b/src/skills/build-skills.ts
@@ -61,6 +61,18 @@ export interface SkillOverrides {
   disabled?: readonly string[];
 }
 
+/** An assembled blob plus what the runtime context dropped from it. */
+export interface AssembledSkills {
+  /** The skills string returned in the ppal-connect tool result. */
+  skills: string;
+  /**
+   * Fragments this document referenced that the TOOLSET or AUDIENCE emptied, in
+   * include order. The user's own off switches are excluded — those they can
+   * already see in the editor; these are the ones nothing on screen explains.
+   */
+  dropped: string[];
+}
+
 /**
  * Assemble the Producer Pal Skills string for the active runtime context. Small-
  * model mode picks the driver root (`basic` vs `standard`); everything else —
@@ -90,6 +102,29 @@ export interface SkillOverrides {
  * @returns The skills string returned in the ppal-connect tool result.
  */
 export function buildSkills(
+  options: BuildSkillsOptions = {},
+  overrides: SkillOverrides = {},
+  onWarn?: (message: string) => void,
+): string {
+  return assembleSkills(options, overrides, onWarn).skills;
+}
+
+/**
+ * Assemble as {@link buildSkills} does, and also report which of the document's
+ * fragments the toolset or audience emptied. Separate from `buildSkills` because
+ * only a surface that EXPLAINS the blob needs the second half — the live inject
+ * wants the string and nothing else.
+ *
+ * @param options - Runtime context ({@link BuildSkillsOptions}).
+ * @param options.notation - The global notation setting (defaults to bar|beat).
+ * @param options.smallModelMode - Whether small-model mode is active.
+ * @param options.tools - The tools available to this caller (omit for no gating).
+ * @param options.audience - Who the blob is for (omit for the user-facing chat).
+ * @param overrides - Per-fragment user overrides (empty by default).
+ * @param onWarn - Sink for non-fatal assembly warnings.
+ * @returns The blob and the fragments gating dropped from it.
+ */
+export function assembleSkills(
   {
     notation = DEFAULT_NOTATION,
     smallModelMode = false,
@@ -98,21 +133,25 @@ export function buildSkills(
   }: BuildSkillsOptions = {},
   overrides: SkillOverrides = {},
   onWarn?: (message: string) => void,
-): string {
+): AssembledSkills {
   const builtIns = builtinFragments();
   const root = smallModelMode ? "basic" : "standard";
   const fragments = overrides.fragments ?? {};
-  // Tool gating, audience gating, and the user's per-slot off switches empty a
-  // fragment in exactly the same way, so all three resolve through one set.
-  const suppressed = new Set([
+  // Reported separately from the other two: a user's own off switch is already
+  // visible as an unchecked box, while these have nothing on screen to explain
+  // them.
+  const gated = new Set([
     ...gatedOutFragments(tools),
     ...audienceGatedFragments(audience),
-    ...(overrides.disabled ?? []),
   ]);
+  // Tool gating, audience gating, and the user's per-slot off switches empty a
+  // fragment in exactly the same way, so all three resolve through one set.
+  const suppressed = new Set([...gated, ...(overrides.disabled ?? [])]);
 
   warnRetiredOverrides(overrides, onWarn);
 
   const included = new Set<string>();
+  const dropped = new Set<string>();
   const skills = resolveIncludes(root, {
     notation,
     lookup: (name) => {
@@ -133,13 +172,25 @@ export function buildSkills(
     onFragment: (name) => {
       const key = resolveFragmentAlias(name);
 
-      if (!suppressed.has(key)) included.add(key);
+      if (suppressed.has(key)) {
+        // Only fragments that would otherwise have carried text. `code-transforms`
+        // in a release build, and the `-write` placeholders a notation without an
+        // authoring half registers, are empty either way — reporting them as
+        // "left out" describes a loss the caller never took.
+        if (gated.has(key) && (fragments[key] ?? builtIns[key])) {
+          dropped.add(key);
+        }
+
+        return;
+      }
+
+      included.add(key);
     },
   });
 
   warnUnmetRequirements(included, onWarn);
 
-  return skills;
+  return { skills, dropped: [...dropped] };
 }
 
 // --- Helpers below main export ---

--- a/src/skills/builtin-fragments.ts
+++ b/src/skills/builtin-fragments.ts
@@ -23,6 +23,13 @@
 //                               Small-model mode means FEWER fragments, not
 //                               basic variants of all of them.
 //
+// A notation head may also carry a `-write` SIBLING holding the syntax only the
+// clip writers can act on, so a read-only caller stops paying for the authoring
+// guide (ADR-0019). The base name keeps its meaning — that is what lets the
+// standard driver's `{notation}-standard` ref stay put — and each notation opts
+// in separately. bar|beat is split; stark and midi-json are not, so their
+// `-write` refs resolve to an empty body (below).
+//
 // Two entries are not quite leaves-as-written:
 //   code-transforms ........... build-gated. It is always PRESENT here and empty
 //                               when disabled, rather than absent: the resolver
@@ -54,7 +61,10 @@ import { transformsExpressions } from "#src/skills/fragments/transforms-expressi
 import { transformsGenerative } from "#src/skills/fragments/transforms-generative.ts";
 import { workingWithLive } from "#src/skills/fragments/working-with-live.ts";
 import { barbeatBasic } from "#src/skills/notation/barbeat-basic.ts";
-import { barbeatStandard } from "#src/skills/notation/barbeat-standard.ts";
+import {
+  barbeatStandard,
+  barbeatStandardWrite,
+} from "#src/skills/notation/barbeat-standard.ts";
 import { midiJson } from "#src/skills/notation/midi-json.ts";
 import { starkBasic, starkStandard } from "#src/skills/notation/stark.ts";
 
@@ -98,10 +108,18 @@ export function builtinFragments(
     "getting-help": gettingHelp,
 
     "barbeat-standard": barbeatStandard,
+    "barbeat-standard-write": barbeatStandardWrite,
     "barbeat-basic": barbeatBasic,
     "stark-standard": starkStandard,
     "stark-basic": starkBasic,
     "midi-json": midiJson,
+
+    // Present-but-empty, the code-transforms precedent: the standard driver's
+    // `-write` ref is notation-templated, and these two heads aren't split, so
+    // their authoring content stays inline in the head above. Registering the
+    // names keeps an unknown fragment a real error rather than a shrug.
+    "stark-standard-write": "",
+    "midi-json-standard-write": "",
   };
 }
 

--- a/src/skills/drivers.ts
+++ b/src/skills/drivers.ts
@@ -33,11 +33,19 @@ const HEADER = "# Producer Pal Skills";
  * between includes are the blank lines between the assembled sections —
  * fragments carry no leading/trailing blank lines, and the resolver collapses
  * any run left behind by a fragment that resolved to nothing (an override the
- * user emptied, or `code-transforms` in a release build).
+ * user emptied, `code-transforms` in a release build, or a notation whose head
+ * has no authoring half to split off).
+ *
+ * The notation head takes two adjacent lines so the guide stays contiguous: the
+ * base head, then its `-write` sibling carrying the syntax only the clip writers
+ * can act on (ADR-0019). Only bar|beat is split so far; the other notations
+ * resolve that second ref to nothing.
  */
 export const standardDriver = `${HEADER}
 
 @include "./{notation}-standard.md"
+
+@include "./{notation}-standard-write.md"
 
 @include "./time-and-values.md"
 

--- a/src/skills/fragment-tool-gates.ts
+++ b/src/skills/fragment-tool-gates.ts
@@ -33,11 +33,10 @@ const UPDATE_CLIP = "ppal-update-clip";
  * them makes the notation head load-bearing.
  *
  * Spanning both directions is deliberate and can't be narrowed to the writers: a
- * read-only caller still needs the grammar to parse what read-clip RETURNS. The
- * cost is that it also receives the authoring half it can't use (~680-1160 tokens
- * of `barbeat-standard`), which is a known, measured floor rather than an
- * oversight — splitting the head is blocked on override migration, not on this
- * table. See ADR-0016.
+ * read-only caller still needs the grammar to parse what read-clip RETURNS. What
+ * a read-only caller does NOT need is the authoring syntax, and that is a
+ * separate `-write` fragment rather than a narrower gate here — see
+ * {@link NOTE_WRITE_TOOLS} and ADR-0019.
  */
 const NOTE_TOOLS = [
   "ppal-read-clip",
@@ -46,6 +45,14 @@ const NOTE_TOOLS = [
   "ppal-read-track",
   "ppal-read-scene",
 ] as const;
+
+/**
+ * The two tools that take `notes` as INPUT — the gate on a notation head's
+ * `-write` sibling. A strict subset of {@link NOTE_TOOLS}, so the requires-subset
+ * invariant holds: any toolset keeping the authoring half also keeps the base
+ * head whose grammar it builds on.
+ */
+const NOTE_WRITE_TOOLS = [CREATE_CLIP, UPDATE_CLIP] as const;
 
 /** The tools whose schemas accept `transforms` / `preTransforms`. */
 const TRANSFORM_TOOLS = [CREATE_CLIP, UPDATE_CLIP, "ppal-duplicate"] as const;
@@ -121,6 +128,13 @@ export const FRAGMENT_GATES: Record<string, FragmentGate> = {
   "stark-standard": NOTE_TOOLS,
   "stark-basic": NOTE_TOOLS,
   "midi-json": NOTE_TOOLS,
+
+  // The authoring halves. The two empty ones are placeholders for heads that
+  // aren't split (see builtin-fragments.ts); gating them the same way keeps the
+  // rule uniform, and an empty body costs a caller nothing either way.
+  "barbeat-standard-write": NOTE_WRITE_TOOLS,
+  "stark-standard-write": NOTE_WRITE_TOOLS,
+  "midi-json-standard-write": NOTE_WRITE_TOOLS,
 };
 
 /**

--- a/src/skills/fragment-tool-gates.ts
+++ b/src/skills/fragment-tool-gates.ts
@@ -138,6 +138,27 @@ export const FRAGMENT_GATES: Record<string, FragmentGate> = {
 };
 
 /**
+ * The condition one fragment ships under, for a surface that has to SHOW the
+ * rule rather than apply it (the webui fragment editor). Null for the driver
+ * roots, which have no entry — they are the document being assembled, not a
+ * section of it.
+ *
+ * Names reach this from user text (an override filename, a route param), so the
+ * `hasOwn` guard is load-bearing for the same reason it is in
+ * `resolveFragmentAlias`: a bare index would hand back
+ * `Object.prototype.toString` for a fragment named `toString`.
+ *
+ * @param name - Fragment name
+ * @returns The fragment's gate, or null when it has none
+ */
+export function fragmentGate(name: string): FragmentGate | null {
+  // hasOwn doesn't narrow an index signature; the key is present by the check.
+  return Object.hasOwn(FRAGMENT_GATES, name)
+    ? (FRAGMENT_GATES[name] as FragmentGate)
+    : null;
+}
+
+/**
  * The fragments to drop for a given toolset: those whose every tool is off.
  *
  * No transitive close over {@link SkillSlotDef.requires} happens here, and none

--- a/src/skills/notation/barbeat-standard.ts
+++ b/src/skills/notation/barbeat-standard.ts
@@ -4,42 +4,71 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
- * bar|beat standard notation head. Just the bar|beat-specific syntax (positions,
- * the note-writing grammar, bar copying). The notation-neutral note-value /
- * `Nbar` / dual-meter grammar lives in the `time-and-values` fragment (shared by
- * every notation's transforms and length fields); the `standard` driver's
- * manifest orders the two — `resolveIncludes` composes them, buildSkills glues
+ * bar|beat standard notation head, in two halves. The notation-neutral note-value
+ * / `Nbar` / dual-meter grammar lives in the `time-and-values` fragment (shared
+ * by every notation's transforms and length fields); the `standard` driver's
+ * manifest orders all three — `resolveIncludes` composes them, buildSkills glues
  * nothing.
+ *
+ * The split is by DIRECTION, so a caller with only the read tools stops paying
+ * for the authoring guide (see ADR-0019). {@link barbeatStandard} keeps the base
+ * slot name and holds what reading a clip needs — the positions grammar and the
+ * `v/n/p pitch bar|beat` shape the serializer actually emits;
+ * {@link barbeatStandardWrite} is the sibling gated on the two clip writers,
+ * holding the input-only sugar (repeats, brackets, bar copies, `v0`) that no
+ * read-back ever contains.
+ *
+ * The seam runs by whole bullet/section, NOT by trimming sentences inside the
+ * v/n/p bullets: a mis-sorted line degrades either reading or writing with
+ * nothing to catch it, so the ambiguous lines stay on the read side where both
+ * audiences get them. Two places needed real rewriting rather than moving, and
+ * they are where a regression would show up first — the meter paragraph below
+ * (its "use a repeat pattern instead" prescription moved, its meter FACT stayed)
+ * and the comma-list bullet (its "or repeat pattern" clause moved, restated by
+ * the write half's lead-in).
  */
 export const barbeatStandard = `## Positions & Meter
 
 - Positions: bar|beat — reads left-to-right like the name: \`4|2\` is bar 4 beat 2, \`2|4\` is bar 2 beat 4. 1-indexed, meter-relative grid. For one note per bar, step the LEFT number (\`1|1 2|1 3|1 4|1\`); to move within a bar, step the right number. Sub-beat placement has two tools for two jobs: a **decimal** (\`2|3.5\`) for *partway through a beat* (a fraction of the musical beat), and a **\`±n\` offset** (\`1|1+n/12\` = beat 1 + an eighth triplet, \`1|2-n/24\`) for an *exact note value* off the grid beat (tuplets, compound-meter placement). The offset attaches to an integer **or decimal** grid beat — \`1|1.5+n/4\` is beat 1.5 plus a quarter. They coincide only in x/4 — see the meter note below. A \`-n\` offset can pull *before* a downbeat for a **pickup**: \`1|1-n/4\` is a quarter-note pickup ahead of bar 1 (it lands before the clip start, which Live allows); use \`n/8\`, \`n/12\`, etc. for the lead-in you want. Serialized output uses the exact \`±n\` form for tuplet positions. No bare fractions (beats are 1-indexed — beat 0 is invalid; use a \`-n\` pickup instead). See **Time & Note Values** for note values (\`n/4\`, \`Nbar\`) and the dual-meter rule
 
-**In meters other than x/4, the grid beat is NOT a quarter** (in 6/8 it's an eighth), so consecutive grid beats are not one note value apart. To place notes a fixed note value apart — e.g. fill a bar with quarter notes — use a repeat pattern \`1|1x<count>\` with a real number for \`<count>\` (its step defaults to the current duration, which is meter-safe), not hand-enumerated grid beats: in 6/8, \`n/4 C1 1|1x3\` lands quarters on grid beats 1, 3, 5 (filling the bar), and in 5/4 \`n/4 C1 1|1x5\` fills the bar, while \`n/4 C1 1|1,2,3\` is consecutive *eighths* in 6/8 (wrong). Same trap for decimals: in 6/8 \`1|1.5\` is half an eighth, \`1|1+n/8\` a full eighth.
+**In meters other than x/4, the grid beat is NOT a quarter** (in 6/8 it's an eighth), so consecutive grid beats are not one note value apart: in 6/8, \`1|1,2,3\` is three consecutive *eighths*, not quarters. Same trap for decimals: in 6/8 \`1|1.5\` is half an eighth, \`1|1+n/8\` a full eighth.
 
 ## MIDI Syntax
 
-Create MIDI clips using the bar|beat notation syntax:
+MIDI clip notes use the bar|beat notation syntax:
 
 \`v0-127 n<duration> [p0-1] note(s) bar|beat(s)\`
 
 - v/n/p are prefixes — they apply to the pitches that follow. Vary per pitch by interspersing: \`v80 C4 v90 G4\` (C4 at 80, G4 at 90)
 - Notes emit at time positions (bar|beat)
   - time positions are relative to clip start
-  - the beat in bar|beat can be a comma-separated list or repeat pattern. Spaces after commas are fine, and a list item may restate its own \`bar|\` — that bar then sticks for the following bare items (\`1|1,2|1,3\` = \`1|1 2|1 2|3\`)
-  - **Repeat patterns**: \`{bar|beat}x{count}[@{step}]\` generates sequences. count = how many notes
-    - \`@step\` uses the same note-value form as \`n\` — \`@n/4\`, \`@1bar\` (bare \`@/4\` or \`@1\` is invalid). Defaults to the current duration (legato)
-    - \`1|1x4@n/4\` → 4 notes a quarter apart; \`n/8 1|1x4\` → 4 eighths (step defaults to n value)
-    - \`1|1x3@n/12\` → eighth-note triplets (3 in a quarter); \`n/16 1|1x16\` → 16 sixteenths spanning 4 quarters (a full bar in 4/4)
-    - **Prefer repeats over hand-listing beats for evenly-spaced notes** — the step is a note value, so spacing stays correct in any meter (see Positions & Meter for the meter trap this avoids)
-    - **Pattern brackets** \`[...]\`: a *cycle* of one parameter's values, stepped across notes instead of repeated. **Pitch**: \`[C3 E3 G3] 1|1x3@n/4\` (or across separate beats, \`[C3 E3 G3] 1|1 1|2 1|3\`) plays C3, E3, G3 (a melodic line, not 3× one pitch); \`(...)\` is a chord step (\`[(C3 E3) (D3 F3)] 1|1x2@n/4\`). Multiple pitch brackets (or a bare pitch + a bracket) **layer** into chords: \`C4 [E4 G4 C5] 1|1,2,3,4\` is a held C4 under a moving line; \`[C3 C4] [E3 G3 E4] 1|1,2,3,4\` stacks two voices that phase (only pitch layers — v/n/p are last-wins). **Velocity/duration/probability**: \`[v100 v60]\`, \`[n/4 n/8]\`, \`[p1 p0.5]\` cycle that value (e.g. \`[v100 v60 v60 v60] C1 1|1x16@n/16\` = accent every 4th hat). A duration bracket with **no** \`@step\` also sets the spacing — the notes gallop (\`[n/4 n/8] C3 1|1x8\` = long-short long-short). One kind per bracket. **Zip** sibling brackets to vary several at once against the same step: \`[v80 v100] [C3 E3 G3] 1|1x8@n/8\` → eight 8th notes C3 v80, E3 v100, G3 v80, C3 v100, E3 v80, G3 v100, C3 v80, E3 v100 (velocity cycles every 2, pitch every 3 — coprime lengths phase against each other). Each cycle wraps at its own length and persists until you reassign that parameter
+  - the beat in bar|beat can be a comma-separated list. Spaces after commas are fine, and a list item may restate its own \`bar|\` — that bar then sticks for the following bare items (\`1|1,2|1,3\` = \`1|1 2|1 2|3\`)
 - v<velocity>: 0-127 (default: v100). Range v80-120 randomizes per note for humanization (low bound ≥1; \`v0-N\` is an error — v0 is the delete sentinel, not a range floor)
-  - \`v0\` deletes earlier notes at the same pitch/time — **sticky** like any \`v\` (keeps deleting until you set a non-zero \`v\`). Reserve it for notes built in this same \`notes\` string; to delete notes already in the clip prefer \`preTransforms\`/\`transforms\` \`delete\` (see Editing Existing Notes). Always follow an inline \`v0\` with \`vN\` (N>0) to exit delete state
 - n<duration>: Note length as an absolute note value (default \`n/4\`). \`n\` is **stateful** — it carries until changed and applies to notes **after** it, so put the \`n\` change *before* the note it should affect (\`n/8 G3 4|2 A3\`, not \`G3 4|2 n/8 A3\`, which leaves G3 at the old length). Length matters for sustained/melodic notes (it *is* the articulation); for one-shot drums a carried length is usually inaudible, so re-set \`n\` only when the intended length actually changes. REQUIRES denominator — \`n1\`, \`n2.5\`, \`n0.5\` are invalid; write \`n/4\`, \`n5/8\`, \`n/8\`. \`n/12\` = eighth triplet (3 in a quarter), \`n/6\` = quarter triplet (3 in a half). A \`d\`/\`t\` suffix is a shortcut for dotted/triplet: \`n/4d\` = dotted quarter (= \`n3/8\`), \`n/8t\` = eighth triplet (= \`n/12\`) — see **Time & Note Values**
 - p<chance>: Probability from 0.0 to 1.0 (default: 1.0 = always). Opt-in — if any note uses probability, set it on every note (a stray p otherwise rides along)
 - Notes: C0-G8 with # or b for sharps/flats (C#3, Bb2; case-insensitive). C3 = middle C
 - **Shortcut (stateful)**: omit any of v/n/p to reuse its last value — they don't reset per note, so re-state one whenever it should change. v/n/p and pitch persist until changed
-- **Same-pitch overlap**: two notes of the same pitch can't sound at once — if one's length runs into the next same-pitch note, Live truncates the earlier to end where the next starts. Both are kept (authored notes aren't dropped for overlapping); same pitch *and* start collapses to one
+- **Same-pitch overlap**: two notes of the same pitch can't sound at once — if one's length runs into the next same-pitch note, Live truncates the earlier to end where the next starts. Both are kept (authored notes aren't dropped for overlapping); same pitch *and* start collapses to one`;
+
+/**
+ * bar|beat authoring half: the syntax only `ppal-create-clip` / `ppal-update-clip`
+ * can act on. Gated on those two, so a read-only caller never receives it — the
+ * serializer emits none of this, so a read-back provably never contains it.
+ *
+ * Opens by restating that a beat may be a repeat pattern and that v/n/p/pitch may
+ * be brackets, because the read half's comma-list bullet no longer says so.
+ */
+export const barbeatStandardWrite = `## Writing Notes
+
+The beat in bar|beat may also be a **repeat pattern**, and v/n/p/pitch may be **pattern brackets**:
+
+- **Repeat patterns**: \`{bar|beat}x{count}[@{step}]\` generates sequences. count = how many notes
+  - \`@step\` uses the same note-value form as \`n\` — \`@n/4\`, \`@1bar\` (bare \`@/4\` or \`@1\` is invalid). Defaults to the current duration (legato)
+  - \`1|1x4@n/4\` → 4 notes a quarter apart; \`n/8 1|1x4\` → 4 eighths (step defaults to n value)
+  - \`1|1x3@n/12\` → eighth-note triplets (3 in a quarter); \`n/16 1|1x16\` → 16 sixteenths spanning 4 quarters (a full bar in 4/4)
+  - **Prefer repeats over hand-listing beats for evenly-spaced notes** — the step is a note value, so spacing stays correct in any meter. To place notes a fixed note value apart — e.g. fill a bar with quarter notes — give \`<count>\` a real number instead of enumerating grid beats: in 6/8, \`n/4 C1 1|1x3\` lands quarters on grid beats 1, 3, 5 (filling the bar), and in 5/4 \`n/4 C1 1|1x5\` fills the bar (see **Positions & Meter** for the meter trap this avoids)
+- **Pattern brackets** \`[...]\`: a *cycle* of one parameter's values, stepped across notes instead of repeated. **Pitch**: \`[C3 E3 G3] 1|1x3@n/4\` (or across separate beats, \`[C3 E3 G3] 1|1 1|2 1|3\`) plays C3, E3, G3 (a melodic line, not 3× one pitch); \`(...)\` is a chord step (\`[(C3 E3) (D3 F3)] 1|1x2@n/4\`). Multiple pitch brackets (or a bare pitch + a bracket) **layer** into chords: \`C4 [E4 G4 C5] 1|1,2,3,4\` is a held C4 under a moving line; \`[C3 C4] [E3 G3 E4] 1|1,2,3,4\` stacks two voices that phase (only pitch layers — v/n/p are last-wins). **Velocity/duration/probability**: \`[v100 v60]\`, \`[n/4 n/8]\`, \`[p1 p0.5]\` cycle that value (e.g. \`[v100 v60 v60 v60] C1 1|1x16@n/16\` = accent every 4th hat). A duration bracket with **no** \`@step\` also sets the spacing — the notes gallop (\`[n/4 n/8] C3 1|1x8\` = long-short long-short). One kind per bracket. **Zip** sibling brackets to vary several at once against the same step: \`[v80 v100] [C3 E3 G3] 1|1x8@n/8\` → eight 8th notes C3 v80, E3 v100, G3 v80, C3 v100, E3 v80, G3 v100, C3 v80, E3 v100 (velocity cycles every 2, pitch every 3 — coprime lengths phase against each other). Each cycle wraps at its own length and persists until you reassign that parameter
+- \`v0\` deletes earlier notes at the same pitch/time — **sticky** like any \`v\` (keeps deleting until you set a non-zero \`v\`). Reserve it for notes built in this same \`notes\` string; to delete notes already in the clip prefer \`preTransforms\`/\`transforms\` \`delete\` (see Editing Existing Notes). Always follow an inline \`v0\` with \`vN\` (N>0) to exit delete state
 - copying bars (**MERGES** - clear unwanted notes with \`preTransforms\`/\`transforms\` \`delete\`, or a sticky inline \`v0\`):
   - @N= copies previous bar; @N=M copies bar M to N; @N-M=P copies bar P to range
   - @N-M=P-Q tiles bars P-Q across range; @clear clears copy buffer

--- a/src/skills/skill-slots.ts
+++ b/src/skills/skill-slots.ts
@@ -22,7 +22,10 @@ import { transformsExpressions } from "#src/skills/fragments/transforms-expressi
 import { transformsGenerative } from "#src/skills/fragments/transforms-generative.ts";
 import { workingWithLive } from "#src/skills/fragments/working-with-live.ts";
 import { barbeatBasic } from "#src/skills/notation/barbeat-basic.ts";
-import { barbeatStandard } from "#src/skills/notation/barbeat-standard.ts";
+import {
+  barbeatStandard,
+  barbeatStandardWrite,
+} from "#src/skills/notation/barbeat-standard.ts";
 import { midiJson } from "#src/skills/notation/midi-json.ts";
 import { starkBasic, starkStandard } from "#src/skills/notation/stark.ts";
 
@@ -50,6 +53,13 @@ const TRANSFORMS_EXPRESSIONS = "transforms-expressions";
 // renaming those to pair with it would retire three live slot names to buy
 // symmetry.
 //
+// A second, independent suffix axis is DIRECTION: a head may spin its authoring
+// syntax out into a `-write` sibling, gated on the two clip writers, so a
+// read-only caller stops paying for it (ADR-0019). The base name keeps meaning
+// what it meant — the head, minus what only a writer can use — which is why
+// splitting one costs no rename and no retired slot. Only `barbeat-standard` is
+// split so far.
+//
 // `code-transforms` is deliberately absent: it only carries text in a build with
 // code execution enabled, so there is nothing stable for a user to override.
 export const SKILL_SLOT_NAMES = [
@@ -71,6 +81,7 @@ export const SKILL_SLOT_NAMES = [
   "getting-help",
 
   "barbeat-standard",
+  "barbeat-standard-write",
   "barbeat-basic",
   "midi-json",
   "stark-standard",
@@ -259,8 +270,16 @@ export const SKILL_SLOTS: Record<SkillSlotName, SkillSlotDef> = {
   "barbeat-standard": {
     title: "bar|beat notation (standard)",
     description:
-      "How to read and write bar|beat notation, the default note format. Used with capable models.",
+      "How to read bar|beat notation, the default note format: positions, meter, and the note syntax read-clip returns. Used with capable models. The syntax for writing notes is the separate section below.",
     builtIn: barbeatStandard,
+  },
+
+  "barbeat-standard-write": {
+    title: "bar|beat notation: writing notes (standard)",
+    description:
+      "The bar|beat syntax only used to CREATE notes — repeat patterns, pattern brackets, bar copying, v0 deletes, and the examples. Never appears in a clip you read back, so it's dropped for anything that can't write clips. Needs the bar|beat notation guide it builds on.",
+    builtIn: barbeatStandardWrite,
+    requires: ["barbeat-standard"],
   },
 
   "barbeat-basic": {

--- a/src/skills/tests/build-skills-gating.test.ts
+++ b/src/skills/tests/build-skills-gating.test.ts
@@ -87,6 +87,62 @@ describe("buildSkills - tool gating", () => {
     expect(minimal.length).toBeLessThan(full.length / 2);
   });
 
+  it("keeps the note format but drops the authoring half for a read-only caller", () => {
+    // The case the notation-head split exists for: a worker that reads clips
+    // needs the grammar to PARSE what read-clip returns, and none of the sugar a
+    // serializer never emits. Silent, like any gating — nothing is broken.
+    const warnings: string[] = [];
+    const result = buildSkills(
+      {
+        notation: "barbeat",
+        tools: ["ppal-read-clip", "ppal-read-track", "ppal-read-scene"],
+      },
+      {},
+      (message) => warnings.push(message),
+    );
+
+    expect(result).toContain("## Positions & Meter");
+    expect(result).toContain("## MIDI Syntax");
+    expect(result).not.toContain("## Writing Notes");
+    expect(result).not.toContain("**Pattern brackets**");
+    expect(result).not.toContain("### Bar Copying");
+    expect(result).not.toContain("### Editing Existing Notes");
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("keeps both halves for anything that can write a clip", () => {
+    // Either writer alone is enough, and each keeps the base head it builds on —
+    // the requires-subset invariant, seen from the assembled document.
+    for (const tool of ["ppal-create-clip", "ppal-update-clip"]) {
+      const result = buildSkills({ notation: "barbeat", tools: [tool] });
+
+      expect(result, `${tool} lost the note format`).toContain(
+        "## Positions & Meter",
+      );
+      expect(result, `${tool} lost the authoring half`).toContain(
+        "## Writing Notes",
+      );
+    }
+  });
+
+  it("leaves an unsplit notation head whole, with no gap where its write half would be", () => {
+    // stark and midi-json register an EMPTY `-write` fragment so the driver's
+    // notation-templated ref resolves. That must read as one clean section
+    // break, not a stack of blank lines, and must never warn.
+    for (const notation of ["stark", "midi-json"] as const) {
+      const warnings: string[] = [];
+      const result = buildSkills(
+        { notation, tools: ALL_TOOLS },
+        {},
+        (message) => warnings.push(message),
+      );
+
+      expect(result, `${notation} lost its head`).toContain("## MIDI Notation");
+      expect(result, `${notation} stacked blank lines`).not.toMatch(/\n{3,}/);
+      expect(warnings, `${notation} warned`).toStrictEqual([]);
+    }
+  });
+
   it("gates the small-model document the same way", () => {
     const result = buildSkills({
       smallModelMode: true,

--- a/src/skills/tests/build-skills-gating.test.ts
+++ b/src/skills/tests/build-skills-gating.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, it } from "vitest";
 import { TOOL_NAMES } from "#src/mcp-server/create-mcp-server.ts";
-import { buildSkills } from "#src/skills/build-skills.ts";
+import { assembleSkills, buildSkills } from "#src/skills/build-skills.ts";
 
 const HEADER = "# Producer Pal Skills";
 
@@ -223,5 +223,61 @@ describe("buildSkills - audience gating", () => {
     });
 
     expect(result).toContain(HEADER);
+  });
+});
+
+describe("assembleSkills - dropped fragments", () => {
+  const ALL_TOOLS = [...TOOL_NAMES];
+
+  it("reports nothing when no gate fires", () => {
+    expect(assembleSkills({ tools: ALL_TOOLS }).dropped).toStrictEqual([]);
+  });
+
+  it("names the fragments a disabled tool emptied", () => {
+    const { dropped } = assembleSkills({
+      notation: "barbeat",
+      tools: ALL_TOOLS.filter((name) => name !== "ppal-library"),
+    });
+
+    expect(dropped).toContain("library");
+    expect(dropped).not.toContain("devices");
+  });
+
+  it("names an audience-dropped fragment too", () => {
+    const { dropped } = assembleSkills({
+      tools: ALL_TOOLS,
+      audience: "subagent",
+    });
+
+    expect(dropped).toStrictEqual(["getting-help"]);
+  });
+
+  it("omits fragments this document never referenced", () => {
+    // transforms-basic belongs to the small-model driver, so the standard
+    // document dropping nothing of the sort is the point: the preview must not
+    // list sections that were never on the table.
+    const { dropped } = assembleSkills({ tools: [] });
+
+    expect(dropped).not.toContain("transforms-basic");
+    expect(dropped).toContain("transforms-core");
+  });
+
+  it("omits a fragment the USER switched off", () => {
+    // Their own off switch already shows as an unchecked box; only gating has
+    // nothing on screen to explain it.
+    const { dropped } = assembleSkills(
+      { tools: ALL_TOOLS },
+      {
+        disabled: ["library"],
+      },
+    );
+
+    expect(dropped).toStrictEqual([]);
+  });
+
+  it("returns the same string buildSkills does", () => {
+    const options = { notation: "stark", tools: ALL_TOOLS } as const;
+
+    expect(assembleSkills(options).skills).toBe(buildSkills(options));
   });
 });

--- a/src/skills/tests/build-skills.test.ts
+++ b/src/skills/tests/build-skills.test.ts
@@ -46,6 +46,33 @@ describe("buildSkills - composition", () => {
     expect(result).toContain("## Getting Help");
   });
 
+  it("loses nothing to the bar|beat read/write carve", () => {
+    // The split moved whole sections between two fragments. Nothing catches a
+    // section dropped on the floor mid-move — every include still resolves and
+    // both halves still look like prose — so pin the markers of everything that
+    // moved, plus the two lines that were REWRITTEN rather than moved (the meter
+    // fact kept on the read side, the repeat prescription sent to the write one).
+    const result = buildSkills({ notation: "barbeat" });
+
+    for (const marker of [
+      "## Positions & Meter",
+      "## MIDI Syntax",
+      "## Writing Notes",
+      "**Repeat patterns**",
+      "**Pattern brackets**",
+      "@N-M=P-Q tiles bars",
+      "### Editing Existing Notes (update-clip)",
+      "## Examples",
+      "### Bar Copying",
+      "### Repeats with Variations",
+      "the grid beat is NOT a quarter",
+      "Prefer repeats over hand-listing beats",
+      "`v0` deletes earlier notes",
+    ]) {
+      expect(result, `lost "${marker}"`).toContain(marker);
+    }
+  });
+
   it("gives every notation its own head at both depths — never a fallback", () => {
     for (const notation of NOTATIONS) {
       const standard = buildSkills({ notation });

--- a/src/skills/tests/fragment-tool-gates.test.ts
+++ b/src/skills/tests/fragment-tool-gates.test.ts
@@ -9,6 +9,7 @@ import { builtinFragments } from "#src/skills/builtin-fragments.ts";
 import {
   FRAGMENT_GATES,
   audienceGatedFragments,
+  fragmentGate,
   gatedOutFragments,
 } from "#src/skills/fragment-tool-gates.ts";
 import { SKILL_SLOT_NAMES, SKILL_SLOTS } from "#src/skills/skill-slots.ts";
@@ -189,5 +190,39 @@ describe("audienceGatedFragments", () => {
         expect(dropped).not.toContain(required);
       }
     }
+  });
+});
+
+describe("fragmentGate", () => {
+  it("uses only the two string gates the webui mirrors", () => {
+    // webui hand-copies FragmentGate (it may only import #src/shared) and reads
+    // an unrecognized value as "no gate" — silently, so nothing would fail.
+    // A third literal here means updating SkillGate and toGate alongside it.
+    const literals = Object.values(FRAGMENT_GATES).filter(
+      (gate) => typeof gate === "string",
+    );
+
+    expect(new Set(literals)).toStrictEqual(
+      new Set(["always", "conversation-only"]),
+    );
+  });
+
+  it("returns each gate shape", () => {
+    expect(fragmentGate("library")).toStrictEqual(["ppal-library"]);
+    expect(fragmentGate("time-and-values")).toBe("always");
+    expect(fragmentGate("getting-help")).toBe("conversation-only");
+  });
+
+  it("returns null for a driver root and for an unknown fragment", () => {
+    expect(fragmentGate("standard")).toBeNull();
+    expect(fragmentGate("no-such-fragment")).toBeNull();
+  });
+
+  it("returns null for an inherited Object property name", () => {
+    // Names reach this from user text (an override filename), so a bare index
+    // would hand back Object.prototype.toString — a function where a gate is
+    // expected, which the editor would then try to render.
+    expect(fragmentGate("toString")).toBeNull();
+    expect(fragmentGate("constructor")).toBeNull();
   });
 });

--- a/webui/src/components/context/skills/SkillGateNote.tsx
+++ b/webui/src/components/context/skills/SkillGateNote.tsx
@@ -1,0 +1,67 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { type SkillGate } from "#webui/hooks/context/use-skill-overrides";
+
+interface SkillGateNoteProps {
+  /** The selected fragment's gate (null for the whole-document drivers). */
+  gate: SkillGate | null;
+}
+
+/**
+ * States the tool rule for the selected fragment. That rule was previously only
+ * paraphrased inside each fragment's prose description, where it drifts and
+ * can't be checked; this names the tools instead.
+ *
+ * Worded as what DROPS a fragment, not what includes one, because that is the
+ * only direction the gate runs (see fragment-tool-gates.ts). Several fragments
+ * also depend on the notation or on small-model mode — a note promising
+ * inclusion would be wrong for every notation head.
+ * @param props - Note props
+ * @returns The note, or null for a driver (which has no gate to state)
+ */
+export function SkillGateNote(
+  props: SkillGateNoteProps,
+): preact.JSX.Element | null {
+  const { gate } = props;
+
+  if (gate == null) return null;
+
+  if (gate === "always") {
+    return <Note>Never dropped — no tool setting leaves this out.</Note>;
+  }
+
+  if (gate === "conversation-only") {
+    return (
+      <Note>
+        Chat only — never sent to a subagent, which has no one to explain
+        anything to.
+      </Note>
+    );
+  }
+
+  return (
+    <Note>
+      Dropped unless at least one of these tools is enabled:{" "}
+      <span className="font-mono">{gate.join(", ")}</span>
+    </Note>
+  );
+}
+
+// --- Helpers below main export ---
+
+/**
+ * Shared styling for the note line.
+ * @param props - Note props
+ * @param props.children - Note content
+ * @returns Note element
+ */
+function Note(props: {
+  children: preact.ComponentChildren;
+}): preact.JSX.Element {
+  return (
+    <p className="text-xs text-zinc-500 dark:text-zinc-400">{props.children}</p>
+  );
+}

--- a/webui/src/components/context/skills/SkillSlotScreen.tsx
+++ b/webui/src/components/context/skills/SkillSlotScreen.tsx
@@ -24,6 +24,7 @@ import {
   type SkillSlotView,
   type UseSkillOverridesReturn,
 } from "#webui/hooks/context/use-skill-overrides";
+import { SkillGateNote } from "./SkillGateNote";
 import { SkillSlotSelect } from "./SkillSlotSelect";
 
 const RESET_CONFIRM =
@@ -192,9 +193,10 @@ interface SkillControlsProps {
 
 /**
  * Controls strip: the slot dropdown, the include toggle, the selected slot's
- * human title and one-line explainer, and a drift note. The title lives here
- * rather than in the dropdown, which lists fragments by filename so it reads the
- * way an `@include` line does (see {@link SkillSlotSelect}).
+ * human title and one-line explainer, and a drift note, over a second line
+ * naming the tools that gate the fragment ({@link SkillGateNote}). The title
+ * lives here rather than in the dropdown, which lists fragments by filename so
+ * it reads the way an `@include` line does (see {@link SkillSlotSelect}).
  *
  * The border spans full width while the content is centered to match the editor
  * below. The Preview/Source view toggle
@@ -210,25 +212,28 @@ function SkillControls(props: SkillControlsProps): preact.JSX.Element {
 
   return (
     <div className="px-4 py-2 border-b border-zinc-200 dark:border-zinc-700">
-      <div className={`mx-auto w-full ${widthClass} flex items-center gap-3`}>
-        <SkillSlotSelect
-          slots={slots}
-          selected={selected}
-          onSelect={onSelectSlot}
-        />
-        <IncludeToggle slot={slot} onSetEnabled={onSetEnabled} />
-        <span className="min-w-0 flex-1 text-xs text-zinc-500 dark:text-zinc-400">
-          <span className="font-medium text-zinc-700 dark:text-zinc-300">
-            {slot.title}
+      <div className={`mx-auto w-full ${widthClass} flex flex-col gap-1`}>
+        <div className="flex items-center gap-3">
+          <SkillSlotSelect
+            slots={slots}
+            selected={selected}
+            onSelect={onSelectSlot}
+          />
+          <IncludeToggle slot={slot} onSetEnabled={onSetEnabled} />
+          <span className="min-w-0 flex-1 text-xs text-zinc-500 dark:text-zinc-400">
+            <span className="font-medium text-zinc-700 dark:text-zinc-300">
+              {slot.title}
+            </span>
+            {" — "}
+            {slot.description}
           </span>
-          {" — "}
-          {slot.description}
-        </span>
-        <DriftNote
-          drifted={slot.drifted}
-          forkedFromVersion={slot.forkedFromVersion}
-        />
-        <ContextIoButtons onImport={onImport} onExport={onExport} />
+          <DriftNote
+            drifted={slot.drifted}
+            forkedFromVersion={slot.forkedFromVersion}
+          />
+          <ContextIoButtons onImport={onImport} onExport={onExport} />
+        </div>
+        <SkillGateNote gate={slot.gate} />
       </div>
     </div>
   );

--- a/webui/src/components/context/skills/SkillsPreviewScreen.tsx
+++ b/webui/src/components/context/skills/SkillsPreviewScreen.tsx
@@ -255,7 +255,7 @@ function PreviewBody(props: PreviewBodyProps): preact.JSX.Element {
     );
   }
 
-  const { skills, head, driver, warnings } = status.preview;
+  const { skills, head, driver, dropped, warnings } = status.preview;
 
   return (
     <PreviewFrame
@@ -270,6 +270,7 @@ function PreviewBody(props: PreviewBodyProps): preact.JSX.Element {
       }
     >
       {warnings.length > 0 && <PreviewWarnings warnings={warnings} />}
+      {dropped.length > 0 && <DroppedNote dropped={dropped} />}
       <MarkdownEditor
         key={skills}
         ariaLabel="Assembled skills preview"
@@ -312,6 +313,28 @@ function PreviewFrame(props: PreviewFrameProps): preact.JSX.Element {
         <div className="justify-self-end">{right}</div>
       </div>
       {children}
+    </div>
+  );
+}
+
+interface DroppedNoteProps {
+  dropped: string[];
+}
+
+/**
+ * Names the fragments this blob is missing because the tools that would use them
+ * are switched off in Settings. Without it the preview just looks short — the
+ * gating is the only part of assembly nothing else on screen accounts for.
+ * @param props - Note props
+ * @returns Note element
+ */
+function DroppedNote(props: DroppedNoteProps): preact.JSX.Element {
+  const { dropped } = props;
+
+  return (
+    <div className="shrink-0 rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50 p-2 text-xs text-zinc-600 dark:text-zinc-400">
+      <span className="font-medium">Left out — no enabled tool uses them:</span>{" "}
+      <span className="font-mono">{dropped.join(", ")}</span>
     </div>
   );
 }

--- a/webui/src/components/context/skills/tests/SkillGateNote.test.tsx
+++ b/webui/src/components/context/skills/tests/SkillGateNote.test.tsx
@@ -1,0 +1,40 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @vitest-environment happy-dom
+ */
+import { render, screen } from "@testing-library/preact";
+import { describe, expect, it } from "vitest";
+import { SkillGateNote } from "#webui/components/context/skills/SkillGateNote";
+
+describe("SkillGateNote", () => {
+  it("names the tools that keep the fragment", () => {
+    render(<SkillGateNote gate={["ppal-read-clip", "ppal-create-clip"]} />);
+
+    // "Dropped unless", not "included when": the gate is a necessary condition,
+    // and a notation head also depends on the notation and the model depth.
+    expect(screen.getByText(/Dropped unless/)).toBeTruthy();
+    expect(screen.getByText("ppal-read-clip, ppal-create-clip")).toBeTruthy();
+  });
+
+  it("says so when no toolset can drop the fragment", () => {
+    render(<SkillGateNote gate="always" />);
+
+    expect(screen.getByText(/Never dropped/)).toBeTruthy();
+  });
+
+  it("says a conversation-only fragment never reaches a subagent", () => {
+    render(<SkillGateNote gate="conversation-only" />);
+
+    expect(screen.getByText(/never sent to a subagent/)).toBeTruthy();
+  });
+
+  it("renders nothing for a driver, which has no gate to state", () => {
+    const { container } = render(<SkillGateNote gate={null} />);
+
+    expect(container.textContent).toBe("");
+  });
+});

--- a/webui/src/components/context/tests/ContextTabs.test.tsx
+++ b/webui/src/components/context/tests/ContextTabs.test.tsx
@@ -60,6 +60,7 @@ vi.mock(import("#webui/hooks/context/use-skill-overrides"), () => ({
           override: "",
           enabled: true,
           canDisable: true,
+          gate: null,
           drifted: false,
           forkedFromVersion: null,
         },

--- a/webui/src/components/context/tests/SkillsPreviewScreen.test.tsx
+++ b/webui/src/components/context/tests/SkillsPreviewScreen.test.tsx
@@ -17,6 +17,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SkillsPreviewScreen } from "#webui/components/context/skills/SkillsPreviewScreen";
 
 const CONFIG_URL = "http://localhost:3000/config";
+
+/** Preview response fields beyond the blob itself. */
+interface PreviewExtras {
+  warnings?: string[];
+  dropped?: string[];
+}
+
 const TAB_SLOT = <div data-testid="tabs">tabs</div>;
 const VIEW_SLOT = <div data-testid="view-toggle">toggle</div>;
 
@@ -37,13 +44,13 @@ function jsonResponse(body: unknown): Response {
  * requested combination so assertions can key off the selected values.
  * @param config - Live config to return, or "fail" for a non-ok response
  * @param preview - "ok" echoes the combo; "fail" returns a non-ok response
- * @param previewWarnings - Assembly warnings to include in the preview response
+ * @param extras - Extra preview fields (assembly warnings, gated-out fragments)
  * @returns The fetch mock
  */
 function stubFetch(
   config: { notation: string; smallModelMode: boolean } | "fail",
   preview: "ok" | "fail" = "ok",
-  previewWarnings: string[] = [],
+  extras: PreviewExtras = {},
 ): ReturnType<typeof vi.fn> {
   const fetchMock = vi.fn((input: unknown) => {
     const url = String(input);
@@ -67,7 +74,8 @@ function stubFetch(
         head: notation,
         driver: small ? "basic" : "standard",
         skills: `S:${notation}:${small}`,
-        warnings: previewWarnings,
+        warnings: extras.warnings ?? [],
+        dropped: extras.dropped ?? [],
       }),
     );
   });
@@ -81,18 +89,18 @@ function stubFetch(
  * Stub `fetch` and render the screen with the standard slots.
  * @param config - Live config to return, or "fail" for a non-ok response
  * @param preview - "ok" echoes the combo; "fail" returns a non-ok response
- * @param previewWarnings - Assembly warnings to include in the preview response
+ * @param extras - Extra preview fields (assembly warnings, gated-out fragments)
  * @returns The fetch mock
  */
 function renderPreview(
   config?: { notation: string; smallModelMode: boolean } | "fail",
   preview: "ok" | "fail" = "ok",
-  previewWarnings: string[] = [],
+  extras: PreviewExtras = {},
 ): ReturnType<typeof vi.fn> {
   const fetchMock = stubFetch(
     config ?? { notation: "barbeat", smallModelMode: false },
     preview,
-    previewWarnings,
+    extras,
   );
 
   render(<SkillsPreviewScreen tabSlot={TAB_SLOT} viewSlot={VIEW_SLOT} />);
@@ -193,9 +201,9 @@ describe("SkillsPreviewScreen", () => {
   });
 
   it("surfaces override assembly warnings above the blob", async () => {
-    renderPreview({ notation: "barbeat", smallModelMode: false }, "ok", [
-      `skills include names an unknown fragment: "core-devices"`,
-    ]);
+    renderPreview({ notation: "barbeat", smallModelMode: false }, "ok", {
+      warnings: [`skills include names an unknown fragment: "core-devices"`],
+    });
 
     await waitFor(() => {
       expect(screen.getByRole("alert")).toBeTruthy();
@@ -204,6 +212,26 @@ describe("SkillsPreviewScreen", () => {
       screen.getByText(/This override didn't fully assemble/),
     ).toBeTruthy();
     expect(screen.getByText(/unknown fragment/)).toBeTruthy();
+  });
+
+  it("names the fragments the toolset left out", async () => {
+    renderPreview({ notation: "barbeat", smallModelMode: false }, "ok", {
+      dropped: ["library", "devices"],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/no enabled tool uses them/)).toBeTruthy();
+    });
+    expect(screen.getByText("library, devices")).toBeTruthy();
+  });
+
+  it("says nothing about gating when the toolset dropped nothing", async () => {
+    renderPreview();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Driver: standard/)).toBeTruthy();
+    });
+    expect(screen.queryByText(/no enabled tool uses them/)).toBeNull();
   });
 
   it("shows no warning banner when the blob assembled cleanly", async () => {

--- a/webui/src/components/context/tests/skill-slot-test-helpers.ts
+++ b/webui/src/components/context/tests/skill-slot-test-helpers.ts
@@ -19,6 +19,7 @@ export function slot(over: Partial<SkillSlotView> = {}): SkillSlotView {
     override: "",
     enabled: true,
     canDisable: true,
+    gate: null,
     drifted: false,
     forkedFromVersion: null,
     ...over,

--- a/webui/src/hooks/context/tests/use-skill-overrides.test.ts
+++ b/webui/src/hooks/context/tests/use-skill-overrides.test.ts
@@ -97,6 +97,7 @@ describe("useSkillOverrides", () => {
         override: "",
         enabled: true,
         canDisable: true,
+        gate: null,
         drifted: false,
         forkedFromVersion: null,
       },
@@ -108,11 +109,37 @@ describe("useSkillOverrides", () => {
         override: "MINE",
         enabled: true,
         canDisable: true,
+        gate: null,
         drifted: true,
         forkedFromVersion: "1.4.0",
       },
     ]);
     expect(fetchMock).toHaveBeenCalledWith(LIST_URL, { cache: "no-store" });
+  });
+
+  it("maps each gate shape, and reads anything unrecognized as no gate", async () => {
+    const result = await renderReady([
+      rawSlot({ gate: ["ppal-read-clip", "ppal-create-clip"] }),
+      rawSlot({ gate: "always" }),
+      rawSlot({ gate: "conversation-only" }),
+      // A driver, and — same handling — a value from a server this webui
+      // doesn't understand. Saying nothing beats stating the wrong rule.
+      rawSlot({ gate: null }),
+      rawSlot({ gate: "made-up" }),
+      rawSlot({ gate: [1, 2] }),
+    ]);
+    const status = result.current.status;
+
+    expect(
+      status.kind === "ready" && status.slots.map((s) => s.gate),
+    ).toStrictEqual([
+      ["ppal-read-clip", "ppal-create-clip"],
+      "always",
+      "conversation-only",
+      null,
+      null,
+      null,
+    ]);
   });
 
   it("falls back to an empty list when slots is missing", async () => {

--- a/webui/src/hooks/context/use-skill-overrides.ts
+++ b/webui/src/hooks/context/use-skill-overrides.ts
@@ -31,11 +31,21 @@ export interface SkillSlotView {
   enabled: boolean;
   /** Whether to offer an off switch (false for the whole-document drivers). */
   canDisable: boolean;
+  /** What the assembler requires for this fragment to ship (null for drivers). */
+  gate: SkillGate | null;
   /** Whether the built-in changed since this override was forked. */
   drifted: boolean;
   /** Producer Pal version the override was forked from (null when none). */
   forkedFromVersion: string | null;
 }
+
+/**
+ * What a fragment ships under: any-of a tool list, or one of the two conditions
+ * no toolset decides. Declared here rather than imported from `src/skills`
+ * because webui may only reach into `#src/shared` — the server sends the value
+ * verbatim, so this mirrors `FragmentGate`.
+ */
+export type SkillGate = readonly string[] | "always" | "conversation-only";
 
 /** Status of the whole slot collection. */
 export type SkillOverridesStatus =
@@ -157,6 +167,8 @@ interface RawSkillSlot {
   /** Optional so a slot from an older server reads as on rather than off. */
   enabled?: boolean;
   canDisable?: boolean;
+  /** Absent on an older server, and legitimately null for the drivers. */
+  gate?: unknown;
 }
 
 /** The fields a per-slot PUT may carry; either alone is a valid write. */
@@ -272,7 +284,26 @@ function toView(raw: RawSkillSlot): SkillSlotView {
     // ships, and the toggle shows.
     enabled: raw.enabled !== false,
     canDisable: raw.canDisable !== false,
+    gate: toGate(raw.gate),
     drifted: raw.drifted,
     forkedFromVersion: raw.provenance?.producerPalVersion ?? null,
   };
+}
+
+/**
+ * Narrow the server's `gate` field to {@link SkillGate}. Anything unrecognized
+ * reads as null — the same as a driver, which renders no gate note — so an older
+ * server (or a field this webui doesn't know yet) simply says nothing rather
+ * than stating a rule that isn't the one being applied.
+ * @param raw - The server's gate value
+ * @returns The gate, or null when absent or unrecognized
+ */
+function toGate(raw: unknown): SkillGate | null {
+  if (raw === "always" || raw === "conversation-only") return raw;
+
+  if (Array.isArray(raw) && raw.every((tool) => typeof tool === "string")) {
+    return raw;
+  }
+
+  return null;
 }

--- a/webui/src/hooks/context/use-skills-preview.ts
+++ b/webui/src/hooks/context/use-skills-preview.ts
@@ -28,6 +28,12 @@ export interface SkillsPreview extends SkillsCombination {
   skills: string;
   /** Exact character count of the blob (token estimate is derived at display). */
   charCount: number;
+  /**
+   * Fragments the device's disabled tools left out of this blob. The one part of
+   * assembly with nothing else on screen to explain it — a user's own off
+   * switches already show as unchecked boxes in the fragment editor.
+   */
+  dropped: string[];
   /** Non-fatal assembly warnings (unknown/nested/unsafe refs); [] when clean. */
   warnings: string[];
 }
@@ -151,7 +157,19 @@ interface RawPreview {
   head?: unknown;
   driver?: unknown;
   skills?: unknown;
+  dropped?: unknown;
   warnings?: unknown;
+}
+
+/**
+ * Keep only the strings in a value the server sent as an array of them.
+ * @param raw - The server's field value
+ * @returns The strings it carried (empty when it wasn't an array)
+ */
+function stringList(raw: unknown): string[] {
+  return Array.isArray(raw)
+    ? raw.filter((v): v is string => typeof v === "string")
+    : [];
 }
 
 /**
@@ -185,9 +203,8 @@ async function fetchPreview(
     driver: typeof raw.driver === "string" ? raw.driver : "",
     skills,
     charCount: skills.length,
-    warnings: Array.isArray(raw.warnings)
-      ? raw.warnings.filter((w): w is string => typeof w === "string")
-      : [],
+    dropped: stringList(raw.dropped),
+    warnings: stringList(raw.warnings),
   };
 }
 


### PR DESCRIPTION
Notation heads gate as one fragment on `NOTE_TOOLS`, spanning the three read tools and the two clip writers. But the head teaches two things in one body — how to **parse** what read-clip returns, and how to **generate** notes — so a read-only caller (the narrow-toolset subagent worker gating exists to serve) paid for both.

`barbeat-serializer.ts` emits only `v/n/p pitch(es) bar|beat` with comma-merged beat lists and `±n` offsets. It never emits a repeat pattern, a pattern bracket, a bar copy, or a `v0`, so a read-only caller provably never encounters that syntax.

**5,275 of the head's 8,954 chars (59%) now drop for a caller that can't write clips.**

## The shape

The base head keeps its name and its meaning: the format, minus what only a writer can use. That's what makes the split free — the driver's `{notation}-standard` ref never changes, no slot is retired, no alias is added, and each notation opts in separately. stark and midi-json aren't split, so they register an empty `-write` fragment (the shape `code-transforms` already uses).

The `-read`/`-write` symmetry considered first would have renamed the base ref, forcing alias entries for every notation that *isn't* split — complexity bought for nothing.

## Where to look hardest

Two lines were **rewritten rather than moved**, and they're where a regression would surface first:

- The meter paragraph in `## Positions & Meter` keeps its meter FACT on the read side (parsing 6/8 positions needs it) and sends its "use a repeat pattern instead" prescription to the write half.
- The comma-list bullet's "or repeat pattern" clause moves, restated by the write half's lead-in.

Leaving either mention behind is the `transforms-core` failure mode — vocabulary whose grammar is gone.

Everything else moved by whole bullet/section. Ambiguous lines (the `v`/`n`/`p` bullets, same-pitch overlap) stayed on the read side, where both audiences get them.

## Decision record

Supersedes ADR-0016, which made one fragment per notation the gating floor. Its blocker was override migration, on the assumption of an install base carrying `barbeat-standard` overrides. Adam's call: there is none yet, so the window is now. ADR-0017 records this.

## Verification

- `npm run check` and `npm run check:build` green (10,699 tests, 100% function coverage).
- New tests: a read-only toolset keeps `## Positions & Meter` / `## MIDI Syntax` and drops the authoring half **with zero warnings**; either writer alone keeps both halves; unsplit heads assemble with no blank-line gap; and a no-content-lost assertion pins every marker that moved.
- **Evals not yet run** — needs Ableton free. The scenarios that exercise the moved syntax, `bar-beat-meter-fill` first (it tests exactly the rewritten meter paragraph):
  ```
  scripts/eval -m claude-sonnet-4-5 \
    -t bar-beat-meter-fill -t arpeggio-bracket-idiom -t bar-beat-zip-streams \
    -t bar-beat-gallop -t bar-beat-velocity-accent \
    -t drum-transforms -t create-and-edit-clip
  ```

## Known residual

`transforms-core` gates on `[create-clip, update-clip, duplicate]` and mentions `v0` in `notes` strings and "generate with repeats/bar-copies". A caller with read tools + `ppal-duplicate` but no clip writer now keeps those mentions while the write half drops. Left alone deliberately — trimming mentions in `transforms-core` is exactly what cost a `drum-transforms` eval turn before. Noted in the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)