### PR TITLE
Subagent follow-ups: withheld tools on briefing failure, stale subagent preset id

### DIFF
--- a/dev/Architecture.md
+++ b/dev/Architecture.md
@@ -339,6 +339,8 @@ Two things move the blob out of message history and into the system prompt:
 Every failure path — server down, Live unreachable (the route answers 502),
 malformed body — resolves to no briefing, and the worker keeps `ppal-connect`
 and bootstraps itself the old way. A worker with neither is blind.
+`ppal-context` is not handed back with it: workers never get that one, briefed
+or not, so a parallel fan-out can't race on the user's context store.
 
 ## Build System
 

--- a/dev/Chat-UI.md
+++ b/dev/Chat-UI.md
@@ -376,9 +376,11 @@ overview, the skills for its toolset and notation, and the user's context
 layers, fetched once from `GET /subagent-briefing`
 (`subagent/subagent-briefing.ts`). That replaces the `ppal-connect` call each
 worker used to make, so `ppal-connect` and `ppal-context` are withheld from a
-briefed worker. If the briefing can't be fetched, both stay enabled and the
-worker bootstraps itself as before — see Architecture.md → Subagent briefings
-for why the blob belongs in the system prompt.
+briefed worker. If the briefing can't be fetched, `ppal-connect` comes back and
+the worker bootstraps itself as before; `ppal-context` stays withheld either
+way, since it's withheld to keep parallel workers off the user's context store
+rather than because the briefing replaced it — see Architecture.md → Subagent
+briefings for why the blob belongs in the system prompt.
 
 **Formatting:**
 

--- a/webui/src/chat/sdk/subagent/spawn-subagent-tool.ts
+++ b/webui/src/chat/sdk/subagent/spawn-subagent-tool.ts
@@ -111,9 +111,9 @@ export interface SpawnSubagentDeps {
   /**
    * Fetch the worker's system-prompt briefing (skills, Live Set, context) for a
    * resolved worker config. Resolving null — or omitting this dep entirely —
-   * leaves the worker to bootstrap itself with ppal-connect, which is the
-   * pre-briefing behavior and the required fallback when the server or Live
-   * can't be reached.
+   * leaves the worker to bootstrap itself with ppal-connect, the required
+   * fallback when the server or Live can't be reached. ppal-context is not
+   * handed back with it; see resolveWorkerConfig.
    */
   getBriefing?: (
     config: ChatClientConfig,
@@ -238,9 +238,7 @@ export function createSpawnSubagentTool(deps: SpawnSubagentDeps): Tool {
  *
  * Without a briefing the worker gets ppal-connect back, since one with neither
  * knows nothing about the Live Set it is about to edit — but only that one.
- * ppal-context stays withheld either way: it's withheld to keep parallel workers
- * off the user's context store, which has nothing to do with whether the briefing
- * arrived.
+ * ALWAYS_WITHHELD_TOOLS is withheld for a reason the briefing has no bearing on.
  *
  * @param deps - The tool's injected dependencies
  * @param session - Recorded session to continue; omit to start fresh

--- a/webui/src/chat/sdk/subagent/spawn-subagent-tool.ts
+++ b/webui/src/chat/sdk/subagent/spawn-subagent-tool.ts
@@ -10,7 +10,11 @@ import {
   isToolEnabled,
   SPAWN_SUBAGENT_TOOL_NAME,
 } from "#webui/lib/utils/enabled-tools";
-import { withBriefing, withheldToolsApplied } from "./subagent-briefing";
+import {
+  alwaysWithheldApplied,
+  withBriefing,
+  withheldToolsApplied,
+} from "./subagent-briefing";
 
 /**
  * Safety/cost cap on worker spawn ATTEMPTS one orchestrator TURN may make,
@@ -230,10 +234,13 @@ export function createSpawnSubagentTool(deps: SpawnSubagentDeps): Tool {
  * The order matters and is not interchangeable. The withheld tools are applied
  * FIRST because the briefing request reads its toolset off the config — asking
  * for a briefing before withholding ppal-context would ship the worker guidance
- * for a tool it won't have. They are only KEPT when a briefing came back: a
- * worker with neither a briefing nor ppal-connect knows nothing about the Live
- * Set it is about to edit, which is strictly worse than the round-trip this
- * whole path exists to avoid.
+ * for a tool it won't have.
+ *
+ * Without a briefing the worker gets ppal-connect back, since one with neither
+ * knows nothing about the Live Set it is about to edit — but only that one.
+ * ppal-context stays withheld either way: it's withheld to keep parallel workers
+ * off the user's context store, which has nothing to do with whether the briefing
+ * arrived.
  *
  * @param deps - The tool's injected dependencies
  * @param session - Recorded session to continue; omit to start fresh
@@ -247,12 +254,14 @@ async function resolveWorkerConfig(
 ): Promise<ChatClientConfig> {
   const inherited = buildWorkerConfig(deps.config, session);
 
-  if (!deps.getBriefing) return inherited;
+  if (!deps.getBriefing) return alwaysWithheldApplied(inherited);
 
   const narrowed = withheldToolsApplied(inherited);
   const briefing = await deps.getBriefing(narrowed, abortSignal);
 
-  return briefing == null ? inherited : withBriefing(narrowed, briefing);
+  return briefing == null
+    ? alwaysWithheldApplied(inherited)
+    : withBriefing(narrowed, briefing);
 }
 
 /**

--- a/webui/src/chat/sdk/subagent/subagent-briefing.ts
+++ b/webui/src/chat/sdk/subagent/subagent-briefing.ts
@@ -23,18 +23,33 @@ import { type ChatClientConfig } from "#webui/chat/sdk/types";
 import { getSubagentBriefingUrl } from "#webui/utils/mcp-url";
 
 /**
- * The tools a briefed worker does without. `ppal-connect` is what the briefing
- * replaces; `ppal-context` reads and writes the user's context and memory, which
- * is the orchestrator's business — a worker gets the context it needs handed to
- * it, and letting a parallel fan-out of workers write to a
- * whole-document-replacing store is a race with the user's own notes as the
- * stake.
+ * The tools no worker ever gets, briefed or not. `ppal-context` reads and writes
+ * the user's context and memory, which is the orchestrator's business — a worker
+ * gets the context it needs handed to it, and letting a parallel fan-out of
+ * workers write to a whole-document-replacing store is a race with the user's own
+ * notes as the stake. That race has nothing to do with the briefing, so these
+ * stay withheld on the no-briefing path too.
+ */
+export const ALWAYS_WITHHELD_TOOLS = ["ppal-context"] as const;
+
+/**
+ * The tools the briefing replaces, withheld only when one came back: a worker
+ * with neither a briefing nor `ppal-connect` knows nothing about the Live Set it
+ * is about to edit.
+ */
+export const BRIEFING_REPLACED_TOOLS = ["ppal-connect"] as const;
+
+/**
+ * Everything a briefed worker does without.
  *
- * Withholding them also shortens the briefing itself: the server drops the
- * skills fragments that teach a withheld tool, so the same list that removes
+ * Withholding also shortens the briefing itself: the server drops the skills
+ * fragments that teach a withheld tool, so the same list that removes
  * ppal-context removes its guidance.
  */
-export const WORKER_WITHHELD_TOOLS = ["ppal-connect", "ppal-context"] as const;
+export const WORKER_WITHHELD_TOOLS = [
+  ...ALWAYS_WITHHELD_TOOLS,
+  ...BRIEFING_REPLACED_TOOLS,
+] as const;
 
 /**
  * Fetch the briefing for a worker about to run under `config`.
@@ -94,9 +109,37 @@ export async function fetchSubagentBriefing(
 export function withheldToolsApplied(
   config: ChatClientConfig,
 ): ChatClientConfig {
+  return withoutTools(config, WORKER_WITHHELD_TOOLS);
+}
+
+/**
+ * The worker config with only {@link ALWAYS_WITHHELD_TOOLS} switched off — what
+ * a worker runs under when no briefing came back. It keeps `ppal-connect` to
+ * bootstrap itself the old way, but still can't race its siblings writing the
+ * user's context.
+ *
+ * @param config - The worker config to narrow
+ * @returns A copy with the always-withheld tools disabled
+ */
+export function alwaysWithheldApplied(
+  config: ChatClientConfig,
+): ChatClientConfig {
+  return withoutTools(config, ALWAYS_WITHHELD_TOOLS);
+}
+
+/**
+ * Copy the config with `tools` disabled.
+ * @param config - The worker config to narrow
+ * @param tools - The tool ids to switch off
+ * @returns A copy with those tools disabled
+ */
+function withoutTools(
+  config: ChatClientConfig,
+  tools: readonly string[],
+): ChatClientConfig {
   const enabledTools = { ...config.enabledTools };
 
-  for (const tool of WORKER_WITHHELD_TOOLS) enabledTools[tool] = false;
+  for (const tool of tools) enabledTools[tool] = false;
 
   return { ...config, enabledTools };
 }

--- a/webui/src/chat/sdk/subagent/subagent-briefing.ts
+++ b/webui/src/chat/sdk/subagent/subagent-briefing.ts
@@ -99,12 +99,13 @@ export async function fetchSubagentBriefing(
 }
 
 /**
- * The worker config with {@link WORKER_WITHHELD_TOOLS} switched off. Applied
- * BEFORE fetching, because the fetch reads the toolset off this config; applied
- * to the config the worker actually runs under only when a briefing came back.
+ * The worker config with every {@link WORKER_WITHHELD_TOOLS} entry switched off.
+ * Applied BEFORE fetching, because the fetch reads the toolset off this config;
+ * applied to the config the worker actually runs under only when a briefing came
+ * back. Without one, use {@link alwaysWithheldApplied}.
  *
  * @param config - The worker config to narrow
- * @returns A copy with the briefing-replaced tools disabled
+ * @returns A copy with both withheld lists disabled
  */
 export function withheldToolsApplied(
   config: ChatClientConfig,
@@ -114,9 +115,8 @@ export function withheldToolsApplied(
 
 /**
  * The worker config with only {@link ALWAYS_WITHHELD_TOOLS} switched off — what
- * a worker runs under when no briefing came back. It keeps `ppal-connect` to
- * bootstrap itself the old way, but still can't race its siblings writing the
- * user's context.
+ * a worker runs under when no briefing came back, keeping `ppal-connect` to
+ * bootstrap itself the old way.
  *
  * @param config - The worker config to narrow
  * @returns A copy with the always-withheld tools disabled

--- a/webui/src/chat/sdk/tests/subagent/spawn-subagent-tool.test.ts
+++ b/webui/src/chat/sdk/tests/subagent/spawn-subagent-tool.test.ts
@@ -333,6 +333,19 @@ describe("createSpawnSubagentTool", () => {
     expect(workerConfig.chatHistory).toStrictEqual([]);
   });
 
+  it("withholds ppal-context even with no briefing to fetch", async () => {
+    // Nothing about the context store's write race depends on the briefing, so
+    // the tool withholds it on every path — here, one with no getBriefing dep.
+    const { tool, runWorker } = setup();
+
+    await tool.execute!({ task: "x" }, options());
+
+    const workerConfig = await firstCall(runWorker).resolveConfig();
+
+    expect(workerConfig.enabledTools?.["ppal-context"]).toBe(false);
+    expect(workerConfig.enabledTools?.["ppal-connect"]).toBeUndefined();
+  });
+
   it("forwards the tool-call id and abort signal to the worker", async () => {
     const { tool, runWorker } = setup();
     const controller = new AbortController();

--- a/webui/src/chat/sdk/tests/subagent/subagent-briefing.test.ts
+++ b/webui/src/chat/sdk/tests/subagent/subagent-briefing.test.ts
@@ -13,7 +13,10 @@ import { NOTATION_HEADER } from "#src/shared/notation";
 import { createSpawnSubagentTool } from "#webui/chat/sdk/subagent/spawn-subagent-tool";
 import { SPAWN_SUBAGENT_TOOL_NAME } from "#webui/lib/utils/enabled-tools";
 import {
+  ALWAYS_WITHHELD_TOOLS,
+  BRIEFING_REPLACED_TOOLS,
   WORKER_WITHHELD_TOOLS,
+  alwaysWithheldApplied,
   fetchSubagentBriefing,
   withBriefing,
   withheldToolsApplied,
@@ -134,6 +137,31 @@ describe("withheldToolsApplied", () => {
   });
 });
 
+describe("alwaysWithheldApplied", () => {
+  it("switches off only the tools no worker ever gets", () => {
+    const narrowed = alwaysWithheldApplied(createConfig());
+
+    for (const tool of ALWAYS_WITHHELD_TOOLS) {
+      expect(narrowed.enabledTools?.[tool]).toBe(false);
+    }
+
+    // The briefing-replaced ones are left alone — that's the whole difference.
+    for (const tool of BRIEFING_REPLACED_TOOLS) {
+      expect(narrowed.enabledTools?.[tool]).toBeUndefined();
+    }
+  });
+
+  it("leaves the rest of the toolset alone and doesn't mutate the input", () => {
+    const config = createConfig({
+      enabledTools: { "ppal-read-clip": true, "ppal-context": true },
+    });
+    const narrowed = alwaysWithheldApplied(config);
+
+    expect(narrowed.enabledTools?.["ppal-read-clip"]).toBe(true);
+    expect(config.enabledTools?.["ppal-context"]).toBe(true);
+  });
+});
+
 describe("withBriefing", () => {
   it("appends to the inherited system instruction rather than replacing it", () => {
     const briefed = withBriefing(
@@ -214,15 +242,18 @@ describe("spawn_subagent briefing wiring", () => {
     }
   });
 
-  it("keeps ppal-connect when no briefing came back", async () => {
+  it("keeps ppal-connect — but not ppal-context — when no briefing came back", async () => {
     // A worker with neither a briefing nor a way to connect knows nothing about
-    // the Live Set it is about to edit.
+    // the Live Set it is about to edit. ppal-context is withheld for a different
+    // reason (parallel workers racing on the user's context store), so a failed
+    // briefing must not hand it back.
     getBriefing.mockResolvedValue(null);
 
     await spawn();
 
     expect(workerConfig?.systemInstruction).toBe("Base prompt.");
     expect(workerConfig?.enabledTools?.["ppal-connect"]).toBeUndefined();
+    expect(workerConfig?.enabledTools?.["ppal-context"]).toBe(false);
   });
 
   it("still applies the recursion guard over a briefed toolset", async () => {

--- a/webui/src/chat/sdk/tests/subagent/subagent-briefing.test.ts
+++ b/webui/src/chat/sdk/tests/subagent/subagent-briefing.test.ts
@@ -118,7 +118,7 @@ describe("fetchSubagentBriefing", () => {
 });
 
 describe("withheldToolsApplied", () => {
-  it("switches off the tools the briefing replaces", () => {
+  it("switches off everything a briefed worker does without", () => {
     const narrowed = withheldToolsApplied(createConfig());
 
     for (const tool of WORKER_WITHHELD_TOOLS) {
@@ -244,9 +244,8 @@ describe("spawn_subagent briefing wiring", () => {
 
   it("keeps ppal-connect — but not ppal-context — when no briefing came back", async () => {
     // A worker with neither a briefing nor a way to connect knows nothing about
-    // the Live Set it is about to edit. ppal-context is withheld for a different
-    // reason (parallel workers racing on the user's context store), so a failed
-    // briefing must not hand it back.
+    // the Live Set it is about to edit. ppal-context is withheld for a reason
+    // the briefing has no bearing on, so a failure must not hand it back.
     getBriefing.mockResolvedValue(null);
 
     await spawn();

--- a/webui/src/components/settings/PresetControls.tsx
+++ b/webui/src/components/settings/PresetControls.tsx
@@ -4,6 +4,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { useState } from "preact/hooks";
+import {
+  loadSubagentPresetId,
+  saveSubagentPresetId,
+} from "#webui/hooks/settings/settings-helpers";
 import { presetMatchesFields } from "#webui/hooks/settings/presets/preset-storage";
 import { type PresetSelection } from "#webui/hooks/settings/presets/use-preset-selection";
 import { usePresetDraft } from "#webui/hooks/settings/presets/use-preset-draft";
@@ -135,15 +139,7 @@ export function PresetControls({
           // the list, and clearing here would drop the user out of Update/Delete
           // with only the error notice to say why.
           if (selected && deletePreset(selected.id) != null) return;
-
-          // Drop the Subagent-preset pointer with the preset it names, so a
-          // dangling id can't outlive it in storage. Buffered like every other
-          // setting (it lands on the footer Save) even though the delete itself
-          // already hit storage — the split this tab warns about.
-          if (selected?.id === settings.subagentPresetId) {
-            settings.setSubagentPresetId(null);
-          }
-
+          if (selected) clearSubagentPreset(settings, selected.id);
           setSelectedId("");
           setEditDescription("");
         }}
@@ -195,6 +191,31 @@ export function PresetControls({
       />
     </div>
   );
+}
+
+/**
+ * Drop the Subagent-preset pointer at a just-deleted preset, in both places it
+ * lives.
+ *
+ * Storage is written directly rather than left to the footer Save, because the
+ * delete already landed there: buffering the clear alone would let a Cancel —
+ * which re-reads this value from storage — restore an id naming nothing.
+ *
+ * The two are tested separately because they can disagree. With an unsaved pick
+ * in the buffer, storage still holds the last saved one, and deleting either
+ * preset must clear only the copy that named it.
+ * @param settings - The live settings buffer
+ * @param deletedId - The preset that was just deleted
+ */
+function clearSubagentPreset(
+  settings: UseSettingsReturn,
+  deletedId: string,
+): void {
+  if (settings.subagentPresetId === deletedId) {
+    settings.setSubagentPresetId(null);
+  }
+
+  if (loadSubagentPresetId() === deletedId) saveSubagentPresetId(null);
 }
 
 /**

--- a/webui/src/components/settings/PresetControls.tsx
+++ b/webui/src/components/settings/PresetControls.tsx
@@ -135,6 +135,15 @@ export function PresetControls({
           // the list, and clearing here would drop the user out of Update/Delete
           // with only the error notice to say why.
           if (selected && deletePreset(selected.id) != null) return;
+
+          // Drop the Subagent-preset pointer with the preset it names, so a
+          // dangling id can't outlive it in storage. Buffered like every other
+          // setting (it lands on the footer Save) even though the delete itself
+          // already hit storage — the split this tab warns about.
+          if (selected?.id === settings.subagentPresetId) {
+            settings.setSubagentPresetId(null);
+          }
+
           setSelectedId("");
           setEditDescription("");
         }}

--- a/webui/src/components/settings/tests/PresetControls.test.tsx
+++ b/webui/src/components/settings/tests/PresetControls.test.tsx
@@ -387,6 +387,58 @@ describe("PresetControls", () => {
     );
   });
 
+  it("clears the Subagent preset when the preset it names is deleted", () => {
+    savePresets([seeded]);
+    const setSubagentPresetId = vi.fn();
+
+    render(
+      <Controls
+        settings={makeSettings({
+          subagentPresetId: "seed",
+          setSubagentPresetId,
+        })}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("preset-select"), {
+      target: { value: "seed" },
+    });
+    fireEvent.click(screen.getByTestId("preset-delete"));
+
+    expect(setSubagentPresetId).toHaveBeenCalledWith(null);
+  });
+
+  it("keeps the Subagent preset when the delete misses it or fails", () => {
+    savePresets([seeded, { ...seeded, id: "other", name: "Other" }]);
+    const setSubagentPresetId = vi.fn();
+    const settings = { subagentPresetId: "other", setSubagentPresetId };
+
+    const { unmount } = render(<Controls settings={makeSettings(settings)} />);
+
+    // Deleting a different preset leaves the pointer alone.
+    fireEvent.change(screen.getByTestId("preset-select"), {
+      target: { value: "seed" },
+    });
+    fireEvent.click(screen.getByTestId("preset-delete"));
+    expect(setSubagentPresetId).not.toHaveBeenCalled();
+    unmount();
+
+    // And a delete that never reached storage must not clear it either — the
+    // preset it names is still there.
+    render(
+      <Controls
+        settings={makeSettings({ ...settings, subagentPresetId: "other" })}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("preset-select"), {
+      target: { value: "other" },
+    });
+    breakStorageWrites();
+    fireEvent.click(screen.getByTestId("preset-delete"));
+
+    expect(setSubagentPresetId).not.toHaveBeenCalled();
+  });
+
   it("offers Inherit plus every preset in the Subagent preset selector", () => {
     savePresets([seeded]);
     render(<Controls settings={makeSettings({ subagentPresetId: "seed" })} />);

--- a/webui/src/components/settings/tests/PresetControls.test.tsx
+++ b/webui/src/components/settings/tests/PresetControls.test.tsx
@@ -18,6 +18,10 @@ import {
   savePresets,
 } from "#webui/hooks/settings/presets/preset-storage";
 import { usePresetSelection } from "#webui/hooks/settings/presets/use-preset-selection";
+import {
+  loadSubagentPresetId,
+  saveSubagentPresetId,
+} from "#webui/hooks/settings/settings-helpers";
 import { breakStorageWrites } from "#webui/test-utils/dom-test-helpers";
 import { type ChatPreset, type UseSettingsReturn } from "#webui/types/settings";
 
@@ -387,8 +391,20 @@ describe("PresetControls", () => {
     );
   });
 
-  it("clears the Subagent preset when the preset it names is deleted", () => {
+  /**
+   * Select a preset and press Delete.
+   * @param id - The preset to delete
+   */
+  function deletePreset(id: string): void {
+    fireEvent.change(screen.getByTestId("preset-select"), {
+      target: { value: id },
+    });
+    fireEvent.click(screen.getByTestId("preset-delete"));
+  }
+
+  it("clears the Subagent preset from the buffer and storage", () => {
     savePresets([seeded]);
+    saveSubagentPresetId("seed");
     const setSubagentPresetId = vi.fn();
 
     render(
@@ -399,44 +415,72 @@ describe("PresetControls", () => {
         })}
       />,
     );
-
-    fireEvent.change(screen.getByTestId("preset-select"), {
-      target: { value: "seed" },
-    });
-    fireEvent.click(screen.getByTestId("preset-delete"));
+    deletePreset("seed");
 
     expect(setSubagentPresetId).toHaveBeenCalledWith(null);
+    // Storage too, not just the buffer: Cancel re-reads this value, and would
+    // otherwise restore an id naming a preset that no longer exists.
+    expect(loadSubagentPresetId()).toBeNull();
   });
 
-  it("keeps the Subagent preset when the delete misses it or fails", () => {
+  it("clears storage only, when an unsaved pick named another preset", () => {
     savePresets([seeded, { ...seeded, id: "other", name: "Other" }]);
+    saveSubagentPresetId("seed");
     const setSubagentPresetId = vi.fn();
-    const settings = { subagentPresetId: "other", setSubagentPresetId };
 
-    const { unmount } = render(<Controls settings={makeSettings(settings)} />);
-
-    // Deleting a different preset leaves the pointer alone.
-    fireEvent.change(screen.getByTestId("preset-select"), {
-      target: { value: "seed" },
-    });
-    fireEvent.click(screen.getByTestId("preset-delete"));
-    expect(setSubagentPresetId).not.toHaveBeenCalled();
-    unmount();
-
-    // And a delete that never reached storage must not clear it either — the
-    // preset it names is still there.
     render(
       <Controls
-        settings={makeSettings({ ...settings, subagentPresetId: "other" })}
+        settings={makeSettings({
+          subagentPresetId: "other",
+          setSubagentPresetId,
+        })}
       />,
     );
-    fireEvent.change(screen.getByTestId("preset-select"), {
-      target: { value: "other" },
-    });
-    breakStorageWrites();
-    fireEvent.click(screen.getByTestId("preset-delete"));
+    deletePreset("seed");
 
+    // The buffer names a preset that still exists, so it survives untouched.
     expect(setSubagentPresetId).not.toHaveBeenCalled();
+    expect(loadSubagentPresetId()).toBeNull();
+  });
+
+  it("clears the buffer only, when the saved id named another preset", () => {
+    savePresets([seeded, { ...seeded, id: "other", name: "Other" }]);
+    saveSubagentPresetId("other");
+    const setSubagentPresetId = vi.fn();
+
+    render(
+      <Controls
+        settings={makeSettings({
+          subagentPresetId: "seed",
+          setSubagentPresetId,
+        })}
+      />,
+    );
+    deletePreset("seed");
+
+    expect(setSubagentPresetId).toHaveBeenCalledWith(null);
+    expect(loadSubagentPresetId()).toBe("other");
+  });
+
+  it("keeps the Subagent preset when the delete can't be written", () => {
+    savePresets([seeded]);
+    saveSubagentPresetId("seed");
+    const setSubagentPresetId = vi.fn();
+
+    render(
+      <Controls
+        settings={makeSettings({
+          subagentPresetId: "seed",
+          setSubagentPresetId,
+        })}
+      />,
+    );
+    breakStorageWrites();
+    deletePreset("seed");
+
+    // The preset is still there, so the pointer at it is still good.
+    expect(setSubagentPresetId).not.toHaveBeenCalled();
+    expect(loadSubagentPresetId()).toBe("seed");
   });
 
   it("offers Inherit plus every preset in the Subagent preset selector", () => {


### PR DESCRIPTION
Two small subagent items from the 2.1.0 pre-release review ([AJM-886](https://linear.app/adamjmurray/issue/AJM-886/subagent-follow-ups-from-the-210-review)). Neither is a regression.

### `ppal-context` no longer comes back when a briefing fails

A worker is denied `ppal-context` to keep a parallel fan-out from racing on the user's context store — a reason that has nothing to do with the briefing. But the fallback path handed the whole withheld list back, so a failed briefing re-enabled it.

The list is now split into `ALWAYS_WITHHELD_TOOLS` (`ppal-context`) and `BRIEFING_REPLACED_TOOLS` (`ppal-connect`), with `WORKER_WITHHELD_TOOLS` as their union. Without a briefing, only `ppal-connect` comes back — a worker with neither that nor a briefing knows nothing about the Live Set it is about to edit, which is still the thing the fallback exists to prevent.

### The Subagent preset id is cleared when its preset is deleted

The dangling id was handled gracefully everywhere that read it (the picker fell back to "Inherit", the resolver ignored it), but it lingered in storage with nothing left to name.

It is cleared in both places it lives — the settings buffer and storage. Writing storage directly is deliberate: the delete already landed there, so buffering the clear alone would let a Cancel (which re-reads that value) restore the dangling id. The two copies are tested separately because an unsaved pick can leave them disagreeing, and only the copy that named the deleted preset should clear.

One knock-on worth knowing: clearing the buffer makes the settings modal dirty, so after deleting the named preset, Esc and backdrop-click stop dismissing it until you Save or Cancel. Both exits now land on the correct cleared state.

### Notes

- Three commits, each pushed on its own for a separate green CI build. Please **merge, not squash**.
- Reviewed by a subagent; the third commit is that review's fixes.
- Split out of the ticket rather than fixed here: [AJM-925](https://linear.app/adamjmurray/issue/AJM-925/cap-the-size-of-a-subagents-final-message) (size cap on a worker's final message), [AJM-926](https://linear.app/adamjmurray/issue/AJM-926/a-tool-call-abandoned-mid-flight-shows-a-permanently-working-card) (the permanently "working…" card — the general dangling-tool-call behavior), and [AJM-928](https://linear.app/adamjmurray/issue/AJM-928/memory-index-points-at-ppal-context-even-when-its-withheld) (the connect memory index names `ppal-context` even when it's withheld — pre-existing, also reachable from the Tools tab, but this PR adds a second way in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)