### PR TITLE
fix(webui): stop a failed turn from destroying a saved conversation

### DIFF
--- a/webui/src/hooks/chat/helpers/streaming-helpers.ts
+++ b/webui/src/hooks/chat/helpers/streaming-helpers.ts
@@ -188,8 +188,8 @@ export function recoverFromChatError<
   // Fall back to the restored-but-not-yet-sent history when no client was built
   // (init threw early, e.g. MCP down) so a failed fork/send renders the existing
   // conversation instead of an empty view. Copy it — createErrorMessage mutates
-  // the array, and pendingHistoryRef must stay clean for a later send to
-  // bootstrap from.
+  // the array, and a failed fork (which stashes nothing) must leave
+  // pendingHistoryRef untouched for a later send to bootstrap from.
   const baseHistory =
     clientRef.current?.chatHistory ??
     (pendingHistoryRef.current ? [...pendingHistoryRef.current] : []);
@@ -200,7 +200,12 @@ export function recoverFromChatError<
   const errorHistory = includeStashed ? [...baseHistory, stashed] : baseHistory;
 
   if (!clientRef.current && includeStashed) {
-    pendingHistoryRef.current = [stashed];
+    // Keep the conversation the message was sent from. Stashing the message
+    // alone truncated a restored conversation to it, and the autosave that
+    // follows the failed turn wrote that truncation over the saved record.
+    // errorHistory picks up the error below, matching what the client branch
+    // persists.
+    pendingHistoryRef.current = errorHistory;
   }
 
   setMessages(adapter.createErrorMessage(error, errorHistory));

--- a/webui/src/hooks/chat/helpers/streaming-helpers.ts
+++ b/webui/src/hooks/chat/helpers/streaming-helpers.ts
@@ -246,6 +246,8 @@ interface RunChatTurnDeps<
   pendingForkRef?: PendingForkRef;
   /** Ticket dispenser: bumped per turn, so a late turn knows it was superseded. */
   turnIdRef: { current: number };
+  /** Bumped when the loaded conversation is torn down (switch, new chat). */
+  conversationGenRef: { current: number };
   pendingUserMessageRef: { current: TMessage | null };
   setMessages: (msgs: UIMessage[]) => void;
   setIsAssistantResponding: (responding: boolean) => void;
@@ -287,9 +289,10 @@ export async function runChatTurn<
   userMessage: TMessage | undefined,
   deps: RunChatTurnDeps<TClient, TMessage, TConfig>,
 ): Promise<T | undefined> {
-  const { turnIdRef, pendingUserMessageRef } = deps;
+  const { turnIdRef, conversationGenRef, pendingUserMessageRef } = deps;
   const turnId = ++turnIdRef.current;
   const stillCurrent = () => turnId === turnIdRef.current;
+  const conversationGen = conversationGenRef.current;
 
   deps.setIsAssistantResponding(true);
   // A new request clears any prior tool-limit notice before streaming.
@@ -314,6 +317,14 @@ export async function runChatTurn<
     // reassign the shared client's chatHistory, and autosaves, so a stale one
     // would corrupt the turn now streaming.
     if (!stillCurrent()) return undefined;
+
+    // The user switched conversations while this turn's setup was in flight.
+    // Recovery reads the shared refs, which now hold the conversation they
+    // switched TO, so it would render this turn's stray message and error there
+    // — and the autosave that follows would persist them under it. A switch
+    // sends nothing, so it never bumps the ticket above; this check is what
+    // stops it.
+    if (conversationGen !== conversationGenRef.current) return undefined;
 
     recoverFromChatError({
       ...deps,

--- a/webui/src/hooks/chat/tests/use-chat-setup-invalidation.test.ts
+++ b/webui/src/hooks/chat/tests/use-chat-setup-invalidation.test.ts
@@ -8,10 +8,12 @@
  */
 import { act } from "@testing-library/preact";
 import { describe, expect, it, vi } from "vitest";
+import { validateMcpConnection } from "#webui/hooks/chat/helpers/streaming-helpers";
 import {
   firstPartContent,
   renderChat,
   restoreHistory,
+  sendMessage,
   stopResponse,
   type MockChatProps,
 } from "./helpers/use-chat-render-test-helpers";
@@ -196,5 +198,55 @@ describe("turn invalidation during setup", () => {
       releaseStreams();
       await send;
     });
+  });
+});
+
+describe("setup failure on a restored conversation", () => {
+  it("renders the restored conversation under the failed send", async () => {
+    // MCP down: validateMcpConnection throws before a client exists, so the
+    // recovery has only the restored history to render against. Nulling it up
+    // front left an empty base, so the whole transcript was replaced by the one
+    // message that failed to send — and the teardown autosave then wrote that
+    // truncation over the saved record.
+    const { result } = renderChat(defaultProps);
+
+    await restoreHistory(result, OTHER_CONVERSATION);
+    vi.mocked(validateMcpConnection).mockRejectedValueOnce(
+      new Error("MCP connection failed"),
+    );
+    await sendMessage(result, "add a hi-hat");
+
+    expect(result.current.getChatHistory()).toStrictEqual([
+      ...OTHER_CONVERSATION,
+      { role: "user", content: "add a hi-hat" },
+      {
+        role: "assistant",
+        content: expect.stringContaining("MCP connection failed"),
+        isError: true,
+      },
+    ]);
+    expect(firstPartContent(result, "user")).toBe("hello");
+  });
+
+  it("bootstraps the next send from the whole conversation", async () => {
+    // The send after the failure builds the client from the pending history. If
+    // the failure left only its own message there, the conversation the user
+    // reopened is gone for good once that client's stream autosaves.
+    const { result } = renderChat(defaultProps);
+
+    await restoreHistory(result, OTHER_CONVERSATION);
+    vi.mocked(validateMcpConnection).mockRejectedValueOnce(
+      new Error("MCP connection failed"),
+    );
+    await sendMessage(result, "add a hi-hat");
+    await sendMessage(result, "add a hi-hat");
+
+    expect(vi.mocked(mockAdapter.buildConfig).mock.lastCall?.[3]).toStrictEqual(
+      [
+        ...OTHER_CONVERSATION,
+        { role: "user", content: "add a hi-hat" },
+        expect.objectContaining({ isError: true }),
+      ],
+    );
   });
 });

--- a/webui/src/hooks/chat/tests/use-chat-setup-invalidation.test.ts
+++ b/webui/src/hooks/chat/tests/use-chat-setup-invalidation.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it, vi } from "vitest";
 import { validateMcpConnection } from "#webui/hooks/chat/helpers/streaming-helpers";
 import {
   firstPartContent,
+  hasErrorPart,
   renderChat,
   restoreHistory,
   sendMessage,
@@ -142,6 +143,44 @@ describe("turn invalidation during setup", () => {
       expect(result.current.getChatHistory()).toStrictEqual(OTHER_CONVERSATION);
       expect(firstPartContent(result, "user")).toBe("hello");
       expect(firstPartContent(result, "model")).toBe("hi");
+    });
+
+    it("keeps it intact when the parked setup fails rather than resolves", async () => {
+      // The bail on a successful setup is only half of it: when the setup
+      // itself rejects (MCP down, a connect torn up by the switch), the
+      // rejection goes straight to the turn's error recovery, which renders and
+      // stashes against whatever conversation is loaded now. B's transcript
+      // grew a stray user bubble and an error from A, and the next autosave
+      // wrote that stray message over B.
+      let releaseCheck!: () => void;
+      const checking = new Promise<void>((resolve) => {
+        releaseCheck = resolve;
+      });
+
+      vi.mocked(validateMcpConnection).mockImplementationOnce(async () => {
+        await checking;
+
+        throw new Error("MCP connection failed");
+      });
+
+      const { result } = renderChat(defaultProps);
+      const send = act(async () => {
+        await result.current.handleSend("first");
+      });
+
+      await tick();
+      await act(() => {
+        result.current.clearConversation();
+      });
+      await restoreHistory(result, OTHER_CONVERSATION);
+
+      releaseCheck();
+      await send;
+      await tick();
+
+      expect(result.current.getChatHistory()).toStrictEqual(OTHER_CONVERSATION);
+      expect(result.current.messages).toHaveLength(2);
+      expect(hasErrorPart(result)).toBe(false);
     });
 
     it("doesn't lock the abandoned turn's settings over the restored ones", async () => {

--- a/webui/src/hooks/chat/use-chat.ts
+++ b/webui/src/hooks/chat/use-chat.ts
@@ -292,10 +292,11 @@ export function useChat<
           );
 
           if (!clientRef.current) {
-            const pendingHistory = pendingHistoryRef.current ?? undefined;
-
-            pendingHistoryRef.current = null;
-            await initializeChat(pendingHistory, sendOptions, stillLive);
+            await initializeChat(
+              pendingHistoryRef.current ?? undefined,
+              sendOptions,
+              stillLive,
+            );
           } else if (pendingInitRef.current) {
             // A client is here but another turn is still connecting it — the
             // user stopped that turn mid-connect (which re-enables the composer)
@@ -319,6 +320,13 @@ export function useChat<
           if (!client) {
             throw new Error("Failed to initialize chat client");
           }
+
+          // The client owns the restored history now (init baked it in), so
+          // drop the fallback. Deferred until here, same as a fork: a thrown
+          // init leaves it intact so the failure renders the existing
+          // conversation instead of replacing it with the message that failed
+          // to send — which the teardown autosave would then persist.
+          pendingHistoryRef.current = null;
 
           // This turn is the one that streams, so it owns the lock for the
           // client it's about to use — including one published by an init that

--- a/webui/src/hooks/chat/use-chat.ts
+++ b/webui/src/hooks/chat/use-chat.ts
@@ -83,6 +83,9 @@ export function useChat<
   const abortControllerRef = useRef<AbortController | null>(null);
   // Per-turn state runChatTurn owns; see there for why a turn takes a ticket.
   const turnIdRef = useRef(0);
+  // Bumped every time the loaded conversation is torn down. A turn that fails
+  // after a bump has nothing left to recover onto — see runChatTurn.
+  const conversationGenRef = useRef(0);
   const pendingUserMessageRef = useRef<TMessage | null>(null);
   const thinkingRef = useRef(active.activeThinking);
 
@@ -162,6 +165,9 @@ export function useChat<
 
   const clearConversation = useCallback(() => {
     setMessages([]);
+    // Every switch/new/delete/back-forward funnels through here, so this is the
+    // one place that knows the conversation a running turn belongs to is gone.
+    conversationGenRef.current++;
     clientRef.current?.dispose?.();
     clientRef.current = null;
     // The client this lock described is gone, so it must not carry into the
@@ -240,6 +246,7 @@ export function useChat<
         autoSaveRef,
         pendingForkRef,
         turnIdRef,
+        conversationGenRef,
         pendingUserMessageRef,
         setMessages,
         setIsAssistantResponding,


### PR DESCRIPTION
Two ways a failed chat turn could overwrite a saved conversation in IndexedDB.

## 1. A restored conversation was destroyed when a send's setup threw

Reopen a saved conversation with Ableton closed and send: `validateMcpConnection` throws before a client exists, so the error recovery had nothing but the stashed message to render — `handleSend` had already nulled the restored history. The whole transcript was replaced by that one message plus the error, and the autosave that follows a failed turn wrote the truncation over the saved record under the same id.

**Fix:** `handleSend` drops the restored history only once a client owns it (the fork path already deferred it this way), and `recoverFromChatError` stashes the failed message on top of that history instead of in place of it.

## 2. A failed turn spliced itself into the conversation the user switched TO

Send in conversation A while MCP is slow or down, then click conversation B before the check gives up. The rejection went straight to `runChatTurn`'s catch, which only checked the turn ticket — and a conversation switch sends nothing, so it never bumps the ticket. Recovery then rendered A's message and error into B and left A's stray message as B's history for the next autosave.

**Fix:** count conversation teardowns (`clearConversation` is the single funnel for switch / new / delete / Back-Forward) and skip recovery when the count moved under the turn.

Two other fix shapes were considered and rejected: passing the turn's `stillLive` into `runChatTurn`, and skipping recovery when the turn's controller is aborted. Both are the same check, and both break deliberate existing behavior — Stop during a rate-limit retry delay must still persist its cancellation error (`use-chat-retry.test.ts` pins that). A switch, not an abort, is what invalidates the recovery.

## Tests

`use-chat-setup-invalidation.test.ts` gains three regression tests, all failing before their fix:

- a send whose setup throws keeps the restored conversation in `getChatHistory()` (what the autosave writes) and on screen
- the next send bootstraps from the whole conversation, not just the message that failed
- a setup **rejection** after a conversation switch leaves B untouched — the file's existing switch test only exercised a setup that succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)