### PR TITLE
Easy wins from the 2.1.1 milestone, batch 2

### DIFF
--- a/docs/guide/chat-ui.md
+++ b/docs/guide/chat-ui.md
@@ -544,6 +544,11 @@ The Preferences tab controls visual preferences and conversation management:
   GitHub once per device load whether a newer release exists, and shows an
   `(update)` link next to the version number when there is one. Turn this off
   and it never contacts GitHub.
+- **Tool steps per turn** - How much tool work one turn may do before it stops
+  and hands control back (5-100, default 25). Raise it if long arrangement tasks
+  keep stopping partway; lower it to keep a looping model on a shorter leash.
+  Subagent orchestrators and workers get proportionally larger budgets, so this
+  one setting moves all three.
 - **Cleanup Conversations** - Bulk-delete conversations:
   - **Delete unstarred** - Remove all non-bookmarked conversations
   - **Delete all** - Remove every conversation

--- a/e2e/ui/README.md
+++ b/e2e/ui/README.md
@@ -46,6 +46,16 @@ Chat UI (`ui-test-helpers.ts`, IndexedDB-backed):
 - `conversation-branching.spec.ts`, `assistant-markdown.spec.ts` — edit/retry
   forks and assistant markdown rendering.
 
+Settings modal (`settings/settings-test-helpers.ts`, localStorage-backed):
+
+- `settings/presets.spec.ts` — the Presets tab: create → persists across reload
+  → re-select, blank/duplicate-name rejection, delete, description edits, and
+  the Subagent-preset picker. Presets write to localStorage on click rather than
+  through the footer Save, so every assertion reads the stored list back.
+
+  The live `../webui/settings.spec.ts` covers the save/restore round-trip that
+  needs a real device; it never covered presets, so nothing moved here.
+
 Context editor (`context-test-helpers.ts`, REST-backed) — the `/context` app
 (Project | Global | Instructions | Skills | Memory tabs):
 
@@ -78,8 +88,8 @@ chat UI, whose state lives client-side in IndexedDB).
 ## Adding tests
 
 Use `setupUiTest` for the chat "configured app + seeded history" starting point,
-or `setupContextTest` for the `/context` editor, then drive the UI with
-role/test-id locators. Conversation rows expose
-`data-testid="conversation-item"`; row actions use their accessible labels
-(`Rename conversation`, `Delete conversation`, `Bookmark conversation` /
+`setupSettingsTest` for the settings modal, or `setupContextTest` for the
+`/context` editor, then drive the UI with role/test-id locators. Conversation
+rows expose `data-testid="conversation-item"`; row actions use their accessible
+labels (`Rename conversation`, `Delete conversation`, `Bookmark conversation` /
 `Remove bookmark`, `Export conversation`).

--- a/e2e/ui/settings/preferences.spec.ts
+++ b/e2e/ui/settings/preferences.spec.ts
@@ -1,0 +1,50 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// The Preferences tab's tool-step budget. Unlike the presets next door, this
+// one is buffered and written by the footer Save, so the round-trip through the
+// modal is the part worth guarding.
+
+import { expect, test } from "@playwright/test";
+import {
+  openPreferencesTab,
+  openSettings,
+  readMaxToolSteps,
+  saveSettings,
+  setupSettingsTest,
+} from "./settings-test-helpers";
+
+test.describe("Settings — tool-step budget (stubbed backend)", () => {
+  test("saves a new budget and reloads it", async ({ page }) => {
+    await setupSettingsTest(page);
+    await openPreferencesTab(page);
+
+    // Unset until the user picks one — the chat falls back to the default.
+    expect(await readMaxToolSteps(page)).toBeNull();
+
+    await page.getByTestId("max-tool-steps").fill("40");
+    await saveSettings(page);
+
+    expect(await readMaxToolSteps(page)).toBe("40");
+
+    await page.reload();
+    await openSettings(page);
+    await openPreferencesTab(page);
+
+    await expect(page.getByTestId("max-tool-steps")).toHaveValue("40");
+  });
+
+  test("does not store an out-of-range budget", async ({ page }) => {
+    await setupSettingsTest(page);
+    await openPreferencesTab(page);
+
+    await page.getByTestId("max-tool-steps").fill("4");
+    await saveSettings(page);
+
+    // Never committed to the buffer, so Save writes the default it still holds
+    // rather than a budget that would strand every turn.
+    expect(await readMaxToolSteps(page)).toBe("25");
+  });
+});

--- a/e2e/ui/settings/presets.spec.ts
+++ b/e2e/ui/settings/presets.spec.ts
@@ -1,0 +1,135 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// The Presets tab in the stubbed suite, so it guards in CI. A preset bundles
+// the provider, model, inference settings and toolset — the mechanism worker
+// profiles are built on — and the only coverage before this was
+// ../webui/settings.spec.ts, which needs real Live and API keys and so never
+// runs there.
+//
+// Presets are their own persistence channel: every button writes to
+// localStorage on click, while the surrounding settings stay buffered until the
+// footer Save. So each test asserts against the stored list, not just the
+// picker.
+
+import { expect, test } from "@playwright/test";
+import {
+  createPreset,
+  openPresetsTab,
+  readPresets,
+  setupSettingsTest,
+} from "./settings-test-helpers";
+
+test.describe("Settings — Presets tab (stubbed backend)", () => {
+  test("creates a preset from the current settings and persists it", async ({
+    page,
+  }) => {
+    await setupSettingsTest(page);
+    await openPresetsTab(page);
+    await createPreset(page, "Bulk edit worker", "cheap, tools trimmed");
+
+    const presets = await readPresets(page);
+
+    expect(presets).toHaveLength(1);
+
+    const [stored] = presets;
+
+    expect(stored).toMatchObject({
+      name: "Bulk edit worker",
+      description: "cheap, tools trimmed",
+      provider: "gemini",
+      model: "gemini-3.7-flash",
+    });
+    // The whole point of the bundle: a preset carries the toolset too, not just
+    // the connection fields.
+    expect(stored?.enabledTools).toBeDefined();
+  });
+
+  test("survives a reload and re-selects its bundle", async ({ page }) => {
+    await setupSettingsTest(page);
+    await openPresetsTab(page);
+    await createPreset(page, "Mixing");
+
+    await page.reload();
+    await openPresetsTab(page);
+
+    const select = page.getByTestId("preset-select");
+
+    await expect(select.getByRole("option", { name: "Mixing" })).toBeAttached();
+
+    const [stored] = await readPresets(page);
+
+    await select.selectOption(stored?.id ?? "");
+
+    // Selecting loads the bundle into the live buffer, which is what puts the
+    // per-selection controls on screen.
+    await expect(page.getByTestId("preset-update")).toBeVisible();
+    await expect(page.getByTestId("preset-delete")).toBeVisible();
+  });
+
+  test("refuses a blank name and a duplicate one, keeping the list intact", async ({
+    page,
+  }) => {
+    await setupSettingsTest(page);
+    await openPresetsTab(page);
+    await createPreset(page, "Sketching");
+
+    await page.getByTestId("preset-new").click();
+    await page.getByTestId("preset-create-confirm").click();
+
+    await expect(page.getByTestId("preset-error")).toBeVisible();
+
+    await page.getByTestId("preset-name-input").fill("Sketching");
+    await page.getByTestId("preset-create-confirm").click();
+
+    await expect(page.getByTestId("preset-error")).toBeVisible();
+    // Stays open on the rejected draft rather than closing over it.
+    await expect(page.getByTestId("preset-create-form")).toBeVisible();
+    expect(await readPresets(page)).toHaveLength(1);
+  });
+
+  test("deletes the selected preset and clears the selection", async ({
+    page,
+  }) => {
+    await setupSettingsTest(page);
+    await openPresetsTab(page);
+    await createPreset(page, "Throwaway");
+
+    await page.getByTestId("preset-delete").click();
+
+    await expect(page.getByTestId("preset-delete")).toBeHidden();
+    expect(await readPresets(page)).toStrictEqual([]);
+  });
+
+  test("stores a description edit on every keystroke, not on the footer Save", async ({
+    page,
+  }) => {
+    await setupSettingsTest(page);
+    await openPresetsTab(page);
+    await createPreset(page, "Arranging");
+
+    await page
+      .getByTestId("preset-description-input")
+      .fill("for long-form arrangement passes");
+
+    // Esc dismisses the dialog straight from the focused field, so a blur that
+    // never fires must not lose the edit.
+    await expect
+      .poll(async () => (await readPresets(page))[0]?.description)
+      .toBe("for long-form arrangement passes");
+  });
+
+  test("offers a saved preset as the subagent preset", async ({ page }) => {
+    await setupSettingsTest(page);
+    await openPresetsTab(page);
+    await createPreset(page, "Worker");
+
+    await expect(
+      page.getByTestId("subagent-preset-select").getByRole("option", {
+        name: /Worker/,
+      }),
+    ).toBeAttached();
+  });
+});

--- a/e2e/ui/settings/settings-test-helpers.ts
+++ b/e2e/ui/settings/settings-test-helpers.ts
@@ -56,6 +56,37 @@ export async function openPresetsTab(page: Page): Promise<void> {
 }
 
 /**
+ * Switch to the Preferences tab and wait for its first control.
+ * @param page - Playwright page
+ */
+export async function openPreferencesTab(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Preferences" }).click();
+  await expect(page.getByTestId("max-tool-steps")).toBeVisible();
+}
+
+/**
+ * Commit the buffered settings through the footer Save and wait for the modal
+ * to close.
+ * @param page - Playwright page
+ */
+export async function saveSettings(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(page.getByTestId("max-tool-steps")).toBeHidden();
+}
+
+/**
+ * Read the stored tool-step budget. Null when the user has never set one, which
+ * is not the same as storing the default — the chat falls back instead.
+ * @param page - Playwright page
+ * @returns The stored value verbatim, or null when unset
+ */
+export async function readMaxToolSteps(page: Page): Promise<string | null> {
+  return page.evaluate(() =>
+    localStorage.getItem("producer_pal_max_tool_steps"),
+  );
+}
+
+/**
  * Read the stored preset list back out of localStorage. Presets persist on
  * click rather than on the footer Save, so this is what the assertions check.
  * @param page - Playwright page

--- a/e2e/ui/settings/settings-test-helpers.ts
+++ b/e2e/ui/settings/settings-test-helpers.ts
@@ -1,0 +1,94 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Harness for the stubbed settings-modal specs. The chat UI's own stubs already
+// bypass the first-run screen, so this only has to open the modal and read back
+// the one store the settings screen writes outside the footer Save: presets.
+
+import { type Page, expect } from "@playwright/test";
+import { installStubs } from "../ui-test-helpers";
+
+/** localStorage key holding the JSON-serialized preset list. Mirrors
+ * PRESETS_STORAGE_KEY in webui/src/hooks/settings/presets/preset-storage.ts. */
+export const PRESETS_STORAGE_KEY = "producer_pal_presets";
+
+/** A preset as stored, with only the fields these specs assert on. */
+export interface StoredPreset {
+  id: string;
+  name: string;
+  description?: string;
+  provider: string;
+  model: string;
+  thinking: string;
+  smallModelMode: boolean;
+  enabledTools?: Record<string, boolean>;
+  notation?: string;
+}
+
+/**
+ * Install the stubs, load the chat UI, and open the settings modal.
+ * @param page - Playwright page
+ */
+export async function setupSettingsTest(page: Page): Promise<void> {
+  await installStubs(page);
+  await page.goto("/chat-ui.html");
+  await openSettings(page);
+}
+
+/**
+ * Open the settings modal from the chat header.
+ * @param page - Playwright page
+ */
+export async function openSettings(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Settings" }).click();
+  await expect(page.getByRole("button", { name: "Presets" })).toBeVisible();
+}
+
+/**
+ * Switch to the Presets tab and wait for its picker.
+ * @param page - Playwright page
+ */
+export async function openPresetsTab(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Presets" }).click();
+  await expect(page.getByTestId("preset-select")).toBeVisible();
+}
+
+/**
+ * Read the stored preset list back out of localStorage. Presets persist on
+ * click rather than on the footer Save, so this is what the assertions check.
+ * @param page - Playwright page
+ * @returns The stored presets, or [] when nothing has been written
+ */
+export async function readPresets(page: Page): Promise<StoredPreset[]> {
+  return page.evaluate((key) => {
+    const raw = localStorage.getItem(key);
+
+    return raw == null ? [] : (JSON.parse(raw) as StoredPreset[]);
+  }, PRESETS_STORAGE_KEY);
+}
+
+/**
+ * Create a preset with the given name from the current settings, leaving it
+ * selected. The create form is the only way in — a seeded list wouldn't prove
+ * the write path works.
+ * @param page - Playwright page
+ * @param name - Preset name to create
+ * @param description - Optional description to type into the draft
+ */
+export async function createPreset(
+  page: Page,
+  name: string,
+  description?: string,
+): Promise<void> {
+  await page.getByTestId("preset-new").click();
+  await page.getByTestId("preset-name-input").fill(name);
+
+  if (description != null) {
+    await page.getByTestId("preset-description-input").fill(description);
+  }
+
+  await page.getByTestId("preset-create-confirm").click();
+  await expect(page.getByTestId("preset-update")).toBeVisible();
+}

--- a/e2e/ui/tsconfig.json
+++ b/e2e/ui/tsconfig.json
@@ -21,5 +21,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["*.ts"]
+  "include": ["*.ts", "**/*.ts"]
 }

--- a/src/live-api-adapter/live-api-adapter.ts
+++ b/src/live-api-adapter/live-api-adapter.ts
@@ -283,6 +283,10 @@ function applyRestoredProjectContext(
 ): void {
   if (restored == null) return;
 
+  // Two session starts applying the SAME restore is not a divergence, even
+  // though the second one's snapshot no longer matches. Nothing left to do.
+  if (sessionState.projectContext.content === restored) return;
+
   if (sessionState.projectContext.content !== snapshot) {
     console.warn(
       "Project context changed while the backup restore was in flight; " +

--- a/src/live-api-adapter/tests/project-context-setter.test.ts
+++ b/src/live-api-adapter/tests/project-context-setter.test.ts
@@ -7,6 +7,7 @@
 // distinction, and applying a restore without losing a write that raced it.
 
 import { describe, expect, it, vi } from "vitest";
+import * as console from "#src/shared/max/v8-max-console.ts";
 
 vi.mock(import("#src/live-api-adapter/project-context-sync.ts"), () => ({
   backupProjectContextOnEdit: vi.fn(),
@@ -130,5 +131,24 @@ describe("applying a restored blob around a concurrent write", () => {
     expect(restoreOutlets()).toStrictEqual([
       [0, "update_project_context", "notes from the sidecar"],
     ]);
+  });
+
+  it("stays quiet when a concurrent restore already applied the same blob", async () => {
+    projectContext("");
+    vi.mocked(outlet).mockClear();
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Two session starts racing on the same sidecar. The second one's snapshot
+    // no longer matches, but the param already holds exactly what it carries —
+    // that is agreement, not the divergence the warning is for.
+    await requestWithPendingSync("notes from the sidecar", () => {
+      projectContext("notes from the sidecar");
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(restoreOutlets()).toStrictEqual([]);
+
+    warnSpy.mockRestore();
   });
 });

--- a/src/mcp-server/live-library/library-routes.ts
+++ b/src/mcp-server/live-library/library-routes.ts
@@ -32,10 +32,20 @@ import { librarySearch } from "./query/library-search.ts";
  * Register all library routes. Idempotency is the caller's responsibility;
  * the underlying registry throws on duplicate registration.
  *
- * TODO: each route currently opens and closes its own DB handle. Cheap
- * with `immutable=1` (no locking) but redundant. If a single MCP request
- * ever composes multiple routes (e.g. search + listTags), pull the open
- * up into a per-request scope.
+ * Each route opens and closes its own DB handle, including inside a
+ * `searchBatch` that runs up to 20 searches in one MCP request. Measured
+ * rather than assumed, on a 47MB Live-files DB: reopening per query costs
+ * ~3.5ms across a 20-query batch (~20% of the DB time — mostly the page
+ * cache being thrown away, not the open itself, which is 0.02ms under
+ * `immutable=1`). Locating the DB and reading staleness add ~0.09ms per
+ * query between them.
+ *
+ * Not worth a shared handle. Node sees each search as its own node_request
+ * with no MCP-request correlation, so a per-request scope needs either an
+ * explicit begin/end from V8 (two more round trips, which is most of the
+ * 3.5ms back) or a time-based handle cache (a stale snapshot window, since
+ * an `immutable=1` handle never sees Live's later writes). Either buys
+ * 0.17ms per query on a path already paying a V8↔Node round trip for it.
  */
 export function registerLibraryRoutes(): void {
   registerNodeRoute(

--- a/src/skills/fragments/arrangement.ts
+++ b/src/skills/fragments/arrangement.ts
@@ -34,13 +34,13 @@ export const arrangement = `## Arrangement
 export const arrangementWrite = `### Moving Clips
 
 \`arrangementStart\` moves arrangement clips; \`toSlot\` (trackIndex/sceneIndex, both 0-based — scene 1 = index 0) moves session clips. Moving clips changes their IDs - re-read to get new IDs.
-\`arrangementLength\` sets arrangement playback region. \`split\` divides arrangement clips at bar|beat positions measured from the clip's own start (1|1 = clip start, NOT song position).
+\`arrangementLength\` sets arrangement playback region.
 
 ### Take Lanes (Arrangement Variations)
 
 Stack alternate takes of an arrangement clip at the same position; only the active take plays (the user auditions/comps in Live's UI).
 
-- \`takeLane\` on create-clip + duplicate (arrangement only; duplicate is MIDI-only): omit/\`0\` = main lane; \`1+\` = that lane (auto-created up to it); \`"new"\` = append a fresh lane. \`takeLaneName\` names a lane this call creates.
+- \`takeLane\` is on create-clip + duplicate (arrangement only; duplicate is MIDI-only).
 - Variation workflow: a few duplicate calls with \`takeLane: "new"\` + \`transforms\` to vary each copy. read-track \`arrangement-clips\` include lists \`takeLanes\` — each entry carries \`takeLane\` (1-based, matching the write param) and its \`name\`, so you can round-trip a read back to a write directly.
 - 8 lanes/track max; creating over an existing clip replaces it (like the main lane). One-way: Producer Pal can't delete or comp take lanes — that's done in Live (expand the track's take-lane arrow to see them).
 - Take-lane clips are append-only: \`update-clip\` (\`split\`, \`arrangementStart\`, \`arrangementLength\`) and \`ppal-delete\` warn+skip on them. Main→take duplicate recreates the clip from notes and drops envelope automation; take→main promote isn't supported. For any of these, ask the user to do it in Live's UI.`;

--- a/src/skills/fragments/context.ts
+++ b/src/skills/fragments/context.ts
@@ -49,8 +49,9 @@ Managing memory:
  * small-model mode's ppal-context is blobs-only (no memory scope), so this
  * covers the project/global documents and nothing else.
  *
- * Two rules here are a deliberate token spend in the tier that can least afford
- * it, because both defects they fix are invisible to the tool schema:
+ * What each scope holds is the `scope` param's job — this states only the two
+ * rules that are a deliberate token spend in the tier that can least afford it,
+ * because both defects they fix are invisible to the tool schema:
  *  - **Exactly one scope.** Small models wrote an always-applies preference to
  *    global AND copied it into project. A duplicated fact burns context on every
  *    turn (both layers are always injected) and goes stale as soon as one side
@@ -67,7 +68,7 @@ Managing memory:
  */
 export const contextBasic = `## Context
 
-\`ppal-context\` scope:project stores facts about THIS Live Set; scope:global stores who the user is (style, preferences, goals). Put a fact in exactly ONE scope, never both.
+Put a fact in exactly ONE \`ppal-context\` scope, never both.
 
 Writing replaces the whole document — read the same scope first. Already has content? Propose what you'd add and wait for a yes. Empty? Just write it. Either way, say what you saved.
 

--- a/src/skills/fragments/transforms/transforms-core.ts
+++ b/src/skills/fragments/transforms/transforms-core.ts
@@ -90,11 +90,9 @@ Across a batch (update-clip \`ids\` / duplicate copies / create-clip multiple sl
  * `quantizeGrid` appear in no other schema, so a create-clip or duplicate caller
  * was paying ~1.1k characters it could never use.
  *
- * The merge rule leads because it is the same gate and the same subject: only
- * update-clip merges (create-clip replaces the slot outright), and each notation
- * head used to state it separately — three copies, all shipping to read-only and
- * create-clip-only callers who have nothing to merge into and, without this
- * fragment, no definition of the `preTransforms` those copies pointed at.
+ * The merge rule itself is the `notes` param's job in every notation — this
+ * carries only what a schema can't say: the
+ * `preTransforms → notes → transforms` pipeline.
  *
  * Notation-neutral like tier 1: merge keys on pitch+start in every notation, so
  * nothing here may name a notation's syntax for deleting inline.
@@ -104,11 +102,7 @@ Across a batch (update-clip \`ids\` / duplicate copies / create-clip multiple sl
  */
 export const transformsEditing = `### Editing Notes Already in a Clip (update-clip only)
 
-\`notes\` MERGES into an existing clip — a new note overwrites the existing note at the *same* pitch+start (restate it with the length or velocity you want); every other note is untouched. So **don't rewrite the whole clip to change a few notes** — restate just those.
-
-\`preTransforms\` is *the* way to delete or change notes already in the clip. Pipeline: \`preTransforms → notes (merge) → transforms\`. It runs on the existing notes BEFORE any new \`notes\` merge — clear a whole bar (\`3|*: delete\`), a region (\`1|1-2|1: delete\`), a lane (\`C1: delete\`), everything (\`delete\`), or remap (\`C1: C4\`); the \`delete\` shorthand (alias \`v0\`) is preferred for clearing (\`velocity = 0\` is the longhand equivalent). Prefer it over deleting inline in \`notes\`. Works with or without \`notes\`; ignored on audio clips. Same syntax as transforms. To *replace* a region rather than edit it in place, clear it first (\`preTransforms: "1|1-2|1: delete"\`) or the notes you didn't restate stay behind. \`transforms\` then mutates the merged result — also the efficient way to *thin* density: generate densely in \`notes\`, then prune with a selector instead of scattering \`delete\`s.
-
-\`quantizeGrid\` uses Live's native grid enum (\`1/4\`,\`1/8\`,\`1/8T\`,\`1/16\`,\`1/16T\`,\`1/32\`) but also accepts the equivalent \`n/N\` note value (\`n/12\`=\`1/8T\`, \`n/24\`=\`1/16T\`, etc.); the mixed grids \`1/8+1/8T\`/\`1/16+1/16T\` are enum-only.`;
+\`preTransforms\` is *the* way to delete or change notes already in the clip. Pipeline: \`preTransforms → notes (merge) → transforms\`. It runs on the existing notes BEFORE any new \`notes\` merge — clear a whole bar (\`3|*: delete\`), a span (\`1|1-2|1: delete\`), one pitch (\`C1: delete\`), a pitch range (\`C1-C5: delete\`), everything (\`delete\`), or remap a drum lane (\`C1: C4\`); the \`delete\` shorthand (alias \`v0\`) is preferred for clearing (\`velocity = 0\` is the longhand equivalent). Prefer it over deleting inline in \`notes\`. Works with or without \`notes\`; ignored on audio clips. Same syntax as transforms. To *replace* a region rather than edit it in place, clear it first (\`preTransforms: "1|1-2|1: delete"\`) or the notes you didn't restate stay behind. \`transforms\` then mutates the merged result — also the efficient way to *thin* density: generate densely in \`notes\`, then prune with a selector instead of scattering \`delete\`s.`;
 
 /**
  * The transforms fragment at basic (small-model) depth: the merge rule and

--- a/src/skills/include-resolver.ts
+++ b/src/skills/include-resolver.ts
@@ -33,8 +33,14 @@ import { type Notation } from "#src/shared/notation.ts";
 /** Matches a single `@include "<ref>"` directive; ref is captured group 1. */
 const INCLUDE_PATTERN = /@include\s+"([^\n"]*)"/g;
 
-/** Runs of 3+ newlines left by a fragment that resolved to nothing. */
-const BLANK_LINE_RUN = /\n{3,}/g;
+/**
+ * The same directive plus the newline run after it (group 2), so an expansion
+ * can take the blank line that framed its include line with it.
+ */
+const INCLUDE_LINE_PATTERN = /@include\s+"([^\n"]*)"(\n*)/g;
+
+/** A 3+ newline run at the join between an expansion and what followed it. */
+const SEAM_BLANK_RUN = /\n{3,}$/;
 
 /** Injected context for {@link resolveIncludes}. */
 export interface ResolveIncludesOptions {
@@ -75,34 +81,64 @@ export function resolveIncludes(
 ): string {
   const body = readFragment(root, options) ?? "";
 
-  const expanded = body.replaceAll(
-    INCLUDE_PATTERN,
-    (_match, rawRef: string) => {
-      const name = normalizeIncludeRef(rawRef, options.notation);
-
-      if (name == null) {
-        options.onWarn?.(`skills include rejected unsafe path: "${rawRef}"`);
-
-        return "";
-      }
-
-      const included = readFragment(name, options);
-
-      if (included == null) return "";
-
-      options.onFragment?.(name, included);
-
-      return stripNestedIncludes(included, name, options);
-    },
+  return body.replaceAll(
+    INCLUDE_LINE_PATTERN,
+    (_match, rawRef: string, trailing: string) =>
+      joinExpansion(expandInclude(rawRef, options), trailing),
   );
-
-  // A fragment that resolved to nothing leaves the blank lines that framed its
-  // include line stacked up. Collapse them so an emptied override (or a
-  // release build's absent code-transforms) reads as a clean section break.
-  return expanded.replaceAll(BLANK_LINE_RUN, "\n\n");
 }
 
 // --- Helpers below main export ---
+
+/**
+ * Expand one directive to the fragment body it names, or "" when the ref is
+ * unsafe, the name unknown, or the fragment resolved to nothing.
+ *
+ * @param rawRef - The ref exactly as written in the directive
+ * @param options - Injected notation, lookup, and sinks
+ * @returns The fragment's body, with any nested directives stripped
+ */
+function expandInclude(
+  rawRef: string,
+  options: ResolveIncludesOptions,
+): string {
+  const name = normalizeIncludeRef(rawRef, options.notation);
+
+  if (name == null) {
+    options.onWarn?.(`skills include rejected unsafe path: "${rawRef}"`);
+
+    return "";
+  }
+
+  const included = readFragment(name, options);
+
+  if (included == null) return "";
+
+  options.onFragment?.(name, included);
+
+  return stripNestedIncludes(included, name, options);
+}
+
+/**
+ * Put an expansion back where its include line was, tidying only the seam.
+ *
+ * An expansion of nothing takes the blank line that framed the directive with
+ * it, so an emptied override (or a release build's absent code-transforms)
+ * reads as a clean section break. Anything else keeps its own text verbatim —
+ * collapsing blank runs across the whole document would rewrite a 3+ newline
+ * run INSIDE a user's fragment, e.g. inside a fenced example.
+ *
+ * @param expansion - The fragment body, or "" when nothing resolved
+ * @param trailing - The newline run that followed the include line
+ * @returns The text to substitute for the directive and its trailing newlines
+ */
+function joinExpansion(expansion: string, trailing: string): string {
+  if (expansion === "") return "";
+
+  if (trailing === "") return expansion;
+
+  return (expansion + trailing).replace(SEAM_BLANK_RUN, "\n\n");
+}
 
 /**
  * Look up one fragment's body, warning when the name resolves to nothing.

--- a/src/skills/tests/build-skills-gating.test.ts
+++ b/src/skills/tests/build-skills-gating.test.ts
@@ -162,16 +162,20 @@ describe("buildSkills - tool gating", () => {
     }
   });
 
-  it("keeps the merge rule for update-clip, in every notation", () => {
+  it("keeps the editing pipeline for update-clip, in every notation", () => {
     // The other half of the move: it left three notation heads, so it has to
-    // arrive exactly once for anyone who can actually merge into a clip.
+    // arrive exactly once for anyone who can actually merge into a clip. The
+    // merge rule itself is the `notes` param's now — what stays here is the
+    // pipeline, which no single schema can state.
     for (const notation of ["barbeat", "stark", "midi-json"] as const) {
       const result = buildSkills({ notation, tools: ["ppal-update-clip"] });
 
       expect(result, `${notation} lost the editing section`).toContain(
         "### Editing Notes Already in a Clip",
       );
-      expect(result, `${notation} lost the merge rule`).toContain("MERGES");
+      expect(result, `${notation} lost the pipeline`).toContain(
+        "preTransforms → notes (merge) → transforms",
+      );
     }
   });
 

--- a/src/skills/tests/build-skills.test.ts
+++ b/src/skills/tests/build-skills.test.ts
@@ -151,7 +151,7 @@ describe("buildSkills - composition", () => {
     );
     expect(
       buildSkills({ notation: "barbeat", smallModelMode: true }),
-    ).toContain("scope:project stores facts about THIS Live Set"); // context-basic
+    ).toContain("Put a fact in exactly ONE `ppal-context` scope"); // context-basic
   });
 
   it("defaults to bar|beat at both depths", () => {

--- a/src/skills/tests/include-resolver.test.ts
+++ b/src/skills/tests/include-resolver.test.ts
@@ -266,6 +266,29 @@ describe("resolveIncludes - blank line collapse", () => {
 
     expect(result).toBe("a\n\nb");
   });
+
+  it("leaves a blank-line run inside a fragment alone", () => {
+    // Only reachable through a user override today, and only cosmetic unless
+    // the spacing means something — which inside a fenced block it does.
+    const result = resolveIncludes(
+      "root",
+      options({
+        root: `a\n\n@include "./x.md"\n\nb`,
+        x: "```\nfirst\n\n\nlast\n```",
+      }),
+    );
+
+    expect(result).toBe("a\n\n```\nfirst\n\n\nlast\n```\n\nb");
+  });
+
+  it("tidies the seam when a fragment body ends with its own newline", () => {
+    const result = resolveIncludes(
+      "root",
+      options({ root: `a\n\n@include "./x.md"\n\nb`, x: "body\n" }),
+    );
+
+    expect(result).toBe("a\n\nbody\n\nb");
+  });
 });
 
 describe("resolveIncludes - path safety", () => {

--- a/src/tools/actions/duplicate/duplicate.def.ts
+++ b/src/tools/actions/duplicate/duplicate.def.ts
@@ -85,7 +85,7 @@ export const toolDefDuplicate = defineTool("ppal-duplicate", {
 
     routeToSource: param(z.boolean().optional(), {
       default:
-        "route new track to source's instrument? (for MIDI layering/polyrhythms)",
+        "tracks only (errors otherwise): the copy gets no clips or devices of its own and plays the source track's instrument (for MIDI layering/polyrhythms)",
       smallModel: null,
     }),
 

--- a/src/tools/clip/create/create-clip.def.ts
+++ b/src/tools/clip/create/create-clip.def.ts
@@ -122,7 +122,8 @@ export const toolDefCreateClip = defineTool("ppal-create-clip", {
     warping: param(z.boolean().optional(), {
       default:
         "audio clips only. Omit and Live decides per its Loop/Warp Short Samples setting, often time-stretching the file to the tempo. false = play the file as rendered. The settled state comes back as `warping`",
-      smallModel: "audio clips only: false plays the file as rendered",
+      smallModel:
+        "audio clips only: false plays the file as rendered; omit and Live may time-stretch it to the tempo",
     }),
 
     gainDb: z.coerce
@@ -130,7 +131,7 @@ export const toolDefCreateClip = defineTool("ppal-create-clip", {
       .min(-70)
       .max(24)
       .optional()
-      .describe("audio clip gain in decibels (ignored for MIDI)"),
+      .describe("audio clip gain in decibels, 0 = unity (ignored for MIDI)"),
 
     pitchShift: z.coerce
       .number()

--- a/src/tools/clip/helpers/audio-clip-timing.ts
+++ b/src/tools/clip/helpers/audio-clip-timing.ts
@@ -5,6 +5,13 @@
 
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 
+export interface MarkerScale {
+  /** Beats per marker unit (see markerBeatsPerUnit) */
+  beatsPerMarkerUnit: number;
+  /** Sample duration to clamp markers to (see markerClampSeconds) */
+  markerClampSeconds: number;
+}
+
 export interface AudioClipTiming {
   /** Whether Live is time-stretching the sample to the Set tempo */
   warping: boolean;
@@ -131,6 +138,32 @@ export function markerBeatsPerUnit(clip: LiveAPI): number {
  */
 export function markerClampSeconds(clip: LiveAPI): number {
   return markersAreSeconds(clip) ? audioClipSampleSeconds(clip) : 0;
+}
+
+/**
+ * Read one of a clip's marker properties as beats.
+ *
+ * Applies both corrections a raw `getProperty` misses: the unit factor and the
+ * sample clamp. Everything that reads a marker has to go through this, or a
+ * stale far-out `end_marker` on an externally-unwarped clip leaks into the
+ * comparison unclamped.
+ *
+ * @param clip - The clip whose marker is being read
+ * @param property - Marker property name (start_marker, loop_end, …)
+ * @param scale - The clip's marker unit factor and clamp
+ * @param scale.beatsPerMarkerUnit - Beats per marker unit (see markerBeatsPerUnit)
+ * @param scale.markerClampSeconds - Sample duration to clamp to (see markerClampSeconds)
+ * @returns The marker position in real beats
+ */
+export function markerBeats(
+  clip: LiveAPI,
+  property: string,
+  scale: MarkerScale,
+): number {
+  const raw = clip.getProperty(property) as number;
+  const clamp = scale.markerClampSeconds;
+
+  return (clamp > 0 ? Math.min(raw, clamp) : raw) * scale.beatsPerMarkerUnit;
 }
 
 /**

--- a/src/tools/clip/update/helpers/update-clip-helpers.ts
+++ b/src/tools/clip/update/helpers/update-clip-helpers.ts
@@ -7,6 +7,7 @@ import { type ClipContext } from "#src/notation/transform/helpers/transform-eval
 import { type Notation } from "#src/shared/notation.ts";
 import * as console from "#src/shared/max/v8-max-console.ts";
 import {
+  markerBeats,
   markerBeatsPerUnit,
   markerClampSeconds,
 } from "#src/tools/clip/helpers/audio-clip-timing.ts";
@@ -270,7 +271,10 @@ function writeClipProperties(
     firstStart,
     looping,
   } = params;
-  const beatsPerMarkerUnit = markerBeatsPerUnit(clip);
+  const markerScale = {
+    beatsPerMarkerUnit: markerBeatsPerUnit(clip),
+    markerClampSeconds: markerClampSeconds(clip),
+  };
 
   // Includes the end_marker bounds check for start_marker
   const { startBeats, endBeats, startMarkerBeats } = calculateBeatPositions({
@@ -282,14 +286,13 @@ function writeClipProperties(
     clip,
     isLooping,
     wasLooping,
-    beatsPerMarkerUnit,
-    markerClampSeconds: markerClampSeconds(clip),
+    ...markerScale,
   });
 
   // Both ends: loop_start and start_marker are bounded by different properties,
   // and one call can write both.
-  const markerBeats = (property: string) =>
-    (clip.getProperty(property) as number) * beatsPerMarkerUnit;
+  const readMarker = (property: string) =>
+    markerBeats(clip, property, markerScale);
 
   clip.setAll(
     buildClipPropertiesToSet({
@@ -303,9 +306,9 @@ function writeClipProperties(
       isLooping,
       startBeats,
       endBeats,
-      currentLoopEnd: markerBeats("loop_end"),
-      currentEndMarker: markerBeats("end_marker"),
-      beatsPerMarkerUnit,
+      currentLoopEnd: readMarker("loop_end"),
+      currentEndMarker: readMarker("end_marker"),
+      beatsPerMarkerUnit: markerScale.beatsPerMarkerUnit,
     }),
   );
 

--- a/src/tools/clip/update/helpers/update-clip-timing-helpers.ts
+++ b/src/tools/clip/update/helpers/update-clip-timing-helpers.ts
@@ -10,6 +10,7 @@ import {
 } from "#src/notation/barbeat/time/barbeat-time.ts";
 import { SAME_TIME_EPSILON } from "#src/shared/config.ts";
 import * as console from "#src/shared/max/v8-max-console.ts";
+import { markerBeats } from "#src/tools/clip/helpers/audio-clip-timing.ts";
 import { parseTimeSignature } from "#src/tools/shared/utils.ts";
 
 interface BeatPositions {
@@ -103,20 +104,15 @@ export function calculateBeatPositions({
   // them through this so an unwarped audio clip lands on the same scale. The
   // clamp matters as much as the factor: read-clip reports a clamped length, so
   // handing that length straight back has to derive from the same number.
-  const markerBeats = (property: string) => {
-    const raw = clip.getProperty(property) as number;
-    const bounded =
-      markerClampSeconds > 0 ? Math.min(raw, markerClampSeconds) : raw;
-
-    return bounded * beatsPerMarkerUnit;
-  };
+  const readMarker = (property: string) =>
+    markerBeats(clip, property, { beatsPerMarkerUnit, markerClampSeconds });
 
   // Live keeps two regions per clip and `looping` picks which one plays:
   // start_marker/end_marker while it is off, loop_start/loop_end while it is
   // on. Read the pair that is playing BEFORE this update — on a loop toggle the
   // other pair still holds whatever it was last left with.
-  const currentStart = markerBeats(wasLooping ? "loop_start" : "start_marker");
-  const currentEnd = markerBeats(wasLooping ? "loop_end" : "end_marker");
+  const currentStart = readMarker(wasLooping ? "loop_start" : "start_marker");
+  const currentEnd = readMarker(wasLooping ? "loop_end" : "end_marker");
 
   // Convert start to beats if provided. Validate the standalone position first
   // so a 0-indexed/zero-bar position gets the 1-indexing steer (matching
@@ -187,7 +183,7 @@ export function calculateBeatPositions({
   const startMarkerBeats = determineStartMarker(
     firstStartBeats,
     startBeats,
-    endBeats ?? markerBeats("end_marker"),
+    endBeats ?? readMarker("end_marker"),
   );
 
   return { startBeats, endBeats, firstStartBeats, startMarkerBeats };

--- a/src/tools/clip/update/tests/audio/update-clip-unwarped-region.test.ts
+++ b/src/tools/clip/update/tests/audio/update-clip-unwarped-region.test.ts
@@ -106,6 +106,37 @@ describe("updateClip - unwarped audio clip region", () => {
     expect(mocks.clip123.set).toHaveBeenCalledWith("loop_start", 0);
   });
 
+  it("clamps the stale end_marker the write-order heuristic reads too", async () => {
+    setTempo(120);
+    setupAudioClipMock(mocks.clip123, {
+      warping: 0,
+      looping: 0,
+      start_marker: 0,
+      // Stale on both ends: 10 was beats while warped, now reads as 10 s on a
+      // 2 s sample.
+      end_marker: 10,
+      loop_end: 10,
+      sample_rate: 44100,
+      sample_length: 88200, // 2 s = 4 beats
+    });
+
+    // Beat 6 is past the clamped boundary (4 beats) but well inside the stale
+    // one (20 beats), so the two readings disagree about whether this write
+    // expands the region.
+    await updateClip({ ids: "123", start: "2|3", length: "n/4" });
+
+    const props = mocks.clip123.set.mock.calls.map(([prop]) => prop);
+
+    // Live silently ignores a start_marker past end_marker, so an expanding
+    // write has to move the end first. Reading the markers unclamped here made
+    // this look like a shrink and wrote the start into a region that couldn't
+    // hold it — no error, just a partly applied region.
+    expect(props.indexOf("end_marker")).toBeGreaterThanOrEqual(0);
+    expect(props.indexOf("start_marker")).toBeGreaterThan(
+      props.indexOf("end_marker"),
+    );
+  });
+
   it("still writes beats when the audio clip is warped", async () => {
     setTempo(120);
     setupAudioClipMock(mocks.clip123, {

--- a/src/tools/clip/update/update-clip.def.ts
+++ b/src/tools/clip/update/update-clip.def.ts
@@ -129,7 +129,7 @@ export const toolDefUpdateClip = defineTool("ppal-update-clip", {
     }),
     preTransforms: param(z.string().optional(), {
       default:
-        "transform expressions applied to EXISTING notes BEFORE merging any new notes (broadcast across ids); clear or edit notes already in the clip. v0 deletes (zero velocity): clear a whole bar ('3|*: v0', |* wildcard avoids spilling onto the next downbeat), a span ('1|1-2|1: v0'), or all ('v0'); also remap a drum lane ('C1: C4'). Works with or without notes",
+        "transform expressions applied to EXISTING notes BEFORE merging any new notes (broadcast across ids); clear or edit notes already in the clip. 'delete' (alias 'v0') removes: a whole bar ('3|*: delete', |* wildcard avoids spilling onto the next downbeat), a span ('1|1-2|1: delete'), one pitch ('C1: delete'), a pitch range ('C1-C5: delete'), or all ('delete'); also remap a drum lane ('C1: C4'). Works with or without notes",
       smallModel:
         "clear/edit notes already in the clip. Shorthand only (see Skills): `3|*: v0` clears all of bar 3 (|* wildcard = whole bar), `1|1-2|1: v0` clears a span, `v0` clears all, `C1: C4` remaps a drum lane",
     }),

--- a/src/tools/clip/update/update-clip.def.ts
+++ b/src/tools/clip/update/update-clip.def.ts
@@ -86,7 +86,7 @@ export const toolDefUpdateClip = defineTool("ppal-update-clip", {
       .min(-70)
       .max(24)
       .optional()
-      .describe("audio clip gain in decibels (ignored for MIDI)"),
+      .describe("audio clip gain in decibels, 0 = unity (ignored for MIDI)"),
     pitchShift: z.coerce
       .number()
       .min(-48)

--- a/src/tools/device/create/create-device.def.ts
+++ b/src/tools/device/create/create-device.def.ts
@@ -35,9 +35,9 @@ export const toolDefCreateDevice = defineTool("ppal-create-device", {
       default:
         "applied after creation — array of {name, value}. name = param name or read-device id; value in display units (enum string, note name, number). For a Drum Rack, prefix the name with a pad path to address a pad's device, e.g. {name:'pC1/d0/sample', value:'<abs file path>'} loads a sample into pad C1 (auto-creates the pad's Simpler) — build a full kit in one call",
       // See update-device: small mode has no devices fragment, so the value
-      // format has to survive the trim even though the pad example doesn't.
+      // format and the sample write both have to survive the trim.
       smallModel:
-        "applied after creation — array of {name, value}. name = param name or id; value in display units (enum string, note name, number)",
+        "applied after creation — array of {name, value}. name = param name or id; value in display units (enum string, note name, number). Load a sample with {name:'sample', value:'<abs path>'} (there is no top-level sample arg); for a Drum Rack pad prefix it, e.g. {name:'pC1/d0/sample'}",
     }),
   },
 });

--- a/src/tools/device/read/read-device.def.ts
+++ b/src/tools/device/read/read-device.def.ts
@@ -45,7 +45,7 @@ export const toolDefReadDevice = defineTool("ppal-read-device", {
           'chains, return-chains, drum-pads = rack contents (use maxDepth). params, param-values = parameters. drum-map = pad names keyed by note (drum name in stark, MIDI number in midi-json). sample = Simpler sample file path (flat top-level field; gainDb and other sample params are in params). actions = device-specific actions for update-device (name, signature, description). options = valid pseudo-param values (paramOptions) + dynamic catalogs for specialized devices (IR files, sidechain sources, wavetables) + Wavetable mod routes. "*" = all',
         smallModel: {
           description:
-            "chains = rack contents (use maxDepth). params, param-values = parameters. drum-map = pad names by note. sample = Simpler sample file path. actions = device actions. options = valid param values + device catalogs",
+            "chains = rack contents (use maxDepth). params, param-values = parameters. drum-map = pad names keyed by note (drum name in stark, MIDI number in midi-json). sample = Simpler sample file path. actions = device actions. options = valid param values + device catalogs",
           excludeEnumValues: ["drum-pads", "return-chains", "*"],
         },
       },

--- a/src/tools/device/update/update-device.def.ts
+++ b/src/tools/device/update/update-device.def.ts
@@ -42,11 +42,12 @@ export const toolDefUpdateDevice = defineTool("ppal-update-device", {
     params: param(paramsInputSchema, {
       default:
         "array of {name, value}. name = param name or read-device id; value in display units (enum string, note name, number). For a Drum Rack target, prefix the name with a pad path, e.g. {name:'pC1/d0/sample', value:'<abs file path>'} sets pad C1's sample (auto-creates the pad's Simpler)",
-      // The Drum Rack pad-path example is large-mode only, but the value format
-      // can't go: small mode ships no devices skills fragment, so this is the
-      // only place saying a value is a display value, not a normalized 0-1.
+      // Small mode ships no devices skills fragment, so this is the only place
+      // saying a value is a display value (not a normalized 0-1) AND the only
+      // place teaching the sample write. getting-help-basic promises samples on
+      // Simpler and Drum Rack pads, so the how has to ship with the promise.
       smallModel:
-        "array of {name, value}. name = param name or id; value in display units (enum string, note name, number)",
+        "array of {name, value}. name = param name or id; value in display units (enum string, note name, number). Load a sample with {name:'sample', value:'<abs path>'} (there is no top-level sample arg); for a Drum Rack pad prefix it, e.g. {name:'pC1/d0/sample'}",
     }),
     // Intentionally an array (not the usual comma-separated string): action
     // arguments themselves contain commas (e.g. setModulation('x','y',0.5)), so

--- a/webui/src/chat/sdk/client.ts
+++ b/webui/src/chat/sdk/client.ts
@@ -35,14 +35,17 @@ import {
   highestSubagentIndex,
   isSpawnToolResult,
 } from "./subagent/subagent-session";
+import { DEFAULT_MAX_TOOL_STEPS, orchestratorSteps } from "./step-budget";
 import { type ChatClientConfig, type ChatMessage, toTokenUsage } from "./types";
 
 /**
  * Default tool-step budget: a plain chat turn's, and the floor the orchestrator
- * and worker budgets are set above. Exported so tests assert against the real
- * number instead of a copy that can drift.
+ * and worker budgets are set above. Re-exported so callers and tests keep
+ * reading it from here rather than growing a copy that can drift; the number
+ * and the derivations live in step-budget.ts, which the settings layer also
+ * reads. A user who has set their own budget overrides this per config.
  */
-export const MAX_TOOL_STEPS = 25;
+export const MAX_TOOL_STEPS = DEFAULT_MAX_TOOL_STEPS;
 
 /**
  * The user turn a resume appends when, and only when, the conversation would
@@ -50,16 +53,6 @@ export const MAX_TOOL_STEPS = 25;
  * question — see resumeStream.
  */
 const RESUME_MESSAGE = "continue";
-
-/**
- * Orchestrator step budget when subagents are enabled. Widened off the default
- * because context-gathering steps and each SEQUENTIAL spawn share this budget (a
- * spawn costs one step; N parallel spawns in one turn cost just one). So this
- * bounds how many sequential spawns fit alongside a turn's other tool work, while
- * MAX_SPAWNS bounds how many workers the turn may start at all — a parallel burst
- * costs one step but still spends the whole spawn budget.
- */
-const MAX_ORCHESTRATOR_STEPS = 40;
 
 /**
  * AI SDK client that wraps streamText for chat with MCP tool support.
@@ -76,8 +69,9 @@ export class ChatSdkClient {
   private config: ChatClientConfig;
   /**
    * This client's tool-step budget for streamText's stopWhen. Set in
-   * initialize(): MAX_ORCHESTRATOR_STEPS when subagents are enabled, the config's
-   * budget for a worker (MAX_WORKER_STEPS), else the shared MAX_TOOL_STEPS.
+   * initialize(): the orchestrator budget derived from the user's base when
+   * subagents are enabled, the config's own budget for a worker (already
+   * derived), else the user's base.
    */
   private maxSteps = MAX_TOOL_STEPS;
   /**
@@ -149,8 +143,12 @@ export class ChatSdkClient {
       // Orchestrator with subagents enabled: add the client-side spawn tool and
       // widen the step budget so sequential spawns and context-gathering steps
       // share enough headroom. A worker never reaches here — its cloned config
-      // sets spawn_subagent false (the recursion guard).
-      this.maxSteps = MAX_ORCHESTRATOR_STEPS;
+      // sets spawn_subagent false (the recursion guard). Derived from the
+      // config's base so a user who raised their budget widens this with it;
+      // a worker's own maxSteps arrives pre-derived on the cloned config.
+      this.maxSteps = orchestratorSteps(
+        this.config.baseMaxSteps ?? DEFAULT_MAX_TOOL_STEPS,
+      );
       this.spawnState.nextIndex = highestSubagentIndex(this.chatHistory);
       this.tools = {
         ...tools,
@@ -164,9 +162,12 @@ export class ChatSdkClient {
         }),
       };
     } else {
-      // Worker (config.maxSteps = MAX_WORKER_STEPS) or a subagents-off
-      // orchestrator (undefined → shared default; behavior unchanged).
-      this.maxSteps = this.config.maxSteps ?? MAX_TOOL_STEPS;
+      // A worker carries its own already-derived budget in maxSteps; a
+      // subagents-off chat has none and runs on the user's base.
+      this.maxSteps =
+        this.config.maxSteps ??
+        this.config.baseMaxSteps ??
+        DEFAULT_MAX_TOOL_STEPS;
       this.tools = tools;
     }
   }

--- a/webui/src/chat/sdk/step-budget.ts
+++ b/webui/src/chat/sdk/step-budget.ts
@@ -1,0 +1,54 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * The per-turn tool-step budgets, and the one setting they all derive from.
+ *
+ * A step is one model generation, so the budget bounds how much tool work a
+ * single turn can do before the run stops and hands control back. Too low and
+ * a real arrangement task dies half-finished; too high and a looping model
+ * burns tokens unattended. Where that line sits depends on the model and the
+ * user's patience, which is why it is a setting rather than a constant.
+ *
+ * One knob, not three. The orchestrator and worker budgets are derived, so
+ * raising the base raises them with it and the relationship the defaults were
+ * chosen with (orchestrator > worker > base) holds at any setting. Exposing
+ * each separately would let a user invert them and quietly starve the
+ * orchestrator of the spawns its own budget is supposed to fit.
+ */
+
+/** Shipped default, and what an unset or unusable stored value falls back to. */
+export const DEFAULT_MAX_TOOL_STEPS = 25;
+
+/** Floor. Below a handful of steps almost nothing multi-tool completes. */
+export const MIN_TOOL_STEPS = 5;
+
+/** Ceiling. A runaway turn is the failure this bounds; it is not a quality dial. */
+export const MAX_TOOL_STEPS_LIMIT = 100;
+
+/**
+ * The orchestrator's budget for a given base: wider, because context-gathering
+ * steps and each SEQUENTIAL spawn share it (a spawn costs one step; N parallel
+ * spawns in one turn cost just one). MAX_SPAWNS separately bounds how many
+ * workers a turn may start at all.
+ *
+ * @param baseSteps - The user's configured per-turn budget
+ * @returns The orchestrator's step budget
+ */
+export function orchestratorSteps(baseSteps: number): number {
+  return Math.round(baseSteps * 1.6);
+}
+
+/**
+ * A worker's budget for a given base: above the base so a delegated subtask can
+ * read what it needs and still finish the edit, below the orchestrator's so the
+ * turn that spawned it keeps the wider allowance.
+ *
+ * @param baseSteps - The user's configured per-turn budget
+ * @returns A subagent worker's step budget
+ */
+export function workerSteps(baseSteps: number): number {
+  return Math.round(baseSteps * 1.2);
+}

--- a/webui/src/chat/sdk/subagent/spawn-subagent-tool.ts
+++ b/webui/src/chat/sdk/subagent/spawn-subagent-tool.ts
@@ -10,16 +10,23 @@ import {
   isToolEnabled,
   SPAWN_SUBAGENT_TOOL_NAME,
 } from "#webui/lib/utils/enabled-tools";
+import {
+  DEFAULT_MAX_TOOL_STEPS,
+  workerSteps,
+} from "#webui/chat/sdk/step-budget";
 import { withBriefing, withheldToolsApplied } from "./subagent-briefing";
 
 /**
- * A worker's nested tool-step budget. Higher than the plain-chat default
- * (MAX_TOOL_STEPS) so a delegated subtask — reading what it needs, then
+ * A worker's nested tool-step budget at the DEFAULT base budget. Higher than a
+ * plain chat turn's so a delegated subtask — reading what it needs, then
  * multi-step editing — has room to finish. Not lowered when a briefing removes
  * the connect step: a worker that runs out of steps strands the orchestrator,
  * and the unused headroom of a short task costs nothing.
+ *
+ * A user who raised their budget gets a worker budget derived from it
+ * (see workerSteps); this is the shipped number.
  */
-export const MAX_WORKER_STEPS = 30;
+export const MAX_WORKER_STEPS = workerSteps(DEFAULT_MAX_TOOL_STEPS);
 
 /**
  * Safety/cost cap on worker spawn ATTEMPTS one orchestrator TURN may make,
@@ -315,7 +322,7 @@ export function buildWorkerConfig(
     ...rest,
     ...subagentConfig,
     chatHistory: session ?? [],
-    maxSteps: MAX_WORKER_STEPS,
+    maxSteps: workerSteps(config.baseMaxSteps ?? DEFAULT_MAX_TOOL_STEPS),
     enabledTools: {
       // Preset toolset (if the preset saved one), used as-is; otherwise inherit
       // the orchestrator's. It's a sparse map — absent keys stay default-enabled

--- a/webui/src/chat/sdk/tests/step-budget.test.ts
+++ b/webui/src/chat/sdk/tests/step-budget.test.ts
@@ -1,0 +1,44 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { MAX_TOOL_STEPS } from "#webui/chat/sdk/client";
+import {
+  DEFAULT_MAX_TOOL_STEPS,
+  MAX_TOOL_STEPS_LIMIT,
+  MIN_TOOL_STEPS,
+  orchestratorSteps,
+  workerSteps,
+} from "#webui/chat/sdk/step-budget";
+import { MAX_WORKER_STEPS } from "#webui/chat/sdk/subagent/spawn-subagent-tool";
+
+describe("step budgets", () => {
+  it("reproduces the shipped numbers at the default base", () => {
+    // The derivation replaced three hardcoded constants. Pin the defaults so a
+    // change to the ratios is a deliberate act, not a silent re-tuning of every
+    // shipped turn.
+    expect(DEFAULT_MAX_TOOL_STEPS).toBe(25);
+    expect(MAX_TOOL_STEPS).toBe(25);
+    expect(orchestratorSteps(DEFAULT_MAX_TOOL_STEPS)).toBe(40);
+    expect(MAX_WORKER_STEPS).toBe(30);
+  });
+
+  it("keeps orchestrator > worker > base across the whole range", () => {
+    // The reason there is one knob rather than three: the ordering can't be
+    // inverted by a user, at any setting they can reach.
+    for (let base = MIN_TOOL_STEPS; base <= MAX_TOOL_STEPS_LIMIT; base++) {
+      expect(workerSteps(base)).toBeGreaterThan(base);
+      expect(orchestratorSteps(base)).toBeGreaterThan(workerSteps(base));
+    }
+  });
+
+  it("derives whole steps", () => {
+    // stepCountIs counts generations; a fractional budget is meaningless.
+    for (const base of [MIN_TOOL_STEPS, 7, 13, 25, 99, MAX_TOOL_STEPS_LIMIT]) {
+      expect(Number.isInteger(orchestratorSteps(base))).toBe(true);
+      expect(Number.isInteger(workerSteps(base))).toBe(true);
+    }
+  });
+});

--- a/webui/src/chat/sdk/types.ts
+++ b/webui/src/chat/sdk/types.ts
@@ -180,11 +180,19 @@ export interface ChatClientConfig {
   buildProviderOptions?: (thinking: string) => ProviderOptions | undefined;
   chatHistory?: ChatMessage[];
   /**
-   * Tool-step budget for streamText's stopWhen. Defaults to the shared
-   * MAX_TOOL_STEPS in client.ts. A subagent worker sets MAX_WORKER_STEPS; an
-   * orchestrator with subagents enabled widens to MAX_ORCHESTRATOR_STEPS.
+   * Tool-step budget for streamText's stopWhen. Defaults to
+   * DEFAULT_MAX_TOOL_STEPS. A subagent worker sets its derived worker budget;
+   * an orchestrator with subagents enabled derives a wider one from
+   * baseMaxSteps instead of reading this.
    */
   maxSteps?: number;
+  /**
+   * The user's configured per-turn budget, before any orchestrator/worker
+   * derivation. Carried separately from `maxSteps` because a worker's config
+   * already holds its own derived budget there, and the orchestrator branch
+   * needs the base it was derived from. Absent = the shipped default.
+   */
+  baseMaxSteps?: number;
   /**
    * Preset-derived config a spawned worker runs under (model/inference + the
    * preset's toolset when it saved one). Set on the orchestrator config when the

--- a/webui/src/components/App.tsx
+++ b/webui/src/components/App.tsx
@@ -382,7 +382,8 @@ export function App() {
  * Counted against the full catalog rather than the MCP response, so the
  * denominator holds still while the Live API flag moves and so the Subagent
  * toggle registers in it at all. All zero until the server answers — a fraction
- * of a catalog we haven't loaded would be a made-up number.
+ * of a catalog we haven't loaded would be a made-up number, and so would a
+ * divergence reported against it.
  *
  * @param mcpTools - The server's tool catalog, or null before it loads
  * @param lockedTools - The conversation's pinned toolset, or null when unpinned
@@ -415,6 +416,10 @@ function toolIndicatorState(
     totalToolsCount: catalog.length,
     enabledToolsCount: count(locked ?? settings),
     defaultToolsCount: count(settings),
-    enabledToolsDiverge: locked != null && toolsetsDiffer(locked, settings),
+    // Not flagged before the catalog lands either: every count is 0, so an
+    // amber "Locked: 0/0 tools enabled (default is a different set)" names a
+    // difference in nothing, then corrects itself when /tools answers.
+    enabledToolsDiverge:
+      mcpTools != null && locked != null && toolsetsDiffer(locked, settings),
   };
 }

--- a/webui/src/components/settings/PreferencesTab.tsx
+++ b/webui/src/components/settings/PreferencesTab.tsx
@@ -3,6 +3,7 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import { useEffect, useState } from "preact/hooks";
 import {
   DEFAULT_MAX_TOOL_STEPS,
   MAX_TOOL_STEPS_LIMIT,
@@ -162,6 +163,13 @@ interface StepBudgetFieldProps {
  * "Tool steps per turn": how much tool work one turn may do before it stops and
  * hands control back. Local to this tab rather than a controls/ component
  * because that directory is at its folder-size cap.
+ *
+ * The field keeps its own draft string so a half-typed budget ("", or "1" on
+ * the way to "15") isn't fought back as you type. Only an in-range whole number
+ * reaches the settings buffer; leaving the field snaps the display back to
+ * what's actually committed, so it can never sit there showing a number Save
+ * won't write.
+ *
  * @param {StepBudgetFieldProps} props - Component props
  * @param {number} props.maxToolSteps - The current budget
  * @param {Function} props.setMaxToolSteps - Commits a new budget to the buffer
@@ -171,6 +179,14 @@ function StepBudgetField({
   maxToolSteps,
   setMaxToolSteps,
 }: StepBudgetFieldProps) {
+  const [draft, setDraft] = useState(String(maxToolSteps));
+
+  // Follow the buffer when it moves under us — a Cancel reverts it, and the
+  // post-mount load can replace the mount-time default.
+  useEffect(() => {
+    setDraft(String(maxToolSteps));
+  }, [maxToolSteps]);
+
   return (
     <div className="mt-4 border-t border-zinc-300 pt-4 dark:border-zinc-600">
       <label htmlFor="max-tool-steps" className="mb-1 block text-sm">
@@ -183,14 +199,19 @@ function StepBudgetField({
         min={MIN_TOOL_STEPS}
         max={MAX_TOOL_STEPS_LIMIT}
         step={1}
-        value={maxToolSteps}
+        value={draft}
         // Commit only an in-range whole number: an empty field and a half-typed
         // "1" both parse to something a turn would then run on, and this field
         // is saved with everything else rather than confirmed on its own.
         onInput={(e) => {
-          const next = Number((e.target as HTMLInputElement).value);
+          const value = (e.target as HTMLInputElement).value;
+
+          setDraft(value);
+
+          const next = Number(value);
 
           if (
+            value.trim() !== "" &&
             Number.isInteger(next) &&
             next >= MIN_TOOL_STEPS &&
             next <= MAX_TOOL_STEPS_LIMIT
@@ -198,6 +219,9 @@ function StepBudgetField({
             setMaxToolSteps(next);
           }
         }}
+        // Snap back to what's committed, so an abandoned draft can't sit there
+        // reading like a budget the next turn will use.
+        onBlur={() => setDraft(String(maxToolSteps))}
         className="w-24 rounded border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-600 dark:bg-zinc-700"
       />
       <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-300">

--- a/webui/src/components/settings/PreferencesTab.tsx
+++ b/webui/src/components/settings/PreferencesTab.tsx
@@ -3,6 +3,12 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import {
+  DEFAULT_MAX_TOOL_STEPS,
+  MAX_TOOL_STEPS_LIMIT,
+  MIN_TOOL_STEPS,
+} from "#webui/chat/sdk/step-budget";
+
 interface PreferencesTabProps {
   theme: string;
   setTheme: (theme: string) => void;
@@ -14,6 +20,8 @@ interface PreferencesTabProps {
   setShowTokenUsage: (show: boolean) => void;
   autoUpdateCheck: boolean;
   setAutoUpdateCheck: (enabled: boolean) => void;
+  maxToolSteps: number;
+  setMaxToolSteps: (steps: number) => void;
   onDeleteAllConversations: () => void;
   onDeleteUnbookmarkedConversations: () => void;
 }
@@ -31,6 +39,8 @@ interface PreferencesTabProps {
  * @param {Function} props.setShowTokenUsage - Function to toggle token usage
  * @param {boolean} props.autoUpdateCheck - Whether to check GitHub for new releases
  * @param {Function} props.setAutoUpdateCheck - Function to toggle update checking
+ * @param {number} props.maxToolSteps - Tool steps one turn may spend
+ * @param {Function} props.setMaxToolSteps - Function to set the step budget
  * @param {Function} props.onDeleteAllConversations - Callback to delete all conversations
  * @param {Function} props.onDeleteUnbookmarkedConversations - Callback to delete unstarred conversations
  * @returns {JSX.Element} Preferences tab component
@@ -46,6 +56,8 @@ export function PreferencesTab({
   setShowTokenUsage,
   autoUpdateCheck,
   setAutoUpdateCheck,
+  maxToolSteps,
+  setMaxToolSteps,
   onDeleteAllConversations,
   onDeleteUnbookmarkedConversations,
 }: PreferencesTabProps) {
@@ -67,51 +79,39 @@ export function PreferencesTab({
         </select>
       </div>
 
-      <label className="flex cursor-pointer items-center gap-2 text-sm">
-        <input
-          type="checkbox"
-          checked={showTimestamps}
-          onChange={(e) =>
-            setShowTimestamps((e.target as HTMLInputElement).checked)
-          }
-        />
-        Show message timestamps
-      </label>
-
-      <label className="flex cursor-pointer items-center gap-2 text-sm">
-        <input
-          type="checkbox"
-          checked={showHelpLinks}
-          onChange={(e) =>
-            setShowHelpLinks((e.target as HTMLInputElement).checked)
-          }
-        />
-        Show help links
-      </label>
-
-      <label className="flex cursor-pointer items-center gap-2 text-sm">
-        <input
-          type="checkbox"
-          checked={showTokenUsage}
-          onChange={(e) =>
-            setShowTokenUsage((e.target as HTMLInputElement).checked)
-          }
-        />
-        Show message token usage
-      </label>
-
-      {/* Machine-wide and shared with the Max for Live device, so it applies
+      {/* Rendered from one list so the four stay identical; the tests index
+          them by position, so the order here is the order on screen. The last
+          is machine-wide and shared with the Max for Live device, so it applies
           on change rather than on Save — like the Delete buttons below. */}
-      <label className="flex cursor-pointer items-center gap-2 text-sm">
-        <input
-          type="checkbox"
-          checked={autoUpdateCheck}
-          onChange={(e) =>
-            setAutoUpdateCheck((e.target as HTMLInputElement).checked)
-          }
-        />
-        Automatically check for new versions
-      </label>
+      {(
+        [
+          ["Show message timestamps", showTimestamps, setShowTimestamps],
+          ["Show help links", showHelpLinks, setShowHelpLinks],
+          ["Show message token usage", showTokenUsage, setShowTokenUsage],
+          [
+            "Automatically check for new versions",
+            autoUpdateCheck,
+            setAutoUpdateCheck,
+          ],
+        ] as const
+      ).map(([label, checked, setChecked]) => (
+        <label
+          key={label}
+          className="flex cursor-pointer items-center gap-2 text-sm"
+        >
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={(e) => setChecked((e.target as HTMLInputElement).checked)}
+          />
+          {label}
+        </label>
+      ))}
+
+      <StepBudgetField
+        maxToolSteps={maxToolSteps}
+        setMaxToolSteps={setMaxToolSteps}
+      />
 
       <div className="mt-4 border-t border-zinc-300 pt-4 dark:border-zinc-600">
         <p className="mb-2 text-sm text-zinc-500 dark:text-zinc-300">
@@ -147,6 +147,66 @@ export function PreferencesTab({
         </div>
       </div>
       <div className="border-b border-zinc-300 dark:border-zinc-600" />
+    </div>
+  );
+}
+
+// --- Helpers below main export ---
+
+interface StepBudgetFieldProps {
+  maxToolSteps: number;
+  setMaxToolSteps: (steps: number) => void;
+}
+
+/**
+ * "Tool steps per turn": how much tool work one turn may do before it stops and
+ * hands control back. Local to this tab rather than a controls/ component
+ * because that directory is at its folder-size cap.
+ * @param {StepBudgetFieldProps} props - Component props
+ * @param {number} props.maxToolSteps - The current budget
+ * @param {Function} props.setMaxToolSteps - Commits a new budget to the buffer
+ * @returns {JSX.Element} The step-budget field
+ */
+function StepBudgetField({
+  maxToolSteps,
+  setMaxToolSteps,
+}: StepBudgetFieldProps) {
+  return (
+    <div className="mt-4 border-t border-zinc-300 pt-4 dark:border-zinc-600">
+      <label htmlFor="max-tool-steps" className="mb-1 block text-sm">
+        Tool steps per turn
+      </label>
+      <input
+        id="max-tool-steps"
+        data-testid="max-tool-steps"
+        type="number"
+        min={MIN_TOOL_STEPS}
+        max={MAX_TOOL_STEPS_LIMIT}
+        step={1}
+        value={maxToolSteps}
+        // Commit only an in-range whole number: an empty field and a half-typed
+        // "1" both parse to something a turn would then run on, and this field
+        // is saved with everything else rather than confirmed on its own.
+        onInput={(e) => {
+          const next = Number((e.target as HTMLInputElement).value);
+
+          if (
+            Number.isInteger(next) &&
+            next >= MIN_TOOL_STEPS &&
+            next <= MAX_TOOL_STEPS_LIMIT
+          ) {
+            setMaxToolSteps(next);
+          }
+        }}
+        className="w-24 rounded border border-zinc-300 bg-white px-3 py-2 dark:border-zinc-600 dark:bg-zinc-700"
+      />
+      <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-300">
+        How much tool work one turn may do before it stops and hands back
+        control ({MIN_TOOL_STEPS}–{MAX_TOOL_STEPS_LIMIT}, default{" "}
+        {DEFAULT_MAX_TOOL_STEPS}). Raise it for long arrangement tasks that keep
+        stopping early; lower it to keep a looping model on a shorter leash.
+        Subagent orchestrators and workers scale with it.
+      </p>
     </div>
   );
 }

--- a/webui/src/components/settings/SettingsScreen.tsx
+++ b/webui/src/components/settings/SettingsScreen.tsx
@@ -224,6 +224,8 @@ function SettingsTabContent(
           setShowTokenUsage={display.setShowTokenUsage}
           autoUpdateCheck={globalSettings.autoUpdateCheck}
           setAutoUpdateCheck={globalSettings.setAutoUpdateCheck}
+          maxToolSteps={settings.maxToolSteps}
+          setMaxToolSteps={settings.setMaxToolSteps}
           onDeleteAllConversations={props.onDeleteAllConversations}
           onDeleteUnbookmarkedConversations={
             props.onDeleteUnbookmarkedConversations

--- a/webui/src/components/settings/tests/PreferencesTab.test.tsx
+++ b/webui/src/components/settings/tests/PreferencesTab.test.tsx
@@ -8,6 +8,11 @@
  */
 import { fireEvent, render, screen } from "@testing-library/preact";
 import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_MAX_TOOL_STEPS,
+  MAX_TOOL_STEPS_LIMIT,
+  MIN_TOOL_STEPS,
+} from "#webui/chat/sdk/step-budget";
 import { PreferencesTab } from "#webui/components/settings/PreferencesTab";
 
 describe("PreferencesTab", () => {
@@ -24,6 +29,8 @@ describe("PreferencesTab", () => {
     setShowTokenUsage: vi.fn(),
     autoUpdateCheck: true,
     setAutoUpdateCheck: vi.fn(),
+    maxToolSteps: DEFAULT_MAX_TOOL_STEPS,
+    setMaxToolSteps: vi.fn(),
     onDeleteAllConversations: vi.fn(),
     onDeleteUnbookmarkedConversations: vi.fn(),
   };
@@ -136,6 +143,48 @@ describe("PreferencesTab", () => {
 
     fireEvent.click(checkboxes[3]!);
     expect(setAutoUpdateCheck).toHaveBeenCalledWith(false);
+  });
+
+  it("shows the step budget with the supported range on the input", () => {
+    const { container } = render(
+      <PreferencesTab {...defaultProps} maxToolSteps={40} />,
+    );
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="max-tool-steps"]',
+    );
+
+    expect(input?.value).toBe("40");
+    expect(input?.min).toBe(String(MIN_TOOL_STEPS));
+    expect(input?.max).toBe(String(MAX_TOOL_STEPS_LIMIT));
+  });
+
+  it("commits an in-range step budget", () => {
+    const setMaxToolSteps = vi.fn();
+    const { container } = render(
+      <PreferencesTab {...defaultProps} setMaxToolSteps={setMaxToolSteps} />,
+    );
+    const input = container.querySelector('[data-testid="max-tool-steps"]')!;
+
+    fireEvent.input(input, { target: { value: "40" } });
+
+    expect(setMaxToolSteps).toHaveBeenCalledWith(40);
+  });
+
+  it.each([
+    ["blank while retyping", ""],
+    ["below the floor", String(MIN_TOOL_STEPS - 1)],
+    ["above the ceiling", String(MAX_TOOL_STEPS_LIMIT + 1)],
+    ["fractional", "12.5"],
+  ])("ignores a %s value rather than running a turn on it", (_label, value) => {
+    const setMaxToolSteps = vi.fn();
+    const { container } = render(
+      <PreferencesTab {...defaultProps} setMaxToolSteps={setMaxToolSteps} />,
+    );
+    const input = container.querySelector('[data-testid="max-tool-steps"]')!;
+
+    fireEvent.input(input, { target: { value } });
+
+    expect(setMaxToolSteps).not.toHaveBeenCalled();
   });
 
   it("renders cleanup buttons", () => {

--- a/webui/src/components/settings/tests/PreferencesTab.test.tsx
+++ b/webui/src/components/settings/tests/PreferencesTab.test.tsx
@@ -187,6 +187,39 @@ describe("PreferencesTab", () => {
     expect(setMaxToolSteps).not.toHaveBeenCalled();
   });
 
+  it("lets a rejected value stay visible while the field has focus", () => {
+    // Typing "1" on the way to "15" must not be yanked out from under the
+    // cursor; it just hasn't reached the settings buffer yet.
+    const { container } = render(<PreferencesTab {...defaultProps} />);
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="max-tool-steps"]',
+    )!;
+
+    fireEvent.input(input, { target: { value: "1" } });
+
+    expect(input.value).toBe("1");
+  });
+
+  it.each([
+    ["below the floor", String(MIN_TOOL_STEPS - 1)],
+    ["blank", ""],
+    ["fractional", "12.5"],
+  ])("snaps a %s draft back to the committed budget on blur", (_l, value) => {
+    // Otherwise the field sits there reading like a budget the next turn will
+    // use, while Save writes the old one.
+    const { container } = render(
+      <PreferencesTab {...defaultProps} maxToolSteps={30} />,
+    );
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="max-tool-steps"]',
+    )!;
+
+    fireEvent.input(input, { target: { value } });
+    fireEvent.blur(input);
+
+    expect(input.value).toBe("30");
+  });
+
   it("renders cleanup buttons", () => {
     render(<PreferencesTab {...defaultProps} />);
     expect(

--- a/webui/src/components/settings/tests/SettingsScreen.test.tsx
+++ b/webui/src/components/settings/tests/SettingsScreen.test.tsx
@@ -8,6 +8,7 @@
  */
 import { render, screen, fireEvent } from "@testing-library/preact";
 import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_MAX_TOOL_STEPS } from "#webui/chat/sdk/step-budget";
 import { installJsonFetchMock } from "#webui/hooks/context/tests/doc-transport-test-helpers";
 import { type UseSettingsReturn } from "#webui/types/settings";
 import { SettingsScreen } from "#webui/components/settings/SettingsScreen";
@@ -145,6 +146,8 @@ describe("SettingsScreen", () => {
     setSmallModelMode: vi.fn(),
     subagentPresetId: null,
     setSubagentPresetId: vi.fn(),
+    maxToolSteps: DEFAULT_MAX_TOOL_STEPS,
+    setMaxToolSteps: vi.fn(),
     liveApiEnabled: false,
     liveApiEnabledDirty: false,
     setLiveApiEnabled: vi.fn(),

--- a/webui/src/hooks/chat/adapter.ts
+++ b/webui/src/hooks/chat/adapter.ts
@@ -7,6 +7,7 @@ import { type ProviderOptions } from "@ai-sdk/provider-utils";
 import { ChatSdkClient } from "#webui/chat/sdk/client";
 import { formatChatMessages } from "#webui/chat/sdk/formatter";
 import { createProviderModel } from "#webui/chat/sdk/provider-factories";
+import { DEFAULT_MAX_TOOL_STEPS } from "#webui/chat/sdk/step-budget";
 import {
   type ChatClientConfig,
   type ChatMessage,
@@ -280,6 +281,9 @@ export const chatAdapter: ChatAdapter<
     // was written; a brand-new one takes the current setting. Null when neither
     // exists: no header, device global wins, external MCP clients unaffected.
     const notation = resolveLockedNotation(extraParams ?? {});
+    const maxToolSteps =
+      (extraParams?.maxToolSteps as number | undefined) ??
+      DEFAULT_MAX_TOOL_STEPS;
 
     const languageModel = createProviderModel(provider, model, apiKey, baseUrl);
     const providerOptions = buildProviderOptions(provider, thinking, model);
@@ -306,6 +310,12 @@ export const chatAdapter: ChatAdapter<
         buildProviderOptions(provider, overrideThinking, model),
       chatHistory,
       subagentConfig,
+      // The user's per-turn step budget. Deliberately NOT locked per
+      // conversation the way notation and small-model mode are: those change
+      // what the model is told, so an open conversation has to keep its own;
+      // this only bounds how long a turn runs, and the setting the user can see
+      // should be the one the next turn obeys.
+      baseMaxSteps: maxToolSteps,
       // Conditional: ChatClientConfig.notation is optional and a present-but-
       // undefined key would still be read as "the caller has an opinion".
       ...(notation ? { notation } : {}),

--- a/webui/src/hooks/chat/use-chat-mode-state.ts
+++ b/webui/src/hooks/chat/use-chat-mode-state.ts
@@ -201,6 +201,9 @@ export function useChatModeState(params: UseChatModeStateParams) {
       // send is gated below until this is a real answer rather than the
       // provisional mount-time default.
       notation: settings.notation,
+      // Not locked per conversation — see buildConfig. The next turn of any
+      // conversation runs on whatever budget is set now.
+      maxToolSteps: settings.maxToolSteps,
       [SUBAGENT_PRESET_PARAM]: subagentPreset,
     },
     autoSaveRef,

--- a/webui/src/hooks/settings/presets/preset-storage.ts
+++ b/webui/src/hooks/settings/presets/preset-storage.ts
@@ -122,9 +122,11 @@ function isValidPreset(value: unknown): value is ChatPreset {
     typeof p.thinking === "string" &&
     typeof p.smallModelMode === "boolean" &&
     // The additive fields are all optional; reject only a present-but-wrong-
-    // typed value so a hand-edited entry can't crash the picker.
-    (p.description === undefined || typeof p.description === "string") &&
-    (p.enabledTools === undefined || isEnabledToolsMap(p.enabledTools)) &&
-    (p.notation === undefined || isNotation(p.notation))
+    // typed value so a hand-edited entry can't crash the picker. A JSON `null`
+    // counts as absent — every reader of these three is nullish-tolerant, and
+    // dropping a whole preset over one is worse than honoring the rest of it.
+    (p.description == null || typeof p.description === "string") &&
+    (p.enabledTools == null || isEnabledToolsMap(p.enabledTools)) &&
+    (p.notation == null || isNotation(p.notation))
   );
 }

--- a/webui/src/hooks/settings/presets/use-presets.ts
+++ b/webui/src/hooks/settings/presets/use-presets.ts
@@ -154,7 +154,7 @@ export function usePresets(): UsePresetsReturn {
  * @returns The preset with its description normalized
  */
 function withDescription(preset: ChatPreset, description?: string): ChatPreset {
-  if (description === undefined) return preset;
+  if (description == null) return preset;
 
   const trimmed = description.trim();
   const next = { ...preset };

--- a/webui/src/hooks/settings/settings-helpers.ts
+++ b/webui/src/hooks/settings/settings-helpers.ts
@@ -3,6 +3,11 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import {
+  DEFAULT_MAX_TOOL_STEPS,
+  MAX_TOOL_STEPS_LIMIT,
+  MIN_TOOL_STEPS,
+} from "#webui/chat/sdk/step-budget";
 import { THINKING_LEVELS } from "#webui/components/settings/controls/helpers/thinking-levels";
 import { decryptApiKey, encryptApiKey } from "#webui/lib/api-key-crypto";
 import {
@@ -507,6 +512,52 @@ export function loadSmallModelMode(): boolean {
  */
 export function saveSmallModelMode(enabled: boolean): void {
   localStorage.setItem("producer_pal_small_model_mode", String(enabled));
+}
+
+const MAX_TOOL_STEPS_KEY = "producer_pal_max_tool_steps";
+
+/**
+ * Loads the per-turn tool-step budget from localStorage, falling back to the
+ * shipped default. Anything unparseable or out of range falls back too, so a
+ * hand-edited value can't strand a turn at one step or run away.
+ * @returns {number} The configured budget, clamped to the supported range
+ */
+export function loadMaxToolSteps(): number {
+  const raw = localStorage.getItem(MAX_TOOL_STEPS_KEY);
+
+  if (raw == null) return DEFAULT_MAX_TOOL_STEPS;
+
+  return clampToolSteps(Number(raw)) ?? DEFAULT_MAX_TOOL_STEPS;
+}
+
+/**
+ * Saves the per-turn tool-step budget. An out-of-range or non-numeric value
+ * clears the key instead of storing it, so the default applies.
+ * @param {number} steps - The budget to store
+ */
+export function saveMaxToolSteps(steps: number): void {
+  const valid = clampToolSteps(steps);
+
+  if (valid == null) {
+    localStorage.removeItem(MAX_TOOL_STEPS_KEY);
+
+    return;
+  }
+
+  localStorage.setItem(MAX_TOOL_STEPS_KEY, String(valid));
+}
+
+/**
+ * A tool-step budget if it is a whole number in the supported range, else null.
+ * @param {number} steps - Candidate budget
+ * @returns {number | null} The budget, or null when it isn't usable
+ */
+function clampToolSteps(steps: number): number | null {
+  if (!Number.isInteger(steps)) return null;
+
+  return steps >= MIN_TOOL_STEPS && steps <= MAX_TOOL_STEPS_LIMIT
+    ? steps
+    : null;
 }
 
 const SUBAGENT_PRESET_KEY = "producer_pal_subagent_preset";

--- a/webui/src/hooks/settings/tests/settings-helpers.test.ts
+++ b/webui/src/hooks/settings/tests/settings-helpers.test.ts
@@ -8,11 +8,17 @@
  */
 import "fake-indexeddb/auto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_MAX_TOOL_STEPS,
+  MAX_TOOL_STEPS_LIMIT,
+  MIN_TOOL_STEPS,
+} from "#webui/chat/sdk/step-budget";
 import { encryptApiKey, isEncrypted } from "#webui/lib/api-key-crypto";
 import {
   checkHasApiKey,
   loadAllProviderSettingsAsync,
   loadCurrentProvider,
+  loadMaxToolSteps,
   loadSubagentPresetId,
   loadEnabledTools,
   loadProviderSettings,
@@ -20,6 +26,7 @@ import {
   loadVoiceLanguage,
   loadVoiceSpeed,
   loadVoiceVolume,
+  saveMaxToolSteps,
   saveSubagentPresetId,
   saveProviderSettings,
   saveVoiceLanguage,
@@ -291,6 +298,41 @@ describe("settings-helpers", () => {
 
       expect(loadSubagentPresetId()).toBeNull();
       expect(localStorage.getItem("producer_pal_subagent_preset")).toBeNull();
+    });
+  });
+
+  describe("tool-step budget persistence", () => {
+    it("returns the shipped default when nothing is stored", () => {
+      expect(loadMaxToolSteps()).toBe(DEFAULT_MAX_TOOL_STEPS);
+    });
+
+    it("round-trips a budget through localStorage", () => {
+      saveMaxToolSteps(40);
+      expect(loadMaxToolSteps()).toBe(40);
+    });
+
+    it.each([
+      ["below the floor", MIN_TOOL_STEPS - 1],
+      ["above the ceiling", MAX_TOOL_STEPS_LIMIT + 1],
+      ["fractional", 12.5],
+    ])("clears the key rather than storing a %s value", (_label, steps) => {
+      saveMaxToolSteps(40);
+      saveMaxToolSteps(steps);
+
+      expect(loadMaxToolSteps()).toBe(DEFAULT_MAX_TOOL_STEPS);
+      expect(localStorage.getItem("producer_pal_max_tool_steps")).toBeNull();
+    });
+
+    it.each([
+      ["garbage", "not-a-number"],
+      ["out of range", "5000"],
+      ["empty", ""],
+    ])("falls back to the default on a %s stored value", (_label, raw) => {
+      // A hand-edited localStorage must not strand a turn at one step or let it
+      // run away — the load path re-validates rather than trusting the save.
+      localStorage.setItem("producer_pal_max_tool_steps", raw);
+
+      expect(loadMaxToolSteps()).toBe(DEFAULT_MAX_TOOL_STEPS);
     });
   });
 

--- a/webui/src/hooks/settings/tests/use-has-unsaved-changes.test.ts
+++ b/webui/src/hooks/settings/tests/use-has-unsaved-changes.test.ts
@@ -171,6 +171,15 @@ describe("useHasUnsavedChanges", () => {
     expect(result.current).toBe(true);
   });
 
+  it("detects a tool-step budget change", () => {
+    // Buffered like the two above, so leaving it out of the snapshot would
+    // discard an edited budget on Esc with no unsaved-changes warning.
+    const { result, update } = renderWithOpenModal(makeSettings());
+
+    update(makeSettings({ maxToolSteps: 40 }));
+    expect(result.current).toBe(true);
+  });
+
   it("flags a notation change via its dirty flag (notation is not serialized)", () => {
     const { result, update } = renderWithOpenModal(makeSettings());
 

--- a/webui/src/hooks/settings/use-has-unsaved-changes.ts
+++ b/webui/src/hooks/settings/use-has-unsaved-changes.ts
@@ -33,6 +33,7 @@ function serialize(s: UseSettingsReturn, a: AppearanceSettings): string {
     enabledTools: s.enabledTools,
     smallModelMode: s.smallModelMode,
     subagentPresetId: s.subagentPresetId,
+    maxToolSteps: s.maxToolSteps,
     realtimeVoice: s.realtimeVoice,
     voiceSpeed: s.voiceSpeed,
     voiceVolume: s.voiceVolume,

--- a/webui/src/hooks/settings/use-settings.ts
+++ b/webui/src/hooks/settings/use-settings.ts
@@ -20,6 +20,7 @@ import {
   DEFAULT_SETTINGS,
   loadAllProviderSettingsAsync,
   loadCurrentProvider,
+  loadMaxToolSteps,
   loadSubagentPresetId,
   loadEnabledTools,
   loadProviderSettings,
@@ -28,6 +29,7 @@ import {
   type ProviderSettingsApplier,
   type ProviderStateSetters,
   saveCurrentSettings,
+  saveMaxToolSteps,
   saveSubagentPresetId,
   saveSmallModelMode,
 } from "./settings-helpers";
@@ -108,6 +110,9 @@ export function useSettings(): UseSettingsReturn {
   const [subagentPresetId, setSubagentPresetId] = useState<string | null>(
     loadSubagentPresetId,
   );
+  // How many tool steps one turn may spend. Same buffered lifecycle as the two
+  // above: persisted on Save, reverted on Cancel.
+  const [maxToolSteps, setMaxToolSteps] = useState<number>(loadMaxToolSteps);
   // False until the post-mount async decrypt has applied the real apiKeys.
   // saveSettings gates on this — saving the placeholder blanks would wipe
   // every stored encrypted key.
@@ -230,6 +235,7 @@ export function useSettings(): UseSettingsReturn {
         providerSettings,
         smallModelMode,
         subagentPresetId,
+        maxToolSteps,
       );
     } catch (err) {
       console.error("Failed to save provider settings", err);
@@ -253,6 +259,7 @@ export function useSettings(): UseSettingsReturn {
     enabledTools,
     smallModelMode,
     subagentPresetId,
+    maxToolSteps,
     voiceModeSettings,
     providerSettings,
   ]);
@@ -262,6 +269,7 @@ export function useSettings(): UseSettingsReturn {
     setEnabledToolsState(loadEnabledTools());
     setSmallModelModeState(loadSmallModelMode());
     setSubagentPresetId(loadSubagentPresetId());
+    setMaxToolSteps(loadMaxToolSteps());
     voiceModeSettings.revert();
     // Re-decrypt and restore saved provider settings (async; the apiKey lands a
     // tick later, mirroring the post-mount load). Pass the same onLoaded as the
@@ -336,6 +344,8 @@ export function useSettings(): UseSettingsReturn {
     setSmallModelMode: setSmallModelModeState,
     subagentPresetId,
     setSubagentPresetId,
+    maxToolSteps,
+    setMaxToolSteps,
     saveError,
     liveApiEnabled,
     liveApiEnabledDirty,
@@ -394,6 +404,7 @@ function warnIfNotLoaded(settingsLoaded: boolean): boolean {
  * @param {AllProviderSettings} allSettings - Settings for every provider
  * @param {boolean} smallModelMode - Small-model-mode flag
  * @param {string | null} subagentPresetId - Subagent preset id (null = inherit)
+ * @param {number} maxToolSteps - Per-turn tool-step budget
  */
 async function persistAllSettings(
   provider: Provider,
@@ -401,10 +412,12 @@ async function persistAllSettings(
   allSettings: AllProviderSettings,
   smallModelMode: boolean,
   subagentPresetId: string | null,
+  maxToolSteps: number,
 ): Promise<void> {
   await saveCurrentSettings(provider, enabledTools, allSettings);
   saveSmallModelMode(smallModelMode);
   saveSubagentPresetId(subagentPresetId);
+  saveMaxToolSteps(maxToolSteps);
 }
 
 /**

--- a/webui/src/lib/conversation-transfer.ts
+++ b/webui/src/lib/conversation-transfer.ts
@@ -224,7 +224,7 @@ function hasUsableMessages(messages: unknown[]): boolean {
 function isValidImportedMessage(message: unknown): boolean {
   return (
     typeof message === "object" &&
-    message !== null &&
+    message != null &&
     typeof (message as { content?: unknown }).content === "string"
   );
 }
@@ -363,11 +363,11 @@ function sanitizeToolField(
  * @returns The entry, with `args` an object
  */
 function sanitizeToolCall(entry: unknown): unknown {
-  if (typeof entry !== "object" || entry === null) return entry;
+  if (typeof entry !== "object" || entry == null) return entry;
 
   const { args } = entry as { args?: unknown };
 
-  if (typeof args === "object" && args !== null && !Array.isArray(args)) {
+  if (typeof args === "object" && args != null && !Array.isArray(args)) {
     return entry;
   }
 
@@ -388,7 +388,7 @@ function sanitizeToolCall(entry: unknown): unknown {
  * @returns The entry with unusable subagent fields removed
  */
 function sanitizeToolResult(entry: unknown): unknown {
-  if (typeof entry !== "object" || entry === null) return entry;
+  if (typeof entry !== "object" || entry == null) return entry;
 
   const { subagentTranscript, subagentIndex, ...rest } = entry as {
     subagentTranscript?: unknown;

--- a/webui/src/types/settings.ts
+++ b/webui/src/types/settings.ts
@@ -212,6 +212,11 @@ export interface UseSettingsReturn extends VoiceModeSettingsFields {
    * conversation) and a modal-local buffer persisted on Save. */
   subagentPresetId: string | null;
   setSubagentPresetId: (id: string | null) => void;
+  /** Tool steps one turn may spend before the run stops and hands back control.
+   * The orchestrator and worker budgets derive from it (see step-budget.ts), so
+   * this is the only knob. A modal-local buffer persisted on Save. */
+  maxToolSteps: number;
+  setMaxToolSteps: (steps: number) => void;
   // Mirrors server-side ProducerPalConfig.liveApiEnabled, kept in modal-local
   // state. Source of truth is the server (which mirrors the device Setup-tab
   // toggle) — not localStorage. The dirty flag distinguishes "user toggled


### PR DESCRIPTION
Another batch of small, independent 2.1.1 tickets. One commit per ticket, so
this is meant to be **merged, not squashed** — the history is the point.

## Commits

- [x] **Clean up the low-severity findings from the 2.1.0 reviews.** Five narrow
  edges the review passes turned up and nobody wanted to hold a release for. A
  clip region write read its markers unclamped while the position math read them
  clamped; two session starts applying the *same* restored project context
  warned about a conflict that wasn't one; the tools indicator flashed amber
  "Locked: 0/0 tools enabled" before the tool list arrived; the skills blank-line
  collapse rewrote spacing *inside* fragment content instead of just closing the
  gap an emptied include leaves; and some newer webui code drifted off the
  `== null` house rule.

- [x] **Close the gaps in sole-carrier param descriptions.** Facts that live only
  in a param description, checked against: names exact literals, states units,
  says what happens on misuse. `routeToSource` never said it's track-only or
  that the copy plays the *source's* instrument — and it throws on a non-track
  rather than ignoring the param, so it says that now. Plus `warping` in small
  mode, read-device's `drum-map` key spelling, "0 = unity" on clip `gainDb`, and
  the sample write that small mode promised in help text but taught nowhere.

- [x] **Cut fragment text the tool schemas already carry.** The skills blob ships
  on every call, so anything duplicated between a fragment and a schema is paid
  for twice. `quantizeGrid`, the `takeLane` value legend, `split`'s position
  semantics, the `notes` MERGES paragraph, and context-basic's scope rundown all
  had twins in a schema; what only the skills can say (the 8-lane cap,
  append-only, the `preTransforms → notes → transforms` pipeline, "exactly ONE
  scope") stays. Also merged the two `preTransforms` example lists, which had
  diverged — the schema taught `v0` while the skills preferred `delete`, and
  neither listed all four selector forms. Standard bar|beat drops 722 chars.

- [x] **Close the per-request DB scope TODO with the measurement.** The TODO said
  to share one Live DB handle once a request composed multiple routes;
  `searchBatch` now does, so this measured it. Reopening per query costs ~3.5ms
  across a 20-query batch on a 47MB DB — and Node sees each search as its own
  `node_request` with no MCP-request correlation, so scoping needs either an
  explicit begin/end from V8 (two more round trips) or a time-based handle cache
  (a stale-snapshot window). Not worth 0.17ms on a query already paying a
  V8↔Node round trip. The numbers are in the comment so nobody re-derives them.

- [x] **Cover the Presets tab in the stubbed UI suite.** A preset bundles the
  provider, model, inference settings and toolset — the mechanism worker
  profiles are built on — and the only coverage needed real Live and API keys,
  so it never ran in CI. Six cases, each reading the stored list back rather
  than trusting the picker, since presets write on click instead of through the
  footer Save.

- [x] **Make the per-turn tool-step budget configurable.** Where the "stop and
  hand back control" line sits depends on the model and the user's patience, so
  it's a Preferences setting now (5–100, default 25 — unchanged). One knob: the
  orchestrator and worker budgets derive from it, so raising the base raises
  them together and orchestrator > worker > base holds at any setting. Not
  locked per conversation — it doesn't change what the model is told, only how
  long a turn runs.

Each commit passes `npm run check` and has its own green CI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
