### PR TITLE
fix(webui): say a tool was interrupted, not canceled, when the stream fails

### DIFF
--- a/webui/src/chat/sdk/build-model-messages.ts
+++ b/webui/src/chat/sdk/build-model-messages.ts
@@ -150,10 +150,10 @@ function appendAssistantMessages(
   });
 
   // Tool message pairing EVERY tool-call with a result (required by providers
-  // for multi-turn). buildToolResultContent backfills a canceled result for
-  // any call the user stopped before it returned, so a persisted "stopped
-  // mid-tool" history can still be sent without a provider 400. (This runs
-  // before the stream's reconcile, so it must not assume a complete history.)
+  // for multi-turn). buildToolResultContent backfills a placeholder for any call
+  // still missing one, so a history persisted mid-tool can be sent without a
+  // provider 400. (This runs before the stream's reconcile, so it must not
+  // assume a complete history.)
   messages.push({
     role: "tool",
     content: buildToolResultContent(msg),
@@ -240,10 +240,14 @@ export function reconcileDanglingToolCalls(
 
 /**
  * Build tool result content for the tool role message, one part per tool-call
- * (not per recorded result). A call with a recorded result emits it; a call the
- * user stopped before it returned emits a synthetic "canceled" result. This
- * guarantees no assistant tool-call is left without a matching tool-result,
- * which Anthropic/OpenAI reject with a 400.
+ * (not per recorded result). A call with a recorded result emits it; one without
+ * gets a synthetic result, so no assistant tool-call is left unmatched (which
+ * Anthropic/OpenAI reject with a 400).
+ *
+ * The synthetic one says the request failed rather than that the user canceled,
+ * because reaching here means the turn's reconcile never ran — a history saved
+ * mid-tool and reloaded (autosave fires on the first tool-call part), which says
+ * nothing about who ended the turn.
  * @param msg - Assistant message with tool calls
  * @returns Array of ToolResultPart, one per tool-call, in tool-call order
  */
@@ -256,7 +260,7 @@ function buildToolResultContent(msg: ChatMessage): ToolResultPart[] {
     const tr = resultsById.get(tc.id);
     const value =
       tr == null
-        ? CANCELED_TOOL_RESULT_TEXT
+        ? FAILED_TOOL_RESULT_TEXT
         : typeof tr.result === "string"
           ? tr.result
           : JSON.stringify(tr.result);

--- a/webui/src/chat/sdk/build-model-messages.ts
+++ b/webui/src/chat/sdk/build-model-messages.ts
@@ -21,6 +21,18 @@ export const CANCELED_TOOL_RESULT_TEXT =
   "Canceled by the user before this tool finished.";
 
 /**
+ * Placeholder for the other way a tool-call is left without a result: the
+ * stream failed under it (a rate limit, a dropped connection). Same job as
+ * CANCELED_TOOL_RESULT_TEXT, different truth — nobody canceled anything, and
+ * the tool may or may not have run before the stream died.
+ */
+export const FAILED_TOOL_RESULT_TEXT =
+  "The request failed before this tool finished; it may or may not have run.";
+
+/** Why a tool-call was left without a result. */
+export type DanglingToolReason = "canceled" | "failed";
+
+/**
  * Convert chat history to AI SDK ModelMessage format.
  * Assistant messages with tool calls produce two ModelMessages:
  * 1. assistant message with text + tool-call parts
@@ -183,18 +195,27 @@ export function endsOnAssistantTurn(
 }
 
 /**
- * Backfill a "canceled" tool-result for any tool-call in the streamed assistant
- * messages that never received one — i.e. the user pressed Stop while a tool was
- * still running. Without this, the dangling tool-call (a) makes the next request
- * fail with a provider 400 (unmatched tool_use) and (b) leaves the tool rendered
- * as perpetually running in the UI. A no-op when every call already has a result.
+ * Backfill a placeholder tool-result for any tool-call in the streamed assistant
+ * messages that never received one. Without this, the dangling tool-call (a)
+ * makes the next request fail with a provider 400 (unmatched tool_use) and (b)
+ * leaves the tool rendered as perpetually running in the UI. A no-op when every
+ * call already has a result.
+ *
+ * The caller says WHY, because the placeholder becomes history the model reads
+ * back: a resumed turn that was rate-limited must not be told the user canceled
+ * a tool they never touched.
  * @param history - The full chat history (mutated in place)
  * @param fromIndex - Index of the first message added by the current stream
+ * @param reason - Whether the user stopped the turn or the stream failed
  */
 export function reconcileDanglingToolCalls(
   history: ChatMessage[],
   fromIndex: number,
+  reason: DanglingToolReason,
 ): void {
+  const result =
+    reason === "canceled" ? CANCELED_TOOL_RESULT_TEXT : FAILED_TOOL_RESULT_TEXT;
+
   for (let i = fromIndex; i < history.length; i++) {
     const msg = history[i] as ChatMessage;
 
@@ -210,7 +231,7 @@ export function reconcileDanglingToolCalls(
         id: tc.id,
         name: tc.name,
         args: tc.args,
-        result: CANCELED_TOOL_RESULT_TEXT,
+        result,
         isError: false,
       });
     }

--- a/webui/src/chat/sdk/client.ts
+++ b/webui/src/chat/sdk/client.ts
@@ -461,6 +461,7 @@ export class ChatSdkClient {
 
     let completedSteps = 0;
     let finalFinishReason: FinishReason | undefined;
+    let streamFailed = false;
 
     try {
       for await (const part of stream) {
@@ -496,12 +497,28 @@ export class ChatSdkClient {
             .finishReason;
         }
       }
+    } catch (error) {
+      // An abort throws here too, so the throw alone says nothing about who
+      // ended the turn: the signal, or an AbortError from a stream aborted
+      // without one (a worker's, or a Stop the caller didn't route through us).
+      streamFailed = abortSignal?.aborted !== true && !isAbortError(error);
+
+      throw error;
     } finally {
-      // If the user pressed Stop mid-tool, the in-flight assistant message holds
-      // a tool-call with no tool-result. Backfill a "canceled" result so the
-      // history stays valid (providers reject an unmatched tool-call) and the UI
-      // doesn't render the tool as perpetually running. No-op on clean finishes.
-      reconcileDanglingToolCalls(this.chatHistory, historyLengthBefore);
+      // A stream that ended mid-tool leaves the in-flight assistant message
+      // holding a tool-call with no tool-result. Backfill one so the history
+      // stays valid (providers reject an unmatched tool-call) and the UI doesn't
+      // render the tool as perpetually running. No-op on clean finishes.
+      //
+      // The reason matters: a rate limit that lands between a tool-call and its
+      // result is retried by resuming this same history, so labeling it
+      // "canceled by the user" would hand the model a cancellation that never
+      // happened — and it may well tell the user it stopped for that reason.
+      reconcileDanglingToolCalls(
+        this.chatHistory,
+        historyLengthBefore,
+        streamFailed ? "failed" : "canceled",
+      );
       // Wait for any worker still unwinding. On a Stop with parallel spawns this
       // stream can close while a sibling's abort is still in flight — its
       // transcript reaches the stash in its own finally, which may not have run
@@ -510,7 +527,7 @@ export class ChatSdkClient {
       // the workers have actually stopped, not when the orchestrator's socket
       // does.
       await Promise.allSettled(this.spawnRuns);
-      // A stopped subagent's tool-result is one of those synthetic "canceled"
+      // A halted subagent's tool-result is one of those synthetic placeholder
       // entries, so it never passed through the mid-stream attach above. Hang the
       // worker's partial transcript off it here so its work log survives the Stop.
       attachStashedTranscripts(
@@ -548,6 +565,16 @@ export function detectToolLimitReached(
   maxSteps: number = MAX_TOOL_STEPS,
 ): boolean {
   return completedSteps >= maxSteps && finishReason === "tool-calls";
+}
+
+/**
+ * Whether a thrown value is the rejection an aborted stream produces — the same
+ * name check the UI's stream handler uses to tell a Stop from a real error.
+ * @param error - The value the stream threw
+ * @returns True when the stream was aborted rather than failing
+ */
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
 }
 
 /**

--- a/webui/src/chat/sdk/client.ts
+++ b/webui/src/chat/sdk/client.ts
@@ -461,6 +461,10 @@ export class ChatSdkClient {
 
     let completedSteps = 0;
     let finalFinishReason: FinishReason | undefined;
+    // The default is what labels a real Stop: the AI SDK answers an aborted
+    // signal by emitting an `abort` part and CLOSING the stream, so a Stop ends
+    // this loop normally and never reaches the catch below. Don't invert this to
+    // "failed unless proven otherwise" — that would mislabel every Stop.
     let streamFailed = false;
 
     try {
@@ -498,9 +502,11 @@ export class ChatSdkClient {
         }
       }
     } catch (error) {
-      // An abort throws here too, so the throw alone says nothing about who
-      // ended the turn: the signal, or an AbortError from a stream aborted
-      // without one (a worker's, or a Stop the caller didn't route through us).
+      // Only reached when the stream ERRORS, which is not the same as being
+      // aborted (see the default above). Both guards are still needed: an abort
+      // that raced the read arrives as a throw with our signal already set, and
+      // an abort raised without our signal — a worker's, or one the caller
+      // didn't route through this call — only says so by its error name.
       streamFailed = abortSignal?.aborted !== true && !isAbortError(error);
 
       throw error;

--- a/webui/src/chat/sdk/tests/client-test-helpers.ts
+++ b/webui/src/chat/sdk/tests/client-test-helpers.ts
@@ -40,3 +40,33 @@ export function mockStreamParts(parts: Record<string, unknown>[]): void {
     stream: iterate(),
   });
 }
+
+/**
+ * A stream that emits `parts` and then fails — how a provider stream ends when
+ * the turn is aborted or the request dies partway through.
+ * @param parts - Stream parts to emit before failing
+ * @param error - The error to throw after the last part
+ * @returns A streamText-shaped result
+ */
+export function failingAfterStream(
+  parts: Record<string, unknown>[],
+  error: unknown,
+): { stream: AsyncIterable<Record<string, unknown>> } {
+  async function* iterate(): AsyncIterable<Record<string, unknown>> {
+    for (const p of parts) yield p;
+
+    throw error;
+  }
+
+  return { stream: iterate() };
+}
+
+/**
+ * The error an aborted fetch/stream rejects with.
+ * @returns An AbortError
+ */
+export function abortError(): Error {
+  return Object.assign(new Error("The operation was aborted."), {
+    name: "AbortError",
+  });
+}

--- a/webui/src/chat/sdk/tests/client/client-stream-failure.test.ts
+++ b/webui/src/chat/sdk/tests/client/client-stream-failure.test.ts
@@ -1,0 +1,153 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("ai"), async (importOriginal) => {
+  const actual = await importOriginal();
+
+  return { ...actual, streamText: vi.fn(), generateText: vi.fn() };
+});
+
+vi.mock(import("#webui/chat/sdk/mcp-tools"), () => ({
+  createMcpTools: vi.fn().mockResolvedValue({ tools: {}, mcpClient: {} }),
+}));
+
+vi.mock(import("#webui/utils/mcp-url"), () => ({
+  getMcpUrl: vi.fn(() => "http://localhost:3000/mcp"),
+}));
+
+import { streamText } from "ai";
+import {
+  CANCELED_TOOL_RESULT_TEXT,
+  FAILED_TOOL_RESULT_TEXT,
+} from "#webui/chat/sdk/build-model-messages";
+import { ChatSdkClient } from "#webui/chat/sdk/client";
+import {
+  abortError,
+  createConfig,
+  failingAfterStream,
+  mockStreamParts,
+} from "#webui/chat/sdk/tests/client-test-helpers";
+import { type ChatMessage } from "#webui/chat/sdk/types";
+
+/** The tool-call part a turn emits just before the stream dies under it. */
+const TOOL_CALL_PART = {
+  type: "tool-call",
+  toolCallId: "tc1",
+  toolName: "ppal-create-clip",
+  input: {},
+};
+
+/**
+ * A stream that emits the tool-call and then aborts the turn — the shape a Stop
+ * mid-tool produces, where the signal is what says the user did it.
+ * @param controller - Aborted as the stream fails, as a real Stop would
+ * @returns A streamText-shaped result
+ */
+function stoppedMidTool(controller: AbortController): {
+  stream: AsyncIterable<Record<string, unknown>>;
+} {
+  async function* iterate(): AsyncIterable<Record<string, unknown>> {
+    yield TOOL_CALL_PART;
+    controller.abort();
+
+    throw abortError();
+  }
+
+  return { stream: iterate() };
+}
+
+/**
+ * Drive one turn whose stream dies mid-tool and return the resulting history.
+ * @param stream - The failing stream to serve
+ * @param abortSignal - Signal the turn runs under, when there is one
+ * @returns The client, so callers can read its history or resume it
+ */
+async function turnDyingMidTool(
+  stream: { stream: AsyncIterable<Record<string, unknown>> },
+  abortSignal?: AbortSignal,
+): Promise<ChatSdkClient> {
+  (streamText as ReturnType<typeof vi.fn>).mockReturnValue(stream);
+
+  const client = new ChatSdkClient("key", createConfig());
+
+  await expect(async () => {
+    for await (const _ of client.sendMessage("add a bass", abortSignal)) {
+      /* consume */
+    }
+  }).rejects.toThrow();
+
+  return client;
+}
+
+/**
+ * The synthetic result the reconcile left on the turn's dangling tool-call.
+ * @param client - The client whose turn died mid-tool
+ * @returns The backfilled result text
+ */
+function backfilledResult(client: ChatSdkClient): unknown {
+  const assistant = client.chatHistory.find(
+    (m: ChatMessage) => m.role === "assistant",
+  );
+
+  expect(assistant?.toolResults).toHaveLength(1);
+
+  return assistant?.toolResults?.[0]?.result;
+}
+
+describe("a stream that dies between a tool-call and its result", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("says the request failed when nobody canceled it", async () => {
+    // A 429 (or any mid-stream error) after the tool-call part. The turn is
+    // retried by resuming this history, so claiming the user canceled would put
+    // a statement in it that never happened.
+    const client = await turnDyingMidTool(
+      failingAfterStream([TOOL_CALL_PART], new Error("429 rate limit")),
+    );
+
+    expect(backfilledResult(client)).toBe(FAILED_TOOL_RESULT_TEXT);
+  });
+
+  it("still says canceled when the user pressed Stop", async () => {
+    const controller = new AbortController();
+    const client = await turnDyingMidTool(
+      stoppedMidTool(controller),
+      controller.signal,
+    );
+
+    expect(backfilledResult(client)).toBe(CANCELED_TOOL_RESULT_TEXT);
+  });
+
+  it("hands the retry the failure text, not a cancellation", async () => {
+    // The end of the bug: the resumed request ends on tool results, so the model
+    // is handed this text as the answer to the tool it never saw finish.
+    const client = await turnDyingMidTool(
+      failingAfterStream([TOOL_CALL_PART], new Error("429 rate limit")),
+    );
+
+    mockStreamParts([{ type: "finish", finishReason: "stop" }]);
+
+    for await (const _ of client.resumeStream()) {
+      /* consume */
+    }
+
+    const lastCall = (streamText as ReturnType<typeof vi.fn>).mock.calls.at(
+      -1,
+    )?.[0] as
+      | { messages: { role: string; content: { output: unknown }[] }[] }
+      | undefined;
+    const toolMsg = lastCall?.messages.at(-1);
+
+    expect(toolMsg?.role).toBe("tool");
+    expect(toolMsg?.content[0]?.output).toStrictEqual({
+      type: "text",
+      value: FAILED_TOOL_RESULT_TEXT,
+    });
+  });
+});

--- a/webui/src/chat/sdk/tests/client/client-stream-failure.test.ts
+++ b/webui/src/chat/sdk/tests/client/client-stream-failure.test.ts
@@ -42,19 +42,23 @@ const TOOL_CALL_PART = {
 };
 
 /**
- * A stream that emits the tool-call and then aborts the turn — the shape a Stop
- * mid-tool produces, where the signal is what says the user did it.
- * @param controller - Aborted as the stream fails, as a real Stop would
+ * A stream that emits the tool-call and then loses the race with an abort: the
+ * signal is already set when it throws. The AI SDK usually closes cleanly on an
+ * aborted signal instead (covered in client.test.ts), so this is the variant
+ * that reaches the catch with the signal — not the error — carrying the truth.
+ * @param controller - Aborted before the stream fails, as a Stop would
+ * @param error - What the stream throws once aborted
  * @returns A streamText-shaped result
  */
-function stoppedMidTool(controller: AbortController): {
-  stream: AsyncIterable<Record<string, unknown>>;
-} {
+function abortedMidTool(
+  controller: AbortController,
+  error: unknown,
+): { stream: AsyncIterable<Record<string, unknown>> } {
   async function* iterate(): AsyncIterable<Record<string, unknown>> {
     yield TOOL_CALL_PART;
     controller.abort();
 
-    throw abortError();
+    throw error;
   }
 
   return { stream: iterate() };
@@ -114,11 +118,23 @@ describe("a stream that dies between a tool-call and its result", () => {
     expect(backfilledResult(client)).toBe(FAILED_TOOL_RESULT_TEXT);
   });
 
-  it("still says canceled when the user pressed Stop", async () => {
+  it("still says canceled when our own signal was aborted", async () => {
+    // A plain Error, so the signal is the only thing saying this was a Stop.
+    // (An AbortError with no signal is the other canceled shape — a worker's
+    // abort, pinned in client-subagent-stop.test.ts.)
     const controller = new AbortController();
     const client = await turnDyingMidTool(
-      stoppedMidTool(controller),
+      abortedMidTool(controller, new Error("stream closed")),
       controller.signal,
+    );
+
+    expect(backfilledResult(client)).toBe(CANCELED_TOOL_RESULT_TEXT);
+  });
+
+  it("still says canceled for an AbortError raised without our signal", async () => {
+    const controller = new AbortController();
+    const client = await turnDyingMidTool(
+      abortedMidTool(controller, abortError()),
     );
 
     expect(backfilledResult(client)).toBe(CANCELED_TOOL_RESULT_TEXT);

--- a/webui/src/chat/sdk/tests/client/client-subagent-stop.test.ts
+++ b/webui/src/chat/sdk/tests/client/client-subagent-stop.test.ts
@@ -46,8 +46,10 @@ import { SPAWN_SUBAGENT_TOOL_NAME } from "#webui/lib/utils/enabled-tools";
 import { fetchSubagentBriefing } from "#webui/chat/sdk/subagent/subagent-briefing";
 import {
   abortError,
-  blockedAfterStream,
   failingAfterStream,
+} from "#webui/chat/sdk/tests/client-test-helpers";
+import {
+  blockedAfterStream,
   findSpawnEntry,
   orchestratorWithSpawnTool,
   streamTextMock,

--- a/webui/src/chat/sdk/tests/client/client.test.ts
+++ b/webui/src/chat/sdk/tests/client/client.test.ts
@@ -28,6 +28,7 @@ vi.mock(import("#webui/utils/mcp-url"), () => ({
 }));
 
 import { generateText, streamText } from "ai";
+import { FAILED_TOOL_RESULT_TEXT } from "#webui/chat/sdk/build-model-messages";
 import {
   ChatSdkClient,
   MAX_TOOL_STEPS,
@@ -626,17 +627,18 @@ describe("ChatSdkClient", () => {
       });
     });
 
-    it("synthesizes a canceled tool-result for a tool-call stopped mid-execution", async () => {
-      // User pressed Stop after the tool-call streamed but before the result:
-      // toolCalls present, toolResults missing. Sending again must still pair the
-      // tool-call with a result, or Anthropic/OpenAI reject the request (400).
+    it("synthesizes a tool-result for a tool-call left unfinished", async () => {
+      // A history saved mid-tool and reloaded: toolCalls present, toolResults
+      // missing, and the turn's reconcile never ran. Sending again must still
+      // pair the tool-call with a result, or Anthropic/OpenAI reject the request
+      // (400) — and it must not claim a cancellation it can't know about.
       const chatHistory: ChatMessage[] = [
         { role: "user", content: "Connect" },
         {
           role: "assistant",
           content: "Connecting",
           toolCalls: [{ id: "tc1", name: "ppal-connect", args: {} }],
-          // no toolResults — stopped mid-tool
+          // no toolResults — persisted mid-tool
         },
       ];
 
@@ -647,13 +649,13 @@ describe("ChatSdkClient", () => {
       expect(callArgs.messages[2].role).toBe("tool");
       expect(callArgs.messages[2].content).toHaveLength(1);
       expect(callArgs.messages[2].content[0].toolCallId).toBe("tc1");
-      expect(callArgs.messages[2].content[0].output.value).toContain(
-        "Canceled",
+      expect(callArgs.messages[2].content[0].output.value).toBe(
+        FAILED_TOOL_RESULT_TEXT,
       );
     });
 
     it("backfills only the missing result when some tool-calls completed", async () => {
-      // Two tools called; first returned, second interrupted by Stop.
+      // Two tools called; first returned, second left unfinished.
       const chatHistory: ChatMessage[] = [
         { role: "user", content: "Do two things" },
         {
@@ -686,14 +688,15 @@ describe("ChatSdkClient", () => {
       expect(toolMsg.content[0].toolCallId).toBe("tc1");
       expect(toolMsg.content[0].output.value).toBe("OK");
       expect(toolMsg.content[1].toolCallId).toBe("tc2");
-      expect(toolMsg.content[1].output.value).toContain("Canceled");
+      expect(toolMsg.content[1].output.value).toBe(FAILED_TOOL_RESULT_TEXT);
     });
 
     it("backfills a canceled result in history when the stream stops mid-tool", async () => {
-      // Stream emits a tool-call then ends with no tool-result (Stop pressed
-      // while the tool was running). The assistant message must not be left with
-      // a dangling tool-call — the in-history reconcile fixes the next send AND
-      // the perpetual-running UI state.
+      // The shape a real Stop takes: the AI SDK answers an aborted signal by
+      // closing the stream, so it simply ENDS after the tool-call with no
+      // tool-result and nothing thrown. The assistant message must not be left
+      // with a dangling tool-call — the in-history reconcile fixes the next send
+      // AND the perpetual-running UI state.
       const last = await sendWithParts([
         {
           type: "tool-call",

--- a/webui/src/chat/sdk/tests/client/subagent-test-helpers.ts
+++ b/webui/src/chat/sdk/tests/client/subagent-test-helpers.ts
@@ -61,26 +61,6 @@ export function spawnToolExecute(): SpawnExecute {
 }
 
 /**
- * A stream that emits `parts` and then fails — how a provider stream ends when
- * the turn is aborted partway through.
- * @param parts - Stream parts to emit before failing
- * @param error - The error to throw after the last part
- * @returns A streamText-shaped result
- */
-export function failingAfterStream(
-  parts: Record<string, unknown>[],
-  error: unknown,
-): { stream: AsyncIterable<Record<string, unknown>> } {
-  async function* iterate(): AsyncIterable<Record<string, unknown>> {
-    for (const p of parts) yield p;
-
-    throw error;
-  }
-
-  return { stream: iterate() };
-}
-
-/**
  * A stream that emits `parts`, then parks on `gate` before failing — a worker
  * whose abort is still unwinding after the orchestrator's stream has closed.
  * @param parts - Stream parts to emit before parking
@@ -102,16 +82,6 @@ export function blockedAfterStream(
   }
 
   return { stream: iterate() };
-}
-
-/**
- * The error an aborted fetch/stream rejects with.
- * @returns An AbortError
- */
-export function abortError(): Error {
-  return Object.assign(new Error("The operation was aborted."), {
-    name: "AbortError",
-  });
 }
 
 /**

--- a/webui/src/components/chat/assistant/tests/AssistantSubagentCall.test.tsx
+++ b/webui/src/components/chat/assistant/tests/AssistantSubagentCall.test.tsx
@@ -121,6 +121,23 @@ describe("AssistantSubagentCall", () => {
     expect(screen.queryByText("done")).toBeNull();
   });
 
+  it("reads as interrupted when the turn's request failed under the worker", () => {
+    // Not a Stop and not the worker's own failure: the orchestrator's stream
+    // died (a rate limit, a dropped connection) while this worker was running.
+    render(
+      <AssistantSubagentCall
+        task="rename tracks"
+        result={JSON.stringify(
+          "The request failed before this tool finished; it may or may not have run.",
+        )}
+        index={1}
+      />,
+    );
+
+    expect(screen.getByText("interrupted")).toBeDefined();
+    expect(screen.queryByText("done")).toBeNull();
+  });
+
   it("shows a failed status and red border on error", () => {
     const { container } = render(
       <AssistantSubagentCall task="x" result={"boom"} isError />,

--- a/webui/src/components/chat/assistant/tool-calls/AssistantSubagentCall.tsx
+++ b/webui/src/components/chat/assistant/tool-calls/AssistantSubagentCall.tsx
@@ -5,7 +5,10 @@
 
 import { type ComponentChildren } from "preact";
 import { useEffect, useState } from "preact/hooks";
-import { CANCELED_TOOL_RESULT_TEXT } from "#webui/chat/sdk/build-model-messages";
+import {
+  CANCELED_TOOL_RESULT_TEXT,
+  FAILED_TOOL_RESULT_TEXT,
+} from "#webui/chat/sdk/build-model-messages";
 import { SUBAGENT_LABEL_PATTERN } from "#webui/chat/sdk/subagent/spawn-subagent-tool";
 import {
   type SubagentRateLimitStatus,
@@ -69,10 +72,10 @@ export function AssistantSubagentCall({
   // A wait forced by a sibling's backoff (attempt null) is not this worker's own
   // rate limit — the docs promise that shared pause, so name it distinctly.
   const waiting = running && rateLimit != null;
-  // Stop mid-worker leaves the synthetic canceled result here, which is not a
+  // A turn that ended mid-worker leaves a synthetic result here, which is not a
   // failure and certainly not "done" — and the worker is resumable from this
   // card's transcript, so say what actually happened.
-  const stopped = !running && returnValue === CANCELED_TOOL_RESULT_TEXT;
+  const halted = running ? null : haltedStatus(returnValue);
   const status = waiting
     ? rateLimit.attempt == null
       ? "waiting"
@@ -81,9 +84,7 @@ export function AssistantSubagentCall({
       ? "working…"
       : isError
         ? "failed"
-        : stopped
-          ? "stopped"
-          : "done";
+        : (halted ?? "done");
 
   return (
     <details
@@ -210,6 +211,21 @@ function useSecondsUntil(targetMs: number): number {
   }, [targetMs]);
 
   return Math.max(0, Math.ceil(remainingMs / 1000));
+}
+
+/**
+ * Read a finished run's status off the synthetic result the reconcile left
+ * behind: the user stopping the turn and the request failing under it both cut
+ * the worker short, and they say different things.
+ * @param {string} returnValue - The unwrapped tool-result text
+ * @returns {string | null} Status label, or null for a real return value
+ */
+function haltedStatus(returnValue: string): string | null {
+  if (returnValue === CANCELED_TOOL_RESULT_TEXT) return "stopped";
+
+  if (returnValue === FAILED_TOOL_RESULT_TEXT) return "interrupted";
+
+  return null;
 }
 
 /**


### PR DESCRIPTION
Fixes AJM-831.

`reconcileDanglingToolCalls` backfilled "Canceled by the user before this tool finished." for every tool-call left without a result. It runs in `processStream`'s `finally`, which the error path goes through too — so a 429 landing between a tool-call part and its result wrote a cancellation nobody performed.

The retry then resumes on that history. Its wire form already ends on tool results, so `endsOnAssistantTurn` appends nothing and the model reads the placeholder as the tool's answer — and may tell the user it stopped because they canceled.

## The fix

The backfill is load-bearing (an unmatched `tool_use` is a provider 400, and the UI would otherwise render the tool as forever running), so the caller now says *why*:

- abort → the canceled text, unchanged
- error → `FAILED_TOOL_RESULT_TEXT`: "The request failed before this tool finished; it may or may not have run."

`ai` does not throw when our signal is aborted — it emits an `abort` part and closes the stream — so a real Stop ends the loop normally and is labeled by the `streamFailed = false` default. The new `catch` handles the two aborts that *do* throw: one that raced the read (our signal is already set), and one raised without our signal (only its `AbortError` name says so, the same check `streaming-helpers.ts` uses a layer up).

`buildToolResultContent` has its own fallback for a history whose tool-call has no recorded result, and it hardwired the same canceled text. That path is reachable without a crash: autosave fires on the first assistant content, which a tool-call part already satisfies, so a turn whose first output is a tool call persists a dangling call before the reconcile runs — reload in that window and the next send made the same false claim. Reaching that fallback means the reconcile never ran, which says nothing about who ended the turn, so it uses the failure text too.

The subagent card reads the new placeholder as "interrupted" instead of falling through to "done".

The ticket also floated checking whether the tool actually ran before labeling it. The stream never tells us that — a tool-result part is the only evidence — so the text says "may or may not have run" rather than guessing.

## Tests

New `client-stream-failure.test.ts` covers the three shapes the classification has to tell apart, plus the end-to-end one: after a mid-tool 429, the resumed request's tool message carries the failure text on the wire. Each half of the abort check is pinned on its own (a plain error with the signal set; an `AbortError` without it). `failingAfterStream`/`abortError` moved from `subagent-test-helpers.ts` to `client-test-helpers.ts` now that two suites use them.

`npm run fix`, `check` (100% function coverage), `check:build`, and `ui:test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)