### PR TITLE
fix: treat a coerced-null takeLane as unsent

### DIFF
--- a/src/tools/actions/duplicate/tests/duplicate-validation.test.ts
+++ b/src/tools/actions/duplicate/tests/duplicate-validation.test.ts
@@ -8,8 +8,10 @@ import "./duplicate-mocks-test-helpers.ts";
 import { duplicate } from "#src/tools/actions/duplicate/duplicate.ts";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import {
+  registerArrangementClip,
   registerMockObject,
   registerSessionClipDuplication,
+  registerTrackWithArrangementDup,
 } from "#src/tools/actions/duplicate/helpers/duplicate-test-helpers.ts";
 import { mockNonExistentObjects } from "#src/test/mocks/mock-registry.ts";
 
@@ -118,6 +120,41 @@ describe("duplicate - clip session validation", () => {
       expect.stringContaining("arrangementLength ignored"),
     );
   });
+});
+
+// A caller on the old schema still sends takeLane, and z.coerce.string() turns
+// its null into "null" — which used to throw before any copy was made.
+describe("duplicate - coerced-null takeLane", () => {
+  it.each([
+    ["omitted", undefined],
+    ["a coerced null", "null"],
+    ["a coerced undefined", "undefined"],
+  ])(
+    "copies to the main lane when takeLane is %s",
+    async (_label, takeLane) => {
+      registerMockObject("clip1", {
+        path: livePath.track(0).clipSlot(0).clip(),
+      });
+
+      const track0 = registerTrackWithArrangementDup(0);
+
+      registerArrangementClip(0, 0, 8);
+
+      const result = await duplicate({
+        type: "clip",
+        id: "clip1",
+        arrangementStart: "3|1",
+        takeLane,
+      });
+
+      expect(track0.call).not.toHaveBeenCalledWith("create_take_lane");
+      expect(result).toStrictEqual({
+        id: livePath.track(0).arrangementClip(0),
+        path: "t0",
+        arrangementStart: "3|1",
+      });
+    },
+  );
 });
 
 describe("duplicate - return format", () => {

--- a/src/tools/clip/create/tests/create-clip-take-lanes.test.ts
+++ b/src/tools/clip/create/tests/create-clip-take-lanes.test.ts
@@ -149,6 +149,34 @@ describe("createClip take lanes", () => {
     expect(result.path).toBe("t0/l0");
   });
 
+  // A caller on the old schema still sends takeLane, and z.coerce.string()
+  // turns its null into "null" — which used to throw before any clip was made.
+  it.each([
+    ["omitted", undefined],
+    ["a coerced null", "null"],
+    ["a coerced undefined", "undefined"],
+  ])(
+    "creates on the main lane when takeLane is %s",
+    async (_label, takeLane) => {
+      registerLiveSet();
+      const track = registerTakeLaneTrack({ initialLanes: 0 });
+
+      const result = (await createClip({
+        trackIndex: 0,
+        arrangementStart: "1|1",
+        notes: "C3",
+        takeLane,
+      })) as { path?: string };
+
+      expect(track.call).toHaveBeenCalledWith("create_midi_clip", 0, 4);
+      expect(track.call).not.toHaveBeenCalledWith("create_take_lane");
+      expect(result.path).toBe("t0");
+      expect(consoleMock.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("takeLane"),
+      );
+    },
+  );
+
   it("warns and ignores takeLane for session-only requests", async () => {
     registerEmptySessionSlot();
 

--- a/src/tools/shared/arrangement/take-lane-helpers.ts
+++ b/src/tools/shared/arrangement/take-lane-helpers.ts
@@ -24,6 +24,7 @@
 
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import { type ClipPath } from "#src/tools/shared/validation/object-path-helpers.ts";
+import { hiddenParamNamesSomething } from "#src/tools/shared/utils.ts";
 
 /** Maximum take lanes per track (soft cap; total non-main lanes). */
 export const MAX_TAKE_LANES = 8;
@@ -155,25 +156,24 @@ export interface ResolvedTakeLane {
 }
 
 /**
- * Whether a raw takeLane value requests a (non-main) take lane. The main lane is
- * the default, selected by `0`, `null`, `undefined`, `""`, or `"0"`.
+ * Whether a raw takeLane value requests a (non-main) take lane. `0` and `"0"`
+ * pick the main lane, and so does anything that names nothing. takeLane is
+ * deprecated, so a caller dropping it may still send a null — which arrives as
+ * the string "null", and which the framework already treats as unsent.
  * @param takeLane - Raw takeLane value from a tool argument
  * @returns true when a non-main take lane was requested
  */
 export function isTakeLaneRequested(
   takeLane: number | string | null | undefined,
 ): boolean {
-  return !(
-    takeLane == null ||
-    takeLane === "" ||
-    takeLane === 0 ||
-    takeLane === "0"
-  );
+  if (!hiddenParamNamesSomething(takeLane)) return false;
+
+  return takeLane !== 0 && takeLane !== "0";
 }
 
 /**
  * Normalize a raw takeLane argument to a target, or null for the main lane.
- * `0`, `null`, `undefined`, and `""` mean the main lane (unchanged behavior).
+ * Everything {@link isTakeLaneRequested} calls unset means the main lane.
  * The param is 1-based and the target is 0-based, so `N` becomes lane `N - 1`.
  * @param takeLane - Raw takeLane value from a tool argument
  * @returns A TakeLaneTarget, or null to target the main lane

--- a/src/tools/shared/arrangement/tests/take-lane-helpers.test.ts
+++ b/src/tools/shared/arrangement/tests/take-lane-helpers.test.ts
@@ -88,6 +88,14 @@ describe("isTakeLaneRequested", () => {
     expect(isTakeLaneRequested("0")).toBe(false);
   });
 
+  // z.coerce.string() renders a JSON null as "null" and undefined as
+  // "undefined". takeLane is deprecated, so a caller dropping it can still send
+  // one of those, and it has to read as unset.
+  it("is false for a coerced null", () => {
+    expect(isTakeLaneRequested("null")).toBe(false);
+    expect(isTakeLaneRequested("undefined")).toBe(false);
+  });
+
   it("is true for any non-main value (including invalid ones)", () => {
     expect(isTakeLaneRequested(1)).toBe(true);
     expect(isTakeLaneRequested("new")).toBe(true);
@@ -103,6 +111,11 @@ describe("normalizeTakeLaneTarget", () => {
     expect(normalizeTakeLaneTarget("")).toBeNull();
     expect(normalizeTakeLaneTarget(0)).toBeNull();
     expect(normalizeTakeLaneTarget("0")).toBeNull();
+  });
+
+  it("treats a coerced null as the main lane, not an error", () => {
+    expect(normalizeTakeLaneTarget("null")).toBeNull();
+    expect(normalizeTakeLaneTarget("undefined")).toBeNull();
   });
 
   it('passes "new" through', () => {


### PR DESCRIPTION
## Bug

`z.coerce.string()` renders a JSON `null` as the literal string `"null"` (and `undefined` as `"undefined"`). `isTakeLaneRequested` only special-cased `null` / `""` / `0` / `"0"`, so `"null"` counted as a real request and `normalizeTakeLaneTarget` computed `Number("null")` → `NaN` → threw.

```
ppal-create-clip {path:"t0", arrangementStart:"1|1", takeLane:null, notes:...}
  → THROW: takeLane must be 0, a positive integer, or "new" (got "null")
  → nothing is created
```

Same for `ppal-duplicate`. Reachable from any caller still holding the pre-2.2 schema. Meanwhile the tool framework already ran the same value through `hiddenParamNamesSomething` and read it as *unsent*, so it didn't warn about the deprecated param while the handler died on its value.

## Fix

`isTakeLaneRequested` now goes through `hiddenParamNamesSomething` — the guard `slot`, `toSlot`, `slots`, and `devicePath` already use via `namedHiddenPath`. `takeLane` is a `deprecatedParam`, so per that helper's stated policy it should have had the pass all along. A null `takeLane` now lands on the main lane, exactly as an omitted one does.

Scope is deliberately just `takeLane`; the other `z.coerce.string()` sites are untouched.

## Tests

- `take-lane-helpers.test.ts` — `isTakeLaneRequested` / `normalizeTakeLaneTarget` unit coverage for `"null"` and `"undefined"`.
- `create-clip-take-lanes.test.ts` and `duplicate-validation.test.ts` — parametrized over omitted / `"null"` / `"undefined"`, asserting the same main-lane result for all three, with no lane created and no `takeLane` warning.

All 6 new assertions fail on `dev` and pass with the fix. `npm run fix`, `npm run check`, and `npm run check:build` all pass; function coverage stays at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)