### PR TITLE
fix(select): refuse a target that isn't there

### DIFF
--- a/e2e/mcp/control/ppal-select.test.ts
+++ b/e2e/mcp/control/ppal-select.test.ts
@@ -206,6 +206,49 @@ describe("ppal-select", () => {
     expect(viewOnly.view).toBe("session");
     expect(viewOnly.selectedTrack).toBeUndefined();
     expect(viewOnly.selectedScene).toBeUndefined();
+
+    // Test 16: A target that isn't there is refused, not silently skipped, and
+    // in the same words whichever spelling named it.
+    const expectNoTarget = async (
+      args: Record<string, unknown>,
+      message: string,
+    ) => {
+      const result = await ctx.client!.callTool({
+        name: "ppal-select",
+        arguments: args,
+      });
+
+      expect(
+        isToolError(result),
+        `expected ${JSON.stringify(args)} to fail`,
+      ).toBe(true);
+      expect(getToolErrorMessage(result)).toContain(message);
+    };
+
+    await expectNoTarget({ path: "t99" }, 'no track at "t99"');
+    await expectNoTarget({ trackIndex: 99 }, 'no track at "t99"');
+    await expectNoTarget(
+      { trackIndex: 99, trackType: "return" },
+      'no track at "rt99"',
+    );
+    await expectNoTarget({ path: "s99" }, 'no scene at "s99"');
+    await expectNoTarget({ sceneIndex: 99 }, 'no scene at "s99"');
+    await expectNoTarget({ path: "t0/s99" }, 'no scene at "s99"');
+    await expectNoTarget({ path: "t0/d99" }, 'no device at "t0/d99"');
+
+    // Test 17: A refused select changes nothing — a scene selection would have
+    // switched to session view before it ever looked for the scene.
+    await ctx.client!.callTool({
+      name: "ppal-select",
+      arguments: { view: "arrangement" },
+    });
+    await expectNoTarget({ sceneIndex: 99 }, 'no scene at "s99"');
+
+    const afterFailure = parseToolResult<SelectResult>(
+      await ctx.client!.callTool({ name: "ppal-select", arguments: {} }),
+    );
+
+    expect(afterFailure.view).toBe("arrangement");
   });
 });
 

--- a/src/tools/session/helpers/select-existence-helpers.ts
+++ b/src/tools/session/helpers/select-existence-helpers.ts
@@ -1,0 +1,141 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Existence checks for what select was asked to select. Nothing bounds the
+// index in a path or an index param, so "t99" is a well-formed request for a
+// track that isn't there — and a selection that quietly doesn't happen reads to
+// a model exactly like one that did.
+//
+// Checked up front, before any view switch or selection, so a failed select
+// leaves Live untouched and the update helpers can assume their target is there.
+
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import { resolvePathToLiveApi } from "#src/tools/shared/device/helpers/path/device-path-to-live-api.ts";
+import { buildTrackPath, type TrackCategory } from "./select-helpers.ts";
+
+interface SelectTargets {
+  trackId?: string;
+  category: TrackCategory;
+  trackIndex?: number;
+  sceneId?: string;
+  sceneIndex?: number;
+  clipSlot?: { trackIndex: number; sceneIndex: number };
+  devicePath?: string;
+}
+
+/**
+ * Refuse a select naming something that isn't there. IDs are checked where
+ * they're resolved, so this covers the path and index spellings.
+ * @param targets - What the caller asked to select
+ * @param targets.trackId - Track ID, when the track came from an ID
+ * @param targets.category - Track category
+ * @param targets.trackIndex - 0-based index within the category
+ * @param targets.sceneId - Scene ID, when the scene came from an ID
+ * @param targets.sceneIndex - 0-based scene index
+ * @param targets.clipSlot - Session position coordinates
+ * @param targets.devicePath - Device path, e.g. "t0/d1"
+ */
+export function requireSelectTargets({
+  trackId,
+  category,
+  trackIndex,
+  sceneId,
+  sceneIndex,
+  clipSlot,
+  devicePath,
+}: SelectTargets): void {
+  const trackPath =
+    trackId == null ? buildTrackPath(category, trackIndex) : null;
+
+  if (trackPath != null) {
+    requireTarget(
+      LiveAPI.from(trackPath),
+      "track",
+      trackPathLabel(category, trackIndex),
+    );
+  }
+
+  if (sceneId == null && sceneIndex != null) {
+    requireTarget(
+      LiveAPI.from(livePath.scene(sceneIndex)),
+      "scene",
+      `s${sceneIndex}`,
+    );
+  }
+
+  if (clipSlot != null) requireClipSlot(clipSlot);
+
+  if (devicePath != null) requireDevice(devicePath);
+}
+
+// --- Helpers below main exports ---
+
+/**
+ * The path spelling for a track target, so an index param is refused in the
+ * same words as the path that replaced it.
+ * @param category - Track category
+ * @param trackIndex - 0-based index within the category
+ * @returns The path spelling, e.g. "t2", "rt0", "mt"
+ */
+function trackPathLabel(category: TrackCategory, trackIndex?: number): string {
+  if (category === "master") return "mt";
+
+  return category === "return" ? `rt${trackIndex}` : `t${trackIndex}`;
+}
+
+/**
+ * Refuse a target that isn't there, naming it the way the caller could ask for it.
+ * @param api - The object the caller named
+ * @param kind - What it was meant to be
+ * @param path - The path spelling of the target
+ */
+function requireTarget(api: LiveAPI, kind: string, path: string): void {
+  if (!api.exists()) {
+    throw new Error(`select failed: no ${kind} at "${path}"`);
+  }
+}
+
+/**
+ * Refuse a session position, saying whether the track or the scene is missing.
+ * @param slot - The clip slot coordinates
+ * @param slot.trackIndex - 0-based track index
+ * @param slot.sceneIndex - 0-based scene index
+ */
+function requireClipSlot({
+  trackIndex,
+  sceneIndex,
+}: {
+  trackIndex: number;
+  sceneIndex: number;
+}): void {
+  requireTarget(
+    LiveAPI.from(livePath.track(trackIndex)),
+    "track",
+    `t${trackIndex}`,
+  );
+  requireTarget(
+    LiveAPI.from(livePath.scene(sceneIndex)),
+    "scene",
+    `s${sceneIndex}`,
+  );
+  requireTarget(
+    LiveAPI.from(livePath.track(trackIndex).clipSlot(sceneIndex)),
+    "clip slot",
+    `t${trackIndex}/s${sceneIndex}`,
+  );
+}
+
+/**
+ * Refuse a device path pointing at nothing. A path naming a chain instead of a
+ * device is left to the selection itself to reject.
+ * @param devicePath - The device path, e.g. "t0/d1"
+ */
+function requireDevice(devicePath: string): void {
+  const resolved = resolvePathToLiveApi(devicePath);
+
+  if (resolved.targetType !== "device") return;
+
+  requireTarget(LiveAPI.from(resolved.liveApiPath), "device", devicePath);
+}

--- a/src/tools/session/helpers/select-helpers.ts
+++ b/src/tools/session/helpers/select-helpers.ts
@@ -189,18 +189,14 @@ export function updateTrackSelection({
     const trackPath = buildTrackPath(category, trackIndex);
 
     if (trackPath) {
-      const trackAPI = LiveAPI.from(trackPath);
+      const liveApiTrackId = toLiveApiId(LiveAPI.from(trackPath).id);
 
-      if (trackAPI.exists()) {
-        const liveApiTrackId = toLiveApiId(trackAPI.id);
+      songView.setProperty("selected_track", liveApiTrackId);
+      result.selectedTrackId = liveApiTrackId;
+      result.selectedCategory = finalCategory;
 
-        songView.setProperty("selected_track", liveApiTrackId);
-        result.selectedTrackId = liveApiTrackId;
-        result.selectedCategory = finalCategory;
-
-        if (finalCategory !== "master" && trackIndex != null) {
-          result.selectedTrackIndex = trackIndex;
-        }
+      if (finalCategory !== "master" && trackIndex != null) {
+        result.selectedTrackIndex = trackIndex;
       }
     }
   }
@@ -234,15 +230,13 @@ export function updateSceneSelection({
       result.selectedSceneIndex = sceneIndex;
     }
   } else if (sceneIndex != null) {
-    const sceneAPI = LiveAPI.from(livePath.scene(sceneIndex));
+    const finalSceneId = toLiveApiId(
+      LiveAPI.from(livePath.scene(sceneIndex)).id,
+    );
 
-    if (sceneAPI.exists()) {
-      const finalSceneId = toLiveApiId(sceneAPI.id);
-
-      songView.setProperty("selected_scene", finalSceneId);
-      result.selectedSceneId = finalSceneId;
-      result.selectedSceneIndex = sceneIndex;
-    }
+    songView.setProperty("selected_scene", finalSceneId);
+    result.selectedSceneId = finalSceneId;
+    result.selectedSceneIndex = sceneIndex;
   }
 
   return result;
@@ -278,11 +272,9 @@ export function updateDeviceSelection({
 
     const deviceAPI = LiveAPI.from(resolved.liveApiPath);
 
-    if (deviceAPI.exists()) {
-      songView.call("select_device", toLiveApiId(deviceAPI.id));
+    songView.call("select_device", toLiveApiId(deviceAPI.id));
 
-      return deviceAPI;
-    }
+    return deviceAPI;
   }
 
   return undefined;
@@ -367,8 +359,6 @@ export function updateClipSlotSelection({
   const clipSlotAPI = LiveAPI.from(
     livePath.track(clipSlot.trackIndex).clipSlot(clipSlot.sceneIndex),
   );
-
-  if (!clipSlotAPI.exists()) return false;
 
   const hasClip = clipSlotAPI.getProperty("has_clip") as number;
 

--- a/src/tools/session/select.ts
+++ b/src/tools/session/select.ts
@@ -17,6 +17,7 @@ import {
   validateParameters,
   type TrackCategory,
 } from "./helpers/select-helpers.ts";
+import { requireSelectTargets } from "./helpers/select-existence-helpers.ts";
 import {
   determineAutoDetailView,
   resolveIdParam,
@@ -105,6 +106,16 @@ export function select(
   if (!resolved.hasArgs) {
     return readFullState();
   }
+
+  requireSelectTargets({
+    trackId,
+    category,
+    trackIndex,
+    sceneId,
+    sceneIndex,
+    clipSlot: parsedClipSlot,
+    devicePath,
+  });
 
   const appView = LiveAPI.from(livePath.view.app);
   const songView = LiveAPI.from(livePath.view.song);

--- a/src/tools/session/tests/select/select-basic.test.ts
+++ b/src/tools/session/tests/select/select-basic.test.ts
@@ -173,7 +173,7 @@ describe("view", () => {
       expect(result.selectedTrack).toBeDefined();
     });
 
-    it("skips track selection when track does not exist", () => {
+    it("refuses a track that does not exist", () => {
       // Register non-existent track (id "0" makes exists() return false)
       registerMockObject("0", {
         path: livePath.track(99),
@@ -181,13 +181,13 @@ describe("view", () => {
       });
       const songView = setupSongViewMock();
 
-      const result = select({ trackIndex: 99 });
-
+      expect(() => select({ trackIndex: 99 })).toThrow(
+        'select failed: no track at "t99"',
+      );
       expect(songView.set).not.toHaveBeenCalledWith(
         "selected_track",
         expect.anything(),
       );
-      expect(result.selectedTrack).toBeUndefined();
     });
   });
 
@@ -244,20 +244,20 @@ describe("view", () => {
       expect(result.view).toBe("session");
     });
 
-    it("skips scene selection when scene does not exist", () => {
+    it("refuses a scene that does not exist", () => {
       registerMockObject("0", {
         path: livePath.scene(99),
         type: "Scene",
       });
       const songView = setupSongViewMock();
 
-      const result = select({ sceneIndex: 99 });
-
+      expect(() => select({ sceneIndex: 99 })).toThrow(
+        'select failed: no scene at "s99"',
+      );
       expect(songView.set).not.toHaveBeenCalledWith(
         "selected_scene",
         expect.anything(),
       );
-      expect(result.selectedScene).toBeUndefined();
     });
   });
 

--- a/src/tools/session/tests/select/select-edge-cases.test.ts
+++ b/src/tools/session/tests/select/select-edge-cases.test.ts
@@ -130,8 +130,9 @@ describe("select edge cases", () => {
   });
 
   describe("device path selection with non-existent device at path", () => {
-    it("skips device selection when device at path doesn't exist", () => {
-      setupSongViewMock();
+    it("refuses a device path with nothing at it", () => {
+      const songView = setupSongViewMock();
+
       setupAppViewMock();
       mockNonExistentObjects();
 
@@ -141,10 +142,13 @@ describe("select edge cases", () => {
         type: "Track",
       });
 
-      const result = select({ devicePath: "t0/d99" });
-
-      // Device doesn't exist at path, so no selection made
-      expect(result.selectedDevice).toBeUndefined();
+      expect(() => select({ devicePath: "t0/d99" })).toThrow(
+        'select failed: no device at "t0/d99"',
+      );
+      expect(songView.call).not.toHaveBeenCalledWith(
+        "select_device",
+        expect.anything(),
+      );
     });
   });
 });

--- a/src/tools/session/tests/select/select-helpers.test.ts
+++ b/src/tools/session/tests/select/select-helpers.test.ts
@@ -121,19 +121,8 @@ describe("select-helpers", () => {
     });
   });
 
+  // A slot that isn't there is refused before this runs — see select-path.test.ts.
   describe("updateClipSlotSelection", () => {
-    it("returns false when the clip slot does not exist", () => {
-      mockNonExistentObjects();
-      const { api } = setupSongView();
-
-      const result = updateClipSlotSelection({
-        songView: api,
-        clipSlot: { trackIndex: 5, sceneIndex: 5 },
-      });
-
-      expect(result).toBe(false);
-    });
-
     it("returns true but skips selecting the clip when the clip object is gone", () => {
       mockNonExistentObjects();
       const { mock, api } = setupSongView();

--- a/src/tools/session/tests/select/select-path.test.ts
+++ b/src/tools/session/tests/select/select-path.test.ts
@@ -128,19 +128,106 @@ describe("select path param", () => {
     expect(songView.set).toHaveBeenCalledWith("selected_scene", "id scene_3");
   });
 
-  // KNOWN GAP, pinned so a fix is a deliberate change: select does nothing and
-  // says nothing for a track that isn't there. The grammar bounds no index, so
-  // "t99" parses and select has no existence check behind it. Not new — the
-  // trackIndex param it replaced behaves identically, which is why this pins
-  // both: whatever select ends up doing here, it has to do it for the pair.
-  it("silently no-ops on a track that doesn't exist, path or param", () => {
+  // The grammar bounds no index, so "t99" parses and names a track that isn't
+  // there. Refuse it in the same words whichever spelling the caller reached
+  // for — a selection that quietly doesn't happen reads like one that did.
+  it("refuses a track that doesn't exist, path or param", () => {
     mockNonExistentObjects();
     const songView = setupSongViewMock();
 
-    expect(select({ path: "t99" })).toStrictEqual({});
-    expect(select({ trackIndex: 99 })).toStrictEqual({});
+    expect(() => select({ path: "t99" })).toThrow(
+      'select failed: no track at "t99"',
+    );
+    expect(() => select({ trackIndex: 99 })).toThrow(
+      'select failed: no track at "t99"',
+    );
     expect(songView.set).not.toHaveBeenCalledWith(
       "selected_track",
+      expect.anything(),
+    );
+  });
+
+  it("refuses a return or master track that doesn't exist", () => {
+    mockNonExistentObjects();
+    setupSongViewMock();
+
+    expect(() => select({ path: "rt9" })).toThrow(
+      'select failed: no track at "rt9"',
+    );
+    expect(() => select({ trackType: "return", trackIndex: 9 })).toThrow(
+      'select failed: no track at "rt9"',
+    );
+    expect(() => select({ path: "mt" })).toThrow(
+      'select failed: no track at "mt"',
+    );
+  });
+
+  it("refuses a scene that doesn't exist, path or param", () => {
+    mockNonExistentObjects();
+    const songView = setupSongViewMock();
+
+    expect(() => select({ path: "s99" })).toThrow(
+      'select failed: no scene at "s99"',
+    );
+    expect(() => select({ sceneIndex: 99 })).toThrow(
+      'select failed: no scene at "s99"',
+    );
+    expect(songView.set).not.toHaveBeenCalledWith(
+      "selected_scene",
+      expect.anything(),
+    );
+  });
+
+  // A session position names two things, so say which one is missing.
+  it("refuses a session position, naming the missing half", () => {
+    mockNonExistentObjects();
+    registerMockObject("track_0", { path: livePath.track(0), type: "Track" });
+    registerMockObject("scene_0", { path: livePath.scene(0), type: "Scene" });
+    setupSongViewMock();
+    setupAppViewMock();
+
+    expect(() => select({ path: "t9/s0" })).toThrow(
+      'select failed: no track at "t9"',
+    );
+    expect(() => select({ path: "t0/s99" })).toThrow(
+      'select failed: no scene at "s99"',
+    );
+    expect(() => select({ slot: "9/0" })).toThrow(
+      'select failed: no track at "t9"',
+    );
+
+    // Live keeps a clip slot per scene on every track, so a track and scene
+    // that both exist should have one — but say so rather than no-op if not.
+    expect(() => select({ path: "t0/s0" })).toThrow(
+      'select failed: no clip slot at "t0/s0"',
+    );
+  });
+
+  it("refuses a device that isn't there, path or param", () => {
+    mockNonExistentObjects();
+    setupSongViewMock();
+
+    expect(() => select({ path: "t0/d9" })).toThrow(
+      'select failed: no device at "t0/d9"',
+    );
+    expect(() => select({ devicePath: "t0/d9" })).toThrow(
+      'select failed: no device at "t0/d9"',
+    );
+  });
+
+  // Nothing is touched until every target checks out, so the view a scene
+  // selection would have switched to stays where it was.
+  it("leaves the view alone when the target isn't there", () => {
+    mockNonExistentObjects();
+    setupSongViewMock();
+
+    const appView = setupAppViewMock();
+
+    expect(() => select({ view: "session", path: "s99" })).toThrow(
+      'select failed: no scene at "s99"',
+    );
+    expect(appView.call).not.toHaveBeenCalledWith(
+      "show_view",
       expect.anything(),
     );
   });


### PR DESCRIPTION
`ppal-select` set nothing and said nothing when the target didn't exist. The model got `{}` back with no way to tell that from success — while `select` already threw for a bad `id`, and `read-clip` / `create-clip` already threw for a bad index.

Now it throws for all four target kinds, in both the `path` and index spellings:

| call | before | after |
|---|---|---|
| `{ path: "t99" }` / `{ trackIndex: 99 }` | `{}` | `select failed: no track at "t99"` |
| `{ path: "s99" }` / `{ sceneIndex: 99 }` | `{ view: "session" }` | `select failed: no scene at "s99"` |
| `{ path: "t0/s99" }` | `{ view: "session" }` | `select failed: no scene at "s99"` |
| `{ path: "t0/d9" }` / `{ devicePath: "t0/d9" }` | `{}` | `select failed: no device at "t0/d9"` |

A session position names two things, so it says which half is missing, the way `readClip` does. Return and master tracks report as `rt9` / `mt`.

## Behavior change

A `select` call used as a probe for "does this track exist?" now errors instead of returning `{}`. That's the deliberate part — erroring matches every sibling reader.

## Note on the shape

The checks are one up-front pass (`select-existence-helpers.ts`), not in-place checks in each `update*Selection` helper. `select` switches the view before it selects anything, so in-place checks would have left Live switched to Session view and *then* errored. Up front matches `validateParameters` and `create-clip-validation-helpers`, and a failed select now changes nothing. That made the old `exists()` guards in the update helpers dead code, so they're gone — existence is checked in one place.

## Testing

- Unit: the test pinning the old silent no-op is replaced by six covering all four kinds in both spellings, plus one asserting the view is untouched on failure. Three other tests that asserted the old skip were updated.
- E2E: ran `npm run e2e:mcp -- ppal-select` against a real Ableton Live — passes, including the new refusal cases and the view-untouched check.
- `npm run check` (11,865 pass, functions 100%) and `npm run check:build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
