### PR TITLE
fix(webui): stop the Subagent-preset delete faking unsaved changes

### DIFF
--- a/webui/src/components/settings/PresetControls.tsx
+++ b/webui/src/components/settings/PresetControls.tsx
@@ -4,10 +4,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { useState } from "preact/hooks";
-import {
-  loadSubagentPresetId,
-  saveSubagentPresetId,
-} from "#webui/hooks/settings/settings-helpers";
 import { presetMatchesFields } from "#webui/hooks/settings/presets/preset-storage";
 import { type PresetSelection } from "#webui/hooks/settings/presets/use-preset-selection";
 import { usePresetDraft } from "#webui/hooks/settings/presets/use-preset-draft";
@@ -139,7 +135,7 @@ export function PresetControls({
           // the list, and clearing here would drop the user out of Update/Delete
           // with only the error notice to say why.
           if (selected && deletePreset(selected.id) != null) return;
-          if (selected) clearSubagentPreset(settings, selected.id);
+          if (selected) settings.forgetDeletedPreset(selected.id);
           setSelectedId("");
           setEditDescription("");
         }}
@@ -191,31 +187,6 @@ export function PresetControls({
       />
     </div>
   );
-}
-
-/**
- * Drop the Subagent-preset pointer at a just-deleted preset, in both places it
- * lives.
- *
- * Storage is written directly rather than left to the footer Save, because the
- * delete already landed there: buffering the clear alone would let a Cancel —
- * which re-reads this value from storage — restore an id naming nothing.
- *
- * The two are tested separately because they can disagree. With an unsaved pick
- * in the buffer, storage still holds the last saved one, and deleting either
- * preset must clear only the copy that named it.
- * @param settings - The live settings buffer
- * @param deletedId - The preset that was just deleted
- */
-function clearSubagentPreset(
-  settings: UseSettingsReturn,
-  deletedId: string,
-): void {
-  if (settings.subagentPresetId === deletedId) {
-    settings.setSubagentPresetId(null);
-  }
-
-  if (loadSubagentPresetId() === deletedId) saveSubagentPresetId(null);
 }
 
 /**

--- a/webui/src/components/settings/tests/PresetControls.test.tsx
+++ b/webui/src/components/settings/tests/PresetControls.test.tsx
@@ -18,10 +18,6 @@ import {
   savePresets,
 } from "#webui/hooks/settings/presets/preset-storage";
 import { usePresetSelection } from "#webui/hooks/settings/presets/use-preset-selection";
-import {
-  loadSubagentPresetId,
-  saveSubagentPresetId,
-} from "#webui/hooks/settings/settings-helpers";
 import { breakStorageWrites } from "#webui/test-utils/dom-test-helpers";
 import { type ChatPreset, type UseSettingsReturn } from "#webui/types/settings";
 import { makePresetSettings } from "./helpers/preset-settings-test-helpers";
@@ -108,38 +104,28 @@ function subagentOptionLabels(): (string | null)[] {
 }
 
 /**
- * Seed presets and render with a Subagent preset chosen. The stored id and the
- * unsaved buffer are seeded separately because deleting a preset has to clear
- * each one on its own.
- * @param options - The seeding for this scenario
- * @param options.presets - Presets to write to storage
- * @param options.storedId - The Subagent preset id already in storage
- * @param options.bufferedId - The Subagent preset id in the unsaved buffer
- * @returns The spy standing in for the buffer's setter
+ * Seed presets and render with a Subagent preset chosen. Which copies of the
+ * pointer a delete clears is useSettings' job, tested against the real hook in
+ * use-settings-subagent-preset.test.ts; here we only check the hand-off.
+ * @param presets - Presets to write to storage
+ * @returns The spy standing in for useSettings' forgetDeletedPreset
  */
-function renderWithSubagentPreset({
-  presets,
-  storedId,
-  bufferedId,
-}: {
-  presets: ChatPreset[];
-  storedId: string;
-  bufferedId: string;
-}): ReturnType<typeof vi.fn> {
+function renderWithSubagentPreset(
+  presets: ChatPreset[],
+): ReturnType<typeof vi.fn> {
   savePresets(presets);
-  saveSubagentPresetId(storedId);
-  const setSubagentPresetId = vi.fn();
+  const forgetDeletedPreset = vi.fn();
 
   render(
     <Controls
       settings={makePresetSettings({
-        subagentPresetId: bufferedId,
-        setSubagentPresetId,
+        subagentPresetId: presets[0]?.id,
+        forgetDeletedPreset,
       })}
     />,
   );
 
-  return setSubagentPresetId;
+  return forgetDeletedPreset;
 }
 
 describe("PresetControls", () => {
@@ -426,61 +412,22 @@ describe("PresetControls", () => {
     fireEvent.click(screen.getByTestId("preset-delete"));
   }
 
-  it("clears the Subagent preset from the buffer and storage", () => {
-    const setSubagentPresetId = renderWithSubagentPreset({
-      presets: [seeded],
-      storedId: "seed",
-      bufferedId: "seed",
-    });
+  it("hands the deleted preset to useSettings to drop the pointer", () => {
+    const forgetDeletedPreset = renderWithSubagentPreset([seeded]);
 
     deletePreset("seed");
 
-    expect(setSubagentPresetId).toHaveBeenCalledWith(null);
-    // Storage too, not just the buffer: Cancel re-reads this value, and would
-    // otherwise restore an id naming a preset that no longer exists.
-    expect(loadSubagentPresetId()).toBeNull();
-  });
-
-  it("clears storage only, when an unsaved pick named another preset", () => {
-    const setSubagentPresetId = renderWithSubagentPreset({
-      presets: [seeded, { ...seeded, id: "other", name: "Other" }],
-      storedId: "seed",
-      bufferedId: "other",
-    });
-
-    deletePreset("seed");
-
-    // The buffer names a preset that still exists, so it survives untouched.
-    expect(setSubagentPresetId).not.toHaveBeenCalled();
-    expect(loadSubagentPresetId()).toBeNull();
-  });
-
-  it("clears the buffer only, when the saved id named another preset", () => {
-    const setSubagentPresetId = renderWithSubagentPreset({
-      presets: [seeded, { ...seeded, id: "other", name: "Other" }],
-      storedId: "other",
-      bufferedId: "seed",
-    });
-
-    deletePreset("seed");
-
-    expect(setSubagentPresetId).toHaveBeenCalledWith(null);
-    expect(loadSubagentPresetId()).toBe("other");
+    expect(forgetDeletedPreset).toHaveBeenCalledWith("seed");
   });
 
   it("keeps the Subagent preset when the delete can't be written", () => {
-    const setSubagentPresetId = renderWithSubagentPreset({
-      presets: [seeded],
-      storedId: "seed",
-      bufferedId: "seed",
-    });
+    const forgetDeletedPreset = renderWithSubagentPreset([seeded]);
 
     breakStorageWrites();
     deletePreset("seed");
 
     // The preset is still there, so the pointer at it is still good.
-    expect(setSubagentPresetId).not.toHaveBeenCalled();
-    expect(loadSubagentPresetId()).toBe("seed");
+    expect(forgetDeletedPreset).not.toHaveBeenCalled();
   });
 
   it("offers Inherit plus every preset in the Subagent preset selector", () => {

--- a/webui/src/components/settings/tests/SettingsScreen.test.tsx
+++ b/webui/src/components/settings/tests/SettingsScreen.test.tsx
@@ -146,6 +146,8 @@ describe("SettingsScreen", () => {
     setSmallModelMode: vi.fn(),
     subagentPresetId: null,
     setSubagentPresetId: vi.fn(),
+    savedSubagentPresetId: null,
+    forgetDeletedPreset: vi.fn(),
     maxToolSteps: DEFAULT_MAX_TOOL_STEPS,
     setMaxToolSteps: vi.fn(),
     liveApiEnabled: false,

--- a/webui/src/components/settings/tests/helpers/preset-settings-test-helpers.ts
+++ b/webui/src/components/settings/tests/helpers/preset-settings-test-helpers.ts
@@ -24,6 +24,7 @@ export function makePresetSettings(
     applyPreset: vi.fn(),
     subagentPresetId: null,
     setSubagentPresetId: vi.fn(),
+    forgetDeletedPreset: vi.fn(),
     settingsLoaded: true,
     getProviderConnection: vi.fn(() => ({ apiKey: "sk-test" })),
     ...over,

--- a/webui/src/components/settings/tests/preset-controls-unsaved-changes.test.tsx
+++ b/webui/src/components/settings/tests/preset-controls-unsaved-changes.test.tsx
@@ -1,0 +1,161 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @vitest-environment happy-dom
+ */
+import "fake-indexeddb/auto";
+import { fireEvent, render, screen, waitFor } from "@testing-library/preact";
+import { beforeEach, describe, expect, it } from "vitest";
+import { PresetControls } from "#webui/components/settings/PresetControls";
+import { savePresets } from "#webui/hooks/settings/presets/preset-storage";
+import { usePresetSelection } from "#webui/hooks/settings/presets/use-preset-selection";
+import {
+  DEFAULT_SETTINGS,
+  loadCurrentProvider,
+  saveSubagentPresetId,
+} from "#webui/hooks/settings/settings-helpers";
+import {
+  type AppearanceSettings,
+  useHasUnsavedChanges,
+} from "#webui/hooks/settings/use-has-unsaved-changes";
+import { useSettings } from "#webui/hooks/settings/use-settings";
+import { type ChatPreset, type UseSettingsReturn } from "#webui/types/settings";
+
+const appearance: AppearanceSettings = {
+  theme: "dark",
+  showTimestamps: false,
+  showHelpLinks: false,
+  showTokenUsage: false,
+};
+
+// Derived from the defaults useSettings starts from, so selecting it in the
+// picker applies nothing — the state the repro needs, where the only thing the
+// delete can change is the Subagent preset pointer. Hardcoding the model would
+// quietly turn Select into a real edit the day a default changes.
+const provider = loadCurrentProvider();
+const seeded: ChatPreset = {
+  id: "seed",
+  name: "Seeded",
+  provider,
+  model: DEFAULT_SETTINGS[provider].model,
+  thinking: DEFAULT_SETTINGS[provider].thinking,
+  smallModelMode: false,
+  enabledTools: {},
+};
+
+/**
+ * The Presets tab wired the way the app wires it: App owns useSettings and the
+ * unsaved-changes detector, and the preset controls sit under it with their own
+ * selection state. The split matters — a delete that only reaches storage would
+ * leave a stale answer up here.
+ * @returns A readout of the two states the assertions need, plus the controls
+ */
+function SettingsTab() {
+  const settings = useSettings();
+  const hasUnsavedChanges = useHasUnsavedChanges(settings, appearance, true);
+
+  return (
+    <>
+      <span data-testid="loaded">{String(settings.settingsLoaded)}</span>
+      <span data-testid="unsaved">{String(hasUnsavedChanges)}</span>
+      <PresetsPane settings={settings} />
+    </>
+  );
+}
+
+/**
+ * The controls plus the selection state that lives beside them, below the
+ * detector — SettingsScreen's arrangement.
+ * @param props - Component props
+ * @param props.settings - The settings hook from the parent
+ * @returns The preset controls
+ */
+function PresetsPane({ settings }: { settings: UseSettingsReturn }) {
+  return (
+    <PresetControls settings={settings} selection={usePresetSelection()} />
+  );
+}
+
+/**
+ * Render the tab with a preset already saved as the Subagent preset, then wait
+ * out the async decrypt so the unsaved-changes baseline has been captured.
+ */
+async function renderTab(): Promise<void> {
+  savePresets([seeded]);
+  saveSubagentPresetId("seed");
+  render(<SettingsTab />);
+
+  await waitFor(() =>
+    expect(screen.getByTestId("loaded").textContent).toBe("true"),
+  );
+}
+
+/**
+ * Whether the modal currently reports unsaved changes.
+ * @returns The readout, as a boolean
+ */
+function unsaved(): boolean {
+  return screen.getByTestId("unsaved").textContent === "true";
+}
+
+/**
+ * Pick a value in the Subagent preset selector.
+ * @param value - The option value ("" for Inherit)
+ */
+function pickSubagentPreset(value: string): void {
+  fireEvent.change(screen.getByTestId("subagent-preset-select"), {
+    target: { value },
+  });
+}
+
+/**
+ * Select a preset and press Delete.
+ * @param id - The preset to delete
+ */
+function deletePreset(id: string): void {
+  fireEvent.change(screen.getByTestId("preset-select"), {
+    target: { value: id },
+  });
+  fireEvent.click(screen.getByTestId("preset-delete"));
+}
+
+describe("PresetControls unsaved-changes wiring", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("stays closable after deleting the preset that is the Subagent preset", async () => {
+    await renderTab();
+
+    deletePreset("seed");
+
+    // The delete already cleared both copies of the pointer, so there is
+    // nothing left to save and Escape/backdrop must close instead of shaking.
+    await waitFor(() => expect(unsaved()).toBe(false));
+  });
+
+  it("stays closable when the delete only has the saved copy left to clear", async () => {
+    await renderTab();
+
+    // Switching to Inherit is a real unsaved edit...
+    pickSubagentPreset("");
+    await waitFor(() => expect(unsaved()).toBe(true));
+
+    // ...but deleting the preset the saved copy still names settles it: both
+    // copies are now empty. Nothing here touches the buffer, so this only
+    // reads clean if the saved copy is reactive state and not a bare read.
+    deletePreset("seed");
+    await waitFor(() => expect(unsaved()).toBe(false));
+  });
+
+  it("still flags a Subagent preset the user picks", async () => {
+    await renderTab();
+
+    pickSubagentPreset("");
+
+    await waitFor(() => expect(unsaved()).toBe(true));
+  });
+});

--- a/webui/src/hooks/settings/tests/use-has-unsaved-changes.test.ts
+++ b/webui/src/hooks/settings/tests/use-has-unsaved-changes.test.ts
@@ -37,6 +37,8 @@ function makeSettings(
     voiceVolume: 1,
     voiceLanguage: "en",
     turnDetection: DEFAULT_TURN_DETECTION,
+    subagentPresetId: null,
+    savedSubagentPresetId: null,
     liveApiEnabledDirty: false,
     notationDirty: false,
     settingsLoaded: true,
@@ -168,6 +170,51 @@ describe("useHasUnsavedChanges", () => {
     const { result, update } = renderWithOpenModal(makeSettings());
 
     update(makeSettings({ subagentPresetId: "cheap-worker" }));
+    expect(result.current).toBe(true);
+  });
+
+  it("detects a subagent preset change away from a saved one", () => {
+    const saved = { subagentPresetId: "cheap", savedSubagentPresetId: "cheap" };
+    const { result, update } = renderWithOpenModal(makeSettings(saved));
+
+    expect(result.current).toBe(false);
+
+    update(makeSettings({ ...saved, subagentPresetId: "big" }));
+    expect(result.current).toBe(true);
+  });
+
+  it("ignores a subagent preset clear that a preset delete already saved", () => {
+    // Deleting the preset the Subagent preset names saves the clear itself
+    // (nothing is left to save), so the modal must stay closable.
+    const { result, update } = renderWithOpenModal(
+      makeSettings({
+        subagentPresetId: "doomed",
+        savedSubagentPresetId: "doomed",
+      }),
+    );
+
+    update(
+      makeSettings({ subagentPresetId: null, savedSubagentPresetId: null }),
+    );
+    expect(result.current).toBe(false);
+  });
+
+  it("still flags the buffer when a delete cleared only the saved copy", () => {
+    // The buffer names a preset that survived, so saving would write it — an
+    // unsaved change, even though the delete cleared the saved copy.
+    const { result, update } = renderWithOpenModal(
+      makeSettings({
+        subagentPresetId: "survivor",
+        savedSubagentPresetId: "doomed",
+      }),
+    );
+
+    update(
+      makeSettings({
+        subagentPresetId: "survivor",
+        savedSubagentPresetId: null,
+      }),
+    );
     expect(result.current).toBe(true);
   });
 

--- a/webui/src/hooks/settings/tests/use-settings.test.ts
+++ b/webui/src/hooks/settings/tests/use-settings.test.ts
@@ -11,6 +11,10 @@ import "fake-indexeddb/auto";
 import { renderHook, act, waitFor } from "@testing-library/preact";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { decryptApiKey, encryptApiKey } from "#webui/lib/api-key-crypto";
+import {
+  loadSubagentPresetId,
+  saveSubagentPresetId,
+} from "#webui/hooks/settings/settings-helpers";
 import { useSettings } from "#webui/hooks/settings/use-settings";
 import { flushLoad } from "./use-settings-test-helpers";
 
@@ -763,6 +767,91 @@ describe("useSettings", () => {
     expect(result.current.enabledTools).toStrictEqual({});
     // Cleanup
     localStorage.removeItem("producer_pal_enabled_tools");
+  });
+
+  describe("subagent preset", () => {
+    it("seeds the buffer and its saved mirror from storage", () => {
+      saveSubagentPresetId("seed");
+      const { result } = renderHook(() => useSettings());
+
+      expect(result.current.subagentPresetId).toBe("seed");
+      expect(result.current.savedSubagentPresetId).toBe("seed");
+    });
+
+    it("leaves the saved mirror behind until the buffer is saved", async () => {
+      const { result } = renderHook(() => useSettings());
+
+      await act(() => {
+        result.current.setSubagentPresetId("picked");
+      });
+
+      expect(result.current.subagentPresetId).toBe("picked");
+      expect(result.current.savedSubagentPresetId).toBeNull();
+    });
+
+    it("forgetDeletedPreset clears the buffer and the saved copy", async () => {
+      saveSubagentPresetId("doomed");
+      const { result } = renderHook(() => useSettings());
+
+      await act(() => {
+        result.current.forgetDeletedPreset("doomed");
+      });
+
+      expect(result.current.subagentPresetId).toBeNull();
+      expect(result.current.savedSubagentPresetId).toBeNull();
+      // Storage too, not just the state: Cancel re-reads this value, and would
+      // otherwise restore an id naming a preset that no longer exists.
+      expect(loadSubagentPresetId()).toBeNull();
+    });
+
+    it("clears the saved copy only, when an unsaved pick named another preset", async () => {
+      saveSubagentPresetId("doomed");
+      const { result } = renderHook(() => useSettings());
+
+      await act(() => {
+        result.current.setSubagentPresetId("survivor");
+      });
+      await act(() => {
+        result.current.forgetDeletedPreset("doomed");
+      });
+
+      // The buffer names a preset that still exists, so it survives untouched —
+      // and still reads as an unsaved change, because saving would write it.
+      expect(result.current.subagentPresetId).toBe("survivor");
+      expect(result.current.savedSubagentPresetId).toBeNull();
+      expect(loadSubagentPresetId()).toBeNull();
+    });
+
+    it("clears the buffer only, when the saved copy named another preset", async () => {
+      saveSubagentPresetId("survivor");
+      const { result } = renderHook(() => useSettings());
+
+      await act(() => {
+        result.current.setSubagentPresetId("doomed");
+      });
+      await act(() => {
+        result.current.forgetDeletedPreset("doomed");
+      });
+
+      expect(result.current.subagentPresetId).toBeNull();
+      expect(result.current.savedSubagentPresetId).toBe("survivor");
+      expect(loadSubagentPresetId()).toBe("survivor");
+    });
+
+    it("cancelSettings puts the buffer and the saved mirror back in step", async () => {
+      saveSubagentPresetId("seed");
+      const { result } = renderHook(() => useSettings());
+
+      await act(() => {
+        result.current.setSubagentPresetId("picked");
+      });
+      await act(() => {
+        result.current.cancelSettings();
+      });
+
+      expect(result.current.subagentPresetId).toBe("seed");
+      expect(result.current.savedSubagentPresetId).toBe("seed");
+    });
   });
 });
 

--- a/webui/src/hooks/settings/use-has-unsaved-changes.ts
+++ b/webui/src/hooks/settings/use-has-unsaved-changes.ts
@@ -15,10 +15,11 @@ export interface AppearanceSettings {
 
 /**
  * Build a serializable snapshot string from settings and appearance values.
- * liveApiEnabled and notation are intentionally omitted — they can change out
- * from under the modal (device Setup pane, focus refetch), so comparing against
- * a snapshot taken at open time gives false positives. Their dirty flags track
- * user intent instead.
+ * liveApiEnabled, notation, and subagentPresetId are intentionally omitted —
+ * they can change out from under the modal (device Setup pane, focus refetch,
+ * deleting the preset the subagent points at), so comparing against a snapshot
+ * taken at open time gives false positives. The first two track user intent
+ * with dirty flags; subagentPresetId is compared against its saved value.
  * @param {UseSettingsReturn} s - Settings hook return value
  * @param {AppearanceSettings} a - Appearance settings
  * @returns {string} JSON snapshot for comparison
@@ -32,7 +33,6 @@ function serialize(s: UseSettingsReturn, a: AppearanceSettings): string {
     thinking: s.thinking,
     enabledTools: s.enabledTools,
     smallModelMode: s.smallModelMode,
-    subagentPresetId: s.subagentPresetId,
     maxToolSteps: s.maxToolSteps,
     realtimeVoice: s.realtimeVoice,
     voiceSpeed: s.voiceSpeed,
@@ -82,7 +82,23 @@ export function useHasUnsavedChanges(
 
   return (
     serialize(settings, appearance) !== snapshot ||
+    subagentPresetChanged(settings) ||
     settings.liveApiEnabledDirty ||
     settings.notationDirty
   );
+}
+
+/**
+ * Whether the buffered Subagent preset differs from the saved one.
+ *
+ * Compared against the saved value rather than the open-time snapshot because
+ * deleting the preset the Subagent preset points at clears the buffer AND saves
+ * on the spot (forgetDeletedPreset in useSettings). A snapshot still naming the
+ * deleted preset reads that already-saved change as an unsaved edit the user
+ * never made, and the modal then refuses to close.
+ * @param {UseSettingsReturn} s - Settings hook return value
+ * @returns {boolean} True if the buffered id differs from the saved one
+ */
+function subagentPresetChanged(s: UseSettingsReturn): boolean {
+  return s.subagentPresetId !== s.savedSubagentPresetId;
 }

--- a/webui/src/hooks/settings/use-settings.ts
+++ b/webui/src/hooks/settings/use-settings.ts
@@ -110,6 +110,13 @@ export function useSettings(): UseSettingsReturn {
   const [subagentPresetId, setSubagentPresetId] = useState<string | null>(
     loadSubagentPresetId,
   );
+  // What's actually stored, mirrored in state so the unsaved-changes check can
+  // compare against it and re-render when it moves. Deleting a preset writes
+  // storage on the spot (forgetDeletedPreset below), which a plain read of
+  // localStorage during render would never notice.
+  const [savedSubagentPresetId, setSavedSubagentPresetId] = useState<
+    string | null
+  >(loadSubagentPresetId);
   // How many tool steps one turn may spend. Same buffered lifecycle as the two
   // above: persisted on Save, reverted on Cancel.
   const [maxToolSteps, setMaxToolSteps] = useState<number>(loadMaxToolSteps);
@@ -245,6 +252,7 @@ export function useSettings(): UseSettingsReturn {
     }
 
     voiceModeSettings.commit();
+    setSavedSubagentPresetId(subagentPresetId);
     setSavedModel(providerSettings[provider].model);
     setSavedProvider(provider);
     setSavedThinking(providerSettings[provider].thinking);
@@ -269,6 +277,7 @@ export function useSettings(): UseSettingsReturn {
     setEnabledToolsState(loadEnabledTools());
     setSmallModelModeState(loadSmallModelMode());
     setSubagentPresetId(loadSubagentPresetId());
+    setSavedSubagentPresetId(loadSubagentPresetId());
     setMaxToolSteps(loadMaxToolSteps());
     voiceModeSettings.revert();
     // Re-decrypt and restore saved provider settings (async; the apiKey lands a
@@ -288,6 +297,26 @@ export function useSettings(): UseSettingsReturn {
     setSaveError(null);
   }, [applyLoadedSettings, voiceModeSettings]);
 
+  // Drop a just-deleted preset from the Subagent-preset pointer, in both places
+  // it lives. The saved copy is written through immediately rather than left to
+  // the footer Save, because the delete already landed in storage: buffering the
+  // clear alone would let a Cancel — which re-reads this value from storage —
+  // restore an id naming nothing.
+  //
+  // The two are cleared separately because they can disagree. With an unsaved
+  // pick in the buffer, the saved copy still holds the last saved one, and
+  // deleting either preset must clear only the copy that named it.
+  const forgetDeletedPreset = useCallback(
+    (deletedId: string): void => {
+      if (subagentPresetId === deletedId) setSubagentPresetId(null);
+
+      if (savedSubagentPresetId === deletedId) {
+        saveSubagentPresetId(null);
+        setSavedSubagentPresetId(null);
+      }
+    },
+    [subagentPresetId, savedSubagentPresetId],
+  );
   const { setApiKey, setModel, setBaseUrl, setThinking } = useProviderSetters(
     provider,
     providerStateSetters,
@@ -344,6 +373,8 @@ export function useSettings(): UseSettingsReturn {
     setSmallModelMode: setSmallModelModeState,
     subagentPresetId,
     setSubagentPresetId,
+    savedSubagentPresetId,
+    forgetDeletedPreset,
     maxToolSteps,
     setMaxToolSteps,
     saveError,

--- a/webui/src/types/settings.ts
+++ b/webui/src/types/settings.ts
@@ -212,6 +212,12 @@ export interface UseSettingsReturn extends VoiceModeSettingsFields {
    * conversation) and a modal-local buffer persisted on Save. */
   subagentPresetId: string | null;
   setSubagentPresetId: (id: string | null) => void;
+  /** The stored counterpart of `subagentPresetId`, mirrored in state so the
+   * unsaved-changes check has something reactive to compare the buffer against. */
+  savedSubagentPresetId: string | null;
+  /** Drop a just-deleted preset from the Subagent-preset pointer — the buffer,
+   * the saved copy, or both, depending on which named it. */
+  forgetDeletedPreset: (deletedId: string) => void;
   /** Tool steps one turn may spend before the run stops and hands back control.
    * Subagent orchestrators and workers run on the same number (see
    * step-budget.ts). A modal-local buffer persisted on Save. */


### PR DESCRIPTION
Fixes [AJM-1009](https://linear.app/adamjmurray/issue/AJM-1009/deleting-the-preset-that-is-also-the-subagent-preset-makes-the).

Deleting the preset that is also the Subagent preset clears the pointer and saves on the spot, so nothing is left to save. But the unsaved-changes snapshot, taken when the modal opened, still named that preset — the footer claimed unsaved changes and Escape/backdrop shook the dialog instead of closing it.

**Fix:** drop `subagentPresetId` from the open-time `serialize()` snapshot and compare the buffer against its saved value instead. That is what "unsaved" means for this field: the buffer only ever diverges from what is saved through an in-modal edit, and Save and Cancel both put them back in step.

The saved value is mirrored in `useSettings` state (`savedSubagentPresetId`, alongside the existing `savedModel` / `savedProvider` / `savedThinking`), and `useSettings` now owns clearing a deleted preset from both copies (`forgetDeletedPreset`) — logic that used to sit in `PresetControls`. Reading localStorage during render gives the right answer but not a fresh render: a delete that clears only the saved copy — the buffer already names something else — changes no state that `App` owns, so the modal would keep showing the stale answer until an unrelated re-render. This also stops another browser tab's Save from flagging this one.

The alternative — a dirty flag, like `liveApiEnabledDirty` / `notationDirty` — was rejected. Those two mirror server config with nothing saved locally to compare against, and a dirty flag would still misfire on "pick Inherit, then delete the preset that was saved".

**Tests** (each fails on the unfixed code):

- `preset-controls-unsaved-changes.test.tsx` — a new integration test driving the real `useSettings` + `useHasUnsavedChanges` pair through `PresetControls`, with the selection state below the detector the way `SettingsScreen` arranges it. The existing `PresetControls` tests drive a mocked settings object and never touch the snapshot, so they cannot see this bug. Covers both the plain repro and the clears-only-the-saved-copy variant that needs the re-render.
- `use-settings.test.ts` — a `subagent preset` block against the real hook: seeding, the save/cancel lifecycle, and the three ways a delete can land (both copies, buffer only, saved copy only). These moved off the mocked `PresetControls` tests, which now just assert the hand-off.
- `use-has-unsaved-changes.test.ts` — unit cases for flagging a real pick and not flagging an already-saved clear.

`npm run fix`, `npm run check`, `npm run ui:test`, and `npm run check:build` all pass; function coverage stays at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
