### PR TITLE
fix(mixer): match a return track name exactly before a prefix

### DIFF
--- a/src/tools/shared/tests/utils.test.ts
+++ b/src/tools/shared/tests/utils.test.ts
@@ -794,4 +794,16 @@ describe("findReturnIndex", () => {
   it("matches nothing for an empty name", () => {
     expect(findReturnIndex(names, "")).toBe(-1);
   });
+
+  it("prefers an exact name over an earlier prefix match", () => {
+    expect(findReturnIndex(["Delay 2", "Delay"], "Delay")).toBe(1);
+    expect(findReturnIndex(["Reverb Long", "Reverb"], "Reverb")).toBe(1);
+    expect(findReturnIndex(["A Reverb", "A"], "A")).toBe(1);
+    expect(findReturnIndex(["Delay 2", "delay"], "DELAY")).toBe(1);
+  });
+
+  it("falls back to the first prefix match when no name matches exactly", () => {
+    expect(findReturnIndex(["A-Reverb", "B-Delay"], "A")).toBe(0);
+    expect(findReturnIndex(["A Reverb", "A-Delay"], "A")).toBe(0);
+  });
 });

--- a/src/tools/shared/utils.ts
+++ b/src/tools/shared/utils.ts
@@ -238,7 +238,8 @@ export function roundPan(pan: number): number {
 /**
  * Find the return (track or rack chain) a send name refers to: the exact name,
  * or its letter prefix — "A" matches "A-Reverb" (return tracks) and
- * "a Reverb" (rack return chains). Case-insensitive.
+ * "a Reverb" (rack return chains). Case-insensitive. An exact name anywhere in
+ * the list beats a prefix match, so "Delay" finds "Delay", not "Delay 2".
  * @param names - Return names in send order
  * @param sendReturn - Name or letter to match
  * @returns Index of the match, or -1
@@ -252,13 +253,16 @@ export function findReturnIndex(names: string[], sendReturn: string): number {
     return -1;
   }
 
+  const exact = names.findIndex((name) => name.toLowerCase() === wanted);
+
+  if (exact !== -1) {
+    return exact;
+  }
+
   return names.findIndex((name) => {
     const lower = name.toLowerCase();
     const next = lower[wanted.length];
 
-    return (
-      lower === wanted ||
-      (lower.startsWith(wanted) && (next === "-" || next === " "))
-    );
+    return lower.startsWith(wanted) && (next === "-" || next === " ");
   });
 }


### PR DESCRIPTION
## Bug

`findReturnIndex` checked the exact name and the letter prefix in a single `findIndex` pass, so the first *prefix* hit won over a later *exact* hit.

| names | sendReturn | expected | before |
|---|---|---|---|
| `["Delay 2","Delay"]` | `"Delay"` | 1 | 0 |
| `["Reverb Long","Reverb"]` | `"Reverb"` | 1 | 0 |
| `["A Reverb","A"]` | `"A"` | 1 | 0 |

The send gain was written to the wrong return track, silently, with no warning. Regression against `main`, where the matcher was `name === sendReturn || name.startsWith(sendReturn + "-")`.

## Fix

Two passes: an exact case-insensitive match across all names first, then the prefix-with-separator pass as a fallback. The `" "` separator (`"A"` matching `"a Reverb"` rack return chains) is kept — that part was an intentional addition.

## Tests

`src/tools/shared/tests/utils.test.ts` gains two cases: exact-over-earlier-prefix precedence (including a mixed-case variant) and the prefix fallback when nothing matches exactly. Existing `findReturnIndex` cases are unchanged and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)