### PR TITLE
Enable unicorn/no-array-sort

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1101,15 +1101,15 @@
         "no-underscore-dangle": "off"
       }
     },
-    // PERMANENT, both. A polyfill is the one place these two rules are
-    // exactly backwards. The
-    // Max V8 runtime lacks the ES2023 array methods, which is why this module
-    // installs them onto the prototype (no-extend-native, 8 hits, all here) by
-    // hand-writing the very method the rule wants called (no-array-reverse —
-    // its fixer rewrites `[...arr].reverse()` in polyfillToReversed to
-    // `[...arr].toReversed()`, i.e. the polyfill calling itself). If this
-    // opt-out is ever dropped, es2023-array.test.ts is what fails — it deletes
-    // the natives before re-importing — but it fails in a case named for
+    // PERMANENT, all three. A polyfill is the one place these rules are exactly
+    // backwards. The Max V8 runtime lacks the ES2023 array methods, which is why
+    // this module installs them onto the prototype (no-extend-native, 8 hits,
+    // all here) by hand-writing the very methods the rules want called
+    // (no-array-reverse / no-array-sort — the reverse fixer rewrites
+    // `[...arr].reverse()` in polyfillToReversed to `[...arr].toReversed()`,
+    // i.e. the polyfill calling itself; polyfillToSorted is the same shape). If
+    // an opt-out is ever dropped, es2023-array.test.ts is what fails — it
+    // deletes the natives before re-importing — but it fails in a case named for
     // prototype installation, so the message points at the harness rather than
     // at the rewritten body.
     {
@@ -1117,7 +1117,8 @@
       "plugins": ["unicorn"],
       "rules": {
         "no-extend-native": "off",
-        "unicorn/no-array-reverse": "off"
+        "unicorn/no-array-reverse": "off",
+        "unicorn/no-array-sort": "off"
       }
     },
     {
@@ -1157,12 +1158,6 @@
       ],
       "plugins": ["unicorn"],
       "rules": {
-        // DEFERRED. 110 in 54 files (69 in src/). The fix rewrites `.sort()`
-        // to `.toSorted()`, which changes whether the receiver is mutated. Not
-        // mechanical — every call site has to be read for whether something
-        // relies on the mutation. Safe in the V8 runtime: live-api-adapter.ts
-        // imports the es2023-array polyfill.
-        "unicorn/no-array-sort": "off",
         // PERMANENT. 0 — off for a conflict, not for debt. It bans
         // `return undefined`, which is exactly what typescript/consistent-return
         // requires of a function that returns a value on some paths (23 sites,
@@ -1261,10 +1256,9 @@
     // which the unicorn block above does not cover — the alternative was a
     // hand-rolled "unicorn's trees, intersected with test paths" glob list,
     // and test-file-classification.test.ts rejects rival spellings of a whole
-    // category for good reason. The widening surfaced nothing but no-array-sort
-    // (already deferred), so it is turned off here too and the rest of the
-    // plugin becomes new coverage for those suites. Same for
-    // prefer-add-event-listener over e2e/ui's WebSocket handles.
+    // category for good reason. The rest of the plugin becomes new coverage for
+    // those suites; prefer-add-event-listener is off for e2e/ui's WebSocket
+    // handles, same as the block above.
     //
     // consistent-function-scoping: PERMANENT. 136 of its 144 hits are in test
     // files, where a helper defined inside a `describe` sits next to the cases
@@ -1286,7 +1280,6 @@
       "plugins": ["unicorn"],
       "rules": {
         "unicorn/consistent-function-scoping": "off",
-        "unicorn/no-array-sort": "off",
         "unicorn/prefer-add-event-listener": "off"
       }
     },

--- a/config/vite.config.ts
+++ b/config/vite.config.ts
@@ -136,7 +136,7 @@ See https://github.com/adamjmurray/producer-pal/tree/main/licenses for third-par
             {
               buildSha: BUILD_SHA,
               startedAt: buildStartedAt,
-              inputs: [...new Set(buildInputs)].sort(),
+              inputs: [...new Set(buildInputs)].toSorted(),
             },
             null,
             2,

--- a/e2e/docs/downloads.spec.ts
+++ b/e2e/docs/downloads.spec.ts
@@ -34,7 +34,7 @@ function findDownloadHrefs(): string[] {
     }
   }
 
-  return [...hrefs].sort();
+  return [...hrefs].toSorted();
 }
 
 const linkedHrefs = findDownloadHrefs();

--- a/e2e/mcp/clip/create/ppal-create-clip-pattern-brackets.test.ts
+++ b/e2e/mcp/clip/create/ppal-create-clip-pattern-brackets.test.ts
@@ -176,7 +176,7 @@ async function createAndReadback(
  * @param expected - Expected notes in time order
  */
 function expectNotes(events: NoteEvent[], expected: ExpectedNote[]): void {
-  const sorted = [...events].sort(
+  const sorted = events.toSorted(
     (a, b) => a.start_time - b.start_time || a.pitch - b.pitch,
   );
 

--- a/e2e/mcp/clip/helpers/arrangement-splitting-test-helpers.ts
+++ b/e2e/mcp/clip/helpers/arrangement-splitting-test-helpers.ts
@@ -82,7 +82,7 @@ export async function testSplitClip(
 
 /** Sort clips by arrangement start position */
 function sortByArrangementStart(clips: ReadClipResult[]): ReadClipResult[] {
-  return [...clips].sort((a, b) => {
+  return clips.toSorted((a, b) => {
     const aStart = a.arrangementStart ? parseBarBeat(a.arrangementStart) : 0;
     const bStart = b.arrangementStart ? parseBarBeat(b.arrangementStart) : 0;
 

--- a/e2e/mcp/clip/helpers/ppal-clip-transforms-test-helpers.ts
+++ b/e2e/mcp/clip/helpers/ppal-clip-transforms-test-helpers.ts
@@ -315,7 +315,7 @@ export function expectEvenlySpaced(
   pitches: number[],
   step: number,
 ): void {
-  const sorted = [...events].sort((a, b) => a.start_time - b.start_time);
+  const sorted = events.toSorted((a, b) => a.start_time - b.start_time);
 
   expect(sorted).toHaveLength(pitches.length);
 

--- a/e2e/mcp/clip/transforms/ppal-clip-transforms-timing.test.ts
+++ b/e2e/mcp/clip/transforms/ppal-clip-transforms-timing.test.ts
@@ -48,7 +48,7 @@ function extractStartBeats(notes: string): number[] {
     }
   }
 
-  return beats.sort((a, b) => a - b);
+  return beats.toSorted((a, b) => a - b);
 }
 
 /** Extract duration values (n prefix) from notation. */

--- a/e2e/mcp/workflow/ppal-library.test.ts
+++ b/e2e/mcp/workflow/ppal-library.test.ts
@@ -120,7 +120,7 @@ describe("ppal-library", () => {
         expect(item.path.startsWith(SAMPLE_FOLDER)).toBe(true);
       }
 
-      const names = result.items.map((i) => i.name).sort();
+      const names = result.items.map((i) => i.name).toSorted();
 
       expect(names).toStrictEqual(["kick.aiff", "sample.aiff"]);
     });
@@ -220,7 +220,7 @@ describe("ppal-library", () => {
       }
 
       const counts = result.tags.map((t) => t.count);
-      const sortedDesc = [...counts].sort((a, b) => b - a);
+      const sortedDesc = counts.toSorted((a, b) => b - a);
 
       expect(counts).toStrictEqual(sortedDesc);
     });
@@ -321,7 +321,7 @@ describe("ppal-library", () => {
 
       const counts = result.groups.map((g) => g.count);
 
-      expect(counts).toStrictEqual([...counts].sort((a, b) => b - a));
+      expect(counts).toStrictEqual(counts.toSorted((a, b) => b - a));
     });
   });
 
@@ -350,7 +350,7 @@ describe("ppal-library", () => {
         expect(s).toBeLessThanOrEqual(1.0001);
       }
 
-      expect(sims).toStrictEqual([...sims].sort((a, b) => b - a));
+      expect(sims).toStrictEqual(sims.toSorted((a, b) => b - a));
       // The seed itself is never in its own results.
       expect(result.items.every((i) => i.path !== seedPath)).toBe(true);
       // The seed's byte-identical duplicate twin is a ~1.0 top match.

--- a/e2e/portal/portal-test-helpers.ts
+++ b/e2e/portal/portal-test-helpers.ts
@@ -103,7 +103,7 @@ export async function runPortal(
 export async function listToolNames(session: PortalSession): Promise<string[]> {
   const { tools } = await session.client.listTools();
 
-  return tools.map((tool) => tool.name).sort();
+  return tools.map((tool) => tool.name).toSorted();
 }
 
 /**

--- a/e2e/ui/conversation-crud.spec.ts
+++ b/e2e/ui/conversation-crud.spec.ts
@@ -190,7 +190,7 @@ test.describe("Conversation history CRUD (stubbed backend)", () => {
 
     const records = await readConversationsFromDb(page);
 
-    expect(records.map((r) => r.id).sort()).toEqual(["u1", "u2"]);
+    expect(records.map((r) => r.id).toSorted()).toEqual(["u1", "u2"]);
 
     expectNoConsoleOutput(captured);
   });

--- a/evals/chat/codex/codex-cli-protocol.ts
+++ b/evals/chat/codex/codex-cli-protocol.ts
@@ -39,7 +39,7 @@ export const CODEX_CLI_TRANSPORT: AgentCliTransport = {
   strippedEnvVars: ["CODEX_API_KEY", "OPENAI_API_KEY", "OPENAI_KEY"],
   // Fixed alias set (no models endpoint); read from the aliases so a listing
   // can't advertise a name the CLI can't resolve.
-  models: Object.keys(CODEX_MODEL_ALIASES).sort(),
+  models: Object.keys(CODEX_MODEL_ALIASES).toSorted(),
   judgeModel: "luna",
   buildTurnArgs: codexTurnArgs,
   buildJudgeArgs: codexJudgeArgs,

--- a/evals/scenarios/defs/clip/helpers/clip-scenario-helpers.ts
+++ b/evals/scenarios/defs/clip/helpers/clip-scenario-helpers.ts
@@ -243,10 +243,10 @@ export function diffNotes(
   events: NoteEvent[],
   expected: ExpectedNote[],
 ): string {
-  const sortedEvents = [...events].sort(
+  const sortedEvents = events.toSorted(
     (a, b) => a.start_time - b.start_time || a.pitch - b.pitch,
   );
-  const sortedExpected = [...expected].sort(
+  const sortedExpected = expected.toSorted(
     (a, b) =>
       a.start - b.start || pitchSortKey(a.pitch) - pitchSortKey(b.pitch),
   );

--- a/evals/scenarios/defs/clip/notation/bar-beat/bar-beat-absolute-durations.ts
+++ b/evals/scenarios/defs/clip/notation/bar-beat/bar-beat-absolute-durations.ts
@@ -67,7 +67,7 @@ function assertClipNotes(
   expectedDuration?: number,
 ): EvalAssertion {
   return clipStateAssertion(slot, meter, (events) => {
-    const starts = events.map((e) => e.start_time).sort((a, b) => a - b);
+    const starts = events.map((e) => e.start_time).toSorted((a, b) => a - b);
 
     if (starts.length !== expectedStarts.length) return false;
 

--- a/evals/scenarios/defs/clip/notation/bar-beat/bar-beat-multibar-spread.ts
+++ b/evals/scenarios/defs/clip/notation/bar-beat/bar-beat-multibar-spread.ts
@@ -48,7 +48,7 @@ export const barBeatPerBarNote: EvalScenario = leadClipNotationScenario({
   check: (events) => {
     if (events.length !== BAR_DOWNBEATS.length) return false;
 
-    const sorted = [...events].sort((a, b) => a.start_time - b.start_time);
+    const sorted = events.toSorted((a, b) => a.start_time - b.start_time);
 
     return sorted.every(
       (e, i) =>
@@ -81,7 +81,7 @@ export const barBeatPerBarChord: EvalScenario = leadClipNotationScenario({
       const pitches = events
         .filter((e) => Math.abs(e.start_time - downbeat) < EPS)
         .map((e) => e.pitch)
-        .sort((a, b) => a - b);
+        .toSorted((a, b) => a - b);
 
       return (
         pitches.length === C_MAJOR.length &&

--- a/evals/scenarios/defs/clip/notation/bar-beat/bar-beat-value-streams.ts
+++ b/evals/scenarios/defs/clip/notation/bar-beat/bar-beat-value-streams.ts
@@ -58,7 +58,7 @@ function eightNoteCheck(
   return (events) => {
     if (events.length !== 8) return false;
 
-    const sorted = [...events].sort((a, b) => a.start_time - b.start_time);
+    const sorted = events.toSorted((a, b) => a.start_time - b.start_time);
 
     return sorted.every((e, i) => e.pitch === 60 && perNote(e, i));
   };
@@ -153,7 +153,7 @@ const ZIP_JUDGE = `Evaluate whether the assistant produced this polyrhythmic run
 function checkZip(events: NoteEvent[]): boolean {
   if (events.length !== ZIP_NOTE_COUNT) return false;
 
-  const sorted = [...events].sort((a, b) => a.start_time - b.start_time);
+  const sorted = events.toSorted((a, b) => a.start_time - b.start_time);
   let onset = 0;
 
   for (let i = 0; i < ZIP_NOTE_COUNT; i++) {

--- a/evals/scenarios/defs/clip/notation/surgical-note-duration-edit.ts
+++ b/evals/scenarios/defs/clip/notation/surgical-note-duration-edit.ts
@@ -191,8 +191,8 @@ function assertShortenOutcome(
         );
       }
 
-      const targets = [...before]
-        .sort((a, b) => a.start_time - b.start_time)
+      const targets = before
+        .toSorted((a, b) => a.start_time - b.start_time)
         .slice(-2);
 
       checkDurations(before, after, targets);

--- a/evals/scenarios/report.ts
+++ b/evals/scenarios/report.ts
@@ -81,7 +81,7 @@ async function findResultsInDir(dir: string): Promise<string[]> {
 
     return files
       .filter((f) => f.endsWith(".json"))
-      .sort()
+      .toSorted()
       .toReversed()
       .map((f) => join(dir, f));
   } catch {
@@ -141,7 +141,7 @@ async function showRun(runId: string): Promise<void> {
 async function showLatest(): Promise<void> {
   try {
     const runDirs = await readdir(RESULTS_DIR);
-    const sorted = runDirs.sort().toReversed();
+    const sorted = runDirs.toSorted().toReversed();
 
     for (const dir of sorted) {
       const files = await findResultsInDir(join(RESULTS_DIR, dir));
@@ -203,7 +203,7 @@ async function compareRuns(runIds: string[]): Promise<void> {
 
   console.log(styleText("bold", `Comparing: ${runIds.join(" → ")}\n`));
 
-  for (const scenarioId of [...scenarioIds].sort()) {
+  for (const scenarioId of [...scenarioIds].toSorted()) {
     const cells = runIds.map((runId) =>
       formatRunCell(runResults, runId, scenarioId),
     );

--- a/evals/shared/list-models.ts
+++ b/evals/shared/list-models.ts
@@ -227,7 +227,7 @@ async function fetchOpenAiStyleIds(
   return (body.data ?? [])
     .map((entry) => entry.id ?? "")
     .filter(Boolean)
-    .sort();
+    .toSorted();
 }
 
 /**
@@ -247,7 +247,7 @@ async function fetchGoogleModels(): Promise<string[]> {
   return (body.models ?? [])
     .map((entry) => (entry.name ?? "").replace(/^models\//, ""))
     .filter(Boolean)
-    .sort();
+    .toSorted();
 }
 
 /**

--- a/scripts/build-and-release/generate-skill-downloads.ts
+++ b/scripts/build-and-release/generate-skill-downloads.ts
@@ -36,7 +36,7 @@ async function findSkills(): Promise<string[]> {
   const skills = entries
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name)
-    .sort();
+    .toSorted();
 
   if (!skills.includes(MAIN_SKILL)) {
     throw new Error(`No ${MAIN_SKILL} folder in ${SKILLS_DIR}`);

--- a/scripts/probes/verify-live-db-readonly.ts
+++ b/scripts/probes/verify-live-db-readonly.ts
@@ -307,7 +307,7 @@ function maybeReportProgress(
  */
 function reportQueryResults(results: QueryResult[]): void {
   for (const r of results) {
-    const sorted = [...r.timingsMs].sort((a, b) => a - b);
+    const sorted = r.timingsMs.toSorted((a, b) => a - b);
     const min = sorted[0]?.toFixed(1) ?? "—";
     const p50 = sorted[Math.floor(sorted.length / 2)]?.toFixed(1) ?? "—";
     const max = sorted.at(-1)?.toFixed(1) ?? "—";

--- a/scripts/scan-live-api/scan-all-devices.ts
+++ b/scripts/scan-live-api/scan-all-devices.ts
@@ -259,7 +259,7 @@ function formatOutput(
   lines.push("", "=".repeat(70), "", "UNIQUE DEVICE SHAPES:", "");
 
   // Non-generic shapes first, then alphabetical.
-  const keys = [...groups.keys()].sort((a, b) => {
+  const keys = [...groups.keys()].toSorted((a, b) => {
     const aGeneric = a.startsWith("Device:");
     const bGeneric = b.startsWith("Device:");
 

--- a/scripts/stats/e2e-stats.ts
+++ b/scripts/stats/e2e-stats.ts
@@ -200,7 +200,7 @@ function findSlowestTests(
   }
 
   return all
-    .sort((a, b) => b.durationMs - a.durationMs)
+    .toSorted((a, b) => b.durationMs - a.durationMs)
     .slice(0, SLOWEST_COUNT);
 }
 

--- a/scripts/stats/loc.ts
+++ b/scripts/stats/loc.ts
@@ -209,7 +209,7 @@ function aggregateByLanguage(
     stats.code += entry.code;
   }
 
-  return [...map.values()].sort((a, b) => b.code - a.code);
+  return [...map.values()].toSorted((a, b) => b.code - a.code);
 }
 
 /**

--- a/scripts/stats/test-stats.ts
+++ b/scripts/stats/test-stats.ts
@@ -257,7 +257,7 @@ function findSlowestFiles(results: VitestResults): SlowestFile[] {
       tests: file.assertionResults.length,
       durationMs: file.endTime - file.startTime,
     }))
-    .sort((a, b) => b.durationMs - a.durationMs)
+    .toSorted((a, b) => b.durationMs - a.durationMs)
     .slice(0, SLOWEST_COUNT);
 }
 

--- a/src/live-api-adapter/tests/config-key-parity.test.ts
+++ b/src/live-api-adapter/tests/config-key-parity.test.ts
@@ -72,5 +72,5 @@ function findConfigKeys(): string[] {
     }
   }
 
-  return [...keys].sort();
+  return [...keys].toSorted();
 }

--- a/src/live-api-adapter/tests/dispatch-parity.test.ts
+++ b/src/live-api-adapter/tests/dispatch-parity.test.ts
@@ -15,8 +15,8 @@ describe("V8 dispatch parity", () => {
     // orphan dispatch key) would surface only at runtime as "Unknown tool".
     // ppal-live-api is opt-in (not in STANDARD_TOOL_DEFS) but is always
     // dispatchable, so it is expected in the map.
-    const expected = [...TOOL_NAMES, toolDefLiveApi.toolName].sort();
-    const actual = [...DISPATCH_TOOL_NAMES].sort();
+    const expected = [...TOOL_NAMES, toolDefLiveApi.toolName].toSorted();
+    const actual = DISPATCH_TOOL_NAMES.toSorted();
 
     expect(actual).toStrictEqual(expected);
   });

--- a/src/mcp-server/helpers/config-store/config-markdown-store.ts
+++ b/src/mcp-server/helpers/config-store/config-markdown-store.ts
@@ -133,7 +133,7 @@ export function listConfigMarkdownFiles(subdir: string): string[] {
     readdirSync(join(configDir(), subdir), { withFileTypes: true })
       .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
       .map((entry) => entry.name)
-      .sort(),
+      .toSorted(),
   );
 }
 
@@ -157,7 +157,7 @@ export function listConfigMarkdownFilesRecursive(subdir: string): string[] {
       .map((entry) =>
         relative(base, join(entry.parentPath, entry.name)).split(sep).join("/"),
       )
-      .sort(),
+      .toSorted(),
   );
 }
 

--- a/src/mcp-server/helpers/config-store/markdown-collection-store.ts
+++ b/src/mcp-server/helpers/config-store/markdown-collection-store.ts
@@ -11,8 +11,8 @@
 // traversal guard, and the reserved-index-slug protection all live here ONCE so a
 // fix reaches every collection. Callers supply only what genuinely differs: the
 // subdir/index names, how a file parses into an entry (toEntry), how entries are
-// ordered (sort), how the index body renders (renderIndexSections), and any
-// type-specific create-time validation + frontmatter (buildStored).
+// ordered (sortEntries), how the index body renders (renderIndexSections), and
+// any type-specific create-time validation + frontmatter (buildStored).
 
 import {
   deleteConfigMarkdown,
@@ -80,7 +80,7 @@ export interface MarkdownCollectionConfig<
   /** Parse a raw file into an entry (the filename slug is authoritative). */
   toEntry: (slug: string, raw: string) => Entry;
   /** Order entries for listing and the index (returns a new sorted array). */
-  sort: (entries: Entry[]) => Entry[];
+  sortEntries: (entries: Entry[]) => Entry[];
   /** Render the derived index body (no title) from the sorted entries. */
   renderIndexSections: (entries: Entry[]) => string;
   /**
@@ -108,7 +108,7 @@ export interface MarkdownCollectionStore<
   read: (name: string) => Entry | null;
   /** Whether a non-empty entry file already exists for this name. */
   exists: (name: string) => boolean;
-  /** Every stored entry (index file excluded), ordered by the config's sort. */
+  /** Every stored entry (index file excluded), in the config's sortEntries order. */
   list: () => Entry[];
   /** Create or overwrite an entry (same slug ⇒ update), then rebuild the index. */
   remember: (input: Input) => Entry;
@@ -243,7 +243,7 @@ export function makeMarkdownCollectionStore<
       entries.push(config.toEntry(slug, readConfigMarkdown(resolveFile(slug))));
     }
 
-    return config.sort(entries);
+    return config.sortEntries(entries);
   };
 
   const regenerateIndex = (): string => {

--- a/src/mcp-server/helpers/memory/memory-store.ts
+++ b/src/mcp-server/helpers/memory/memory-store.ts
@@ -53,7 +53,7 @@ const store = makeMarkdownCollectionStore<MemoryEntry, RememberMemoryInput>({
   noun: "Memory",
   requireDescription: true,
   toEntry,
-  sort: sortByName,
+  sortEntries: sortByName,
   renderIndexSections: renderMemoryIndex,
   buildStored: buildStoredMemory,
 });
@@ -116,10 +116,10 @@ function toEntry(slug: string, raw: string): MemoryEntry {
  * Order memories alphabetically by name.
  *
  * @param entries - The freshly-read entries to sort
- * @returns The same array, sorted in place
+ * @returns A new array, sorted by name
  */
 function sortByName(entries: MemoryEntry[]): MemoryEntry[] {
-  return entries.sort((a, b) => a.name.localeCompare(b.name));
+  return entries.toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
 /**

--- a/src/mcp-server/helpers/skills-custom/custom-skills-store.ts
+++ b/src/mcp-server/helpers/skills-custom/custom-skills-store.ts
@@ -61,7 +61,7 @@ const store = makeMarkdownCollectionStore<
   indexTitle: "# Producer Pal Custom Skills",
   noun: "Skill",
   toEntry,
-  sort: sortByName,
+  sortEntries: sortByName,
   renderIndexSections: renderSkillsIndexSections,
   buildStored: buildStoredSkill,
 });
@@ -127,10 +127,10 @@ function toEntry(slug: string, raw: string): CustomSkillEntry {
  * Order skills by name.
  *
  * @param entries - The freshly-read entries to sort
- * @returns The same array, sorted in place
+ * @returns A new array, sorted by name
  */
 function sortByName(entries: CustomSkillEntry[]): CustomSkillEntry[] {
-  return entries.sort((a, b) => a.name.localeCompare(b.name));
+  return entries.toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
 /**

--- a/src/mcp-server/live-library/query/find-duplicates.ts
+++ b/src/mcp-server/live-library/query/find-duplicates.ts
@@ -154,5 +154,5 @@ function groupByHash(rows: DuplicateRow[]): DuplicateRow[][] {
 
   return [...byHash.values()]
     .filter((group) => group.length > 1)
-    .sort((a, b) => b.length - a.length);
+    .toSorted((a, b) => b.length - a.length);
 }

--- a/src/mcp-server/live-library/tests/list-plugins.test.ts
+++ b/src/mcp-server/live-library/tests/list-plugins.test.ts
@@ -232,7 +232,7 @@ describe("listPlugins — filtering and derivation", () => {
 
     const result = await listPlugins({ category: "instrument" });
 
-    expect(result.plugins.map((p) => p.name).sort()).toStrictEqual([
+    expect(result.plugins.map((p) => p.name).toSorted()).toStrictEqual([
       "Massive",
       "Serum",
     ]);
@@ -257,7 +257,7 @@ describe("listPlugins — filtering and derivation", () => {
 
     const result = await listPlugins();
     const names = result.plugins.map((p) => p.name);
-    const sorted = [...names].sort((a, b) =>
+    const sorted = names.toSorted((a, b) =>
       a.toLowerCase().localeCompare(b.toLowerCase()),
     );
 

--- a/src/mcp-server/live-library/tests/query/find-duplicates.test.ts
+++ b/src/mcp-server/live-library/tests/query/find-duplicates.test.ts
@@ -49,16 +49,13 @@ describe("findDuplicates", () => {
     expect(result.groups).toHaveLength(2);
     // Group A (size 3) sorts ahead of group B (size 2).
     expect(result.groups[0]?.count).toBe(3);
-    expect(result.groups[0]?.items.map((i) => i.name).sort()).toStrictEqual([
-      "pack_clap.aif",
-      "subfolder_x.wav",
-      "subfolder_z.wav",
-    ]);
+    expect(result.groups[0]?.items.map((i) => i.name).toSorted()).toStrictEqual(
+      ["pack_clap.aif", "subfolder_x.wav", "subfolder_z.wav"],
+    );
     expect(result.groups[1]?.count).toBe(2);
-    expect(result.groups[1]?.items.map((i) => i.name).sort()).toStrictEqual([
-      "pack_kick.wav",
-      "user_kick.aif",
-    ]);
+    expect(result.groups[1]?.items.map((i) => i.name).toSorted()).toStrictEqual(
+      ["pack_kick.wav", "user_kick.aif"],
+    );
   });
 
   it("excludes invalid-format rows even when their hash matches (version insurance)", async () => {

--- a/src/mcp-server/live-library/tests/query/find-similar.test.ts
+++ b/src/mcp-server/live-library/tests/query/find-similar.test.ts
@@ -46,7 +46,7 @@ describe("findSimilar", () => {
     expect(names[0]).toBe("pack_kick.wav");
     expect(result.items[0]?.similarity).toBeGreaterThan(0.9);
     // Descending similarity order.
-    expect(sims).toStrictEqual([...sims].sort((a, b) => b - a));
+    expect(sims).toStrictEqual(sims.toSorted((a, b) => b - a));
     // The seed itself and the invalid-header row are excluded.
     expect(names).not.toContain("user_kick.aif");
     expect(names).not.toContain("subfolder_y.wav");
@@ -55,7 +55,7 @@ describe("findSimilar", () => {
   it("returns every audio sample that has a valid vector", async () => {
     const result = await findSimilar({ similarTo: SEED_KICK });
 
-    expect(result.items.map((i) => i.name).sort()).toStrictEqual([
+    expect(result.items.map((i) => i.name).toSorted()).toStrictEqual([
       "pack_clap.aif",
       "pack_kick.wav",
       "subfolder_x.wav",
@@ -86,7 +86,7 @@ describe("findSimilar", () => {
       inFolder: PACK_ONE,
     });
 
-    expect(result.items.map((i) => i.name).sort()).toStrictEqual([
+    expect(result.items.map((i) => i.name).toSorted()).toStrictEqual([
       "pack_clap.aif",
       "pack_kick.wav",
     ]);

--- a/src/mcp-server/live-library/tests/query/library-search.test.ts
+++ b/src/mcp-server/live-library/tests/query/library-search.test.ts
@@ -67,7 +67,7 @@ describe("librarySearch", () => {
     it("returns only plugins when kind=plugin", async () => {
       const result = await librarySearch({ kind: "plugin" });
 
-      expect(result.items.map((i) => i.name).sort()).toStrictEqual([
+      expect(result.items.map((i) => i.name).toSorted()).toStrictEqual([
         "EQ Eight.vst3",
         "Operator.vst3",
       ]);
@@ -125,7 +125,7 @@ describe("librarySearch", () => {
     it("returns only user library files when source=user", async () => {
       const result = await librarySearch({ source: "user" });
 
-      expect(result.items.map((i) => i.name).sort()).toStrictEqual([
+      expect(result.items.map((i) => i.name).toSorted()).toStrictEqual([
         "user_kick.aif",
         "user_snare.wav",
       ]);
@@ -155,7 +155,7 @@ describe("librarySearch", () => {
     it("returns only builtin files when source=builtin", async () => {
       const result = await librarySearch({ source: "builtin" });
 
-      expect(result.items.map((i) => i.name).sort()).toStrictEqual([
+      expect(result.items.map((i) => i.name).toSorted()).toStrictEqual([
         "EQ Eight.vst3",
         "Operator.vst3",
       ]);
@@ -177,7 +177,7 @@ describe("librarySearch", () => {
     it("filters by name substring", async () => {
       const result = await librarySearch({ query: "kick" });
 
-      expect(result.items.map((i) => i.name).sort()).toStrictEqual([
+      expect(result.items.map((i) => i.name).toSorted()).toStrictEqual([
         "pack_kick.wav",
         "user_kick.aif",
       ]);
@@ -210,7 +210,7 @@ describe("librarySearch", () => {
       // `_kick` does occur literally inside user_kick.aif and pack_kick.wav.
       const literal = await librarySearch({ query: "_kick", kind: "audio" });
 
-      expect(literal.items.map((i) => i.name).sort()).toStrictEqual([
+      expect(literal.items.map((i) => i.name).toSorted()).toStrictEqual([
         "pack_kick.wav",
         "user_kick.aif",
       ]);
@@ -226,7 +226,7 @@ describe("librarySearch", () => {
     it("returns files matching a single tag", async () => {
       const result = await librarySearch({ tags: "Kick" });
 
-      expect(result.items.map((i) => i.name).sort()).toStrictEqual([
+      expect(result.items.map((i) => i.name).toSorted()).toStrictEqual([
         "pack_kick.wav",
         "user_kick.aif",
       ]);
@@ -248,7 +248,7 @@ describe("librarySearch", () => {
     it("trims and dedupes tag tokens", async () => {
       const result = await librarySearch({ tags: " Kick , Kick ,  " });
 
-      expect(result.items.map((i) => i.name).sort()).toStrictEqual([
+      expect(result.items.map((i) => i.name).toSorted()).toStrictEqual([
         "pack_kick.wav",
         "user_kick.aif",
       ]);
@@ -259,7 +259,7 @@ describe("librarySearch", () => {
       // lowercase tags but there's only "kick", returning 0 rows.
       const result = await librarySearch({ tags: "Kick,kick" });
 
-      expect(result.items.map((i) => i.name).sort()).toStrictEqual([
+      expect(result.items.map((i) => i.name).toSorted()).toStrictEqual([
         "pack_kick.wav",
         "user_kick.aif",
       ]);
@@ -270,15 +270,15 @@ describe("librarySearch", () => {
       const upper = await librarySearch({ tags: "KICK" });
       const mixed = await librarySearch({ tags: "kIcK" });
 
-      expect(lower.items.map((i) => i.name).sort()).toStrictEqual([
+      expect(lower.items.map((i) => i.name).toSorted()).toStrictEqual([
         "pack_kick.wav",
         "user_kick.aif",
       ]);
-      expect(upper.items.map((i) => i.name).sort()).toStrictEqual(
-        lower.items.map((i) => i.name).sort(),
+      expect(upper.items.map((i) => i.name).toSorted()).toStrictEqual(
+        lower.items.map((i) => i.name).toSorted(),
       );
-      expect(mixed.items.map((i) => i.name).sort()).toStrictEqual(
-        lower.items.map((i) => i.name).sort(),
+      expect(mixed.items.map((i) => i.name).toSorted()).toStrictEqual(
+        lower.items.map((i) => i.name).toSorted(),
       );
     });
   });
@@ -318,7 +318,7 @@ describe("librarySearch", () => {
     it("filters to one-shots via the underlying Type tags", async () => {
       const result = await librarySearch({ type: "oneshot" });
 
-      expect(result.items.map((i) => i.name).sort()).toStrictEqual([
+      expect(result.items.map((i) => i.name).toSorted()).toStrictEqual([
         "pack_clap.aif",
         "pack_kick.wav",
         "user_kick.aif",
@@ -354,7 +354,7 @@ describe("librarySearch", () => {
         tags: "One Shot",
       });
 
-      expect(result.items.map((i) => i.name).sort()).toStrictEqual([
+      expect(result.items.map((i) => i.name).toSorted()).toStrictEqual([
         "pack_clap.aif",
         "pack_kick.wav",
       ]);
@@ -523,7 +523,7 @@ describe("librarySearch", () => {
         inFolder: "/Users/test/Music/Ableton/Factory Packs/Pack One/SubA",
       });
 
-      expect(result.items.map((i) => i.name).sort()).toStrictEqual([
+      expect(result.items.map((i) => i.name).toSorted()).toStrictEqual([
         "subfolder_x.wav",
         "subfolder_y.wav",
       ]);
@@ -539,7 +539,7 @@ describe("librarySearch", () => {
         kind: "audio",
       });
 
-      const names = result.items.map((i) => i.name).sort();
+      const names = result.items.map((i) => i.name).toSorted();
 
       expect(names).toContain("pack_kick.wav");
       expect(names).not.toContain("subfolder_x.wav");
@@ -554,7 +554,7 @@ describe("librarySearch", () => {
         kind: "audio",
       });
 
-      expect(result.items.map((i) => i.name).sort()).toStrictEqual([
+      expect(result.items.map((i) => i.name).toSorted()).toStrictEqual([
         "subfolder_x.wav",
         "subfolder_y.wav",
       ]);
@@ -595,8 +595,8 @@ describe("librarySearch", () => {
         inFolder: "/Users/test/Music/Ableton/Factory Packs/Pack One/SubA",
       });
 
-      expect(withSlash.items.map((i) => i.name).sort()).toStrictEqual(
-        withoutSlash.items.map((i) => i.name).sort(),
+      expect(withSlash.items.map((i) => i.name).toSorted()).toStrictEqual(
+        withoutSlash.items.map((i) => i.name).toSorted(),
       );
     });
 
@@ -607,8 +607,8 @@ describe("librarySearch", () => {
       const empty = await librarySearch({ inFolder: "", kind: "audio" });
       const unset = await librarySearch({ kind: "audio" });
 
-      expect(empty.items.map((i) => i.name).sort()).toStrictEqual(
-        unset.items.map((i) => i.name).sort(),
+      expect(empty.items.map((i) => i.name).toSorted()).toStrictEqual(
+        unset.items.map((i) => i.name).toSorted(),
       );
       // Crucially, results include items deeper than the root level.
       expect(empty.items.map((i) => i.name)).toContain("user_kick.aif");
@@ -625,8 +625,8 @@ describe("librarySearch", () => {
         inFolder: "/Users/test/Music/Ableton/Factory Packs/Pack One/SubA",
       });
 
-      expect(lower.items.map((i) => i.name).sort()).toStrictEqual(
-        canonical.items.map((i) => i.name).sort(),
+      expect(lower.items.map((i) => i.name).toSorted()).toStrictEqual(
+        canonical.items.map((i) => i.name).toSorted(),
       );
       expect(lower.items.length).toBeGreaterThan(0);
     });

--- a/src/notation/barbeat/barbeat-test-helpers.ts
+++ b/src/notation/barbeat/barbeat-test-helpers.ts
@@ -40,7 +40,7 @@ export function kickSnareNotes(): NoteEvent[] {
  * @returns Sorted copy
  */
 export function sortNotes(notes: NoteEvent[]): NoteEvent[] {
-  return [...notes].sort((a, b) => {
+  return notes.toSorted((a, b) => {
     if (Math.abs(a.start_time - b.start_time) > SAME_TIME_EPSILON)
       return a.start_time - b.start_time;
 

--- a/src/notation/barbeat/interpreter/tests/barbeat-interpreter-copy-advanced.test.ts
+++ b/src/notation/barbeat/interpreter/tests/barbeat-interpreter-copy-advanced.test.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
@@ -68,7 +69,7 @@ describe("bar|beat interpretNotation() - advanced bar copy", () => {
         // Verify no duplicates by checking all start_times
         const startTimes = result
           .map((note) => note.start_time)
-          .sort((a, b) => a - b);
+          .toSorted((a, b) => a - b);
 
         expect(startTimes).toStrictEqual([
           8, // bar 3
@@ -101,7 +102,7 @@ describe("bar|beat interpretNotation() - advanced bar copy", () => {
         // Verify no duplicates by checking all start_times
         const startTimes = result
           .map((note) => note.start_time)
-          .sort((a, b) => a - b);
+          .toSorted((a, b) => a - b);
 
         expect(startTimes).toStrictEqual([
           0, // bar 1

--- a/src/notation/chords/chord-symbols.ts
+++ b/src/notation/chords/chord-symbols.ts
@@ -123,7 +123,7 @@ export function realizeChordSymbol(
 
   const clamped = pitches.map((p) => Math.max(0, Math.min(127, p)));
 
-  return [...new Set(clamped)].sort((a, b) => a - b);
+  return [...new Set(clamped)].toSorted((a, b) => a - b);
 }
 
 /**

--- a/src/notation/chords/tests/chord-symbols.test.ts
+++ b/src/notation/chords/tests/chord-symbols.test.ts
@@ -312,8 +312,8 @@ const EXPECTED_INTERVALS: Record<string, readonly number[]> = {
 
 describe("CHORD_QUALITY_INTERVALS — every quality matches the golden spec", () => {
   it("covers exactly the golden set of qualities (no untested rows drift in)", () => {
-    expect(Object.keys(CHORD_QUALITY_INTERVALS).sort()).toStrictEqual(
-      Object.keys(EXPECTED_INTERVALS).sort(),
+    expect(Object.keys(CHORD_QUALITY_INTERVALS).toSorted()).toStrictEqual(
+      Object.keys(EXPECTED_INTERVALS).toSorted(),
     );
   });
 

--- a/src/notation/note-sort.ts
+++ b/src/notation/note-sort.ts
@@ -19,7 +19,7 @@ import { SAME_TIME_EPSILON } from "#src/shared/config.ts";
 export function sortNotes<T extends { start_time: number; pitch: number }>(
   notes: T[],
 ): T[] {
-  return [...notes].sort((a, b) => {
+  return notes.toSorted((a, b) => {
     if (a.start_time !== b.start_time) {
       return a.start_time - b.start_time;
     }

--- a/src/notation/stark/helpers/stark-serializer-helpers.ts
+++ b/src/notation/stark/helpers/stark-serializer-helpers.ts
@@ -50,7 +50,7 @@ export function classifyPitchedLine(notes: NoteEvent[]): PitchedClassification {
   // mercy of the caller's ordering, so re-serializing the interpreter's
   // (pitch-sorted) output produced a different string — a fixpoint break.
   const sorted = sortNotes(notes);
-  const pitches = sorted.map((n) => n.pitch).sort((a, b) => a - b);
+  const pitches = sorted.map((n) => n.pitch).toSorted((a, b) => a - b);
   const medianPitch = pitches[Math.floor(pitches.length / 2)] ?? 60;
   const lineType = medianPitch < 48 ? "bass" : "melody";
   const registerDefault =

--- a/src/notation/stark/stark-serializer.ts
+++ b/src/notation/stark/stark-serializer.ts
@@ -167,7 +167,7 @@ function walkLine(
   makeHit: (note: NoteEvent) => { core: string; dynamic: string },
   stats: SerializeStats,
 ): LineToken[] {
-  const sorted = [...notes].sort((a, b) => a.start_time - b.start_time);
+  const sorted = notes.toSorted((a, b) => a.start_time - b.start_time);
   const tokens: LineToken[] = [];
   let time = 0;
 
@@ -413,7 +413,7 @@ function serializeStarkDrums(
   // input order) — groupNotesByPitch keeps first-seen order, which made the line
   // sequence depend on how the caller ordered notes, so re-serializing the
   // interpreter's (pitch-sorted) output reordered the lines: a fixpoint break.
-  const byPitch = [...groupNotesByPitch(notes)].sort((a, b) => a[0] - b[0]);
+  const byPitch = [...groupNotesByPitch(notes)].toSorted((a, b) => a[0] - b[0]);
 
   for (const [pitch, pitchNotes] of byPitch) {
     const tokens = walkLine(

--- a/src/notation/stark/tests/stark-interpreter.test.ts
+++ b/src/notation/stark/tests/stark-interpreter.test.ts
@@ -151,7 +151,7 @@ describe("stark interpreter — pitched lines", () => {
   it("warns when drum and pitched lines share a clip but interprets all", () => {
     const notes = interpretNotation("kick: X\nmelody: C'''''");
 
-    expect(notes.map((n) => n.pitch).sort((a, b) => a - b)).toStrictEqual([
+    expect(notes.map((n) => n.pitch).toSorted((a, b) => a - b)).toStrictEqual([
       36, 120,
     ]);
     expect(outlet).toHaveBeenCalledWith(
@@ -163,7 +163,7 @@ describe("stark interpreter — pitched lines", () => {
   it("does not warn for a legit two-register pitched clip (bass + melody)", () => {
     const notes = interpretNotation("bass: C\nmelody: G");
 
-    expect(notes.map((n) => n.pitch).sort((a, b) => a - b)).toStrictEqual([
+    expect(notes.map((n) => n.pitch).toSorted((a, b) => a - b)).toStrictEqual([
       36, 67,
     ]);
     expect(outlet).not.toHaveBeenCalled();

--- a/src/notation/transform/helpers/note-cut-helpers.ts
+++ b/src/notation/transform/helpers/note-cut-helpers.ts
@@ -163,5 +163,5 @@ function resolveSplitPoints(
       abletonScale,
   );
 
-  return [...new Set(beats)].sort((a, b) => a - b);
+  return [...new Set(beats)].toSorted((a, b) => a - b);
 }

--- a/src/notation/transform/tests/transform-note-ops.test.ts
+++ b/src/notation/transform/tests/transform-note-ops.test.ts
@@ -371,9 +371,9 @@ describe("note-count operations (ratchet/merge)", () => {
       applyTransforms(notes, "merge()", 4, 4);
 
       expect(notes).toHaveLength(2);
-      expect(notes.map((n) => n.pitch).sort((a, b) => a - b)).toStrictEqual([
-        60, 64,
-      ]);
+      expect(notes.map((n) => n.pitch).toSorted((a, b) => a - b)).toStrictEqual(
+        [60, 64],
+      );
     });
 
     it("takes dynamics from the earliest note in each group", () => {
@@ -621,7 +621,7 @@ describe("selector float tolerance over a ratcheted burst", () => {
   const gbVelocities = (notes: ReturnType<typeof lastHat>): number[] =>
     notes
       .filter((n) => n.pitch === 42)
-      .sort((a, b) => a.start_time - b.start_time)
+      .toSorted((a, b) => a.start_time - b.start_time)
       .map((n) => Math.round(n.velocity));
 
   it("matches each ratcheted note with an exact-point selector", () => {

--- a/src/notation/transform/tests/transform-repeat-note-op.test.ts
+++ b/src/notation/transform/tests/transform-repeat-note-op.test.ts
@@ -137,7 +137,7 @@ describe("note-count operation: repeat", () => {
       applyTransforms(notes, "1|1-<2|1: repeat(n/4)", 4, 4);
 
       expect(
-        notes.map((n) => n.start_time).sort((a, b) => a - b),
+        notes.map((n) => n.start_time).toSorted((a, b) => a - b),
       ).toStrictEqual([0, 1, 4]);
     });
   });

--- a/src/notation/transform/transform-note-ops.ts
+++ b/src/notation/transform/transform-note-ops.ts
@@ -468,7 +468,7 @@ function resolveMergeTolerance(
  * @returns One sustained note per run
  */
 function mergeRuns(group: NoteEvent[], tolerance: number): NoteEvent[] {
-  const sorted = [...group].sort((a, b) => a.start_time - b.start_time);
+  const sorted = group.toSorted((a, b) => a.start_time - b.start_time);
   const out: NoteEvent[] = [];
 
   // group is non-empty by construction, so index 0 is always present.

--- a/src/portal/tool-listing.ts
+++ b/src/portal/tool-listing.ts
@@ -46,7 +46,7 @@ export async function formatToolListing(
           "",
           ...buildFallbackTools(options)
             .tools.map((tool) => `  ${tool.name}`)
-            .sort(),
+            .toSorted(),
         ]
       : [`Available now (${live.length}):`, "", ...live.map((n) => `  ${n}`)];
 
@@ -113,7 +113,7 @@ async function fetchDeviceToolNames(
 
     const { tools } = await client.listTools();
 
-    return tools.map((tool) => tool.name).sort();
+    return tools.map((tool) => tool.name).toSorted();
   } catch (error) {
     // stderr, not stdout: the caller prints the listing to stdout, and a reader
     // piping it somewhere shouldn't get a diagnostic mixed into the data.

--- a/src/shared/tests/tool-groups-catalog.test.ts
+++ b/src/shared/tests/tool-groups-catalog.test.ts
@@ -23,8 +23,8 @@ import {
 
 describe("tool-groups vs the real catalog", () => {
   it("covers every registered tool, and nothing else", () => {
-    expect([...ALL_TOOL_IDS].sort()).toStrictEqual(
-      [...TOOL_NAMES, toolDefLiveApi.toolName].sort(),
+    expect(ALL_TOOL_IDS.toSorted()).toStrictEqual(
+      [...TOOL_NAMES, toolDefLiveApi.toolName].toSorted(),
     );
   });
 
@@ -44,6 +44,6 @@ describe("tool-groups vs the real catalog", () => {
       .filter((def) => def.toolOptions.annotations?.readOnlyHint === true)
       .map((def) => def.toolName);
 
-    expect([...READ_ONLY_TOOLS].sort()).toStrictEqual(readOnly.sort());
+    expect(READ_ONLY_TOOLS.toSorted()).toStrictEqual(readOnly.toSorted());
   });
 });

--- a/src/shared/tests/tool-groups.test.ts
+++ b/src/shared/tests/tool-groups.test.ts
@@ -83,7 +83,7 @@ describe("resolveToolNames", () => {
 
   it("resolves the read-only alias", () => {
     expect(resolve(READ_ONLY_ALIAS).names).toStrictEqual(
-      [...READ_ONLY_TOOLS].sort(
+      READ_ONLY_TOOLS.toSorted(
         (a, b) => ALL_TOOL_IDS.indexOf(a) - ALL_TOOL_IDS.indexOf(b),
       ),
     );

--- a/src/skills/tests/fragment-tool-gates.test.ts
+++ b/src/skills/tests/fragment-tool-gates.test.ts
@@ -39,7 +39,7 @@ function gateTools(name: string): readonly string[] | null {
  * @returns Each distinct `ppal-` name in it
  */
 function mentionedTools(body: string): string[] {
-  return [...new Set(body.match(/ppal-[a-z-]+/g) ?? [])].sort();
+  return [...new Set(body.match(/ppal-[a-z-]+/g) ?? [])].toSorted();
 }
 
 // Fragments that name a tool outside their own gate ON PURPOSE: the handoff is
@@ -376,7 +376,7 @@ describe("audienceGatedFragments", () => {
     );
 
     expect(conversationOnly.length).toBeGreaterThan(0);
-    expect([...dropped].sort()).toStrictEqual(conversationOnly.sort());
+    expect([...dropped].toSorted()).toStrictEqual(conversationOnly.toSorted());
   });
 
   it("drops nothing a toolset could have decided", () => {

--- a/src/test/meta/blank-line-requirements.test.ts
+++ b/src/test/meta/blank-line-requirements.test.ts
@@ -1,5 +1,6 @@
 // Producer Pal
 // Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
@@ -113,7 +114,7 @@ function assertBlankLineRatio(dirPath: string): void {
 
   if (insufficientFiles.length > 0) {
     const details = insufficientFiles
-      .sort((a, b) => a.ratio - b.ratio)
+      .toSorted((a, b) => a.ratio - b.ratio)
       .map(
         (f) =>
           `  - ${f.path}: ${(f.ratio * 100).toFixed(1)}% blank (${f.blankLines}/${f.totalLines} lines)`,

--- a/src/test/meta/build/build-flags.test.ts
+++ b/src/test/meta/build/build-flags.test.ts
@@ -41,8 +41,8 @@ const ciWorkflow = readRepoFile(".github/workflows/run-checks-and-tests.yml");
 
 describe("build flags", () => {
   it("only reads flags that are classified as build-time or runtime", () => {
-    expect([...flagsReadInSrc()].sort()).toStrictEqual(
-      [...BUILD_FLAGS, ...RUNTIME_FLAGS].sort(),
+    expect([...flagsReadInSrc()].toSorted()).toStrictEqual(
+      [...BUILD_FLAGS, ...RUNTIME_FLAGS].toSorted(),
     );
   });
 

--- a/src/test/skill-frontmatter.test.ts
+++ b/src/test/skill-frontmatter.test.ts
@@ -16,7 +16,7 @@ import { parse } from "yaml";
 const FRONTMATTER = /^---\n([\s\S]*?)\n---/;
 
 describe("example skill frontmatter", () => {
-  const skillFiles = globSync("examples/skills/*/SKILL.md").sort();
+  const skillFiles = globSync("examples/skills/*/SKILL.md").toSorted();
 
   it("finds the example skills", () => {
     expect(skillFiles.length).toBeGreaterThan(0);

--- a/src/tools/clip/update/tests/notes/update-clip-pre-transforms.test.ts
+++ b/src/tools/clip/update/tests/notes/update-clip-pre-transforms.test.ts
@@ -83,8 +83,8 @@ describe("updateClip - preTransforms", () => {
     const finalNotes = addedNotes(mocks.clip123);
     const bar1 = finalNotes.filter((n) => n.start_time < 4);
     const bar2 = finalNotes.filter((n) => n.start_time >= 4);
-    const bar1Pitches = bar1.map((n) => n.pitch).sort((a, b) => a - b);
-    const bar2Pitches = bar2.map((n) => n.pitch).sort((a, b) => a - b);
+    const bar1Pitches = bar1.map((n) => n.pitch).toSorted((a, b) => a - b);
+    const bar2Pitches = bar2.map((n) => n.pitch).toSorted((a, b) => a - b);
 
     // Bar 1: original 60/62/64/65 cleared by preTransforms; only new 72/74/76/77 land
     expect(bar1Pitches).toStrictEqual([72, 74, 76, 77]);
@@ -142,10 +142,10 @@ describe("updateClip - preTransforms", () => {
 
     const clip123Final = addedNotes(mocks.clip123)
       .map((n) => n.pitch)
-      .sort((a, b) => a - b);
+      .toSorted((a, b) => a - b);
     const clip456Final = addedNotes(mocks.clip456)
       .map((n) => n.pitch)
-      .sort((a, b) => a - b);
+      .toSorted((a, b) => a - b);
 
     expect(clip123Final).toStrictEqual([67, 81]); // bar 2 G3 + new bar 1 A4
     expect(clip456Final).toStrictEqual([69, 81]); // bar 2 A3 + new bar 1 A4

--- a/src/tools/live-set/helpers/update-live-set-locator-helpers.ts
+++ b/src/tools/live-set/helpers/update-live-set-locator-helpers.ts
@@ -135,7 +135,7 @@ export async function deleteLocator(
     stopPlaybackIfNeeded(liveSet);
 
     // Delete in reverse order to avoid index shifting issues
-    const times = matches.map((m) => m.time).sort((a, b) => b - a);
+    const times = matches.map((m) => m.time).toSorted((a, b) => b - a);
 
     for (const time of times) {
       liveSet.set("current_song_time", time);

--- a/src/tools/session/library.ts
+++ b/src/tools/session/library.ts
@@ -368,18 +368,18 @@ function sortPartition(
   sort: LibrarySort | undefined,
 ): LibraryItem[] {
   if (sort === "name") {
-    return [...items].sort((a, b) => a.name.localeCompare(b.name));
+    return items.toSorted((a, b) => a.name.localeCompare(b.name));
   }
 
   if (sort === "mod_date") {
     // sampleFolder items have no mod_date metadata; fall back to name order.
     // DB items keep their upstream order (already mod_date-sorted by SQL).
     return items.every((i) => i.source === "sampleFolder")
-      ? [...items].sort((a, b) => a.name.localeCompare(b.name))
+      ? items.toSorted((a, b) => a.name.localeCompare(b.name))
       : [...items];
   }
 
-  return [...items].sort(
+  return items.toSorted(
     (a, b) => b.useCount - a.useCount || a.name.localeCompare(b.name),
   );
 }

--- a/src/tools/shared/arrangement/arrangement-splitting-params.ts
+++ b/src/tools/shared/arrangement/arrangement-splitting-params.ts
@@ -120,5 +120,5 @@ function parseSplitPoints(
   }
 
   // Sort and remove duplicates
-  return [...new Set(points)].sort((a, b) => a - b);
+  return [...new Set(points)].toSorted((a, b) => a - b);
 }

--- a/webui/src/chat/sdk/tests/subagent/spawn-subagent-tool.test.ts
+++ b/webui/src/chat/sdk/tests/subagent/spawn-subagent-tool.test.ts
@@ -430,7 +430,7 @@ describe("createSpawnSubagentTool", () => {
 
     expect(spawnState.count).toBe(2);
     expect(
-      runWorker.mock.calls.map((c) => c[0].toolCallId).sort(),
+      runWorker.mock.calls.map((c) => c[0].toolCallId).toSorted(),
     ).toStrictEqual(["tc1", "tc2"]);
     // Two workers, two distinct identities.
     expect(

--- a/webui/src/components/context/memory/MemoryList.tsx
+++ b/webui/src/components/context/memory/MemoryList.tsx
@@ -35,7 +35,7 @@ interface MemoryListProps {
  */
 export function MemoryList(props: MemoryListProps): preact.JSX.Element {
   const { entries, selectedName, creating, onSelect, onNew, onDelete } = props;
-  const sorted = [...entries].sort((a, b) => a.name.localeCompare(b.name));
+  const sorted = entries.toSorted((a, b) => a.name.localeCompare(b.name));
 
   const confirmDelete = (name: string): void => {
     if (window.confirm(`Delete memory "${name}"? This cannot be undone.`)) {

--- a/webui/src/components/context/skills/CustomSkillsList.tsx
+++ b/webui/src/components/context/skills/CustomSkillsList.tsx
@@ -34,7 +34,7 @@ export function CustomSkillsList(
   props: CustomSkillsListProps,
 ): preact.JSX.Element {
   const { entries, selectedName, creating, onSelect, onNew } = props;
-  const sorted = [...entries].sort((a, b) => a.name.localeCompare(b.name));
+  const sorted = entries.toSorted((a, b) => a.name.localeCompare(b.name));
 
   return (
     <div className="flex flex-col gap-2 overflow-y-auto p-3">

--- a/webui/src/lib/conversation-branch-helpers.ts
+++ b/webui/src/lib/conversation-branch-helpers.ts
@@ -91,7 +91,7 @@ export function collapseBranchFamilies<T extends BranchRecord>(
   }
 
   return [...families.values()]
-    .sort((a, b) => b.latest - a.latest)
+    .toSorted((a, b) => b.latest - a.latest)
     .map((family) => family.rep);
 }
 
@@ -151,7 +151,9 @@ export function computeBranchPoints(
     addBranchPoint(byAnchor, index, activeId, activeId, items);
   }
 
-  return [...byAnchor.values()].sort((a, b) => a.anchorIndex - b.anchorIndex);
+  return [...byAnchor.values()].toSorted(
+    (a, b) => a.anchorIndex - b.anchorIndex,
+  );
 }
 
 /**
@@ -343,7 +345,7 @@ function siblingsOfSet(
     .filter(
       (item) => item.forkParentId === trunkId && item.forkedAtIndex === index,
     )
-    .sort((a, b) => a.createdAt - b.createdAt)
+    .toSorted((a, b) => a.createdAt - b.createdAt)
     .map((item) => item.id);
   const trunkExists = items.some((item) => item.id === trunkId);
 

--- a/webui/src/lib/conversation-db.ts
+++ b/webui/src/lib/conversation-db.ts
@@ -266,7 +266,7 @@ export async function listAllConversationSummaries(): Promise<
         ...(forkedAtIndex != null && { forkedAtIndex }),
       }),
     )
-    .sort((a, b) => b.updatedAt - a.updatedAt);
+    .toSorted((a, b) => b.updatedAt - a.updatedAt);
 }
 
 /**
@@ -427,7 +427,7 @@ async function enforceConversationLimit(
     .filter(
       (r) => !r.bookmarked && r.id !== excludeId && !protectedIds?.has(r.id),
     )
-    .sort((a, b) => a.updatedAt - b.updatedAt);
+    .toSorted((a, b) => a.updatedAt - b.updatedAt);
 
   const toDelete = deletable.slice(0, excess);
 

--- a/webui/src/lib/tests/conversation-branch-helpers.test.ts
+++ b/webui/src/lib/tests/conversation-branch-helpers.test.ts
@@ -336,7 +336,7 @@ describe("branchFamilyIds", () => {
 
     const family = branchFamilyIds(["A"], [a, other]);
 
-    expect([...family].sort()).toStrictEqual(["A"]);
+    expect([...family].toSorted()).toStrictEqual(["A"]);
   });
 
   it("includes every sibling sharing a seed's family root", () => {
@@ -348,7 +348,7 @@ describe("branchFamilyIds", () => {
 
     const family = branchFamilyIds(["A"], [a, b, c]);
 
-    expect([...family].sort()).toStrictEqual(["A", "B", "C"]);
+    expect([...family].toSorted()).toStrictEqual(["A", "B", "C"]);
   });
 
   it("walks the fork chain so a nested family collapses to one root", () => {
@@ -359,7 +359,7 @@ describe("branchFamilyIds", () => {
 
     const family = branchFamilyIds(["C"], [a, b, c]);
 
-    expect([...family].sort()).toStrictEqual(["A", "B", "C"]);
+    expect([...family].toSorted()).toStrictEqual(["A", "B", "C"]);
   });
 
   it("keeps a referenced-but-deleted trunk seed protected", () => {
@@ -370,7 +370,7 @@ describe("branchFamilyIds", () => {
 
     const family = branchFamilyIds(["A"], [b, c]);
 
-    expect([...family].sort()).toStrictEqual(["A", "B", "C"]);
+    expect([...family].toSorted()).toStrictEqual(["A", "B", "C"]);
   });
 
   it("excludes unrelated families", () => {
@@ -381,7 +381,7 @@ describe("branchFamilyIds", () => {
 
     const family = branchFamilyIds(["A"], [a, b, x, y]);
 
-    expect([...family].sort()).toStrictEqual(["A", "B"]);
+    expect([...family].toSorted()).toStrictEqual(["A", "B"]);
   });
 
   it("returns an empty set for no seeds", () => {


### PR DESCRIPTION
Clears the first of the two large oxlint opt-outs ([AJM-841](https://linear.app/adamjmurray/issue/AJM-841/clear-the-two-large-oxlint-opt-outs-unicornno-array-sort-and)). `vitest/require-to-throw-message` stays deferred for its own sitting.

126 call sites across 64 files. Every receiver was already a fresh array — a `.map()`/`.filter()` result, a spread copy, or a local built in the same function — so nothing downstream relied on the in-place sort. Where the receiver was a real array the `[...x].sort()` spread goes too: `x.toSorted()` copies once instead of twice. Set and Map spreads keep theirs.

Two sites are not rewrites:

- `MarkdownCollectionConfig.sort` is renamed `sortEntries`. It is a config callback, not `Array#sort`, but the rule matches on the name — a rename beat spending a lint-suppression budget entry.
- `src/polyfills/**` gets a permanent opt-out beside the existing `no-array-reverse` one: `polyfillToSorted` hand-writes the very method the rule wants called.

Both `"unicorn/no-array-sort": "off"` lines come out of `.oxlintrc.json`, and the comments that referenced the deferral are rewritten.

## Testing

`npm run check` (11584 pass, coverage unchanged), `npm run check:build`, `npm run ui:test` (29 pass). The MCP e2e suite was not run — it needs a real Ableton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)