### PR TITLE
Document arrangementLength tiling and the one-clip alternative

### DIFF
--- a/docs/features/limitations.md
+++ b/docs/features/limitations.md
@@ -79,8 +79,25 @@ more of the timeline takes more clips.
 ::: tip Workaround: Producer Pal tiles them for you
 
 Ask for a longer looped arrangement clip and Producer Pal duplicates and tiles
-it to fill the length. Nothing to do on your side — just expect a row of clips
-instead of one long one.
+it to fill the length. It sounds identical, but the result is a row of clips
+rather than one long one — a 2-bar clip stretched to 32 bars lands as 16 clips,
+and nothing in the API merges them back into a loop.
+
+That's the default because each tile is a real copy, so clip envelopes on the
+original survive.
+
+:::
+
+::: tip Workaround: ask for one long clip instead (MIDI only)
+
+If you'd rather have a single clip, say so. Producer Pal turns looping off,
+extends the clip, and writes the pattern out across the whole span —
+[bar copying](/features/midi-notation#bar-beat) does that in one call however
+many repeats you need.
+
+The repeats are then real notes, not a loop, so changing the pattern later means
+changing every repeat. Audio clips have no equivalent — there are no notes to
+write.
 
 :::
 

--- a/src/tools/actions/duplicate/duplicate.def.ts
+++ b/src/tools/actions/duplicate/duplicate.def.ts
@@ -78,7 +78,8 @@ export const toolDefDuplicate = defineTool("ppal-duplicate", {
       .string()
       .optional()
       .describe(
-        "duration: Nbar (e.g., '4bar'), n<fraction> note value (e.g., 'n/4'), or Nbar+n<fraction> (e.g., '1bar+n/4'). Auto-fills with loops; song meter",
+        "duration: Nbar (e.g., '4bar'), n<fraction> note value (e.g., 'n/4'), or Nbar+n<fraction> (e.g., '1bar+n/4'); song meter. " +
+          "Shorter than the source trims the copy; longer tiles copies to fill the span (many clips, not one) — for a single clip use ppal-update-clip with looping false and notes for the full length",
       ),
     toSlot: deprecatedParam(z.coerce.string().optional(), {
       replacedBy: "toPath",

--- a/src/tools/clip/update/update-clip.def.ts
+++ b/src/tools/clip/update/update-clip.def.ts
@@ -78,7 +78,8 @@ export const toolDefUpdateClip = defineTool("ppal-update-clip", {
       .string()
       .optional()
       .describe(
-        "duration: Nbar (e.g., '4bar'), n<fraction> note value (e.g., 'n/4'), or Nbar+n<fraction> (e.g., '1bar+n/4'). Arrangement clips only; song meter",
+        "duration: Nbar (e.g., '4bar'), n<fraction> note value (e.g., 'n/4'), or Nbar+n<fraction> (e.g., '1bar+n/4'). Arrangement clips only; song meter. " +
+          "Lengthening a looping clip tiles copies to fill the span (many clips, not one); for a single clip, set looping false and supply notes for the full length",
       ),
     toSlot: deprecatedParam(z.coerce.string().optional(), {
       replacedBy: "toPath",


### PR DESCRIPTION
Stretching a short looping arrangement clip with `arrangementLength` fills the span with tiled copies rather than one longer clip. That is the right default — each tile is a real copy, so clip envelopes survive — but nothing said it would happen, and a user was surprised when a 19-clip pattern came back as ~70 fragments.

## Changes

**`docs/features/limitations.md`** — the "Looped Arrangement Clips Can't Be Lengthened in Place" section now says what tiling actually produces (a 2-bar clip stretched to 32 bars lands as 16 clips, and nothing in the API merges them back), why it is the default, and adds a second workaround block for the single-clip route.

**`update-clip.def.ts` / `duplicate.def.ts`** — one line each on `arrangementLength` so the model can offer the choice instead of the user having to know. Duplicate's old text, "Auto-fills with loops", hid the same thing; it now says shorter trims and longer tiles.

## Note on the alternative

The reported workaround was a fresh `ppal-create-clip` using bar copy, which loses envelopes. Unlooped MIDI lengthening keeps the clip ID and its envelopes (`arrangement-unlooped-helpers.ts`), so `looping: false` plus notes inside `update-clip` gets one clip *and* keeps envelopes — strictly better, and it stays in one tool. That is what both descriptions point at.

This is a code-reading conclusion, not an e2e-tested one. Worth confirming against Live before release.

## Not included

No skills change. The `arrangement` fragment is notation-neutral and `fragment-notation-neutrality.test.ts` blocks naming bar copy there, so it would be a third copy of the same fact for callers on any notation.

## Checks

`npm run fix`, `npm run check` (11919 passed), `npm run check:build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)