### PR TITLE
build: speed up the watch loop and drop the last rollup plugin

### DIFF
--- a/config/rolldown-plugin-inline-chat-ui.mjs
+++ b/config/rolldown-plugin-inline-chat-ui.mjs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { execSync } from "node:child_process";
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -27,6 +27,29 @@ function getFilesRecursively(dir) {
 }
 
 /**
+ * Path to the chat UI that the Vite build produces.
+ * @returns Absolute path to chat-ui.html
+ */
+function chatUIPath() {
+  return join(__dirname, "../max-for-live-device/chat-ui.html");
+}
+
+/**
+ * Decide whether chat-ui.html needs rebuilding, by comparing it against
+ * everything the Vite build reads.
+ * @param htmlPath - Path to the built chat-ui.html
+ * @param sources - Source files the build depends on
+ * @returns True when the build output is missing or older than a source
+ */
+function isChatUIStale(htmlPath, sources) {
+  if (!existsSync(htmlPath)) return true;
+
+  const builtAt = statSync(htmlPath).mtimeMs;
+
+  return sources.some((file) => statSync(file).mtimeMs > builtAt);
+}
+
+/**
  * Rolldown plugin to inline chat-ui.html as a virtual module.
  * This allows the MCP server bundle to work in frozen .amxd builds
  * where external file access is not available.
@@ -37,12 +60,23 @@ export function inlineChatUI() {
     buildStart() {
       // Watch all webui source files
       const webuiDir = join(__dirname, "../webui");
+      const sources = [
+        ...getFilesRecursively(webuiDir),
+        join(__dirname, "vite.config.ts"),
+        join(__dirname, "../package.json"),
+      ];
 
-      for (const file of getFilesRecursively(webuiDir)) {
+      for (const file of sources) {
         this.addWatchFile(file);
       }
 
-      execSync("npm run ui:build", { stdio: "inherit" });
+      // The Vite build costs ~600ms and dominates a watch rebuild, so only run
+      // it when its output is actually out of date. This also keeps `npm run
+      // build` from building the chat UI twice — the build script runs
+      // ui:build before rolldown starts.
+      if (isChatUIStale(chatUIPath(), sources)) {
+        execSync("npm run ui:build", { stdio: "inherit" });
+      }
     },
     resolveId(id) {
       if (id === "virtual:chat-ui-html") {
@@ -51,7 +85,7 @@ export function inlineChatUI() {
     },
     load(id) {
       if (id === "virtual:chat-ui-html") {
-        const htmlPath = join(__dirname, "../max-for-live-device/chat-ui.html");
+        const htmlPath = chatUIPath();
 
         try {
           const htmlContent = readFileSync(htmlPath, "utf-8");


### PR DESCRIPTION
Two follow-ups from the rolldown migration (#1086). Separate commits.

## 1. Rebuild the chat UI only when it is out of date

`inlineChatUI` shelled out to `npm run ui:build` on every `buildStart`. That cost ~600ms and dominated the watch loop now that rolldown does its own share in ~30ms. It also meant `npm run build` built the chat UI **twice**, since the build script already runs `ui:build` before rolldown starts.

Now `chat-ui.html`'s mtime is compared against the webui sources, the Vite config, and `package.json`, and the build is skipped when the output is already newer. Staleness comes from the filesystem rather than in-memory state, so it holds across separate processes — which is what fixes the double build too.

| | before | after |
|---|---|---|
| watch rebuild after a `src/` change | ~750ms | **~200ms** (no Vite at all) |
| Vite runs per `npm run build` | 2 | **1** |

A `webui/` change still rebuilds the UI — verified both directions.

## 2. Replace `rollup-plugin-copy`

It was the last rollup-ecosystem package: unmaintained since Sept 2023, and it uniquely pulled in `globby`, `fast-glob`, and the deprecated `inflight`/`glob`/`once` chain. It was only copying 4 static targets with no globs.

Replaced with a ~30 line `buildEnd` hook over `node:fs`'s `cpSync`. **32 packages removed** from the lockfile (1005 → 973).

`buildEnd` rather than `writeBundle` on purpose: these are static repo files unrelated to the bundle, and the portal config writes two outputs, so `writeBundle` would copy them twice.

Note `rollup` itself is still in the lockfile — but transitively, via `vite-plugin-singlefile` and `vitepress`. It is no longer a dependency of ours.

## Verification

- All 21 copied files (LICENSE, `licenses/`, logo, across both dist folders) are **byte-identical** to what `rollup-plugin-copy` produced — verified by sha256 before/after
- `npm run check` and `npm run check:build` green
- Watch mode verified in both directions: `src/` change skips Vite, `webui/` change triggers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)