### PR TITLE
ci: fold the typecheck job into code-hygiene

### DIFF
--- a/.github/workflows/run-checks-and-tests.yml
+++ b/.github/workflows/run-checks-and-tests.yml
@@ -142,24 +142,6 @@ jobs:
           cat /tmp/summary.md >> $GITHUB_STEP_SUMMARY
           echo "summary=$(cat /tmp/summary.md | base64 -w 0)" >> $GITHUB_OUTPUT
 
-  typecheck:
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - run: npm ci
-
-      - name: Type check
-        run: npm run typecheck
-
   code-hygiene:
     runs-on: ubuntu-latest
 
@@ -188,6 +170,12 @@ jobs:
       # seconds, so a dedicated job spent longer on `npm ci` than on linting.
       - name: Lint
         run: npm run lint
+
+      # Folded in for the same reason, once TypeScript 7 made it cheap enough:
+      # the Go compiler took this from ~20s to ~7s, well under the `npm ci` a
+      # separate job would pay.
+      - name: Type check
+        run: npm run typecheck
 
       - name: Check code duplication
         id: summary
@@ -336,7 +324,6 @@ jobs:
     needs:
       [
         build-verification,
-        typecheck,
         unit-tests,
         playwright-tests,
         code-hygiene,
@@ -377,7 +364,6 @@ jobs:
 
             // Check job statuses
             const jobs = {
-              'Typecheck': '${{ needs.typecheck.result }}',
               'Code Hygiene': '${{ needs.code-hygiene.result }}',
               'Unit Tests': '${{ needs.unit-tests.result }}',
               'Build': '${{ needs.build-verification.result }}',
@@ -406,8 +392,7 @@ jobs:
               '|-----|--------|',
               `| Build | ${icon(jobs['Build'])} ${jobs['Build']} |`,
               `| Unit Tests | ${icon(jobs['Unit Tests'])} ${jobs['Unit Tests']} |`,
-              `| Typecheck | ${icon(jobs['Typecheck'])} ${jobs['Typecheck']} |`,
-              `| Lint & Code Hygiene | ${icon(jobs['Code Hygiene'])} ${jobs['Code Hygiene']} |`,
+              `| Lint, Typecheck & Code Hygiene | ${icon(jobs['Code Hygiene'])} ${jobs['Code Hygiene']} |`,
               `| End-to-End Tests | ${icon(jobs['Playwright'])} ${jobs['Playwright']} |`,
               `| Repo Stats | ${icon(jobs['Repo Stats'])} ${jobs['Repo Stats']} |`
             ].join('\n');


### PR DESCRIPTION
Follow-on to the TypeScript 7 upgrade (#1043). Deletes the `typecheck` job and moves its one step into `code-hygiene`, mirroring what was already done for `lint`.

## Why now

The job was waiting on `tsc` getting fast. Measured on `dev` before and after #1043:

| run | commit | `Type check` step |
| -- | -- | -- |
| pre-merge | `1b112c67` | 17s |
| pre-merge | `1a218797` | 21s |
| post-merge | `178d8bed` | **7s** |

The `typecheck` job as a whole is 29s, and only 7s of that is the check. The rest is fixed cost:

```
1s setup + 2s checkout + 1s setup-node + 15s npm ci + 7s Type check = 29s
```

So the job spends more than twice as long installing as checking — exactly the condition that moved `lint` into `code-hygiene`.

## Effect

`code-hygiene` goes from 44s to roughly 51s and one runner disappears. The critical path is `unit-tests` at 153s, so this costs no wall-clock.

AJM's original estimate was "39s + 39s − one npm ci" ≈ 70s; the real number is better because the check itself shrank.

## Required status checks

`typecheck` has already been removed from the required status checks on **both** rulesets — "dev branch protections" (12441471) and "main branch protection" (12441270). That had to happen first, or this PR would block forever on a check that no longer reports. All other rules on both rulesets are unchanged.

## Also in here

The `post-summary` PR comment dropped its `Typecheck` row and renamed the `code-hygiene` row to "Lint, Typecheck & Code Hygiene". Without that, `jobs['Typecheck']` would have been `undefined` and rendered a permanently red-looking row.

`repo-stats` (37s, not a required check) is still its own job — noted in AJM-829 as worth a look, but left alone here to keep this change one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)