### PR TITLE
Keep string length caps out of the tool JSON Schemas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,11 @@ See `dev/Architecture.md` for system design and `dev/Chat-UI.md` for the web UI.
   and the MCP SDK validates before our handler runs. For choosing a param's
   shape and writing per-mode descriptions, see `dev/Tool-Schemas.md`.
 
+- **String length caps of 2000+**: never let them reach the JSON Schema as
+  `maxLength` — llama.cpp-based clients compile it into a grammar repetition and
+  then reject every tool call, for every tool. Use `boundedString()` and state
+  the limit in the param description. See ADR-0021.
+
 - **The filesystem is Node-side only**: the V8 runtime (`src/live-api-adapter/`)
   has no filesystem, and shipped `src/**` can't shell out. All `node:fs` work
   lives in `src/mcp-server/`. User-content features (`~/.producer-pal`

--- a/dev/Tool-Schemas.md
+++ b/dev/Tool-Schemas.md
@@ -32,6 +32,19 @@ schema tolerant. There's no built-in "degrade to a comma-separated string"
 switch — tolerance lives in the schema, e.g. `device-params-schema.ts`'s
 `params` array adds a `preprocess` that also accepts a JSON-stringified array.
 
+## Length caps
+
+`z.string().max(n)` emits `maxLength: n`. llama.cpp-based clients (Jan, LM
+Studio, Ollama, llama-server) compile all the tool schemas into one GBNF grammar
+and turn that into a `char{0,n}` repetition, which their parser rejects at 2000
+or above — killing every tool call, not just the one tool.
+
+So for a cap of 2000 or more, use `boundedString(max)` from
+`src/tools/shared/tool-framework/bounded-string.ts` and put the limit in the
+param description. It validates the same and emits no keyword. Smaller caps can
+stay as `z.string().max()`. `src/test/meta/tool-schema-grammar-safety.test.ts`
+checks every tool. Background: ADR-0021.
+
 ## Coercion
 
 Use `z.coerce.string()` for ID params (`ids`, `trackId`, `clipId`,

--- a/dev/decisions/0021-string-caps-stay-out-of-the-schema.md
+++ b/dev/decisions/0021-string-caps-stay-out-of-the-schema.md
@@ -1,0 +1,50 @@
+# ADR-0021: String length caps stay out of the JSON Schema
+
+- **Status:** Accepted
+- **Date logged:** 2026-08-09
+
+## Context
+
+llama.cpp compiles every tool's JSON Schema into a single GBNF grammar and
+constrains decoding with it. A string's `maxLength: n` becomes the repetition
+`char{0,n}`, and the grammar parser rejects any repetition at or above
+`MAX_REPETITION_THRESHOLD` (2000), a DoS guard added upstream in November 2025.
+Because all tools share one grammar, a single oversized param fails the whole
+request — every tool call, not just the one with the big param.
+
+`ppal-context`'s `content` (`maxLength: 10000`) did exactly that in Jan: chat
+completions failed with `failed to parse grammar` until the tool was disabled.
+The same applies to any llama.cpp-derived runtime (LM Studio, Ollama,
+llama-server). Hosted APIs ignore `maxLength`, so this is invisible until
+someone runs a local model.
+
+## Decision
+
+A cap at or above 2000 characters is enforced with `boundedString()`
+(`src/tools/shared/tool-framework/bounded-string.ts`) — a refinement, which
+validates identically and emits no `maxLength` — and stated in the param's
+description so the model still knows the limit. Below 2000, plain
+`z.string().max()` is fine. `src/test/meta/tool-schema-grammar-safety.test.ts`
+holds the line for every tool.
+
+## Alternatives rejected
+
+- **Lower the caps under 2000.** 2000 characters is a short paragraph. It would
+  cost real capability — a whole context document, a whole generated function
+  body — to work around someone else's bug.
+- **Drop the caps.** They are the guard against a runaway write filling a user's
+  context file, and the model needs to know a limit exists.
+- **Strip `maxLength` only in small-model mode.** The trigger is the client
+  runtime, not the model's size. Large models fail the same way on llama.cpp,
+  and nothing in an MCP request tells us which runtime is calling.
+- **Wait for upstream.** llama.cpp master now clamps an oversized repetition to
+  unbounded instead of throwing, but shipped desktop apps lag master by months,
+  so the broken builds will be in users' hands for a long time.
+
+## Consequences
+
+- The limit is advertised in prose, not machine-readable. A client can't
+  pre-validate against it; our handler still rejects an over-long value.
+- `MAX_CODE_LENGTH` went from 2500 to 10,000 at the same time. It was only that
+  low out of caution, and once the cap stopped shaping the grammar there was no
+  reason to keep code bodies smaller than a context document.

--- a/src/test/meta/tool-schema-grammar-safety.test.ts
+++ b/src/test/meta/tool-schema-grammar-safety.test.ts
@@ -1,0 +1,73 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { GBNF_REPETITION_LIMIT } from "#src/tools/shared/tool-framework/bounded-string.ts";
+
+// llama.cpp-based runtimes compile every tool's JSON Schema into one GBNF
+// grammar, turning a length constraint into a repetition (`char{0,n}`) and
+// rejecting the whole grammar above MAX_REPETITION_THRESHOLD. One oversized
+// param therefore breaks tool calling for ALL tools. Use boundedString() for
+// caps at or above the limit and state them in the description. See ADR-0021.
+const REPETITION_KEYWORDS = new Set(["maxLength", "maxItems"]);
+
+// The `code` params only exist when this flag is on, and it is read when the
+// tool defs load — so stub it before importing them.
+vi.stubEnv("ENABLE_CODE_EXEC", "true");
+const { STANDARD_TOOL_DEFS } =
+  await import("#src/mcp-server/create-mcp-server.ts");
+const { toolDefLiveApi } = await import("#src/tools/advanced/live-api.def.ts");
+
+vi.unstubAllEnvs();
+
+const TOOL_DEFS = [...STANDARD_TOOL_DEFS, toolDefLiveApi];
+
+describe("tool schema grammar safety", () => {
+  it.each(TOOL_DEFS.map((def) => [def.toolName, def] as const))(
+    "%s has no length constraint a GBNF grammar would reject",
+    (_name, def) => {
+      const schema = z.toJSONSchema(
+        z.object(def.toolOptions.inputSchema).loose(),
+      );
+
+      expect(oversizedConstraints(schema, "")).toStrictEqual([]);
+    },
+  );
+
+  it("covers the code params, which are build-flag gated", () => {
+    const codeTools = TOOL_DEFS.filter(
+      (def) => "code" in def.toolOptions.inputSchema,
+    ).map((def) => def.toolName);
+
+    expect(codeTools).toStrictEqual([
+      "ppal-create-clip",
+      "ppal-update-clip",
+      "ppal-duplicate",
+    ]);
+  });
+});
+
+function oversizedConstraints(node: unknown, path: string): string[] {
+  if (node == null || typeof node !== "object") return [];
+
+  if (Array.isArray(node)) {
+    return node.flatMap((item, i) =>
+      oversizedConstraints(item, `${path}[${i}]`),
+    );
+  }
+
+  return Object.entries(node).flatMap(([key, value]) => {
+    const here = `${path}.${key}`;
+    const oversized =
+      REPETITION_KEYWORDS.has(key) &&
+      typeof value === "number" &&
+      value >= GBNF_REPETITION_LIMIT;
+
+    return oversized
+      ? [`${here} = ${String(value)}`]
+      : oversizedConstraints(value, here);
+  });
+}

--- a/src/tools/actions/duplicate/duplicate.def.ts
+++ b/src/tools/actions/duplicate/duplicate.def.ts
@@ -5,6 +5,7 @@
 
 import { z } from "zod";
 import { MAX_CODE_LENGTH } from "#src/tools/constants.ts";
+import { boundedString } from "#src/tools/shared/tool-framework/bounded-string.ts";
 import { defineTool } from "#src/tools/shared/tool-framework/define-tool.ts";
 import { param } from "#src/tools/shared/tool-framework/modal-config.ts";
 
@@ -95,9 +96,8 @@ export const toolDefDuplicate = defineTool("ppal-duplicate", {
     }),
     ...(process.env.ENABLE_CODE_EXEC === "true"
       ? {
-          code: param(z.string().max(MAX_CODE_LENGTH).optional(), {
-            default:
-              "JS function body (broadcast across copies; clips only): receives (notes, context), returns notes array. context.clip.{index,count} for per-copy variation",
+          code: param(boundedString(MAX_CODE_LENGTH).optional(), {
+            default: `JS function body (broadcast across copies; clips only; max ${MAX_CODE_LENGTH} chars): receives (notes, context), returns notes array. context.clip.{index,count} for per-copy variation`,
             smallModel: null,
           }),
         }

--- a/src/tools/clip/create/create-clip.def.ts
+++ b/src/tools/clip/create/create-clip.def.ts
@@ -5,6 +5,7 @@
 
 import { z } from "zod";
 import { MAX_CODE_LENGTH } from "#src/tools/constants.ts";
+import { boundedString } from "#src/tools/shared/tool-framework/bounded-string.ts";
 import { defineTool } from "#src/tools/shared/tool-framework/define-tool.ts";
 import { param } from "#src/tools/shared/tool-framework/modal-config.ts";
 
@@ -98,9 +99,8 @@ export const toolDefCreateClip = defineTool("ppal-create-clip", {
 
     ...(process.env.ENABLE_CODE_EXEC === "true"
       ? {
-          code: param(z.string().max(MAX_CODE_LENGTH).optional(), {
-            default:
-              "JS function body: receives (notes, context), returns notes array (see Skills for properties) - MIDI only",
+          code: param(boundedString(MAX_CODE_LENGTH).optional(), {
+            default: `JS function body (max ${MAX_CODE_LENGTH} chars): receives (notes, context), returns notes array (see Skills for properties) - MIDI only`,
             smallModel: null,
           }),
         }

--- a/src/tools/clip/update/update-clip.def.ts
+++ b/src/tools/clip/update/update-clip.def.ts
@@ -5,6 +5,7 @@
 
 import { z } from "zod";
 import { MAX_CODE_LENGTH, MAX_SPLIT_POINTS } from "#src/tools/constants.ts";
+import { boundedString } from "#src/tools/shared/tool-framework/bounded-string.ts";
 import { defineTool } from "#src/tools/shared/tool-framework/define-tool.ts";
 import { param } from "#src/tools/shared/tool-framework/modal-config.ts";
 
@@ -134,9 +135,8 @@ export const toolDefUpdateClip = defineTool("ppal-update-clip", {
     }),
     ...(process.env.ENABLE_CODE_EXEC === "true"
       ? {
-          code: param(z.string().max(MAX_CODE_LENGTH).optional(), {
-            default:
-              "JS function body (broadcast across ids): receives (notes, context), returns notes array. context.clip.{index,count} for per-clip variation (see Skills for properties)",
+          code: param(boundedString(MAX_CODE_LENGTH).optional(), {
+            default: `JS function body (broadcast across ids; max ${MAX_CODE_LENGTH} chars): receives (notes, context), returns notes array. context.clip.{index,count} for per-clip variation (see Skills for properties)`,
             smallModel: null,
           }),
         }

--- a/src/tools/constants.ts
+++ b/src/tools/constants.ts
@@ -1,12 +1,14 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 export const MAX_AUTO_CREATED_TRACKS = 100;
 export const MAX_AUTO_CREATED_SCENES = 1000;
 export const MAX_ARRANGEMENT_POSITION_BEATS = 1_576_800;
 export const MAX_SPLIT_POINTS = 32;
-export const MAX_CODE_LENGTH = 2500;
+// Enforced with boundedString(), not z.string().max() — see ADR-0021.
+export const MAX_CODE_LENGTH = 10_000;
 
 // State string constants (6 valid states)
 export const STATE = {

--- a/src/tools/core/context.def.ts
+++ b/src/tools/core/context.def.ts
@@ -4,8 +4,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { z } from "zod";
+import { boundedString } from "#src/tools/shared/tool-framework/bounded-string.ts";
 import { defineTool } from "#src/tools/shared/tool-framework/define-tool.ts";
 import { param } from "#src/tools/shared/tool-framework/modal-config.ts";
+
+const MAX_CONTENT_LENGTH = 10_000;
 
 export const toolDefContext = defineTool("ppal-context", {
   title: "Context",
@@ -76,11 +79,11 @@ export const toolDefContext = defineTool("ppal-context", {
       },
     ),
 
-    content: param(z.string().max(10_000).optional(), {
+    content: param(boundedString(MAX_CONTENT_LENGTH).optional(), {
       default:
         "Text to write — project/global: the whole document; memory: the " +
-        "entry body (one fact).",
-      smallModel: "The full document text to write.",
+        `entry body (one fact). Max ${MAX_CONTENT_LENGTH} chars.`,
+      smallModel: `The full document text to write. Max ${MAX_CONTENT_LENGTH} chars.`,
     }),
 
     name: param(z.string().max(200).optional(), {

--- a/src/tools/core/tests/context-def.test.ts
+++ b/src/tools/core/tests/context-def.test.ts
@@ -139,7 +139,9 @@ describe("ppal-context modal config — small-model mode", () => {
     const config = registerContext({ smallModelMode: true });
     const shape = getShape(config);
 
-    expect(shape.content?.description).toBe("The full document text to write.");
+    expect(shape.content?.description).toBe(
+      "The full document text to write. Max 10000 chars.",
+    );
   });
 
   it("uses the shorter blobs-only tool description", () => {

--- a/src/tools/shared/tool-framework/bounded-string.ts
+++ b/src/tools/shared/tool-framework/bounded-string.ts
@@ -1,0 +1,28 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { z } from "zod";
+
+// llama.cpp rejects any grammar repetition above this
+// (MAX_REPETITION_THRESHOLD in src/llama-grammar.cpp).
+export const GBNF_REPETITION_LIMIT = 2000;
+
+/**
+ * A string param with a length cap that stays out of the JSON Schema.
+ *
+ * `z.string().max(n)` emits `maxLength`, which llama.cpp-based runtimes (Jan,
+ * LM Studio, Ollama, llama-server) compile into a `char{0,n}` grammar
+ * repetition. Anything over 2000 is rejected, and since every tool shares one
+ * grammar, one oversized param breaks tool calling for ALL tools. A refinement
+ * validates identically and emits nothing — so state the limit in the param
+ * description instead. See ADR-0021.
+ * @param max - Maximum length in characters
+ * @returns Zod string schema rejecting longer input
+ */
+export function boundedString(max: number): z.ZodString {
+  return z.string().refine((value) => value.length <= max, {
+    message: `must be at most ${max} characters`,
+  });
+}

--- a/src/tools/shared/tool-framework/tests/bounded-string.test.ts
+++ b/src/tools/shared/tool-framework/tests/bounded-string.test.ts
@@ -1,0 +1,30 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { boundedString } from "#src/tools/shared/tool-framework/bounded-string.ts";
+
+describe("boundedString", () => {
+  it("accepts input up to the limit", () => {
+    expect(boundedString(5).parse("12345")).toBe("12345");
+  });
+
+  it("rejects input over the limit", () => {
+    const result = boundedString(5).safeParse("123456");
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(
+      "must be at most 5 characters",
+    );
+  });
+
+  it("emits no maxLength in the JSON Schema", () => {
+    expect(z.toJSONSchema(boundedString(10_000))).toStrictEqual({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "string",
+    });
+  });
+});


### PR DESCRIPTION
Local llama.cpp-based clients (Jan, LM Studio, Ollama, llama-server) compile every tool's JSON Schema into a single GBNF grammar. A string's `maxLength: n` becomes a `char{0,n}` repetition, and the grammar parser rejects anything at or above `MAX_REPETITION_THRESHOLD` (2000) — a DoS guard [added upstream in Nov 2025](https://github.com/ggml-org/llama.cpp/pull/17381).

Because all the tools share one grammar, `ppal-context`'s 10,000-char `content` param failed **every** tool call with `failed to parse grammar`, not just its own. Reproduced in Jan; disabling ppal-context was the only workaround. Hosted APIs ignore `maxLength`, so this was invisible until someone ran a local model.

## What changed

- New `boundedString(max)` — a refinement that validates identically and emits no `maxLength`. Used for `ppal-context.content` and the three `code` params.
- The limit moved into each param's description, so the model still knows it.
- `MAX_CODE_LENGTH` 2500 → 10,000 (it was only that low out of caution).
- `src/test/meta/tool-schema-grammar-safety.test.ts` fails any tool schema with a `maxLength`/`maxItems` of 2000+, including the build-flag gated `code` params.
- ADR-0021 plus notes in AGENTS.md and `dev/Tool-Schemas.md`.

Known upstream issues on the same bug: [#25746](https://github.com/ggml-org/llama.cpp/issues/25746), [#25923](https://github.com/ggml-org/llama.cpp/issues/25923). Master now clamps instead of throwing, but shipped desktop apps lag by months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)