### PR TITLE
fix(device): stop read-device crashing on a drum-pad path

### DIFF
--- a/src/tools/device/read/read-device-drum-map-helpers.ts
+++ b/src/tools/device/read/read-device-drum-map-helpers.ts
@@ -1,0 +1,146 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import * as console from "#src/shared/max/v8-max-console.ts";
+import { type Notation } from "#src/shared/notation.ts";
+import {
+  DEFAULT_MAX_DEPTH,
+  getDrumMap,
+  type DeviceWithDrumPads,
+} from "#src/tools/shared/device/device-reader.ts";
+
+export interface DrumMapPostProcessOptions {
+  /** Whether a drum map was asked for, including via `include: ["*"]` */
+  includeDrumMap: boolean;
+  /** Whether "drum-map" was named outright, so its absence is worth a warning */
+  drumMapExplicit: boolean;
+  /** Whether chains were fetched only to build the map */
+  chainsForDrumMap: boolean;
+  /** Active notation; controls whether drum-map keys are drum names */
+  notation?: Notation;
+}
+
+/**
+ * Add the drum map to a result and strip chain data fetched only to build it.
+ * @param result - Device, chain, or drum pad result to post-process
+ * @param options - What was requested (see DrumMapPostProcessOptions)
+ * @returns Post-processed result
+ */
+export function postProcessDrumMap(
+  result: Record<string, unknown>,
+  options: DrumMapPostProcessOptions,
+): Record<string, unknown> {
+  const { includeDrumMap, drumMapExplicit, chainsForDrumMap, notation } =
+    options;
+
+  if (includeDrumMap) {
+    const devices = drumMapSource(result);
+
+    if (devices == null) {
+      warnNoDrumMap(result, drumMapExplicit);
+    } else {
+      const drumMap = getDrumMap(devices, notation);
+
+      if (drumMap != null) {
+        result.drumMap = drumMap;
+      }
+    }
+  }
+
+  if (chainsForDrumMap) {
+    stripInternalChains(result);
+  }
+
+  return result;
+}
+
+/**
+ * Depth to walk the device tree at.
+ *
+ * A kit can sit several racks down, and read-track finds it there because it
+ * reads at the shared default depth. Match that when the tree is being walked
+ * only to build the map — it gets stripped from the response afterwards, so the
+ * extra depth costs nothing visible. When the caller asked for chains too,
+ * their maxDepth governs what's rendered; the floor of 1 is what reaches a rack
+ * one level in.
+ * @param maxDepth - Depth the caller asked for
+ * @param includeDrumMap - Whether the drum map was requested
+ * @param chainsForDrumMap - Whether chains are being read only for the map
+ * @returns Depth to read at
+ */
+export function drumMapReadDepth(
+  maxDepth: number,
+  includeDrumMap: boolean,
+  chainsForDrumMap: boolean,
+): number {
+  if (chainsForDrumMap) {
+    return Math.max(DEFAULT_MAX_DEPTH, maxDepth);
+  }
+
+  return includeDrumMap ? Math.max(1, maxDepth) : maxDepth;
+}
+
+/**
+ * Devices a drum map can be built from, or null when the target can't have one.
+ *
+ * Notes reach a device or a plain chain directly, so a kit inside either plays
+ * by its own pitches. A drum pad and its drum chains sit behind the pad's note
+ * remap, where only the pad's note plays — so a kit in there gets no map. That
+ * is the same rule that stops getDrumMap's search at the outer kit.
+ * @param result - Device, chain, or drum pad result
+ * @returns Devices to search, or null if a drum map doesn't apply here
+ */
+function drumMapSource(
+  result: Record<string, unknown>,
+): DeviceWithDrumPads[] | null {
+  // A drum pad result carries no `type`; feeding one to getDrumMap crashed it.
+  if (result.type == null || result.type === "DrumChain") {
+    return null;
+  }
+
+  if (result.type === "Chain") {
+    return (result.devices ?? []) as DeviceWithDrumPads[];
+  }
+
+  return [result as unknown as DeviceWithDrumPads];
+}
+
+/**
+ * Say why a drum map is missing, but only when the caller named it. With
+ * `include: ["*"]` nothing was singled out, so silence matches how a device
+ * with no kit in it already answers.
+ * @param result - Result that has no drum map
+ * @param drumMapExplicit - Whether "drum-map" was named outright
+ */
+function warnNoDrumMap(
+  result: Record<string, unknown>,
+  drumMapExplicit: boolean,
+): void {
+  if (!drumMapExplicit) return;
+
+  const kind = result.type == null ? "drum pad" : "drum chain";
+
+  console.warn(
+    `readDevice: a ${kind} has no drum map of its own — read its drum rack for the kit's map`,
+  );
+}
+
+/**
+ * Drop chain data fetched only to build the map. A chain result keeps its own
+ * devices, so their chains go too — otherwise a drum-map read of a chain path
+ * answers with the whole rack tree below it.
+ * @param result - Result to strip in place
+ */
+function stripInternalChains(result: Record<string, unknown>): void {
+  delete result.chains;
+  delete result.drumPads;
+  delete result.hasSoloedChain;
+
+  if (Array.isArray(result.devices)) {
+    for (const device of result.devices) {
+      stripInternalChains(device as Record<string, unknown>);
+    }
+  }
+}

--- a/src/tools/device/read/read-device.ts
+++ b/src/tools/device/read/read-device.ts
@@ -4,20 +4,20 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { assertDefined } from "#src/shared/error-utils.ts";
-import { type Notation } from "#src/shared/notation.ts";
 import { midiToNoteName, noteNameToMidi } from "#src/shared/pitch.ts";
 import { STATE } from "#src/tools/constants.ts";
 import {
   cleanupInternalDrumPads,
-  DEFAULT_MAX_DEPTH,
-  getDrumMap,
   readDevice as readDeviceShared,
-  type DeviceWithDrumPads,
 } from "#src/tools/shared/device/device-reader.ts";
 import { buildChainInfo } from "#src/tools/shared/device/helpers/device-reader-helpers.ts";
 import { navigateRemainingSegments } from "#src/tools/shared/device/helpers/path/device-drumpad-navigation.ts";
 import { resolvePathToLiveApi } from "#src/tools/shared/device/helpers/path/device-path-helpers.ts";
 import { validateExclusiveParams } from "#src/tools/shared/validation/id-validation.ts";
+import {
+  drumMapReadDepth,
+  postProcessDrumMap,
+} from "./read-device-drum-map-helpers.ts";
 
 // ============================================================================
 // Helper functions (placed after main export per code organization rules)
@@ -91,41 +91,15 @@ export function readDevice(
   };
 
   const result = readDeviceTarget(deviceId, path, readOptions);
-  const processed = postProcessDrumMap(
-    result,
+  const processed = postProcessDrumMap(result, {
     includeDrumMap,
+    drumMapExplicit: include.includes("drum-map"),
     chainsForDrumMap,
-    context.notation,
-  );
+    notation: context.notation,
+  });
 
   // Cleanup after drum-map processing (getDrumMap needs _processedDrumPads)
   return cleanupInternalDrumPads(processed) as Record<string, unknown>;
-}
-
-/**
- * Depth to walk the device tree at.
- *
- * A kit can sit several racks down, and read-track finds it there because it
- * reads at the shared default depth. Match that when the tree is being walked
- * only to build the map — it gets stripped from the response afterwards, so the
- * extra depth costs nothing visible. When the caller asked for chains too,
- * their maxDepth governs what's rendered; the floor of 1 is what reaches a rack
- * one level in.
- * @param maxDepth - Depth the caller asked for
- * @param includeDrumMap - Whether the drum map was requested
- * @param chainsForDrumMap - Whether chains are being read only for the map
- * @returns Depth to read at
- */
-function drumMapReadDepth(
-  maxDepth: number,
-  includeDrumMap: boolean,
-  chainsForDrumMap: boolean,
-): number {
-  if (chainsForDrumMap) {
-    return Math.max(DEFAULT_MAX_DEPTH, maxDepth);
-  }
-
-  return includeDrumMap ? Math.max(1, maxDepth) : maxDepth;
 }
 
 /**
@@ -176,41 +150,6 @@ function readDeviceTarget(
     }
     /* v8 ignore stop */
   }
-}
-
-/**
- * Add drum map to result and strip internally-fetched chain data
- * @param result - Device result to post-process
- * @param includeDrumMap - Whether drum-map was requested
- * @param chainsForDrumMap - Whether chains were fetched only for drum map building
- * @param notation - Active notation; controls whether drum-map keys are drum names
- * @returns Post-processed result
- */
-function postProcessDrumMap(
-  result: Record<string, unknown>,
-  includeDrumMap: boolean,
-  chainsForDrumMap: boolean,
-  notation?: Notation,
-): Record<string, unknown> {
-  if (includeDrumMap) {
-    const drumMap = getDrumMap(
-      [result as unknown as DeviceWithDrumPads],
-      notation,
-    );
-
-    if (drumMap != null) {
-      result.drumMap = drumMap;
-    }
-  }
-
-  // Strip chains that were only fetched internally for drum map building
-  if (chainsForDrumMap) {
-    delete result.chains;
-    delete result.drumPads;
-    delete result.hasSoloedChain;
-  }
-
-  return result;
 }
 
 /**

--- a/src/tools/device/read/tests/read-device-drum-map.test.ts
+++ b/src/tools/device/read/tests/read-device-drum-map.test.ts
@@ -1,0 +1,198 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import { children } from "#src/test/mocks/mock-live-api.ts";
+import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
+import { readDevice } from "../read-device.ts";
+import { setupDrumPadMocks } from "./read-device-drum-mocks.ts";
+
+const DEVICE = livePath.track(1).device(0);
+const CHAIN = `${DEVICE} chains 0`;
+const KIT = `${CHAIN} devices 0`;
+
+/**
+ * Register a Drum Rack with one C1 pad holding a Simpler.
+ * @param id - Device id
+ * @param path - Live API path for the rack
+ */
+function registerKit(id: string, path: string): void {
+  registerMockObject(id, {
+    path,
+    type: "Device",
+    properties: {
+      name: "Kit",
+      class_display_name: "Drum Rack",
+      type: 1,
+      can_have_chains: 1,
+      can_have_drum_pads: 1,
+      is_active: 1,
+      drum_pads: children(`${id}-pad`),
+      chains: children(`${id}-chain`),
+    },
+  });
+
+  registerMockObject(`${id}-pad`, {
+    path: `${path} drum_pads 36`,
+    type: "DrumPad",
+    properties: { note: 36, name: "Kick", chains: children(`${id}-chain`) },
+  });
+
+  registerMockObject(`${id}-chain`, {
+    path: `${path} chains 0`,
+    type: "DrumChain",
+    properties: {
+      name: "Kick",
+      in_note: 36,
+      out_note: 36,
+      devices: children(`${id}-device`),
+    },
+  });
+
+  registerMockObject(`${id}-device`, {
+    path: `${path} chains 0 devices 0`,
+    type: "Device",
+    properties: {
+      name: "Kick",
+      class_display_name: "Simpler",
+      type: 1,
+      is_active: 1,
+    },
+  });
+}
+
+/** A Drum Rack whose C1 pad holds a Simpler, reachable at "t1/d0/pC1". */
+function setupKitPad(): void {
+  setupDrumPadMocks({
+    padIds: ["pad-36"],
+    padProperties: {
+      "pad-36": { note: 36, name: "Kick", chainIds: ["chain-1"] },
+    },
+    chainProperties: {
+      "chain-1": { name: "Kick", deviceIds: ["device-1"] },
+    },
+    deviceProperties: {
+      "device-1": { name: "Kick", class_display_name: "Simpler", type: 1 },
+    },
+  });
+}
+
+/** An Instrument Rack whose chain holds a Drum Rack, at "t1/d0/c0/d0". */
+function setupInstrumentRackWithKit(): void {
+  registerMockObject("rack", {
+    path: DEVICE,
+    type: "Device",
+    properties: {
+      name: "Outer",
+      class_display_name: "Instrument Rack",
+      type: 1,
+      can_have_chains: 1,
+      is_active: 1,
+      chains: children("chain-0"),
+    },
+  });
+
+  registerMockObject("chain-0", {
+    path: CHAIN,
+    type: "Chain",
+    properties: { name: "Kit", devices: children("kit") },
+  });
+
+  registerKit("kit", KIT);
+}
+
+const PAD_WARNING =
+  "readDevice: a drum pad has no drum map of its own — read its drum rack for the kit's map";
+
+describe("readDevice drum-map by target kind", () => {
+  it('reads a drum pad with include: ["*"] instead of crashing', () => {
+    setupKitPad();
+
+    const result = readDevice({ path: "t1/d0/pC1", include: ["*"] });
+
+    expect(result).toMatchObject({
+      id: "pad-36",
+      path: "t1/d0/pC1",
+      name: "Kick",
+      note: 36,
+      pitch: "C1",
+    });
+    expect(result.drumMap).toBeUndefined();
+    expect(result.chains).toHaveLength(1);
+    expect(outlet).not.toHaveBeenCalledWith(1, PAD_WARNING);
+  });
+
+  it("warns instead of mapping when drum-map is asked of a drum pad", () => {
+    setupKitPad();
+
+    const result = readDevice({ path: "t1/d0/pC1", include: ["drum-map"] });
+
+    expect(result.drumMap).toBeUndefined();
+    expect(outlet).toHaveBeenCalledWith(1, PAD_WARNING);
+  });
+
+  // A kit behind a pad only plays through that pad's note, so its pitches
+  // aren't the ones to write — the same reason getDrumMap stops at the kit.
+  it("gives no drum map for a kit nested under a pad", () => {
+    setupDrumPadMocks({
+      padIds: ["pad-36"],
+      padProperties: {
+        "pad-36": { note: 36, name: "Sub Kit", chainIds: ["chain-1"] },
+      },
+      chainProperties: { "chain-1": { name: "Sub Kit", deviceIds: ["sub"] } },
+    });
+    registerKit("sub", `${DEVICE} chains 0 devices 0`);
+
+    const result = readDevice({ path: "t1/d0/pC1", include: ["drum-map"] });
+
+    expect(result.drumMap).toBeUndefined();
+    expect(outlet).toHaveBeenCalledWith(1, PAD_WARNING);
+  });
+
+  it("warns instead of mapping when drum-map is asked of a drum chain", () => {
+    setupKitPad();
+
+    const result = readDevice({ path: "t1/d0/pC1/c0", include: ["drum-map"] });
+
+    expect(result.drumMap).toBeUndefined();
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "readDevice: a drum chain has no drum map of its own — read its drum rack for the kit's map",
+    );
+  });
+
+  it("maps a kit inside a plain chain and strips the tree it walked", () => {
+    setupInstrumentRackWithKit();
+
+    const result = readDevice({ path: "t1/d0/c0", include: ["drum-map"] });
+
+    expect(result.drumMap).toStrictEqual({ C1: "Kick" });
+
+    const devices = result.devices as Record<string, unknown>[];
+
+    expect(devices[0]).toStrictEqual({
+      id: "kit",
+      path: "t1/d0/c0/d0",
+      type: "drum-rack",
+      name: "Kit",
+    });
+  });
+
+  it("keeps the chain tree when chains were asked for too", () => {
+    setupInstrumentRackWithKit();
+
+    const result = readDevice({
+      path: "t1/d0/c0",
+      include: ["drum-map", "chains", "drum-pads"],
+    });
+
+    expect(result.drumMap).toStrictEqual({ C1: "Kick" });
+
+    const devices = result.devices as Record<string, unknown>[];
+
+    expect(devices[0]?.drumPads).toHaveLength(1);
+  });
+});

--- a/src/tools/shared/device/device-reader.test.ts
+++ b/src/tools/shared/device/device-reader.test.ts
@@ -258,6 +258,18 @@ describe("device-reader", () => {
       });
     });
 
+    it("cleans the devices of a chain read at the top level", () => {
+      const obj = {
+        type: "Chain",
+        devices: [{ type: "drum-rack", _processedDrumPads: [] }],
+      };
+
+      expect(cleanupInternalDrumPads(obj)).toStrictEqual({
+        type: "Chain",
+        devices: [{ type: "drum-rack" }],
+      });
+    });
+
     it("returns chain unchanged when it has no devices property", () => {
       const obj = {
         type: "audio-effect-rack",

--- a/src/tools/shared/device/device-reader.ts
+++ b/src/tools/shared/device/device-reader.ts
@@ -126,6 +126,12 @@ export function cleanupInternalDrumPads(obj: unknown): unknown {
     result.chains = chains.map(cleanupChain);
   }
 
+  // A chain read stands at the top of its own result, so its devices hang off
+  // `devices` rather than under `chains` — walk them too.
+  if (Array.isArray(rest.devices)) {
+    result.devices = cleanupInternalDrumPads(rest.devices);
+  }
+
   // A nested drum rack carries its own drumPads, each holding chains that can
   // hold further racks — so the walk has to descend both branches, not just
   // chains, or the internal bookkeeping surfaces in the response.


### PR DESCRIPTION
## Bug

`ppal-read-device path:"t1/d0/pC1" include:["*"]` threw
`TypeError: Cannot read properties of undefined (reading 'startsWith')`.

The drum-pad result has no `type` key, and the drum-map step fed it straight to a search
that reads `device.type`. `include:["drum-map"]` failed the same way. `include:["*"]` is the
documented "give me everything" value, so the most obvious call a model makes against a pad
returned nothing at all. No test covered drum-map on a pad path.

## Fix

The drum-map step now picks what to search by what was read:

- **device** — itself, as before.
- **plain chain** — its devices. Previously a chain path returned no map at all while still
  shipping the whole depth-4 rack tree below it, because the strip afterwards only cleared
  top-level keys.
- **drum pad / drum chain** — no map. Both sit behind the pad's note remap, so a kit in
  there can't be played by its own pitches. That is the same rule that already stops the
  search at the outer kit.

Asking for `drum-map` outright on a pad or drum chain warns and says to read the drum rack
instead. `include:["*"]` stays quiet, matching how a device with no kit in it already
answers.

While testing this, internal drum-pad bookkeeping (`_processedDrumPads`) turned out to leak
into *any* chain-path response holding a rack — the cleanup pass walked `chains` and
`drumPads` but not a chain's own `devices`. Fixed in the same pass, since it is what the
chain-path payload above is made of.

The drum-map post-processing moved to `read-device-drum-map-helpers.ts`; `read-device.ts`
was 318 of its 325 allowed lines.

## Tests

New `read-device-drum-map.test.ts` covers drum-map by target kind:

- `include:["*"]` on a pad path returns a usable pad payload, no crash, no warning
- `include:["drum-map"]` on a pad path warns and returns no map
- a kit nested under a pad still gets no map
- `include:["drum-map"]` on a drum-chain path warns and returns no map
- a kit inside a plain chain maps, and the tree walked to find it is stripped
- the tree survives when chains were asked for too

Plus a unit test for the cleanup pass descending into a chain's devices.

`npm run fix`, `npm run check`, and `npm run check:build` all pass; function coverage stays
at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)