### PR TITLE
Pool LiveAPI objects across requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,12 @@ See `dev/Architecture.md` for system design and `dev/Chat-UI.md` for the web UI.
   `LiveAPI.from()` tracks the object for release, and an untracked one leaves a
   Live path listener armed for the life of the device.
 
+- **Never hold a `LiveAPI` across requests** — not in module state, not in a
+  cache, not in a callback that outlives the call. Objects are released when the
+  request ends and reused by the next one, so a stale reference silently points
+  at a different Live object. Build them where you use them. See
+  `src/live-api-adapter/live-api-release.ts`.
+
 - **Update tools never throw** for a bad param combo or an operation that
   doesn't apply. `console.warn()`, skip that operation, and keep going, so the
   rest of a multi-item call still succeeds. Warnings are not silent — they're

--- a/scripts/probes/live-api-context-probe.ts
+++ b/scripts/probes/live-api-context-probe.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Live API context probe: measure how per-call latency grows as the device
+ * builds LiveAPI objects and visits paths, and tell the two costs apart.
+ *
+ * There are two, and they behave differently:
+ *
+ * - Per unique path visited. One-time, persists, saturates. Revisiting a path
+ *   already visited is free.
+ * - Per object constructed. Unbounded — it keeps climbing on paths that were
+ *   registered long ago, and only reloading the device clears it.
+ *
+ * Telling them apart takes an arm that never repeats a path. Measured on
+ * 12.4.3: 40 repeated deep paths read flat (0.99x over 25,000 gotos) while
+ * never-repeating paths climbed 1.52x, and re-running that same never-repeating
+ * sequence picked up where the first run ended and went flat. An arm on too few
+ * paths will report "no growth" no matter how many operations it runs.
+ *
+ * Compare slopes *within* an arm, not absolute numbers across arms: every arm
+ * loads the device further, so a later arm starts slower than an earlier one.
+ * Reload the Producer Pal device between arms for comparable baselines.
+ *
+ * Every arm is read-only. Nothing here writes to the Live Set.
+ *
+ * Usage:
+ *   node scripts/probes/live-api-context-probe.ts                    # goto arm
+ *   node scripts/probes/live-api-context-probe.ts goto-fresh 5 100   # arm, rounds, calls
+ *
+ * Arms:
+ *   baseline    50 exists ops per call    — transport + dispatch overhead
+ *   goto        50 gotos over few paths   — the false-flat case
+ *   goto-fresh  50 gotos, never repeating — exposes per-path cost
+ *   read-track  one ppal-read-track call  — per-object cost
+ *
+ * Requires a debug build (ppal-live-api is not in release builds) and Ableton
+ * Live running with the Producer Pal device loaded.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const DEFAULT_URL = "http://localhost:3350/mcp";
+
+/** Operations per ppal-live-api call. The tool caps this at 50. */
+const OPS_PER_CALL = 50;
+
+/** Shape of the probed Live Set. Only used to build paths that resolve. */
+const TRACK_COUNT = 5;
+const SLOT_COUNT = 8;
+
+/** Named because it's the one arm that isn't a ppal-live-api operation batch. */
+const READ_TRACK = "read-track";
+
+const ARMS = ["baseline", "goto", "goto-fresh", READ_TRACK] as const;
+
+type Arm = (typeof ARMS)[number];
+
+interface ToolCall {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+// Deep paths that resolve, for the arm that deliberately repeats them.
+const repeatedPaths: string[] = [];
+
+for (let track = 0; track < TRACK_COUNT; track++) {
+  for (let slot = 0; slot < SLOT_COUNT; slot++) {
+    repeatedPaths.push(`live_set tracks ${track} clip_slots ${slot} clip`);
+  }
+}
+
+/**
+ * Build the tool call for one iteration of an arm.
+ * @param arm - Which arm is running
+ * @param n - Global call index, so paths vary across calls
+ * @returns The MCP tool call to issue
+ */
+function callFor(arm: Arm, n: number): ToolCall {
+  if (arm === READ_TRACK) {
+    return {
+      name: "ppal-read-track",
+      arguments: { trackIndex: n % TRACK_COUNT },
+    };
+  }
+
+  const operations = [];
+
+  for (let i = 0; i < OPS_PER_CALL; i++) {
+    operations.push(operationFor(arm, n * OPS_PER_CALL + i));
+  }
+
+  return { name: "ppal-live-api", arguments: { path: "live_set", operations } };
+}
+
+/**
+ * Build one operation for a ppal-live-api arm.
+ * @param arm - Which arm is running
+ * @param seq - Global operation index
+ * @returns The operation object
+ */
+function operationFor(arm: Arm, seq: number): Record<string, unknown> {
+  if (arm === "baseline") {
+    return { type: "exists" };
+  }
+
+  if (arm === "goto-fresh") {
+    // Slots past SLOT_COUNT don't resolve, but the path is still distinct and
+    // Live still walks live_set.tracks and tracks N.clip_slots to find out.
+    // That is enough to pay the registration this arm is looking for.
+    return {
+      type: "goto",
+      value: `live_set tracks ${seq % TRACK_COUNT} clip_slots ${seq} clip`,
+    };
+  }
+
+  return {
+    type: "goto",
+    value: repeatedPaths[seq % repeatedPaths.length],
+  };
+}
+
+/**
+ * Run one arm and print per-round means.
+ * @param client - Connected MCP client
+ * @param arm - Which arm to run
+ * @param rounds - Number of rounds
+ * @param callsPerRound - Calls per round
+ */
+async function runArm(
+  client: Client,
+  arm: Arm,
+  rounds: number,
+  callsPerRound: number,
+): Promise<void> {
+  console.log(
+    `arm=${arm} rounds=${rounds} callsPerRound=${callsPerRound} ` +
+      `opsPerCall=${arm === READ_TRACK ? "n/a" : OPS_PER_CALL}`,
+  );
+
+  const means: number[] = [];
+  let n = 0;
+
+  for (let round = 1; round <= rounds; round++) {
+    const started = performance.now();
+
+    for (let i = 0; i < callsPerRound; i++) {
+      await client.callTool(callFor(arm, n++));
+    }
+
+    const mean = (performance.now() - started) / callsPerRound;
+
+    means.push(mean);
+    console.log(`round ${round}: ${mean.toFixed(1)} ms/call`);
+  }
+
+  const first = means[0];
+  const last = means.at(-1);
+
+  if (first == null || last == null) return;
+
+  console.log(
+    `\nfirst→last: ${first.toFixed(1)} → ${last.toFixed(1)} ms/call ` +
+      `(${(last / first).toFixed(2)}x over ${rounds * callsPerRound} calls)`,
+  );
+}
+
+const [armArg, roundsArg, callsArg] = process.argv.slice(2);
+const arm = (armArg ?? "goto") as Arm;
+
+if (!ARMS.includes(arm)) {
+  console.error(`Unknown arm: ${arm}. Valid arms: ${ARMS.join(", ")}`);
+  process.exit(1);
+}
+
+const transport = new StreamableHTTPClientTransport(new URL(DEFAULT_URL));
+const client = new Client(
+  { name: "live-api-context-probe", version: "1.0.0" },
+  { capabilities: {} },
+);
+
+await client.connect(transport);
+
+try {
+  await runArm(client, arm, Number(roundsArg ?? 5), Number(callsArg ?? 100));
+} finally {
+  await client.close();
+}

--- a/scripts/probes/live-api-context-probe.ts
+++ b/scripts/probes/live-api-context-probe.ts
@@ -149,7 +149,14 @@ async function runArm(
     const started = performance.now();
 
     for (let i = 0; i < callsPerRound; i++) {
-      await client.callTool(callFor(arm, n++));
+      const result = await client.callTool(callFor(arm, n++));
+
+      // Without this a release build reads as a very fast Live: ppal-live-api
+      // isn't there, every call errors, and the timings describe the error
+      // round trip.
+      if (result.isError) {
+        throw new Error(`Tool call failed: ${JSON.stringify(result)}`);
+      }
     }
 
     const mean = (performance.now() - started) / callsPerRound;
@@ -169,6 +176,31 @@ async function runArm(
   );
 }
 
+/**
+ * Read a positive-integer argument, rather than letting a typo become NaN — a
+ * NaN count runs zero rounds, prints nothing, and exits 0.
+ * @param value - The raw argument, if given
+ * @param fallback - Value to use when the argument is absent
+ * @param name - Argument name, for the error message
+ * @returns The count to use
+ */
+function count(
+  value: string | undefined,
+  fallback: number,
+  name: string,
+): number {
+  if (value == null) return fallback;
+
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    console.error(`Invalid ${name}: ${value}. Expected a positive integer.`);
+    process.exit(1);
+  }
+
+  return parsed;
+}
+
 const [armArg, roundsArg, callsArg] = process.argv.slice(2);
 const arm = (armArg ?? "goto") as Arm;
 
@@ -186,7 +218,12 @@ const client = new Client(
 await client.connect(transport);
 
 try {
-  await runArm(client, arm, Number(roundsArg ?? 5), Number(callsArg ?? 100));
+  await runArm(
+    client,
+    arm,
+    count(roundsArg, 5, "rounds"),
+    count(callsArg, 100, "callsPerRound"),
+  );
 } finally {
   await client.close();
 }

--- a/src/live-api-adapter/live-api-extensions.ts
+++ b/src/live-api-adapter/live-api-extensions.ts
@@ -9,7 +9,29 @@ import { errorMessage } from "#src/shared/error-utils.ts";
 import { type PathLike } from "#src/shared/live-api-path-builders.ts";
 import * as console from "#src/shared/max/v8-max-console.ts";
 import { parseIdOrPath } from "./live-api-path-utils.ts";
-import { trackLiveApiObject } from "./live-api-release.ts";
+import { acquirePooledObject, trackLiveApiObject } from "./live-api-release.ts";
+
+/**
+ * Point a pooled object at a target, or build one when the pool is empty.
+ *
+ * Construction is what registers a context in MxDCore, and nothing takes that
+ * back short of a device reload, so reuse is much cheaper than a fresh object.
+ * See live-api-release.ts for what pooling does and doesn't buy.
+ *
+ * @param target - Path or "id N" string, already normalized
+ * @returns A tracked object pointing at the target
+ */
+function buildOrReuse(target: string): LiveAPI {
+  const pooled = acquirePooledObject();
+
+  if (pooled == null) {
+    return trackLiveApiObject(new LiveAPI(target));
+  }
+
+  pooled.goto(target);
+
+  return trackLiveApiObject(pooled);
+}
 
 if (typeof LiveAPI !== "undefined") {
   /**
@@ -20,7 +42,7 @@ if (typeof LiveAPI !== "undefined") {
   LiveAPI.from = function (
     idOrPath: string | number | [string, string | number] | PathLike,
   ): LiveAPI {
-    return trackLiveApiObject(new LiveAPI(parseIdOrPath(idOrPath)));
+    return buildOrReuse(parseIdOrPath(idOrPath));
   };
   LiveAPI.prototype.exists = function (this: LiveAPI): boolean {
     // A nonexistent object reports id "0" (a string) on Live 12.4.3 (v8) —
@@ -183,9 +205,7 @@ if (typeof LiveAPI !== "undefined") {
     this: LiveAPI,
     name: string,
   ): LiveAPI[] {
-    return this.getChildIds(name).map((id) =>
-      trackLiveApiObject(new LiveAPI(id)),
-    );
+    return this.getChildIds(name).map((id) => buildOrReuse(id));
   };
 
   LiveAPI.prototype.getColor = function (this: LiveAPI): string | null {

--- a/src/live-api-adapter/live-api-extensions.ts
+++ b/src/live-api-adapter/live-api-extensions.ts
@@ -18,11 +18,20 @@ import { acquirePooledObject, trackLiveApiObject } from "./live-api-release.ts";
  * back short of a device reload, so reuse is much cheaper than a fresh object.
  * See live-api-release.ts for what pooling does and doesn't buy.
  *
+ * Only a path can retarget an object, so an "id N" target always builds. The
+ * constructor is the only thing that accepts that form — measured on 12.4.3,
+ * goto("id 2") returns 1 as though it worked and leaves the object nonexistent
+ * (path "", id "0"), and assigning it to path is ignored outright. Both fail
+ * silently, so this can't be relaxed on the strength of it looking fine.
+ *
+ * Objects built this way still go on the free list when released: once the path
+ * is cleared they retarget by path like any other.
+ *
  * @param target - Path or "id N" string, already normalized
  * @returns A tracked object pointing at the target
  */
 function buildOrReuse(target: string): LiveAPI {
-  const pooled = acquirePooledObject();
+  const pooled = target.startsWith("id ") ? undefined : acquirePooledObject();
 
   if (pooled == null) {
     return trackLiveApiObject(new LiveAPI(target));

--- a/src/live-api-adapter/live-api-extensions.ts
+++ b/src/live-api-adapter/live-api-extensions.ts
@@ -37,9 +37,12 @@ function buildOrReuse(target: string): LiveAPI {
     return trackLiveApiObject(new LiveAPI(target));
   }
 
+  // Track before retargeting: an object that throws mid-goto is off the free
+  // list already, and leaving it untracked too would strand whatever it armed.
+  trackLiveApiObject(pooled);
   pooled.goto(target);
 
-  return trackLiveApiObject(pooled);
+  return pooled;
 }
 
 if (typeof LiveAPI !== "undefined") {

--- a/src/live-api-adapter/live-api-release.ts
+++ b/src/live-api-adapter/live-api-release.ts
@@ -8,8 +8,11 @@
  *
  * Live installs a listener on each collection along a path-based object's path
  * (live_set.tracks, track.devices, ...) and never takes them down. Assigning an
- * empty path is the only thing that does. An unreleased object costs ~5 KB of
- * Ableton log on every later structural change to the Live Set.
+ * empty path is the only thing that does. Every armed listener has to be
+ * notified on any later structural change to the Live Set, so unreleased
+ * objects make those changes slower: on 12.4.3, adding and deleting a track
+ * took 120 ms with none held and 630 ms with 7,190 held. Clearing the paths
+ * gives all of it back.
  *
  * So objects are tracked as they are built and released when the request that
  * built them ends. Identity and lifetime *within* a request are untouched.
@@ -28,6 +31,11 @@
  *
  * Build objects where you use them. Nothing in the codebase holds one across
  * requests today; keep it that way.
+ *
+ * Mode 1 (follow the object) is not the way around this — it is the worst case
+ * measured. The same 7,190 held objects at mode 1 took that track add and
+ * delete to 5.7 s, nine times the mode 0 cost. Caching by id across requests
+ * is the most expensive thing you can do here.
  * ============================================================================
  *
  * Clearing the path is not the whole story, which is why released objects are
@@ -44,9 +52,10 @@
  * difference is that the path cost is paid once per path and saturates, while
  * the construction cost never does.
  *
- * Don't reach for freepeer(): it frees the JS peer and leaves the listener
- * armed. 500 read-track calls still armed 6,002 listeners and the next track
- * delete still wrote 30 MB of log — the state the SendMessage errors come from.
+ * Don't reach for freepeer(), and don't count on the garbage collector. Both
+ * free the JS peer and leave the listener armed, and the slowdown then never
+ * comes back: 7,190 objects in that state held a track add and delete at 1.0 s
+ * (freepeer) and 3.5 s (collected) until the device was reloaded.
  */
 
 import { errorMessage } from "#src/shared/error-utils.ts";

--- a/src/live-api-adapter/live-api-release.ts
+++ b/src/live-api-adapter/live-api-release.ts
@@ -9,13 +9,21 @@
  * Live installs a listener on each collection along a path-based object's path
  * (live_set.tracks, track.devices, ...) and never takes them down. Assigning an
  * empty path is the only thing that does. An unreleased object costs ~5 KB of
- * Ableton log on every later structural change to the Live Set, and makes every
- * later LiveAPI creation slower: measured on 12.4.3, 2,500 read-track calls'
- * worth of leaked objects made the next call 3x slower, and it stays slow until
- * the device is reloaded.
+ * Ableton log on every later structural change to the Live Set.
  *
  * So objects are tracked as they are built and released when the request that
  * built them ends. Identity and lifetime *within* a request are untouched.
+ *
+ * This does not fix the other cost of a LiveAPI object. Construction also
+ * registers a context in MxDCore, and clearing the path only retargets the
+ * object — the registration stays, so every later construction is slower for
+ * it. Measured on 12.4.3, 2,500 read-track calls took the next one from 27 ms
+ * to 90 ms, and the slope is unchanged by this release. Only a device reload
+ * clears it; pooling objects instead of building new ones is the open fix.
+ *
+ * Don't reach for freepeer(): it frees the JS peer and leaves the listener
+ * armed. 500 read-track calls still armed 6,002 listeners and the next track
+ * delete still wrote 30 MB of log — the state the SendMessage errors come from.
  */
 
 import { errorMessage } from "#src/shared/error-utils.ts";

--- a/src/live-api-adapter/live-api-release.ts
+++ b/src/live-api-adapter/live-api-release.ts
@@ -39,18 +39,21 @@
  * ============================================================================
  *
  * Clearing the path is not the whole story, which is why released objects are
- * pooled rather than dropped. Construction also registers a context in MxDCore
- * that clearing the path does not take back, and that registration makes every
- * later construction slower — 2,500 read-track calls took the next one from
- * 27 ms to 90 ms on 12.4.3, and only a device reload clears it. So a released
- * object goes on a free list and the next request retargets it instead of
- * building another one.
+ * pooled rather than dropped. Construction registers a context in MxDCore that
+ * clearing the path does not take back, and only a device reload clears it. So
+ * a released object goes on a free list and the next request retargets it.
+ *
+ * That costs two ways, and pooling avoids both. Building an object runs about
+ * 14 ms slower than retargeting a pooled one, and each build also slows every
+ * later read a little. Measured on 12.4.3 over 2,500 read-track calls: pooled,
+ * a read went from 54 ms to 90 ms; unpooled, from 534 ms to 1.1 s. Same work
+ * either way — 90,006 objects, 92% of them reused when the pool is on.
  *
  * Pooling does not make the cost vanish, and measuring it as though it should
  * will read as failure. Visiting a path registers something too, so latency
- * still rises while a session reaches new corners of the Live Set. The
- * difference is that the path cost is paid once per path and saturates, while
- * the construction cost never does.
+ * still rises while a session reaches new corners of the Live Set — that 54 to
+ * 90 ms is the pool working, not failing. The difference is that the path cost
+ * is paid once per path and saturates, while the construction cost never does.
  *
  * Don't reach for freepeer(), and don't count on the garbage collector. Both
  * free the JS peer and leave the listener armed, and the slowdown then never

--- a/src/live-api-adapter/live-api-release.ts
+++ b/src/live-api-adapter/live-api-release.ts
@@ -118,6 +118,24 @@ export function trackLiveApiObject(api: LiveAPI): LiveAPI {
 }
 
 /**
+ * Forget a tracked object, so the release skips it and it never reaches the
+ * free list.
+ *
+ * For an object whose peer is gone: releasing it would throw, and pooling it
+ * would hand a freed peer to a later request. Dropping it leaks the path
+ * listener, which is the lesser of the two and unavoidable either way.
+ *
+ * @param api - The object to forget
+ */
+export function untrackLiveApiObject(api: LiveAPI): void {
+  const index = trackedObjects.indexOf(api);
+
+  if (index !== -1) {
+    trackedObjects.splice(index, 1);
+  }
+}
+
+/**
  * Take an idle object off the free list, if there is one.
  *
  * The caller retargets it and tracks it. Returns undefined when the pool is
@@ -164,19 +182,29 @@ function releaseTrackedObjects(): void {
 
   for (const api of trackedObjects) {
     try {
+      // Mode first, so the clear below always runs against a path-following
+      // object. Reusing without resetting would carry a mode of 1 into the next
+      // request; the ppal-live-api set_mode operation is what can leave it
+      // there. (Clearing from mode 1 works on 12.4.3 — this is just the order
+      // that doesn't depend on that.)
+      api.mode = 0;
+
       // `path` is readonly in the type so ordinary code can't retarget an
       // object. This is the release; the ppal-live-api set_path operation is
       // the only other write. Assigning "" retargets the object, not the set.
       (api as unknown as { path: string }).path = "";
 
-      // The only writable state on the wrapper, and the ppal-live-api set_mode
-      // operation can leave it at 1 (follow the object, not the path). Reusing
-      // the object without resetting would carry that into the next request.
-      api.mode = 0;
+      // Live ignores some path writes without saying so — an id string is
+      // ignored outright — and a throw is not the only way this fails. A
+      // cleared path reads back "" on 12.4.3, so anything else means the
+      // listener is still armed and the object still points at this request's
+      // target. Pooling it would hand that to the next request.
+      if (api.path !== "") {
+        failures++;
+        firstError ??= `path did not clear: ${api.path}`;
+        continue;
+      }
 
-      // Only after the clear succeeds. An object that refused is in an unknown
-      // state, so reusing it would hand a request something still pointing at
-      // the last request's target.
       if (freeObjects.length < MAX_POOLED_OBJECTS) {
         freeObjects.push(api);
       }

--- a/src/live-api-adapter/live-api-release.ts
+++ b/src/live-api-adapter/live-api-release.ts
@@ -14,12 +14,19 @@
  * So objects are tracked as they are built and released when the request that
  * built them ends. Identity and lifetime *within* a request are untouched.
  *
- * This does not fix the other cost of a LiveAPI object. Construction also
- * registers a context in MxDCore, and clearing the path only retargets the
- * object — the registration stays, so every later construction is slower for
- * it. Measured on 12.4.3, 2,500 read-track calls took the next one from 27 ms
- * to 90 ms, and the slope is unchanged by this release. Only a device reload
- * clears it; pooling objects instead of building new ones is the open fix.
+ * Clearing the path is not the whole story, which is why released objects are
+ * pooled rather than dropped. Construction also registers a context in MxDCore
+ * that clearing the path does not take back, and that registration makes every
+ * later construction slower — 2,500 read-track calls took the next one from
+ * 27 ms to 90 ms on 12.4.3, and only a device reload clears it. So a released
+ * object goes on a free list and the next request retargets it instead of
+ * building another one.
+ *
+ * Pooling does not make the cost vanish, and measuring it as though it should
+ * will read as failure. Visiting a path registers something too, so latency
+ * still rises while a session reaches new corners of the Live Set. The
+ * difference is that the path cost is paid once per path and saturates, while
+ * the construction cost never does.
  *
  * Don't reach for freepeer(): it frees the JS peer and leaves the listener
  * armed. 500 read-track calls still armed 6,002 listeners and the next track
@@ -30,6 +37,21 @@ import { errorMessage } from "#src/shared/error-utils.ts";
 import * as console from "#src/shared/max/v8-max-console.ts";
 
 const trackedObjects: LiveAPI[] = [];
+
+/**
+ * Released objects with a cleared path, waiting to be retargeted.
+ *
+ * Only ever refilled when the last open scope closes, which is what keeps a
+ * reused object from being handed to two requests at once. Requests overlap
+ * whenever a tool awaits, and there is no way to tell which request is calling
+ * — LiveAPI.from is a global with no request handle and Max V8 has no async
+ * context — so "nothing is in flight" is the only safe moment to recycle.
+ *
+ * The cost is that concurrent requests never reach that moment, so the pool
+ * stays empty and every object is built. That is today's behavior, not a
+ * regression, and sequential calls (the normal case) recycle every request.
+ */
+const freeObjects: LiveAPI[] = [];
 
 /**
  * Open request scopes. Requests overlap whenever a tool awaits (code exec, node
@@ -51,6 +73,18 @@ export function trackLiveApiObject(api: LiveAPI): LiveAPI {
   return api;
 }
 
+/**
+ * Take an idle object off the free list, if there is one.
+ *
+ * The caller retargets it and tracks it. Returns undefined when the pool is
+ * empty, which is the signal to build one instead.
+ *
+ * @returns A pooled object with a cleared path, or undefined
+ */
+export function acquirePooledObject(): LiveAPI | undefined {
+  return freeObjects.pop();
+}
+
 /** Mark the start of a request that may build LiveAPI objects. */
 export function beginLiveApiScope(): void {
   openScopes++;
@@ -70,14 +104,15 @@ export function endLiveApiScope(): void {
   }
 }
 
-/** Drop tracked objects without releasing them. For test setup only. */
+/** Drop tracked and pooled objects without releasing them. For test setup only. */
 export function resetLiveApiTracking(): void {
   trackedObjects.length = 0;
+  freeObjects.length = 0;
   openScopes = 0;
 }
 
 /**
- * Clear every tracked object's path and forget it.
+ * Clear every tracked object's path and move it to the free list.
  */
 function releaseTrackedObjects(): void {
   let failures = 0;
@@ -89,6 +124,16 @@ function releaseTrackedObjects(): void {
       // object. This is the release; the ppal-live-api set_path operation is
       // the only other write. Assigning "" retargets the object, not the set.
       (api as unknown as { path: string }).path = "";
+
+      // The only writable state on the wrapper, and the ppal-live-api set_mode
+      // operation can leave it at 1 (follow the object, not the path). Reusing
+      // the object without resetting would carry that into the next request.
+      api.mode = 0;
+
+      // Only after the clear succeeds. An object that refused is in an unknown
+      // state, so reusing it would hand a request something still pointing at
+      // the last request's target.
+      freeObjects.push(api);
     } catch (error) {
       failures++;
       // ??= not ||=: a failure with an empty message is still the first one,

--- a/src/live-api-adapter/live-api-release.ts
+++ b/src/live-api-adapter/live-api-release.ts
@@ -14,6 +14,22 @@
  * So objects are tracked as they are built and released when the request that
  * built them ends. Identity and lifetime *within* a request are untouched.
  *
+ * ============================================================================
+ * NOTHING MAY HOLD A LiveAPI OBJECT ACROSS REQUESTS.
+ *
+ * Not in module state, not in a cache, not captured in a callback that outlives
+ * the call. Every object a request builds is released when it ends, and reused
+ * by a later one.
+ *
+ * A stale reference fails quietly. Straight after release it at least reads as
+ * nonexistent — cleared path, id "0". Once the object is recycled it points at
+ * something else entirely, and reads and writes land on the wrong Live object
+ * with no error anywhere.
+ *
+ * Build objects where you use them. Nothing in the codebase holds one across
+ * requests today; keep it that way.
+ * ============================================================================
+ *
  * Clearing the path is not the whole story, which is why released objects are
  * pooled rather than dropped. Construction also registers a context in MxDCore
  * that clearing the path does not take back, and that registration makes every
@@ -37,6 +53,22 @@ import { errorMessage } from "#src/shared/error-utils.ts";
 import * as console from "#src/shared/max/v8-max-console.ts";
 
 const trackedObjects: LiveAPI[] = [];
+
+/**
+ * Ceiling on the free list.
+ *
+ * Without one it grows forever. A request returns every object it built, but
+ * only takes back the ones it needed for a path — an "id N" target can't
+ * retarget an existing object, so getChildren always builds. Every request
+ * therefore hands back more than it took, and the surplus is exactly the
+ * id-built objects. A read-track loop would pile up tens of thousands.
+ *
+ * Anything over the ceiling is released and dropped. A request that needs more
+ * than this builds the difference, which is what it did before pooling existed.
+ * Set high enough to cover an ordinary request and low enough to stay
+ * negligible memory.
+ */
+export const MAX_POOLED_OBJECTS = 512;
 
 /**
  * Released objects with a cleared path, waiting to be retargeted.
@@ -133,7 +165,9 @@ function releaseTrackedObjects(): void {
       // Only after the clear succeeds. An object that refused is in an unknown
       // state, so reusing it would hand a request something still pointing at
       // the last request's target.
-      freeObjects.push(api);
+      if (freeObjects.length < MAX_POOLED_OBJECTS) {
+        freeObjects.push(api);
+      }
     } catch (error) {
       failures++;
       // ??= not ||=: a failure with an empty message is still the first one,

--- a/src/live-api-adapter/tests/live-api-release.test.ts
+++ b/src/live-api-adapter/tests/live-api-release.test.ts
@@ -224,7 +224,25 @@ describe("live-api release", () => {
     endLiveApiScope();
   });
 
-  it("reuses the objects getChildren built", () => {
+  it("builds a fresh object for an id target instead of retargeting", () => {
+    // goto can't take the "id N" form. Measured on 12.4.3 it reports success
+    // and leaves the object nonexistent, so an id always builds.
+    beginLiveApiScope();
+
+    const first = LiveAPI.from(livePath.track(0));
+
+    endLiveApiScope();
+    beginLiveApiScope();
+
+    const byId = LiveAPI.from(5);
+
+    expect(byId).not.toBe(first);
+    expect(byId.path).toBe("id 5");
+
+    endLiveApiScope();
+  });
+
+  it("pools the objects getChildren built", () => {
     beginLiveApiScope();
 
     const liveSet = LiveAPI.from(livePath.liveSet);

--- a/src/live-api-adapter/tests/live-api-release.test.ts
+++ b/src/live-api-adapter/tests/live-api-release.test.ts
@@ -8,6 +8,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  MAX_POOLED_OBJECTS,
   beginLiveApiScope,
   endLiveApiScope,
   resetLiveApiTracking,
@@ -273,6 +274,34 @@ describe("live-api release", () => {
     const next = LiveAPI.from(livePath.track(0));
 
     expect(next.path).toBe(String(livePath.track(0)));
+
+    endLiveApiScope();
+  });
+
+  it("stops pooling once the free list is full", () => {
+    // Without a ceiling the pool grows forever: a request returns everything it
+    // built but only takes back what it needed for a path, and an id target
+    // always builds. The surplus is every id-built object, every request.
+    const overflow = 10;
+
+    beginLiveApiScope();
+
+    const built = new Set<LiveAPI>();
+
+    for (let i = 0; i < MAX_POOLED_OBJECTS + overflow; i++) {
+      built.add(LiveAPI.from(i + 1));
+    }
+
+    endLiveApiScope();
+    beginLiveApiScope();
+
+    let reused = 0;
+
+    for (let i = 0; i < MAX_POOLED_OBJECTS + overflow; i++) {
+      if (built.has(LiveAPI.from(livePath.track(i)))) reused++;
+    }
+
+    expect(reused).toBe(MAX_POOLED_OBJECTS);
 
     endLiveApiScope();
   });

--- a/src/live-api-adapter/tests/live-api-release.test.ts
+++ b/src/live-api-adapter/tests/live-api-release.test.ts
@@ -176,6 +176,105 @@ describe("live-api release", () => {
     );
   });
 
+  it("retargets a released object instead of building another", () => {
+    beginLiveApiScope();
+
+    const first = LiveAPI.from(livePath.track(0));
+
+    endLiveApiScope();
+    beginLiveApiScope();
+
+    const second = LiveAPI.from(livePath.track(1));
+
+    expect(second).toBe(first);
+    expect(second.path).toBe(String(livePath.track(1)));
+
+    endLiveApiScope();
+  });
+
+  it("resets a mode the last request left behind", () => {
+    beginLiveApiScope();
+
+    const first = LiveAPI.from(livePath.track(0));
+
+    // What the ppal-live-api set_mode operation leaves behind: follow the
+    // object rather than the path.
+    first.mode = 1;
+
+    endLiveApiScope();
+    beginLiveApiScope();
+
+    expect(LiveAPI.from(livePath.track(1)).mode).toBe(0);
+
+    endLiveApiScope();
+  });
+
+  it("hands out a distinct object per call within one request", () => {
+    // The pool only refills once no scope is open, so nothing a request is
+    // still holding can come back to it mid-flight.
+    beginLiveApiScope();
+
+    const first = LiveAPI.from(livePath.track(0));
+    const second = LiveAPI.from(livePath.track(1));
+
+    expect(second).not.toBe(first);
+    expect(first.path).toBe(String(livePath.track(0)));
+    expect(second.path).toBe(String(livePath.track(1)));
+
+    endLiveApiScope();
+  });
+
+  it("reuses the objects getChildren built", () => {
+    beginLiveApiScope();
+
+    const liveSet = LiveAPI.from(livePath.liveSet);
+
+    liveSet.get = vi.fn().mockReturnValue(["id", "1", "id", "2"]);
+
+    const children = liveSet.getChildren("tracks");
+
+    endLiveApiScope();
+    beginLiveApiScope();
+
+    const reused = LiveAPI.from(livePath.track(0));
+
+    expect([liveSet, ...children]).toContain(reused);
+
+    endLiveApiScope();
+  });
+
+  it("does not reuse an object that refused to be cleared", () => {
+    beginLiveApiScope();
+
+    // Its path setter throws, so the release can't know where it points.
+    trackUnclearable("nope");
+
+    endLiveApiScope();
+    beginLiveApiScope();
+
+    const next = LiveAPI.from(livePath.track(0));
+
+    expect(next.path).toBe(String(livePath.track(0)));
+
+    endLiveApiScope();
+  });
+
+  it("forgets pooled objects on reset", () => {
+    beginLiveApiScope();
+
+    const first = LiveAPI.from(livePath.track(0));
+
+    endLiveApiScope();
+    resetLiveApiTracking();
+    beginLiveApiScope();
+
+    const second = LiveAPI.from(livePath.track(1));
+
+    expect(second).not.toBe(first);
+
+    endLiveApiScope();
+  });
+
   it("forgets tracked objects without touching them on reset", () => {
     beginLiveApiScope();
 

--- a/src/live-api-adapter/tests/live-api-release.test.ts
+++ b/src/live-api-adapter/tests/live-api-release.test.ts
@@ -13,6 +13,7 @@ import {
   endLiveApiScope,
   resetLiveApiTracking,
   trackLiveApiObject,
+  untrackLiveApiObject,
 } from "#src/live-api-adapter/live-api-release.ts";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 
@@ -28,6 +29,28 @@ function trackUnclearable(error: string): void {
       throw new Error(error);
     },
   } as unknown as LiveAPI);
+}
+
+/**
+ * Track an object whose path setter silently does nothing, standing in for a
+ * path write Live ignores rather than rejects.
+ *
+ * @returns The tracked object, still pointing where it started
+ */
+function trackSilentlyUnclearable(): LiveAPI {
+  const api = {
+    mode: 0,
+
+    get path(): string {
+      return String(livePath.track(0));
+    },
+
+    set path(_value: string) {
+      // Live ignoring the write.
+    },
+  };
+
+  return trackLiveApiObject(api as unknown as LiveAPI);
 }
 
 describe("live-api release", () => {
@@ -257,7 +280,9 @@ describe("live-api release", () => {
 
     const reused = LiveAPI.from(livePath.track(0));
 
-    expect([liveSet, ...children]).toContain(reused);
+    // The children, not liveSet: an id target always builds, so these are the
+    // objects the pool would drop if id-built ones weren't put back.
+    expect(children).toContain(reused);
 
     endLiveApiScope();
   });
@@ -276,6 +301,53 @@ describe("live-api release", () => {
     expect(next.path).toBe(String(livePath.track(0)));
 
     endLiveApiScope();
+  });
+
+  it("does not reuse an object whose clear was silently ignored", () => {
+    beginLiveApiScope();
+
+    const stuck = trackSilentlyUnclearable();
+
+    endLiveApiScope();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("path did not clear"),
+    );
+
+    beginLiveApiScope();
+
+    expect(LiveAPI.from(livePath.track(1))).not.toBe(stuck);
+
+    endLiveApiScope();
+  });
+
+  it("neither releases nor pools an object it was told to forget", () => {
+    beginLiveApiScope();
+
+    const forgotten = LiveAPI.from(livePath.track(0));
+
+    untrackLiveApiObject(forgotten);
+    endLiveApiScope();
+
+    // Untouched by the release, so it never reaches the free list either.
+    expect(forgotten.path).toBe(String(livePath.track(0)));
+
+    beginLiveApiScope();
+
+    expect(LiveAPI.from(livePath.track(1))).not.toBe(forgotten);
+
+    endLiveApiScope();
+  });
+
+  it("ignores an object it was never tracking", () => {
+    beginLiveApiScope();
+
+    const tracked = LiveAPI.from(livePath.track(0));
+
+    untrackLiveApiObject({} as unknown as LiveAPI);
+    endLiveApiScope();
+
+    expect(tracked.path).toBe("");
   });
 
   it("stops pooling once the free list is full", () => {

--- a/src/test/mocks/mock-live-api.test.ts
+++ b/src/test/mocks/mock-live-api.test.ts
@@ -163,4 +163,104 @@ describe("Mock LiveAPI Infrastructure", () => {
       expect(mock.call).toHaveBeenCalledWith("duplicate_clip_to", 1, 2);
     });
   });
+
+  // A retargeted object has to land where a fresh one at that path would. Only
+  // the constructor used to bind get/set/call and copy the registered
+  // properties, so retargeting left both pointing at the previous target.
+  describe("retargeting", () => {
+    it("rebinds get, set, and call to the new target", () => {
+      const first = registerMockObject("track-0", {
+        path: livePath.track(0),
+        type: "Track",
+      });
+      const second = registerMockObject("track-1", {
+        path: livePath.track(1),
+        type: "Track",
+      });
+
+      const api = new LiveAPI(String(livePath.track(0)));
+
+      api.goto(String(livePath.track(1)));
+      api.get("name");
+      api.set("name", "New Name");
+      api.call("duplicate_clip_to");
+
+      expect(second.get).toHaveBeenCalledWith("name");
+      expect(second.set).toHaveBeenCalledWith("name", "New Name");
+      expect(second.call).toHaveBeenCalledWith("duplicate_clip_to");
+      expect(first.get).not.toHaveBeenCalled();
+      expect(first.set).not.toHaveBeenCalled();
+      expect(first.call).not.toHaveBeenCalled();
+    });
+
+    it("drops a property the new target doesn't define", () => {
+      registerMockObject("track-0", {
+        path: livePath.track(0),
+        type: "Track",
+        properties: { customProp: "first" },
+      });
+      registerMockObject("track-1", {
+        path: livePath.track(1),
+        type: "Track",
+      });
+
+      const api = new LiveAPI(String(livePath.track(0)));
+
+      api.goto(String(livePath.track(1)));
+
+      expect(
+        (api as unknown as Record<string, unknown>).customProp,
+      ).toBeUndefined();
+    });
+
+    it("replaces a property both targets define", () => {
+      registerMockObject("track-0", {
+        path: livePath.track(0),
+        type: "Track",
+        properties: { trackIndex: 0 },
+      });
+      registerMockObject("track-1", {
+        path: livePath.track(1),
+        type: "Track",
+        properties: { trackIndex: 1 },
+      });
+
+      const api = new LiveAPI(String(livePath.track(0)));
+
+      api.goto(String(livePath.track(1)));
+
+      expect(api.trackIndex).toBe(1);
+    });
+
+    it("falls back to the default mocks when retargeted off the registry", () => {
+      const mock = registerMockObject("track-0", {
+        path: livePath.track(0),
+        type: "Track",
+      });
+
+      const api = new LiveAPI(String(livePath.track(0)));
+
+      api.goto(String(livePath.track(9)));
+      api.get("name");
+
+      expect(api.mock).toBeUndefined();
+      expect(mock.get).not.toHaveBeenCalled();
+    });
+
+    it("retargets through a path write the same way as through goto", () => {
+      const second = registerMockObject("track-1", {
+        path: livePath.track(1),
+        type: "Track",
+        properties: { trackIndex: 1 },
+      });
+
+      const api = new LiveAPI(String(livePath.track(0)));
+
+      api.path = String(livePath.track(1));
+      api.get("name");
+
+      expect(second.get).toHaveBeenCalledWith("name");
+      expect(api.trackIndex).toBe(1);
+    });
+  });
 });

--- a/src/test/mocks/mock-live-api.ts
+++ b/src/test/mocks/mock-live-api.ts
@@ -50,15 +50,38 @@ export class LiveAPI {
   _path?: string;
   _id?: string;
   _registered?: RegisteredMockObject;
-  get: Mock;
-  set: Mock;
-  call: Mock;
+  /** Keys copied off the registration, so a retarget can take them back off. */
+  _copiedKeys: string[] = [];
+  get!: Mock;
+  set!: Mock;
+  call!: Mock;
 
   get mock(): RegisteredMockObject | undefined {
     return this._registered;
   }
 
   constructor(path?: string) {
+    this._retarget(path);
+  }
+
+  /**
+   * Point this object at a path and rebind everything derived from it.
+   *
+   * Construction and retargeting share this. The real LiveAPI rebinds on goto
+   * and on a path write, so an object that gets reused instead of rebuilt has
+   * to land where a fresh one would — otherwise it keeps answering get/set/call
+   * for whatever it used to point at.
+   *
+   * @param path - Path or "id N" string to point at
+   */
+  _retarget(path?: string): void {
+    // Properties copied for the previous target would shadow the new one's, and
+    // outlive a registration that doesn't define them at all.
+    for (const key of this._copiedKeys) {
+      delete (this as unknown as Record<string, unknown>)[key];
+    }
+
+    this._copiedKeys = [];
     this._path = path;
     this._id = deriveId(path);
 
@@ -84,6 +107,7 @@ export class LiveAPI {
           enumerable: true,
           configurable: true,
         });
+        this._copiedKeys.push(key);
       }
     } else {
       // Use getters (this.type/this.path) so defaults stay correct after goto
@@ -147,9 +171,15 @@ export class LiveAPI {
 
   /** Retarget the object, mirroring the real LiveAPI's writable path */
   set path(value: string) {
-    this._path = value;
-    this._id = deriveId(value);
-    this._registered = lookupMockObject(this._id, this._path);
+    this._retarget(value);
+  }
+
+  /**
+   * Retarget the object, mirroring the real LiveAPI's goto
+   * @param path - Path to point at
+   */
+  goto(path: string): void {
+    this._retarget(path);
   }
 
   get unquotedpath(): string {
@@ -206,7 +236,9 @@ export class LiveAPI {
   }
 
   // Built-in Max methods with no mock implementation — suites that exercise
-  // them stub the prototype themselves, the way they already do for goto.
+  // them stub the prototype themselves. goto used to be one of these; it now
+  // retargets for real, because reuse depends on it landing where a fresh
+  // object would.
   declare getcount: (name: string) => number;
   declare getstring: (property: string) => string;
 

--- a/src/tools/advanced/live-api.test.ts
+++ b/src/tools/advanced/live-api.test.ts
@@ -4,6 +4,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  beginLiveApiScope,
+  endLiveApiScope,
+  resetLiveApiTracking,
+} from "#src/live-api-adapter/live-api-release.ts";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import {
   clearMockRegistry,
@@ -205,6 +210,34 @@ describe("liveApi", () => {
           ],
         }),
       ).toThrow('Method "nonExistentMethod" not found on LiveAPI object');
+    });
+
+    it("should forget an object whose peer it just freed", () => {
+      // A freed peer on the free list would be handed to a later request.
+      const freed: LiveAPI[] = [];
+      const prototype = LiveAPI.prototype as unknown as {
+        freepeer?: (this: LiveAPI) => void;
+      };
+
+      prototype.freepeer = function (this: LiveAPI) {
+        freed.push(this);
+      };
+
+      try {
+        resetLiveApiTracking();
+        beginLiveApiScope();
+
+        liveApi({ operations: [{ type: "call_method", method: "freepeer" }] });
+
+        endLiveApiScope();
+        beginLiveApiScope();
+
+        expect(LiveAPI.from(livePath.liveSet)).not.toBe(freed[0]);
+
+        endLiveApiScope();
+      } finally {
+        delete prototype.freepeer;
+      }
     });
   });
 

--- a/src/tools/advanced/live-api.ts
+++ b/src/tools/advanced/live-api.ts
@@ -3,6 +3,7 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import { untrackLiveApiObject } from "#src/live-api-adapter/live-api-release.ts";
 import { errorMessage } from "#src/shared/error-utils.ts";
 import {
   MAX_OPERATIONS,
@@ -229,6 +230,13 @@ function executeObjectOperation(
 
       if (typeof methodFn !== "function") {
         throw new Error(`Method "${method}" not found on LiveAPI object`);
+      }
+
+      // freepeer() frees the JS peer and leaves the path listener armed — bad
+      // enough on its own, and it's what the probes here are for. Pooling the
+      // result would be worse: a later request would be handed a freed object.
+      if (method === "freepeer") {
+        untrackLiveApiObject(api);
       }
 
       return methodFn.apply(api, args);


### PR DESCRIPTION
Reuse released `LiveAPI` objects instead of building new ones. Addresses AJM-913.

## The problem

Constructing a `LiveAPI` registers a context in MxDCore that nothing takes back short of a device reload, and every later construction pays for it. The path-listener release shipped earlier doesn't touch this — clearing a path takes the listeners down but leaves the registration.

## What changed

- Released objects go on a free list; the next request retargets one with `goto` instead of constructing. The list is capped at 512.
- Recycling happens only when the last open scope closes. Objects can't be attributed to a request (`LiveAPI.from` is a global with no request handle, and Max V8 has no async context), so "nothing is in flight" is the only provably safe moment. Concurrent requests fall back to constructing — today's behavior, not a regression.
- `mode` is reset on release, and the clear is verified before the object is pooled.
- An `id N` target always constructs — see the landmines below.

## Measured in Live 12.4.3

Pool on vs pool off. Same build with the cap set at runtime, fresh device per arm, same Live Set, 2,500 `ppal-read-track` calls with session clips, devices, and mixer.

| reads | pool on | pool off |
| --- | --- | --- |
| 250 | 54 ms | 534 ms |
| 1000 | 62 ms | 726 ms |
| 1750 | 77 ms | 968 ms |
| 2500 | **90 ms** | **1,139 ms** |

Both arms did exactly 90,006 acquisitions, so the workload is identical; the pool absorbed 92% of them (`built=7504 reused=82502` against `built=90006 reused=0`). Wall clock for the run was about 3 minutes pooled and 35 unpooled.

Two separable effects:

- **Construction costs ~14 ms more than retargeting, immediately.** Pool-off is 10x slower from the first block, before accumulation can explain it.
- **Each construction taxes every later read** — about 4.8 µs per build pooled, 6.7 µs unpooled.

One caveat: two equations, three unknowns. The fixed per-call cost (MCP round trip, tool logic) can't be separated from the per-object cost with this data, so the ~14 ms is a build-vs-reuse *difference*, not a clean per-object total.

Three related results are now recorded in the `live-api-release.ts` header:

- **Path listeners.** A track add and delete took 120 ms with none held and 630 ms with 7,190 held, and clearing the paths gave all of it back.
- **Mode 1 (follow the object) is the worst case: 5.7 s** for those same 7,190 objects, nine times the mode 0 cost. This closes the id-keyed cross-request cache idea on measurement rather than opinion.
- **`freepeer()` and the garbage collector both leave the listener armed**, and the slowdown never comes back: 1.0 s and 3.5 s until the device was reloaded.

## Landmines found

`goto("id 2")` returns 1 as though it worked and leaves the object **nonexistent** (path `""`, id `"0"`). Assigning the id form to `path` is ignored outright. Both fail silently. The first pooling commit hit this and turned every `getChildren` child into a nonexistent object — and the full suite stayed green, because the mock accepted the id form. Only probing the real runtime caught it.

The same shape turned up in review. The release only noticed a clear that *threw*, so an object whose clear was silently ignored would land on the free list still pointing at the last request's target. It now checks the read-back instead — a cleared path reads `""` on 12.4.3, verified directly against Live.

And `freepeer()` through the debug tool frees the JS peer, so pooling that object would hand a freed one to a later request. It gets untracked instead, which keeps the probes that need `freepeer` working.

## The invariant this creates

**Nothing may hold a `LiveAPI` across requests** — not module state, not a cache, not a callback that outlives the call. A stale reference reads as nonexistent right after release, then points at a different Live object entirely once recycled, with no error anywhere. Stated in the header and in AGENTS.md.

## Is it worth it?

Yes, on the direct measurement — a 10x difference on every read. An earlier version of this description argued the opposite, but that verdict came from an indirect slope measurement that the pool-on/pool-off test has since replaced.

Growth is reduced rather than eliminated. `getChildren` builds by id and can't pool, so about 8% of acquisitions still construct (7,504 over 2,500 reads, roughly 3 per call). That residual is what AJM-920 covers, now raised to High off this data.

The real cost is the invariant above: cross-request reuse is something every future change has to respect, and it has already produced one silent-failure bug that a green suite didn't catch.

## Testing

`npm run check` and `npm run check:build` are green. MCP e2e run against Live 12.4.3 for `ppal-read-live-set` (the widest object graph, so the most retargeted paths per request) and `ppal-duplicate` (the heaviest structural churn) — both pass. Probes live in `scripts/probes/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
