### PR TITLE
fix(v8): absorb the config keys the device fans at V8

### DIFF
--- a/src/live-api-adapter/live-api-adapter.ts
+++ b/src/live-api-adapter/live-api-adapter.ts
@@ -125,7 +125,10 @@ Exception: ppal-connect takes args only — its signature intentionally dropped 
 (see the `connect(args)` line below), so it does not follow this pattern.
 */
 /* eslint-disable @typescript-eslint/no-explicit-any -- tools use dynamic dispatch with any types */
-const tools: Record<string, (args: unknown, ctx: ToolContext) => unknown> = {
+const toolDispatch: Record<
+  string,
+  (args: unknown, ctx: ToolContext) => unknown
+> = {
   "ppal-connect": (args) => connect(args as any),
   "ppal-read-live-set": (args, ctx) => readLiveSet(args as any, ctx),
   "ppal-update-live-set": (args, ctx) => updateLiveSet(args as any, ctx),
@@ -165,7 +168,7 @@ const tools: Record<string, (args: unknown, ctx: ToolContext) => unknown> = {
  * (STANDARD_TOOL_DEFS + the opt-in ppal-live-api) — a missing entry would make a
  * shipped tool fail at runtime with "Unknown tool".
  */
-export const DISPATCH_TOOL_NAMES: readonly string[] = Object.keys(tools);
+export const DISPATCH_TOOL_NAMES: readonly string[] = Object.keys(toolDispatch);
 
 /**
  * Call a tool by name with the given arguments and per-request context.
@@ -176,7 +179,7 @@ export const DISPATCH_TOOL_NAMES: readonly string[] = Object.keys(tools);
  * @returns Tool execution result
  */
 function callTool(toolName: string, args: object, ctx: ToolContext): unknown {
-  const tool = tools[toolName];
+  const tool = toolDispatch[toolName];
 
   if (!tool) {
     throw new Error(`Unknown tool: ${toolName}`);
@@ -319,6 +322,25 @@ export function sampleFolder(path: unknown): void {
 
   sessionState.sampleFolder = value;
 }
+
+// The device fans the server's whole config outlet at both V8 and the Setup
+// tab, so keys only the UI needs still arrive here. Max logs "no function <key>"
+// for a config message V8 doesn't export, so each one needs a setter even when
+// V8 ignores the value. Don't delete these as dead code — see the parity test in
+// tests/config-key-parity.test.ts.
+
+/**
+ * Ignore the Direct Live API flag. The tool gate is entirely server-side: the
+ * server decides whether to register ppal-live-api and rejects the name when
+ * it's off, so anything reaching V8 has already passed that gate.
+ */
+export function liveApiEnabled(): void {}
+
+/**
+ * Ignore the enabled-tools whitelist. The server filters tool calls against it
+ * before they reach V8.
+ */
+export function tools(): void {}
 
 /**
  * Send a response back to the MCP server

--- a/src/live-api-adapter/tests/config-key-parity.test.ts
+++ b/src/live-api-adapter/tests/config-key-parity.test.ts
@@ -19,15 +19,28 @@ import {
 // side may ignore a value, but it has to export a setter for it.
 const CONFIG_OUTLET = /Max\.outlet\(\s*"config"\s*,\s*"([^"]+)"/g;
 
+// The scan only sees a literal key spelled inline. A key routed through a
+// helper or a constant would vanish from it and the parity check below would
+// still pass on the rest, which is the drift this test exists to catch — so
+// pin the set. A failure here means either a new key (give V8 a setter and add
+// it) or a call the regex can no longer see (fix the scan).
+const BROADCAST_KEYS = [
+  "compactOutput",
+  "liveApiEnabled",
+  "notation",
+  "projectContext",
+  "sampleFolder",
+  "smallModelMode",
+  "tools",
+];
+
 describe("V8 config key parity", () => {
+  it("finds every config key the server broadcasts", () => {
+    expect(findConfigKeys()).toStrictEqual(BROADCAST_KEYS);
+  });
+
   it("exports a setter for every config key the server broadcasts", () => {
-    const keys = findConfigKeys();
-
-    // Guard against the scan silently matching nothing (a refactor renaming
-    // Max.outlet, say) and passing vacuously.
-    expect(keys.length).toBeGreaterThan(0);
-
-    const missing = keys.filter(
+    const missing = findConfigKeys().filter(
       (key) => typeof (adapter as Record<string, unknown>)[key] !== "function",
     );
 
@@ -48,10 +61,10 @@ describe("V8 config key parity", () => {
 function findConfigKeys(): string[] {
   const keys = new Set<string>();
 
-  for (const file of findSourceFiles(
-    path.join(projectRoot, "src/mcp-server"),
-    true,
-  )) {
+  // All of src/, not just src/mcp-server, so a config outlet added elsewhere
+  // still gets caught. This file's own regex can't self-match (it spells the
+  // call with an escaped paren) and test files are excluded anyway.
+  for (const file of findSourceFiles(path.join(projectRoot, "src"), true)) {
     const source = fs.readFileSync(file, "utf8");
 
     for (const [, key] of source.matchAll(CONFIG_OUTLET)) {

--- a/src/live-api-adapter/tests/config-key-parity.test.ts
+++ b/src/live-api-adapter/tests/config-key-parity.test.ts
@@ -1,0 +1,63 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import * as adapter from "#src/live-api-adapter/live-api-adapter.ts";
+import {
+  findSourceFiles,
+  projectRoot,
+} from "#src/test/helpers/meta-test-helpers.ts";
+
+// Every `Max.outlet("config", <key>, …)` the server emits lands on the v8 object
+// as a `<key> …` message, because the device patch wires the route's config
+// outlet to both v8 and the Setup tab. A key with no matching export makes Max
+// log "no function <key>" — silent to tests, loud in the Max console. The v8
+// side may ignore a value, but it has to export a setter for it.
+const CONFIG_OUTLET = /Max\.outlet\(\s*"config"\s*,\s*"([^"]+)"/g;
+
+describe("V8 config key parity", () => {
+  it("exports a setter for every config key the server broadcasts", () => {
+    const keys = findConfigKeys();
+
+    // Guard against the scan silently matching nothing (a refactor renaming
+    // Max.outlet, say) and passing vacuously.
+    expect(keys.length).toBeGreaterThan(0);
+
+    const missing = keys.filter(
+      (key) => typeof (adapter as Record<string, unknown>)[key] !== "function",
+    );
+
+    expect(missing).toStrictEqual([]);
+  });
+
+  it("accepts the keys V8 deliberately ignores", () => {
+    expect(() => adapter.liveApiEnabled()).not.toThrow();
+    expect(() => adapter.tools()).not.toThrow();
+  });
+});
+
+/**
+ * Scan the server sources for the config keys broadcast to Max.
+ *
+ * @returns Sorted, deduplicated config key names
+ */
+function findConfigKeys(): string[] {
+  const keys = new Set<string>();
+
+  for (const file of findSourceFiles(
+    path.join(projectRoot, "src/mcp-server"),
+    true,
+  )) {
+    const source = fs.readFileSync(file, "utf8");
+
+    for (const [, key] of source.matchAll(CONFIG_OUTLET)) {
+      if (key != null) keys.add(key);
+    }
+  }
+
+  return [...keys].sort();
+}


### PR DESCRIPTION
Fixes AJM-923.

## The bug is real, but not where the ticket says

The ticket blames `tab-setup.maxpat` for sending `liveApiEnabled $1` to the v8 object. It doesn't:

- The `direct-live-api` toggle → `liveApiEnabled $1` → **`s ---node-script`** only. Node has the handler (`create-express-app.ts`).
- The `route smallModelMode compactOutput sampleFolder liveApiEnabled notation` is fed by `r ---config` — that's the server→UI sync path that updates the toggle widget.

Both are correct and needed. The error comes from the other direction: in `Producer_Pal.amxd`, `route started config version update_available` wires its `config` outlet to **both** the v8 object and `s ---config`. So every `Max.outlet("config", key, …)` the server emits lands on V8 as a `key …` message, and V8 has no `liveApiEnabled` export.

Why it fires on every debug device load: the toggle defaults off, the device pushes `liveApiEnabled 0` to Node at `---node-started`, `ENABLE_LIVE_API=true` forces it back on, and the handler re-emits `config liveApiEnabled true` straight into V8.

**Not a regression.** V8 has never had that export on any branch — the broadcast arrived with the commit that replaced the build-time gate with the runtime flag.

**`tools` has the same hole.** `Max.outlet("config", "tools", …)` also reaches V8 unhandled; it just only fires when the chat UI changes the toolset, not at load. Fixed here too.

## The fix

V8 has no use for either value — the tool gate is entirely server-side (registration, name validation, REST), and V8's dispatch map carries `ppal-live-api` unconditionally, so anything reaching V8 already passed that gate. Both are therefore explicit ignores rather than stored state.

- `liveApiEnabled()` and `tools()` exported from `live-api-adapter.ts` as documented no-ops.
- Private dispatch map renamed `tools` → `toolDispatch` to free the export name.
- New `config-key-parity.test.ts` scans `src/mcp-server` for `Max.outlet("config", …)` and fails if a broadcast key has no V8 setter — so this class of bug can't come back silently.

## Testing

`npm run fix`, `npm run check` (11381 passed, 100% function coverage), and `npm run check:build` all pass.

Not verified in Ableton — the diagnosis is read off the patch wiring, not an observed console. Worth a `npm run build:debug` and device load to confirm the message is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)