### PR TITLE
fix(webui): wait for an in-flight connect before streaming on an adopted client (AJM-891)

### DIFF
--- a/webui/src/hooks/chat/helpers/streaming-helpers.ts
+++ b/webui/src/hooks/chat/helpers/streaming-helpers.ts
@@ -64,6 +64,30 @@ export async function validateMcpConnection(
   }
 }
 
+/**
+ * Connect a freshly built client, publishing the in-flight connect so a turn
+ * that adopts the client can await it rather than stream on a client whose MCP
+ * connection hasn't landed. The connecting turn owns the ref: it clears the
+ * promise once it settles, unless a newer init already replaced it.
+ * @param client - The client to connect
+ * @param pendingInitRef - Where to publish the in-flight connect
+ * @param pendingInitRef.current - The published promise, or null when idle
+ */
+export async function connectClient<TMessage>(
+  client: ChatClient<TMessage>,
+  pendingInitRef: { current: Promise<void> | null },
+): Promise<void> {
+  const connecting = client.initialize();
+
+  pendingInitRef.current = connecting;
+
+  try {
+    await connecting;
+  } finally {
+    if (pendingInitRef.current === connecting) pendingInitRef.current = null;
+  }
+}
+
 interface ConversationDefaults {
   thinking: string | null;
 }

--- a/webui/src/hooks/chat/tests/helpers/use-chat-test-helpers.ts
+++ b/webui/src/hooks/chat/tests/helpers/use-chat-test-helpers.ts
@@ -273,6 +273,7 @@ export async function streamingHelpersMockBody(): Promise<
     resolveLockedSmallModelMode: actual.resolveLockedSmallModelMode,
     recoverFromChatError: actual.recoverFromChatError,
     runChatTurn: actual.runChatTurn,
+    connectClient: actual.connectClient,
     handleMessageStream: vi.fn(async (stream, formatter, onUpdate) => {
       for await (const chatHistory of stream) {
         onUpdate(formatter(chatHistory));

--- a/webui/src/hooks/chat/tests/use-chat-retry.test.ts
+++ b/webui/src/hooks/chat/tests/use-chat-retry.test.ts
@@ -815,6 +815,49 @@ describe("useChat", () => {
       await stoppedSend;
     });
 
+    it("waits for the in-flight connect before streaming on an adopted client", async () => {
+      // The newer turn finds a client and skips its own init, but that client's
+      // initialize() — the MCP connect — hasn't resolved yet. Streaming there
+      // would send before the tool catalog landed, so the turn waits it out.
+      let releaseInit!: () => void;
+      let releaseStreams!: () => void;
+      const connecting = new Promise<void>((resolve) => {
+        releaseInit = resolve;
+      });
+      const gate = new Promise<void>((resolve) => {
+        releaseStreams = resolve;
+      });
+      const clients: MockChatClient[] = [];
+      const sent: string[] = [];
+      const adapter = trackingAdapter({ clients, sent, gate }, (c) => {
+        if (clients.length === 1) {
+          c.initialize = vi.fn(async () => await connecting);
+        }
+      });
+      const { result } = renderChat(propsWith(adapter));
+      const stoppedSend = act(async () => {
+        await result.current.handleSend("first");
+      });
+
+      await tick();
+      await stopResponse(result);
+      void act(() => {
+        void result.current.handleSend("second");
+      });
+      await tick();
+
+      expect(clients).toHaveLength(1);
+      expect(sent).toStrictEqual([]);
+
+      releaseInit();
+      await tick();
+
+      expect(sent).toStrictEqual(["second"]);
+
+      releaseStreams();
+      await stoppedSend;
+    });
+
     it("doesn't let a superseded turn's setup dispose the newer turn's client", async () => {
       // Stop lands during the connection check, so the newer turn runs its own
       // init and streams. The stopped turn's setup resumes afterward: replacing

--- a/webui/src/hooks/chat/use-chat.ts
+++ b/webui/src/hooks/chat/use-chat.ts
@@ -6,6 +6,7 @@
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import { type UIMessage } from "#webui/types/messages";
 import {
+  connectClient,
   filterOverrides,
   resolveInitConnection,
   runChatTurn,
@@ -69,6 +70,11 @@ export function useChat<
   } = useMessageQueue();
   const [toolLimitReached, setToolLimitReached] = useState(false);
   const clientRef = useRef<TClient | null>(null);
+  // The in-flight client.initialize() of whichever turn built the current
+  // client, or null once it settles. clientRef is assigned before that connect
+  // resolves, so a turn that finds a client still has to wait on this before
+  // streaming; see the send path below.
+  const pendingInitRef = useRef<Promise<void> | null>(null);
   const pendingHistoryRef = useRef<TMessage[] | null>(null);
   // Bootstraps a client from pending history when compaction is requested on a
   // restored-but-not-yet-sent conversation. Held in a ref because useCompaction
@@ -213,7 +219,7 @@ export function useChat<
       // can already be here.
       clientRef.current?.dispose?.();
       clientRef.current = adapter.createClient(init.apiKey, config);
-      await clientRef.current.initialize();
+      await connectClient(clientRef.current, pendingInitRef);
       lockSettings({
         model: init.model,
         provider: init.provider,
@@ -321,6 +327,12 @@ export function useChat<
 
             pendingHistoryRef.current = null;
             await initializeChat(pendingHistory, sendOptions, stillCurrent);
+          } else if (pendingInitRef.current) {
+            // A client is here but another turn is still connecting it — the
+            // user stopped that turn mid-connect (which re-enables the composer)
+            // and re-sent. Adopt the client, but wait for its connect: streaming
+            // now would send before the MCP tool catalog has landed.
+            await pendingInitRef.current;
           }
 
           // Superseded while setting up: the user stopped this turn mid-connect


### PR DESCRIPTION
Fixes [AJM-891](https://linear.app/adamjmurray/issue/AJM-891/newer-chat-turn-can-stream-on-a-client-whose-initialize-hasnt-resolved).

## The race

`initializeChat` assigns `clientRef.current` *before* awaiting `client.initialize()` (the MCP connect), and `handleSend` skipped client setup entirely whenever it found a non-null `clientRef`.

So: turn A sets `clientRef.current`, then suspends in `await initialize()`. Stop re-enables the composer, the user re-sends, and turn B sees a client, skips init, and streams on one whose connect hasn't resolved — possibly without its tool catalog.

## The fix

B awaits the in-flight init rather than skipping it. The connecting turn owns the promise: a new `connectClient()` helper publishes it to `pendingInitRef` and clears it on settle, unless a newer init already replaced it. `handleSend` awaits it in the `else` branch of the existing setup check, then falls into the `stillCurrent()` re-check that was already there for the run-your-own-init path.

The helper lives in `streaming-helpers.ts` rather than inline because `use-chat.ts` was two lines under its 325-line cap.

## Tests

New case in the "overlapping turns during setup" group: nothing streams while the connect is pending, and the newer turn's message goes out once it resolves. Verified it fails on the unpatched hook.

`npm run fix`, `check`, `check:build`, and `ui:test` all pass.

## Follow-up

[AJM-927](https://linear.app/adamjmurray/issue/AJM-927/superseded-init-can-lock-its-own-settings-over-the-newer-turns) covers the other hole in this window — a superseded init still calls `lockSettings()` on its way out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)