### PR TITLE
fix(paths): warn and skip a bad toPath instead of killing the batch

### DIFF
--- a/src/tools/actions/duplicate/helpers/clip/duplicate-clip-position-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/clip/duplicate-clip-position-helpers.ts
@@ -170,6 +170,11 @@ async function duplicateClipToArrangementPositions(
     resolveDestinationTargets(object, targets),
     takeLane,
   );
+
+  // Only reachable once every named destination was skipped: an omitted toPath
+  // resolves to the source's own track. Nowhere left to copy to.
+  if (destTargets.length === 0) return [];
+
   const liveSet = LiveAPI.from(livePath.liveSet);
   const songTimeSigNumerator = liveSet.getProperty(
     "signature_numerator",

--- a/src/tools/actions/duplicate/helpers/clip/duplicate-clip-slot-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/clip/duplicate-clip-slot-helpers.ts
@@ -50,20 +50,25 @@ export function duplicateClipSlot(
     );
   }
 
+  const sourceClip = sourceClipSlot.child("clip");
+
   // Get destination clip slot
   const destClipSlot = LiveAPI.from(
     livePath.track(toTrackIndex).clipSlot(toSceneIndex),
   );
 
+  // Skip rather than throw, so the other slots of a comma-separated toPath keep
+  // the copies they already made.
   if (!destClipSlot.exists()) {
-    throw new Error(
-      `duplicate failed: destination clip slot at track ${toTrackIndex}, scene ${toSceneIndex} does not exist`,
+    console.warn(
+      `clip ${sourceClip.id} was not duplicated: no clip slot at ${slotPath(toTrackIndex, toSceneIndex)}`,
     );
+
+    return null;
   }
 
   // Live's duplicate_clip_to no-ops on a track that won't take the clip instead
   // of failing, so check first rather than reporting a copy that never happened.
-  const sourceClip = sourceClipSlot.child("clip");
   const clipIsMidi = (sourceClip.getProperty("is_midi_clip") as number) > 0;
   const blocker = clipCopyBlocker(clipIsMidi, toTrackIndex);
 

--- a/src/tools/actions/duplicate/helpers/duplicate-device-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/duplicate-device-helpers.ts
@@ -123,7 +123,12 @@ function duplicateDevice(
     // caller's toPath, not the adjusted one — the temp track shifted its track
     // index. Either way nothing survives: the copy is still on the temp track,
     // which the cleanup below deletes.
-    const outcome = moveDeviceToPath(tempDevice, adjustedDestination, device);
+    const outcome = moveDeviceToPath(
+      tempDevice,
+      adjustedDestination,
+      device,
+      destination,
+    );
 
     if (outcome === "no-destination") {
       console.warn(`duplicate: no destination at toPath "${destination}"`);
@@ -136,6 +141,11 @@ function duplicateDevice(
         `duplicate: the copy could not be moved to "${destination}"`,
       );
 
+      return null;
+    }
+
+    // A path that didn't resolve at all already warned why, naming this path.
+    if (outcome === "unresolvable") {
       return null;
     }
 

--- a/src/tools/actions/duplicate/helpers/duplicate-validation-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/duplicate-validation-helpers.ts
@@ -177,10 +177,12 @@ export function inferDestination(
 }
 
 /**
- * Resolves and validates the tracks a clip is duplicated onto in the arrangement.
+ * Resolves the tracks a clip is duplicated onto in the arrangement, dropping
+ * the ones it can't be copied to. A destination is skipped rather than fatal,
+ * so one bad entry in a comma-separated toPath doesn't cost the good ones.
  * @param sourceClip - The clip being duplicated
  * @param targets - Requested destinations, or empty for the source's own track
- * @returns The destinations, each with the lane it named
+ * @returns The usable destinations, each with the lane it named
  */
 export function resolveDestinationTargets(
   sourceClip: LiveAPI,
@@ -200,11 +202,13 @@ export function resolveDestinationTargets(
 
   const clipIsMidi = sourceClip.getProperty("is_midi_clip") === 1;
 
-  for (const { trackIndex } of targets) {
+  return targets.filter(({ trackIndex }) => {
     const track = LiveAPI.from(livePath.track(trackIndex));
 
     if (!track.exists()) {
-      throw new Error(`duplicate failed: no track at toPath "t${trackIndex}"`);
+      console.warn(`duplicate: no track at toPath "t${trackIndex}"`);
+
+      return false;
     }
 
     // Live's duplicate_clip_to_arrangement no-ops on a type mismatch instead of
@@ -212,14 +216,16 @@ export function resolveDestinationTargets(
     const trackIsMidi = (track.getProperty("has_midi_input") as number) > 0;
 
     if (clipIsMidi !== trackIsMidi) {
-      throw new Error(
-        `duplicate failed: ${clipIsMidi ? "MIDI" : "audio"} clip cannot be duplicated to ` +
+      console.warn(
+        `duplicate: ${clipIsMidi ? "MIDI" : "audio"} clip cannot be duplicated to ` +
           `${trackIsMidi ? "MIDI" : "audio"} track ${trackIndex}`,
       );
-    }
-  }
 
-  return targets;
+      return false;
+    }
+
+    return true;
+  });
 }
 
 /**

--- a/src/tools/actions/duplicate/helpers/tests/duplicate-helpers.test.ts
+++ b/src/tools/actions/duplicate/helpers/tests/duplicate-helpers.test.ts
@@ -413,16 +413,18 @@ describe("duplicate-helpers", () => {
       );
     });
 
-    it("throws error when destination clip slot does not exist", () => {
-      // Mock source clip slot exists with clip
+    it("warns and skips when the destination clip slot does not exist", () => {
+      // Per destination, so the copies a multi-slot toPath already made survive.
       (global as Record<string, unknown>).LiveAPI = createClipSlotMockLiveAPI({
         sourceExists: true,
         sourceHasClip: true,
         destExists: false,
       });
 
-      expect(() => duplicateClipSlot(0, 0, 1, 0)).toThrow(
-        "duplicate failed: destination clip slot at track 1, scene 0 does not exist",
+      expect(duplicateClipSlot(0, 0, 1, 0)).toBeNull();
+      expect(outlet).toHaveBeenCalledWith(
+        1,
+        expect.stringContaining("was not duplicated: no clip slot at t1/s0"),
       );
     });
   });
@@ -467,6 +469,7 @@ interface ClipSlotMockLiveAPIInstance {
   path: string;
   exists: () => boolean;
   getProperty: (prop: string) => boolean | null;
+  child: (name: string) => ClipSlotMockLiveAPIInstance;
   id: string;
 }
 
@@ -499,6 +502,10 @@ function createClipSlotMockLiveAPI({
 
     static from(idOrPath: string | { toString: () => string }): MockLiveAPI {
       return new MockLiveAPI(String(idOrPath));
+    }
+
+    child(name: string): MockLiveAPI {
+      return new MockLiveAPI(`${this.path} ${name}`);
     }
 
     exists(): boolean {

--- a/src/tools/actions/duplicate/helpers/tests/duplicate-validation-helpers.test.ts
+++ b/src/tools/actions/duplicate/helpers/tests/duplicate-validation-helpers.test.ts
@@ -174,47 +174,58 @@ describe("resolveDestinationTargets", () => {
     ).toStrictEqual([mainLane(7), mainLane(8)]);
   });
 
-  it("throws when toPath names a track that does not exist", () => {
+  it("drops a toPath entry naming a track that does not exist", () => {
     const clip = sourceClip(3);
 
     mockNonExistentObjects();
 
-    expect(() => resolveDestinationTargets(clip, [mainLane(99)])).toThrow(
-      'duplicate failed: no track at toPath "t99"',
+    expect(resolveDestinationTargets(clip, [mainLane(99)])).toStrictEqual([]);
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      'duplicate: no track at toPath "t99"',
     );
   });
 
-  it("throws when a MIDI clip targets an audio track", () => {
+  it("drops a track a MIDI clip can't go to", () => {
     // Live's duplicate_clip_to_arrangement silently no-ops on a mismatch, so a
     // reported success here would be a lie.
     const clip = sourceClip(3, true);
 
     destTrack(5, false);
 
-    expect(() => resolveDestinationTargets(clip, [mainLane(5)])).toThrow(
-      "MIDI clip cannot be duplicated to audio track 5",
+    expect(resolveDestinationTargets(clip, [mainLane(5)])).toStrictEqual([]);
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "duplicate: MIDI clip cannot be duplicated to audio track 5",
     );
   });
 
-  it("throws when an audio clip targets a MIDI track", () => {
+  it("drops a track an audio clip can't go to", () => {
     const clip = sourceClip(4, false);
 
     destTrack(8, true);
 
-    expect(() => resolveDestinationTargets(clip, [mainLane(8)])).toThrow(
-      "audio clip cannot be duplicated to MIDI track 8",
+    expect(resolveDestinationTargets(clip, [mainLane(8)])).toStrictEqual([]);
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "duplicate: audio clip cannot be duplicated to MIDI track 8",
     );
   });
 
-  it("checks every named track, not just the first", () => {
+  it("keeps the tracks that work when one of them doesn't", () => {
+    // One bad entry in a comma-separated toPath must not cost the good ones.
     const clip = sourceClip(3, true);
 
     destTrack(7, true);
     destTrack(5, false);
 
-    expect(() =>
+    expect(
       resolveDestinationTargets(clip, [mainLane(7), mainLane(5)]),
-    ).toThrow("MIDI clip cannot be duplicated to audio track 5");
+    ).toStrictEqual([mainLane(7)]);
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      "duplicate: MIDI clip cannot be duplicated to audio track 5",
+    );
   });
 });
 

--- a/src/tools/actions/duplicate/tests/clip/duplicate-clip-bad-destination.test.ts
+++ b/src/tools/actions/duplicate/tests/clip/duplicate-clip-bad-destination.test.ts
@@ -1,0 +1,110 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import "../duplicate-mocks-test-helpers.ts";
+import { duplicate } from "#src/tools/actions/duplicate/duplicate.ts";
+import {
+  registerArrangementClip,
+  registerClipSlot,
+  registerMockObject,
+  registerTrackWithArrangementDup,
+} from "#src/tools/actions/duplicate/helpers/duplicate-test-helpers.ts";
+import { mockNonExistentObjects } from "#src/test/mocks/mock-registry.ts";
+
+// A toPath entry that names nowhere must cost only its own copy. Before this,
+// the first entry's copy was made and then thrown away with the whole call, so
+// the model never learned it existed and made it a second time on retry.
+describe("duplicate clip - a toPath entry that names nowhere", () => {
+  it("keeps the session copy that landed when a later slot is missing", async () => {
+    mockNonExistentObjects();
+
+    registerMockObject("clip1", {
+      path: livePath.track(0).clipSlot(0).clip(),
+      properties: { is_midi_clip: 1 },
+    });
+    registerMockObject("track-0", {
+      path: livePath.track(0),
+      properties: { has_midi_input: 1 },
+    });
+    registerClipSlot(0, 0, true);
+    registerClipSlot(0, 1, false);
+    registerMockObject("live_set/tracks/0/clip_slots/1/clip", {
+      path: livePath.track(0).clipSlot(1).clip(),
+    });
+
+    // Scene 9 doesn't exist, so its slot doesn't either.
+    const result = await duplicate({
+      type: "clip",
+      id: "clip1",
+      toPath: "t0/s1,t0/s9",
+    });
+
+    expect(result).toStrictEqual({
+      id: "live_set/tracks/0/clip_slots/1/clip",
+      path: "t0/s1",
+    });
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("was not duplicated: no clip slot at t0/s9"),
+    );
+  });
+
+  it("keeps the arrangement copy that landed when a later track is missing", async () => {
+    mockNonExistentObjects();
+
+    registerMockObject("clip1", {
+      path: livePath.track(0).clipSlot(0).clip(),
+      properties: { is_midi_clip: 1 },
+    });
+    registerMockObject("live_set", { path: livePath.liveSet });
+
+    const track2 = registerTrackWithArrangementDup(2, { has_midi_input: 1 });
+
+    registerArrangementClip(2, 0, 8);
+
+    const result = await duplicate({
+      type: "clip",
+      id: "clip1",
+      arrangementStart: "3|1",
+      toPath: "t2,t99",
+    });
+
+    expect(track2.call).toHaveBeenCalledWith(
+      "duplicate_clip_to_arrangement",
+      "id clip1",
+      8,
+    );
+    expect(result).toStrictEqual({
+      id: livePath.track(2).arrangementClip(0),
+      path: "t2",
+      arrangementStart: "3|1",
+    });
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      'duplicate: no track at toPath "t99"',
+    );
+  });
+
+  it("copies nowhere, without failing, when every track is missing", async () => {
+    mockNonExistentObjects();
+
+    registerMockObject("clip1", {
+      path: livePath.track(0).clipSlot(0).clip(),
+      properties: { is_midi_clip: 1 },
+    });
+    registerMockObject("live_set", { path: livePath.liveSet });
+
+    const result = await duplicate({
+      type: "clip",
+      id: "clip1",
+      arrangementStart: "3|1",
+      toPath: "t98,t99",
+    });
+
+    expect(result).toStrictEqual([]);
+  });
+});

--- a/src/tools/actions/duplicate/tests/duplicate-device-bad-path.test.ts
+++ b/src/tools/actions/duplicate/tests/duplicate-device-bad-path.test.ts
@@ -1,0 +1,68 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import { duplicate } from "#src/tools/actions/duplicate/duplicate.ts";
+import { registerMockObject } from "#src/tools/actions/duplicate/helpers/duplicate-test-helpers.ts";
+import {
+  lookupMockObject,
+  mockNonExistentObjects,
+} from "#src/test/mocks/mock-registry.ts";
+
+// The real move runs here — the rest of the device suite stubs it out, which is
+// how a destination that threw before returning an outcome went unnoticed.
+describe("duplicate device - a toPath entry that names nowhere", () => {
+  it("keeps the copy that landed when a later destination doesn't resolve", async () => {
+    mockNonExistentObjects();
+
+    registerMockObject("device1", {
+      path: livePath.track(0).device(0),
+      type: "PluginDevice",
+    });
+    registerMockObject("live_set/tracks/1/devices/0", {
+      path: livePath.track(1).device(0),
+      type: "PluginDevice",
+    });
+    // t2 is t3 by the time the move runs: duplicate_track parks a temp copy of
+    // the source track at index 1 and shifts everything after it.
+    registerMockObject("track-3", { path: livePath.track(3), type: "Track" });
+    // The registry answers statically, so the destination has to be told it
+    // holds the device now — otherwise the move reads back as refused.
+    registerMockObject("live_set", {
+      path: livePath.liveSet,
+      methods: {
+        move_device: (device, container) => {
+          const target = lookupMockObject(
+            String(container).slice("id ".length),
+          );
+
+          if (target != null) {
+            target.properties.devices = [
+              "id",
+              String(device).slice("id ".length),
+            ];
+          }
+
+          return null;
+        },
+      },
+    });
+
+    const result = await duplicate({
+      type: "device",
+      id: "device1",
+      toPath: "t2/d0,t99/d0/c0",
+    });
+
+    // The good destination still reports its copy...
+    expect(result).toStrictEqual([{ id: "live_set/tracks/1/devices/0" }]);
+    // ...and the bad one names the path the caller sent, not the shifted t100.
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      'device not moved: Track in path "t99/d0/c0" does not exist',
+    );
+  });
+});

--- a/src/tools/actions/duplicate/tests/duplicate-device.test.ts
+++ b/src/tools/actions/duplicate/tests/duplicate-device.test.ts
@@ -76,6 +76,7 @@ describe("duplicate - device duplication", () => {
       }),
       "t0/d3",
       expect.anything(),
+      expect.any(String),
     );
 
     // Should delete the temp track
@@ -102,6 +103,7 @@ describe("duplicate - device duplication", () => {
       }),
       "t3/d0",
       expect.anything(),
+      expect.any(String),
     );
   });
 
@@ -136,6 +138,7 @@ describe("duplicate - device duplication", () => {
       }),
       "t1/d0/c0/d2",
       expect.objectContaining({ _id: "rack_device1" }),
+      expect.any(String),
     );
 
     // Should delete the temp track at index 2
@@ -207,6 +210,7 @@ describe("duplicate - device duplication", () => {
       expect.anything(),
       "t2/d0",
       expect.anything(),
+      expect.any(String),
     );
   });
 
@@ -271,6 +275,8 @@ describe("duplicate - device duplication", () => {
       expect.anything(),
       "t100",
       expect.anything(),
+      // The move reports failures in the caller's own coordinates, not t100's.
+      "t99",
     );
     expect(liveSet.call).toHaveBeenCalledWith("delete_track", 1);
   });
@@ -333,6 +339,7 @@ describe("duplicate - device duplication", () => {
       expect.anything(),
       "t0/d2",
       expect.anything(),
+      expect.any(String),
     );
   });
 
@@ -359,6 +366,7 @@ describe("duplicate - device duplication", () => {
       expect.anything(),
       "t3/d0",
       expect.anything(),
+      expect.any(String),
     );
   });
 
@@ -373,6 +381,7 @@ describe("duplicate - device duplication", () => {
       expect.anything(),
       "r0/d0",
       expect.anything(),
+      expect.any(String),
     );
   });
 
@@ -423,6 +432,7 @@ describe("duplicate - device duplication", () => {
       expect.anything(),
       "t12/d1",
       expect.anything(),
+      expect.any(String),
     );
   });
 
@@ -445,6 +455,7 @@ describe("duplicate - device duplication", () => {
       expect.anything(),
       "t13/d0",
       expect.anything(),
+      "t12/d0",
     );
   });
 
@@ -469,6 +480,7 @@ describe("duplicate - device duplication", () => {
       expect.anything(),
       "t0/d0/c0",
       expect.anything(),
+      expect.any(String),
     );
   });
 });

--- a/src/tools/device/update/helpers/update-device-helpers.ts
+++ b/src/tools/device/update/helpers/update-device-helpers.ts
@@ -3,6 +3,7 @@
 // AI assistance: Claude (Anthropic)
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import { errorMessage } from "#src/shared/error-utils.ts";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import { noteNameToMidi } from "#src/shared/pitch.ts";
 import * as console from "#src/shared/max/v8-max-console.ts";
@@ -14,6 +15,7 @@ import {
 } from "#src/tools/shared/device/helpers/chain-mixer-helpers.ts";
 import { deviceHasInstrument } from "#src/tools/shared/device/helpers/device-state-helpers.ts";
 import {
+  type InsertionPathResolution,
   resolveInsertionPath,
   resolvePathToLiveApi,
 } from "#src/tools/shared/device/helpers/path/device-path-helpers.ts";
@@ -52,28 +54,44 @@ function targetsSameRack(toPath: string, drumRackPath: string): boolean {
 }
 
 /**
- * What a device move did. The caller words both failures, because only it knows
- * the path the user asked for — a duplicate's is adjusted for its temp track.
+ * What a device move did. The caller words "no-destination" and "refused",
+ * because only it knows the path the user asked for — a duplicate's is adjusted
+ * for its temp track. "unresolvable" is worded here, where the reason is.
  */
-export type DeviceMoveOutcome = "moved" | "no-destination" | "refused";
+export type DeviceMoveOutcome =
+  | "moved"
+  | "no-destination"
+  | "refused"
+  | "unresolvable";
 
 /**
- * Move a device to a new location
+ * Move a device to a new location. Never throws: a toPath naming no place a
+ * device can go warns and reports "unresolvable", so the other ids and
+ * destinations of the same call still get their work done.
  * @param device - LiveAPI device object
  * @param toPath - Target path
  * @param source - The device the user is really moving or copying, when
  *   `device` is a temp copy of it (device duplication); drives the
  *   left-behind chain mixer warning
+ * @param reportPath - How to spell toPath in warnings, when the caller adjusted
+ *   it (device duplication shifts track indices past its temp track)
  * @returns "moved" once the device is at the destination, "no-destination" when
- *   toPath names nothing, or "refused" when Live wouldn't take it
+ *   toPath names nothing, "refused" when Live wouldn't take it, or
+ *   "unresolvable" when toPath doesn't resolve at all
  */
 export function moveDeviceToPath(
   device: LiveAPI,
   toPath: string,
   source: LiveAPI = device,
+  reportPath: string = toPath,
 ): DeviceMoveOutcome {
-  // Every caller here got the path from a `toPath` param, so name it that.
-  const { container, position } = resolveInsertionPath(toPath, "toPath");
+  const destination = resolveMoveDestination(toPath, reportPath);
+
+  if (destination == null) {
+    return "unresolvable";
+  }
+
+  const { container, position } = destination;
 
   if (!container?.exists()) {
     return "no-destination";
@@ -114,6 +132,32 @@ export function moveDeviceToPath(
   }
 
   return "moved";
+}
+
+/**
+ * Resolve where a move should land. Resolution throws for a path that names
+ * nothing a device can go in — a missing track or device, a chain in a Drum
+ * Rack, a device that isn't a rack — so catch it here and warn instead.
+ * @param toPath - Target path, as handed to the move
+ * @param reportPath - How to spell it in the warning
+ * @returns The destination, or null when the path didn't resolve
+ */
+function resolveMoveDestination(
+  toPath: string,
+  reportPath: string,
+): InsertionPathResolution | null {
+  try {
+    // Every caller here got the path from a `toPath` param, so name it that.
+    return resolveInsertionPath(toPath, "toPath");
+  } catch (error) {
+    const reason = errorMessage(error);
+
+    console.warn(
+      `device not moved: ${toPath === reportPath ? reason : reason.replaceAll(toPath, reportPath)}`,
+    );
+
+    return null;
+  }
 }
 
 /**

--- a/src/tools/device/update/tests/update-device-helpers.test.ts
+++ b/src/tools/device/update/tests/update-device-helpers.test.ts
@@ -31,8 +31,47 @@ describe("moveDeviceToPath", () => {
   });
 
   it("blames toPath, the param every caller took the path from", () => {
-    expect(() => moveDeviceToPath(LiveAPI.from(device.path), "x9/d0")).toThrow(
-      'invalid toPath "x9/d0" - "x9" is not a track or scene',
+    expect(moveDeviceToPath(LiveAPI.from(device.path), "x9/d0")).toBe(
+      "unresolvable",
+    );
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining(
+        'device not moved: invalid toPath "x9/d0" - "x9" is not a track or scene',
+      ),
+    );
+  });
+
+  it("warns and skips a path that names no place a device can go", () => {
+    // Resolution throws for these; a caller moving several ids at once would
+    // lose the whole batch over one bad destination.
+    mockNonExistentObjects();
+
+    expect(moveDeviceToPath(LiveAPI.from(device.path), "t99/d0/c0")).toBe(
+      "unresolvable",
+    );
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      'device not moved: Track in path "t99/d0/c0" does not exist',
+    );
+  });
+
+  it("spells the destination the way the caller sent it", () => {
+    // Device duplication shifts track indices past its temp track, so the path
+    // the move used is not the one the user typed.
+    mockNonExistentObjects();
+
+    expect(
+      moveDeviceToPath(
+        LiveAPI.from(device.path),
+        "t100/d0/c0",
+        LiveAPI.from(device.path),
+        "t99/d0/c0",
+      ),
+    ).toBe("unresolvable");
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      'device not moved: Track in path "t99/d0/c0" does not exist',
     );
   });
 
@@ -96,7 +135,7 @@ describe("moveDeviceToPath", () => {
   });
 
   it("reports a missing destination, without moving", () => {
-    // Callers report this one themselves: update-device warns, duplicate throws.
+    // Callers word this one themselves; only they know the path the user sent.
     const liveSet = registerMockObject("live_set", { path: livePath.liveSet });
 
     mockNonExistentObjects();

--- a/src/tools/device/update/tests/update-device-move.test.ts
+++ b/src/tools/device/update/tests/update-device-move.test.ts
@@ -8,11 +8,12 @@ import {
   type RegisteredMockObject,
   children,
   livePath,
+  mockNonExistentObjects,
   registerMockObject,
   updateDevice,
 } from "./update-device-test-helpers.ts";
 
-describe("updateDevice - drum chain moving", () => {
+describe("updateDevice - moving a drum chain", () => {
   let chain0: RegisteredMockObject;
   let chain1: RegisteredMockObject;
   let chain2: RegisteredMockObject;
@@ -147,5 +148,60 @@ describe("updateDevice - drum chain moving", () => {
     expect(outlet).toHaveBeenCalledWith(1, "cannot move Chain");
     expect(chain.set).not.toHaveBeenCalledWith("in_note", expect.anything());
     expect(result).toStrictEqual({ id: "123" });
+  });
+});
+
+// A toPath that names no place a device can go must warn and skip the move, so
+// the rest of the batch still gets its other updates. The bare-track shape
+// always did; the nested ones used to throw and take the whole call with them.
+describe("updateDevice - a toPath that does not resolve", () => {
+  let first: RegisteredMockObject;
+  let second: RegisteredMockObject;
+
+  beforeEach(() => {
+    mockNonExistentObjects();
+
+    first = registerMockObject("123", { type: "PluginDevice" });
+    second = registerMockObject("456", { type: "PluginDevice" });
+
+    registerMockObject("live_set", { path: livePath.liveSet });
+    registerMockObject("track-0", { path: livePath.track(0), type: "Track" });
+
+    // t0/d0 is a Drum Rack (chains can't be auto-created in one) and t0/d1 is a
+    // plain device (no chains at all).
+    registerMockObject("drum-rack", {
+      path: livePath.track(0).device(0),
+      type: "RackDevice",
+      properties: {
+        can_have_chains: 1,
+        can_have_drum_pads: 1,
+        chains: children(),
+      },
+    });
+    registerMockObject("plain-device", {
+      path: livePath.track(0).device(1),
+      type: "PluginDevice",
+      properties: { can_have_chains: 0 },
+    });
+  });
+
+  it.each([
+    ["t99", 'move target at path "t99" does not exist'],
+    ["t99/d0", 'move target at path "t99/d0" does not exist'],
+    ["t99/d0/c0", 'device not moved: Track in path "t99/d0/c0" does not exist'],
+    ["t0/d5/c0", 'device not moved: Device in path "t0/d5/c0" does not exist'],
+    ["garbage", "device not moved: invalid toPath"],
+    ["t0/d0/c0", "device not moved: Auto-creating chains in Drum Racks"],
+    [
+      "t0/d1/c0",
+      'device not moved: Device at path "t0/d1/c0" does not support chains',
+    ],
+  ])("renames both devices and warns about %s", (toPath, warning) => {
+    const result = updateDevice({ ids: "123,456", toPath, name: "X" });
+
+    expect(outlet).toHaveBeenCalledWith(1, expect.stringContaining(warning));
+    expect(first.set).toHaveBeenCalledWith("name", "X");
+    expect(second.set).toHaveBeenCalledWith("name", "X");
+    expect(result).toStrictEqual([{ id: "123" }, { id: "456" }]);
   });
 });

--- a/src/tools/device/update/tests/update-device.test.ts
+++ b/src/tools/device/update/tests/update-device.test.ts
@@ -765,5 +765,5 @@ describe("updateDevice", () => {
     });
   });
 
-  // Drum chain move tests are in update-device-drum-chain-move.test.js
+  // Move tests are in update-device-move.test.ts
 });

--- a/src/tools/device/update/update-device.ts
+++ b/src/tools/device/update/update-device.ts
@@ -337,6 +337,8 @@ function updateTarget(
     if (isDeviceType(type)) {
       const outcome = moveDeviceToPath(target, options.toPath);
 
+      // "unresolvable" said why itself. Either way the move is skipped and the
+      // rest of this update — and of the batch — carries on.
       if (outcome === "no-destination") {
         console.warn(`move target at path "${options.toPath}" does not exist`);
       } else if (outcome === "refused") {


### PR DESCRIPTION
`toPath` obeyed "update tools never throw" only for the bare-track shape. Every nested shape threw, taking the whole call with it — including work it had already done.

| `toPath` (2 ids, `name: "X"`) | before | after |
|---|---|---|
| `t99` | warns, both renamed | unchanged |
| `t99/d0` | warns, both renamed | unchanged |
| `t99/d0/c0` | **throws**, nothing renamed | warns, both renamed |
| `t0/d5/c0` | **throws** | warns, both renamed |
| `garbage` | **throws** | warns, both renamed |

## Sites fixed

**1. `update-device` / **3. `duplicate` type `"device"`** — `src/tools/device/update/helpers/update-device-helpers.ts`

`moveDeviceToPath` now catches destination resolution and returns a new `"unresolvable"` outcome instead of throwing. Both tools go through it, so one fix covers both. It also takes an optional `reportPath` so device duplication's warning spells the path the caller sent, not the one shifted past its temp track (`t99`, not `t100`).

**2. `duplicate` type `"clip"` (session)** — `duplicate-clip-slot-helpers.ts`

A missing destination slot warns and returns `null` instead of throwing, so `toPath: "t1/s1,t1/s9"` keeps the `t1/s1` copy and reports its id.

**4. `duplicate` type `"clip"` (arrangement)** — `duplicate-validation-helpers.ts`

`resolveDestinationTargets` now drops a track that's missing or the wrong kind (MIDI/audio) and keeps the rest, matching what the session route already did. Its caller returns `[]` when every destination was dropped.

## Tests

- `update-device-move.test.ts` (renamed from `update-device-drum-chain-move.test.ts`, keeping the folder at its 12-item cap): the table above as `it.each`, plus a Drum Rack chain and a non-rack device. Each asserts both devices still renamed, both ids still returned, and the warning names the destination and why.
- `duplicate-device-bad-path.test.ts`: end-to-end with the **real** `moveDeviceToPath` — the rest of the device suite stubs it out, which is how this went unnoticed. `toPath: "t2/d0,t99/d0/c0"` returns the `t2` copy's id and warns naming `t99/d0/c0`.
- `duplicate-clip-bad-destination.test.ts`: session and arrangement fan-outs keep the copy that landed; all-bad returns `[]` without failing.
- Existing throw-expectation tests converted to warn-and-skip.

Function coverage stays at 100%. `fix` / `check` / `check:build` all pass.

## Not touched

Adjacent findings deliberately left alone: `wrapInstrumentsInRack` throws where its sibling branch warns for the same condition (single destination, nothing created yet — no lost work), and `duplicateClipSlot`'s source-slot checks stay fatal (constant across the fan-out, so they fire before any copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)