### PR TITLE
perf(skills): cut the library fragment down to what its schema can't say

### DIFF
--- a/docs/guide/customizing-skills.md
+++ b/docs/guide/customizing-skills.md
@@ -51,31 +51,31 @@ release.
 Fragments are cut along the lines of what you're actually doing, so you can drop
 a whole area you never use:
 
-| Fragment                                         | What it teaches                                                                                               |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| `standard`                                       | The standard skills document — the list of `@include` lines below                                             |
-| `basic`                                          | The much shorter document used in small model mode                                                            |
-| `time-and-values`                                | Beats, note values, bar\|beat positions, clip lengths, and pitch names (C3=60)                                |
-| `transforms-core`                                | Selecting notes and setting values on them                                                                    |
-| `transforms-editing`                             | Editing a clip that already has notes: how `notes` merges, `preTransforms`, `quantizeGrid` (update-clip only) |
-| `transforms-expressions`                         | Transform variables, math functions, swing and quantize                                                       |
-| `transforms-generative`                          | ratchet/repeat/split/merge, and the waveforms that modulate a value across a clip                             |
-| `transforms-basic`                               | Merging into a clip and clearing notes with `preTransforms` — the whole transforms guide in small model mode  |
-| `library`                                        | Searching Live's browser library and your sample folder                                                       |
-| `devices`                                        | Device paths and VST/AU limits                                                                                |
-| `devices-write`                                  | Building Simpler and Drum Rack instruments — loading samples                                                  |
-| `specialized-devices`                            | The extra controls specific native devices expose (Drift, Wavetable, EQ Eight…)                               |
-| `arrangement`                                    | What an Arrangement position means — song meter vs. clip meter                                                |
-| `arrangement-write`                              | Moving and splitting clips on the Arrangement timeline, and take lanes                                        |
-| `working-with-live`                              | Session vs. Arrangement habits, playback, and general music-making advice                                     |
-| `context-standard` / `context-basic`             | [Context & Memory](/guide/context) — the project, global, and memory layers                                   |
-| `getting-help`                                   | What to tell you when a request is outside Producer Pal's reach                                               |
-| `getting-help-basic`                             | The audio limits worth saying out loud, in small model mode                                                   |
-| `barbeat-standard` / `barbeat-basic`             | The bar\|beat note notation guide (default notation)                                                          |
-| `barbeat-standard-write` / `barbeat-basic-write` | The bar\|beat syntax used only to _write_ notes — repeats, brackets, bar copying, examples                    |
-| `stark-standard` / `stark-basic`                 | The stark note notation guide                                                                                 |
-| `stark-standard-write` / `stark-basic-write`     | Stark chord symbols (`Am`, `G7`, `Ebm7`) — input only, since read-back returns literal notes                  |
-| `midi-json`                                      | The midi-json note notation guide                                                                             |
+| Fragment                                         | What it teaches                                                                                                |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `standard`                                       | The standard skills document — the list of `@include` lines below                                              |
+| `basic`                                          | The much shorter document used in small model mode                                                             |
+| `time-and-values`                                | Beats, note values, bar\|beat positions, clip lengths, and pitch names (C3=60)                                 |
+| `transforms-core`                                | Selecting notes and setting values on them                                                                     |
+| `transforms-editing`                             | Editing a clip that already has notes: how `notes` merges, `preTransforms`, `quantizeGrid` (update-clip only)  |
+| `transforms-expressions`                         | Transform variables, math functions, swing and quantize                                                        |
+| `transforms-generative`                          | ratchet/repeat/split/merge, and the waveforms that modulate a value across a clip                              |
+| `transforms-basic`                               | Merging into a clip and clearing notes with `preTransforms` — the whole transforms guide in small model mode   |
+| `library`                                        | Reading library search results — checking a tag hit against the file's folder, and where a result's path loads |
+| `devices`                                        | Device paths and VST/AU limits                                                                                 |
+| `devices-write`                                  | Building Simpler and Drum Rack instruments — loading samples                                                   |
+| `specialized-devices`                            | The extra controls specific native devices expose (Drift, Wavetable, EQ Eight…)                                |
+| `arrangement`                                    | What an Arrangement position means — song meter vs. clip meter                                                 |
+| `arrangement-write`                              | Moving and splitting clips on the Arrangement timeline, and take lanes                                         |
+| `working-with-live`                              | Session vs. Arrangement habits, playback, and general music-making advice                                      |
+| `context-standard` / `context-basic`             | [Context & Memory](/guide/context) — the project, global, and memory layers                                    |
+| `getting-help`                                   | What to tell you when a request is outside Producer Pal's reach                                                |
+| `getting-help-basic`                             | The audio limits worth saying out loud, in small model mode                                                    |
+| `barbeat-standard` / `barbeat-basic`             | The bar\|beat note notation guide (default notation)                                                           |
+| `barbeat-standard-write` / `barbeat-basic-write` | The bar\|beat syntax used only to _write_ notes — repeats, brackets, bar copying, examples                     |
+| `stark-standard` / `stark-basic`                 | The stark note notation guide                                                                                  |
+| `stark-standard-write` / `stark-basic-write`     | Stark chord symbols (`Am`, `G7`, `Ebm7`) — input only, since read-back returns literal notes                   |
+| `midi-json`                                      | The midi-json note notation guide                                                                              |
 
 ::: warning Fragment names changed in 2.1.0
 

--- a/docs/guide/customizing-skills.md
+++ b/docs/guide/customizing-skills.md
@@ -51,31 +51,31 @@ release.
 Fragments are cut along the lines of what you're actually doing, so you can drop
 a whole area you never use:
 
-| Fragment                                         | What it teaches                                                                                                |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
-| `standard`                                       | The standard skills document — the list of `@include` lines below                                              |
-| `basic`                                          | The much shorter document used in small model mode                                                             |
-| `time-and-values`                                | Beats, note values, bar\|beat positions, clip lengths, and pitch names (C3=60)                                 |
-| `transforms-core`                                | Selecting notes and setting values on them                                                                     |
-| `transforms-editing`                             | Editing a clip that already has notes: how `notes` merges, `preTransforms`, `quantizeGrid` (update-clip only)  |
-| `transforms-expressions`                         | Transform variables, math functions, swing and quantize                                                        |
-| `transforms-generative`                          | ratchet/repeat/split/merge, and the waveforms that modulate a value across a clip                              |
-| `transforms-basic`                               | Merging into a clip and clearing notes with `preTransforms` — the whole transforms guide in small model mode   |
-| `library`                                        | Reading library search results — checking a tag hit against the file's folder, and where a result's path loads |
-| `devices`                                        | Device paths and VST/AU limits                                                                                 |
-| `devices-write`                                  | Building Simpler and Drum Rack instruments — loading samples                                                   |
-| `specialized-devices`                            | The extra controls specific native devices expose (Drift, Wavetable, EQ Eight…)                                |
-| `arrangement`                                    | What an Arrangement position means — song meter vs. clip meter                                                 |
-| `arrangement-write`                              | Moving and splitting clips on the Arrangement timeline, and take lanes                                         |
-| `working-with-live`                              | Session vs. Arrangement habits, playback, and general music-making advice                                      |
-| `context-standard` / `context-basic`             | [Context & Memory](/guide/context) — the project, global, and memory layers                                    |
-| `getting-help`                                   | What to tell you when a request is outside Producer Pal's reach                                                |
-| `getting-help-basic`                             | The audio limits worth saying out loud, in small model mode                                                    |
-| `barbeat-standard` / `barbeat-basic`             | The bar\|beat note notation guide (default notation)                                                           |
-| `barbeat-standard-write` / `barbeat-basic-write` | The bar\|beat syntax used only to _write_ notes — repeats, brackets, bar copying, examples                     |
-| `stark-standard` / `stark-basic`                 | The stark note notation guide                                                                                  |
-| `stark-standard-write` / `stark-basic-write`     | Stark chord symbols (`Am`, `G7`, `Ebm7`) — input only, since read-back returns literal notes                   |
-| `midi-json`                                      | The midi-json note notation guide                                                                              |
+| Fragment                                         | What it teaches                                                                                                                   |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `standard`                                       | The standard skills document — the list of `@include` lines below                                                                 |
+| `basic`                                          | The much shorter document used in small model mode                                                                                |
+| `time-and-values`                                | Beats, note values, bar\|beat positions, clip lengths, and pitch names (C3=60)                                                    |
+| `transforms-core`                                | Selecting notes and setting values on them                                                                                        |
+| `transforms-editing`                             | Editing a clip that already has notes: how `notes` merges, `preTransforms`, `quantizeGrid` (update-clip only)                     |
+| `transforms-expressions`                         | Transform variables, math functions, swing and quantize                                                                           |
+| `transforms-generative`                          | ratchet/repeat/split/merge, and the waveforms that modulate a value across a clip                                                 |
+| `transforms-basic`                               | Merging into a clip and clearing notes with `preTransforms` — the whole transforms guide in small model mode                      |
+| `library`                                        | Using library search results — sanity-checking a tag hit against the file's folder, and loading a result into a clip or a Simpler |
+| `devices`                                        | Device paths and VST/AU limits                                                                                                    |
+| `devices-write`                                  | Building Simpler and Drum Rack instruments — loading samples                                                                      |
+| `specialized-devices`                            | The extra controls specific native devices expose (Drift, Wavetable, EQ Eight…)                                                   |
+| `arrangement`                                    | What an Arrangement position means — song meter vs. clip meter                                                                    |
+| `arrangement-write`                              | Moving and splitting clips on the Arrangement timeline, and take lanes                                                            |
+| `working-with-live`                              | Session vs. Arrangement habits, playback, and general music-making advice                                                         |
+| `context-standard` / `context-basic`             | [Context & Memory](/guide/context) — the project, global, and memory layers                                                       |
+| `getting-help`                                   | What to tell you when a request is outside Producer Pal's reach                                                                   |
+| `getting-help-basic`                             | The audio limits worth saying out loud, in small model mode                                                                       |
+| `barbeat-standard` / `barbeat-basic`             | The bar\|beat note notation guide (default notation)                                                                              |
+| `barbeat-standard-write` / `barbeat-basic-write` | The bar\|beat syntax used only to _write_ notes — repeats, brackets, bar copying, examples                                        |
+| `stark-standard` / `stark-basic`                 | The stark note notation guide                                                                                                     |
+| `stark-standard-write` / `stark-basic-write`     | Stark chord symbols (`Am`, `G7`, `Ebm7`) — input only, since read-back returns literal notes                                      |
+| `midi-json`                                      | The midi-json note notation guide                                                                                                 |
 
 ::: warning Fragment names changed in 2.1.0
 

--- a/src/skills/fragments/library.ts
+++ b/src/skills/fragments/library.ts
@@ -3,24 +3,12 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// ppal-library search: tags, kinds, sources, and the similarity actions. One of
-// the cleanest tool-line cuts in the set — a task that never searches the
-// browser library never needs a word of it.
+// What the ppal-library schema can't say: how to read a result's `folder`, and
+// where its `path` goes next. The filters and actions all live in
+// library.def.ts — don't restate them here.
 export const library = `## Finding Library Content
 
-Use \`ppal-library\` to search Live's browser library and the user's configured sample folder.
+Use \`ppal-library\` to search Live's browser library and the user's configured sample folder. Its schema covers the filters; two things it doesn't:
 
-- Defaults to audio samples (the only kind loadable into clips/Simpler today). Other \`kind\` values are discovery-only.
-- \`query\` is a name substring; use \`*\` as a multi-character wildcard (e.g., \`kick*acoustic\`).
-- \`tags\` is comma-separated; results must match ALL listed tags. Use \`action: "listTags"\` to discover available tags, or \`action: "listCategories"\` to browse Live's category taxonomy (Sounds, Drums, Genres, …) and \`category: "Drums"\` to list a category's tags.
-- \`type\` filters by playback type: \`loop\` (loops), \`oneshot\` (one-shots, e.g. a kick), \`impulse-response\` (convolution IRs). Each result also reports \`type\`, so you can tell a one-shot kick from a drum loop — prefer \`oneshot\` for hits and \`loop\` for grooves.
-- \`kind: "midi"\` covers ALL MIDI content — both \`.mid\` files and MIDI Live clips (\`.alc\`) — so it's the right kind for melody/chord ideas. \`kind: "live-clip"\` returns every \`.alc\` (MIDI and audio); \`.alc\` results carry \`subtype\` (\`midi\`/\`audio\`) to disambiguate.
-- \`source\`: filter where the file lives. \`sampleFolder\` is the user-configured sample folder on disk (bypasses Live's DB); \`user\`, \`pack\`, \`builtin\`, \`cloud\`, \`plugin\` query Live's DB.
-- \`inFolder\` restricts a search to immediate children of one absolute folder path (composes with the other filters).
-- \`verifyPaths: true\` stats each result and adds \`pathExists\` so you can skip files moved/deleted since Live last indexed (off by default; adds one filesystem check per result).
-- \`action: "searchBatch"\` runs many filtered searches in one call. Pass \`queries\` as an array of objects each carrying the same filters as a single search plus an optional \`label\`; results come back grouped per query (capped at 20).
-- \`action: "listPlugins"\` enumerates installed VST/AU/etc. from Live's plugin DB. Filter with \`query\` (name substring), \`vendor\`, \`format\` (VST/VST3/AU), \`deviceKind\` (\`instrument\` / \`audiofx\` — \`midifx\` has no plugin equivalent), or \`subcategory\`.
-- \`action: "findSimilar"\` ranks samples by audio similarity to a seed sample (\`similarTo\`: an absolute path, e.g. from a prior result); each result carries a \`similarity\` score (-1 to 1, ~1 = very similar). Combine with the search filters to constrain candidates (e.g. \`similarTo\` a kick + \`tags: "Kick"\` for "more kicks like this"). \`action: "findDuplicates"\` groups library samples with identical audio (re-shipped duplicates), scoped by the same filters.
-- Items from the user's sample folder appear before Live's library items in results.
-- Each result includes \`folder\` (its immediate parent folder name). Use it to sanity-check tag hits: Live's tags are noisy, so a \`Kick\`-tagged file under an \`IR Library\` folder is probably a reverb impulse, not a drum.
-- Pass an absolute \`path\` from a result to \`ppal-create-clip\` / \`ppal-update-clip\` (audio clips) or \`ppal-create-device\` / \`ppal-update-device\` (Simpler \`sample\`).`;
+- Live's tags are noisy. Each result carries \`folder\`, its immediate parent folder name — use it to sanity-check a tag hit: a \`Kick\`-tagged file under an \`IR Library\` folder is probably a reverb impulse, not a drum.
+- Pass a result's absolute \`path\` to \`ppal-create-clip\` / \`ppal-update-clip\` (audio clips) or \`ppal-create-device\` / \`ppal-update-device\` (Simpler \`sample\`).`;

--- a/src/skills/fragments/library.ts
+++ b/src/skills/fragments/library.ts
@@ -6,9 +6,14 @@
 // What the ppal-library schema can't say: how to read a result's `folder`, and
 // where its `path` goes next. The filters and actions all live in
 // library.def.ts — don't restate them here.
+//
+// The handoff bullet names four write tools while the gate is ppal-library
+// alone, so a read-only caller pays ~40 tokens it can't act on (declared in
+// DELIBERATE_CROSS_REFERENCES). A `library-write` split would fix that and cost
+// a new public slot — not worth it at this size.
 export const library = `## Finding Library Content
 
-Use \`ppal-library\` to search Live's browser library and the user's configured sample folder. Its schema covers the filters; two things it doesn't:
+Use \`ppal-library\` to search Live's browser library and the user's configured sample folder. Its schema covers the filters. What it doesn't:
 
 - Live's tags are noisy. Each result carries \`folder\`, its immediate parent folder name — use it to sanity-check a tag hit: a \`Kick\`-tagged file under an \`IR Library\` folder is probably a reverb impulse, not a drum.
 - Pass a result's absolute \`path\` to \`ppal-create-clip\` / \`ppal-update-clip\` (audio clips) or \`ppal-create-device\` / \`ppal-update-device\` (Simpler \`sample\`).`;

--- a/src/skills/skill-slots.ts
+++ b/src/skills/skill-slots.ts
@@ -250,7 +250,7 @@ export const SKILL_SLOTS: Record<SkillSlotName, SkillSlotDef> = {
   },
 
   library: {
-    title: "Library search results",
+    title: "Library search",
     description:
       "Reading ppal-library's results: checking a noisy tag hit against the file's folder, and loading a result's path into a clip or a Simpler. The search filters themselves live in the tool's own schema.",
     builtIn: library,

--- a/src/skills/skill-slots.ts
+++ b/src/skills/skill-slots.ts
@@ -250,9 +250,9 @@ export const SKILL_SLOTS: Record<SkillSlotName, SkillSlotDef> = {
   },
 
   library: {
-    title: "Library search",
+    title: "Library search results",
     description:
-      "How to find samples, MIDI clips, and plugins with ppal-library.",
+      "Reading ppal-library's results: checking a noisy tag hit against the file's folder, and loading a result's path into a clip or a Simpler. The search filters themselves live in the tool's own schema.",
     builtIn: library,
   },
 

--- a/src/tools/session/library.def.ts
+++ b/src/tools/session/library.def.ts
@@ -82,10 +82,10 @@ export const toolDefLibrary = defineTool("ppal-library", {
 
     kind: param(z.enum(LIBRARY_KIND_VALUES).optional().default("audio"), {
       default:
-        "content kind filter (search only; default: audio — the only kind loadable into clips/Simpler today, others are discovery-only). audio=.wav/.aif/.mp3/etc. samples | midi=.mid files PLUS MIDI Live clips (.alc), so it covers all MIDI content | live-clip=all .alc Ableton clips (MIDI+audio; each result reports subtype) | preset=instrument/effect presets | device-group=.adg device chains (racks) | m4l-device=.amxd Max for Live devices | live-set=.als project files | plugin=VST/AU specs and presets | image/video=media assets | folder=directory entries (a DB row type, distinct from source:sampleFolder)",
+        "content kind filter (search only; default: audio — the only kind loadable into clips/Simpler today, others are discovery-only). audio=.wav/.aif/.mp3/etc. samples | midi=.mid files PLUS MIDI Live clips (.alc), so it covers all MIDI content — the right kind for melody/chord ideas | live-clip=all .alc Ableton clips (MIDI+audio; each result reports subtype) | preset=instrument/effect presets | device-group=.adg device chains (racks) | m4l-device=.amxd Max for Live devices | live-set=.als project files | plugin=VST/AU specs and presets | image/video=media assets | folder=directory entries (a DB row type, distinct from source:sampleFolder)",
       smallModel: {
         description:
-          "content kind (default: audio). audio | midi | preset | device-group",
+          "content kind (default: audio). audio | midi (melody/chord ideas) | preset | device-group",
         excludeEnumValues: [
           "live-clip",
           "m4l-device",

--- a/src/tools/session/library.def.ts
+++ b/src/tools/session/library.def.ts
@@ -70,8 +70,8 @@ export const toolDefLibrary = defineTool("ppal-library", {
 
     query: param(z.coerce.string().optional(), {
       default:
-        "name substring (search: supports * as a multi-character wildcard; listPlugins: plain case-insensitive substring)",
-      smallModel: "name substring; use * as wildcard",
+        "name substring (search: supports * as a multi-character wildcard, e.g. kick*acoustic; listPlugins: plain case-insensitive substring)",
+      smallModel: "name substring; use * as wildcard, e.g. kick*acoustic",
     }),
 
     tags: param(z.coerce.string().optional(), {
@@ -100,8 +100,9 @@ export const toolDefLibrary = defineTool("ppal-library", {
 
     type: param(z.enum(LIBRARY_TYPE_VALUES).optional(), {
       default:
-        "playback type filter (search only): loop=loops | oneshot=one-shots (e.g. a kick) | impulse-response=convolution IRs. Also reported per result as `type`.",
-      smallModel: "playback type: loop | oneshot | impulse-response",
+        "playback type filter (search only): loop=loops | oneshot=one-shots (e.g. a kick) | impulse-response=convolution IRs. Prefer oneshot for hits and loop for grooves. Also reported per result as `type`.",
+      smallModel:
+        "playback type: loop | oneshot | impulse-response. Prefer oneshot for hits, loop for grooves",
     }),
 
     // listPlugins is discovery-only (like searchBatch); its vendor/format


### PR DESCRIPTION
Item 1 of the "cut skills content the tool schemas already carry" set, split out because it needed a decision rather than an editing pass.

[AJM-916](https://linear.app/adamjmurray/issue/AJM-916/cut-the-library-skills-fragment-into-the-ppal-library-schema-needs-a)

## The problem

`src/skills/fragments/library.ts` restated `ppal-library`'s params almost bullet for bullet — 16 of its 18 lines had a twin in `library.def.ts`, and the `kind` default ("audio only, other kinds are discovery-only") was stated three times across the two. It ships in the standard driver and `ppal-library` is on by default, so this was the largest always-on duplicate left in the blob at ~750 tokens.

## The decision

The issue framed this as delete-the-fragment-and-retire-the-slot, with trimming as the alternative. **Trimming won.** Retiring `library` would buy roughly 50 more tokens than trimming does, and cost:

- a public slot retired one release after it was created — `library` *is* the 2.1.0 destination `core-library` was renamed to, so anyone who followed that migration warning gets broken again with nowhere to go
- new warning wording for `RETIRED_SKILL_SLOTS`, which today maps a retired name to its replacements and has no empty case
- a dangling `RETIRED_SKILL_SLOTS["core-library"] -> ["library"]` that stops typechecking
- ~29 test call sites re-fixtured across 11 files — `library` is the fixture precisely because it's the only slot with a single-tool gate and no `requires` edge
- the natural place for a user to *add* their own library guidance ("my kicks live in /Samples/Kicks")

Not worth 50 tokens.

## What's here

- **Fragment: 3,005 → 543 chars** (assembled). Kept only the two facts the schema can't carry — the `folder` sanity-check heuristic, and the `path` handoff to the clip/device tools. The handoff was a genuine gap: `create-clip`'s `sampleFile` and `create-device`'s `sample` both exist, but nothing anywhere said the paths come from `ppal-library`.
- **Schema: the param-shaped facts moved onto their params** — the `kick*acoustic` wildcard example onto `query`, "prefer oneshot for hits and loop for grooves" onto `type`, and "the right kind for melody/chord ideas" onto `kind`.
- **Slot description** updated to match what's left; title unchanged. The slot *name* is untouched, so no public contract breaks.
- **Docs slot table** row rewritten. The formatter re-aligned the whole table, which is most of that file's diff.

## Net effect

Fragment −2,462 chars, standard-mode schema +106 chars → **~590 tokens saved** per standard-mode connection with `ppal-library` enabled. About 90% of what full deletion would have bought.

Small-model mode is the one place this costs rather than saves: the library fragment was never in `basicDriver`, so it picks up the +84 chars (~21 tokens) of new schema text with no offsetting cut. Judged worth it — concrete examples and intent hints earn their keep most with smaller models — but reverting is a three-line change to the `smallModel` variants.

## Known, deliberate

The handoff bullet names four write tools while the fragment's gate is `ppal-library` alone, so a read-only caller still pays ~40 tokens it can't act on. Pre-existing and already declared in `DELIBERATE_CROSS_REFERENCES`; the trim just makes it a bigger share of a smaller fragment. Fixing it properly means a `library-write` split — a new public slot to recover 40 tokens, which is the same trade this PR declined at 50. Recorded in the fragment's source comment rather than acted on.

## Verification

- `npm run check` clean — 11,430 tests pass, function coverage 100%
- `npm run check:build` clean
- `npm run skills:snapshot` — diff is pure deletion plus the moved facts
- `webui/**` untouched, so `ui:test` not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)