### PR TITLE
fix(playback): accept params that agree, and say what's wrong with the rest

### DIFF
--- a/dev/Object-Paths.md
+++ b/dev/Object-Paths.md
@@ -112,7 +112,7 @@ copying. Deleting and comping stay in Live's UI.
 
 ## Tolerance
 
-Three tiers, in order of preference.
+Four tiers, in order of preference.
 
 1. **Hidden params.** `slot`, `slots`, `toSlot`, `devicePath`, `takeLane` are
    deprecated — accepted, warned, going away. `trackIndex` and `sceneIndex` on
@@ -124,9 +124,20 @@ Three tiers, in order of preference.
    bare `"0"` is honored only where the tool has exactly one legal
    single-segment shape (`create-clip` → `t0`; `read-clip` needs a scene, so it
    errors).
-3. **Conflicts throw.** Two params naming different targets is never resolved by
+3. **Surplus segments narrow.** A path carrying more than the action needs is
+   narrowed rather than refused: `ppal-playback`'s `play-scene` reads `t0/s1` as
+   scene 1, because launching a scene fires every track and the track is spare.
+   Silently — the caller already named the scene, so there is nothing to report.
+   Only surplus bends. A path _missing_ what the action needs still errors,
+   because there is nothing to recover, and it stays an error even where the
+   reverse recovery looks symmetric: `play-session-clips` with `s3` is refused,
+   since firing clips one at a time is a different Live call than launching the
+   scene.
+4. **Conflicts throw.** Two params naming different targets is never resolved by
    picking one. Honoring one and dropping the other is the silent
-   wrong-destination bug this grammar exists to prevent.
+   wrong-destination bug this grammar exists to prevent. A path that names the
+   same target twice over is not a conflict — `play-scene` with `t0/s1,t2/s1`
+   fires scene 1.
 
 ## Results
 

--- a/src/tools/session/helpers/playback-helpers.ts
+++ b/src/tools/session/helpers/playback-helpers.ts
@@ -282,7 +282,7 @@ export function handlePlayScene(
 ): PlaybackState {
   if (sceneIndex == null) {
     throw new Error(
-      `playback failed: sceneIndex is required for action "play-scene"`,
+      `playback failed: sceneIndex or path "s<scene>" is required for action "play-scene"`,
     );
   }
 

--- a/src/tools/session/helpers/playback-helpers.ts
+++ b/src/tools/session/helpers/playback-helpers.ts
@@ -282,7 +282,7 @@ export function handlePlayScene(
 ): PlaybackState {
   if (sceneIndex == null) {
     throw new Error(
-      `playback failed: sceneIndex or path "s<scene>" is required for action "play-scene"`,
+      `playback failed: sceneIndex, path "s<scene>", or a scene id is required for action "play-scene"`,
     );
   }
 

--- a/src/tools/session/helpers/playback-target-helpers.ts
+++ b/src/tools/session/helpers/playback-target-helpers.ts
@@ -23,7 +23,7 @@ export interface SlotPosition {
 }
 
 export interface PlaybackTarget {
-  /** Scene named by a bare "s<scene>" path, for play-scene */
+  /** The one scene to play, agreed by every param that named one */
   sceneIndex: number | null;
   /** Session positions named by `path` or the deprecated `slots` */
   slotPositions: SlotPosition[] | null;
@@ -35,6 +35,7 @@ export interface PlaybackTargetParams {
   ids?: string;
   path?: string;
   slots?: string;
+  sceneIndex?: number;
 }
 
 /** The param a target came from, and its value, for shape errors */
@@ -45,6 +46,12 @@ interface PathSource {
 
 interface PathTarget extends Omit<PlaybackTarget, "ids"> {
   source: PathSource | null;
+}
+
+/** A scene one param named, and how it named it, for disagreement errors */
+interface SceneRef {
+  scene: number;
+  source: string;
 }
 
 /** The one targeting action that takes a scene. The others take clips. */
@@ -58,32 +65,43 @@ const TARGETING_ACTIONS = new Set([
 ]);
 
 /**
- * Resolve what the target params name: a scene ("s3") for play-scene, or
- * session positions ("t0/s1") for the clip actions. The deprecated `slots`
- * still names positions, and refusing both beats guessing which the caller
- * meant.
+ * Resolve what the target params name: one scene for play-scene, or session
+ * positions ("t0/s1") for the clip actions. play-scene settles on a single
+ * scene every param agrees on; the clip actions take their target from `ids`
+ * or a path, and refusing both beats guessing which the caller meant.
  * @param action - The playback action, which decides whether a target applies
  * @param params - The raw target params
- * @param params.ids - Comma-separated clip IDs
+ * @param params.ids - Comma-separated clip IDs, or scene IDs for play-scene
  * @param params.path - A scene, or comma-separated session positions
  * @param params.slots - Deprecated comma-separated trackIndex/sceneIndex positions
+ * @param params.sceneIndex - Scene index, an alternative to a "s<scene>" path
  * @returns What the params named, null where they named nothing
  */
 export function resolvePlaybackTarget(
   action: string,
-  { ids, path, slots }: PlaybackTargetParams,
+  { ids, path, slots, sceneIndex }: PlaybackTargetParams,
 ): PlaybackTarget {
   const namedIds = namedParam(ids, "ids");
 
   // Parsing these for an action that never reads them turns a leftover param
   // into a failed transport command: `stop` has to stop.
   if (!TARGETING_ACTIONS.has(action)) {
-    warnUnusedTarget(action, path, slots, namedIds);
+    warnUnusedTarget(action, { path, slots, ids: namedIds, sceneIndex });
 
     return { sceneIndex: null, slotPositions: null, ids: undefined };
   }
 
   const { source, ...target } = resolvePathTarget(path, slots);
+
+  if (action === PLAY_SCENE) {
+    assertScenePath(target.slotPositions, source);
+
+    return {
+      sceneIndex: resolveSceneTarget(target.sceneIndex, sceneIndex, namedIds),
+      slotPositions: null,
+      ids: undefined,
+    };
+  }
 
   // Both name what to act on, so refusing beats guessing which the caller meant.
   if (namedIds != null && source != null) {
@@ -92,7 +110,14 @@ export function resolvePlaybackTarget(
     );
   }
 
-  assertTargetShape(action, target, source);
+  assertClipPath(action, target.sceneIndex, source);
+
+  if (sceneIndex != null) {
+    console.warn(
+      `sceneIndex ignored: action "${action}" acts on session positions; ` +
+        `use action "${PLAY_SCENE}" for the whole scene`,
+    );
+  }
 
   return { ...target, ids: namedIds };
 }
@@ -207,72 +232,162 @@ function resolvePathTarget(
 }
 
 /**
- * Refuse a path whose shape is wrong for the action. Each handler reads only
- * its own kind of target, so without this a wrong-shaped path falls through to
- * a "you gave me nothing" error about the very param the caller did send.
- * @param action - The playback action
- * @param target - What the path named
- * @param target.sceneIndex - The scene named, or null
- * @param target.slotPositions - The session positions named, or null
- * @param source - The param that named it, or null when neither did
+ * Settle on the one scene to play. Every param that can name a scene gets a
+ * vote: `path`, `sceneIndex`, and each id in `ids`. Only one scene plays at a
+ * time, so params naming different scenes are refused rather than ranked —
+ * picking a winner would silently drop half of what the caller asked for.
+ * @param pathScene - The scene named by `path`, or null when it named none
+ * @param sceneIndex - The `sceneIndex` param
+ * @param ids - The normalized `ids` param
+ * @returns The scene to play, or null when nothing named one
  */
-function assertTargetShape(
-  action: string,
-  { sceneIndex, slotPositions }: Omit<PlaybackTarget, "ids">,
+function resolveSceneTarget(
+  pathScene: number | null,
+  sceneIndex: number | undefined,
+  ids: string | undefined,
+): number | null {
+  const refs: SceneRef[] = [];
+
+  if (pathScene != null) {
+    refs.push({ scene: pathScene, source: `path "s${pathScene}"` });
+  }
+
+  if (sceneIndex != null) {
+    refs.push({ scene: sceneIndex, source: `sceneIndex ${sceneIndex}` });
+  }
+
+  refs.push(...idSceneRefs(ids));
+
+  // Keep the first param to name each scene, so the error names one source per
+  // scene rather than repeating a scene the caller named two ways.
+  const distinct = new Map<number, string>();
+
+  for (const { scene, source } of refs) {
+    if (!distinct.has(scene)) distinct.set(scene, source);
+  }
+
+  if (distinct.size > 1) {
+    const named = [...distinct]
+      .map(([scene, source]) => `scene ${scene} from ${source}`)
+      .join(", ");
+
+    throw new Error(
+      `playback failed: action "${PLAY_SCENE}" plays one scene, but got ${named}`,
+    );
+  }
+
+  return refs[0]?.scene ?? null;
+}
+
+/**
+ * The scene each id names: a scene id names itself, and a session clip or clip
+ * slot id names the scene it sits in. An id naming no scene is warned and
+ * skipped, the way every other bad id in this tool is.
+ * @param ids - The normalized `ids` param
+ * @returns One ref per id that names a scene
+ */
+function idSceneRefs(ids: string | undefined): SceneRef[] {
+  if (ids == null) return [];
+
+  const refs: SceneRef[] = [];
+
+  for (const id of parseCommaSeparatedIds(ids)) {
+    const object = LiveAPI.from(id);
+
+    if (!object.exists()) {
+      console.warn(`playback: id "${id}" does not exist`);
+      continue;
+    }
+
+    // Arrangement clips and everything off the session grid land here. Say
+    // what would work, since "found Clip" alone reads as a contradiction to a
+    // caller who was asked for a clip id.
+    if (object.sceneIndex == null) {
+      console.warn(
+        `playback: id "${id}" is in no scene (found ${object.type}); ` +
+          `action "${PLAY_SCENE}" takes a scene id or a session clip id`,
+      );
+      continue;
+    }
+
+    refs.push({ scene: object.sceneIndex, source: `ids "${id}"` });
+  }
+
+  return refs;
+}
+
+/**
+ * Refuse a path that names session positions when the action plays one scene.
+ * play-scene reads only the scene, so without this the path falls through to a
+ * "you gave me nothing" error about the very param the caller did send.
+ * @param slotPositions - The session positions the path named, or null
+ * @param source - The param that named them, or null when none did
+ */
+function assertScenePath(
+  slotPositions: SlotPosition[] | null,
   source: PathSource | null,
 ): void {
-  if (source == null) return;
+  if (source == null || slotPositions == null) return;
 
-  if (action === PLAY_SCENE && slotPositions != null) {
-    // Non-empty by construction: a path or slots naming nothing is reported as
-    // naming nothing, so it never reaches here with an empty list.
-    const { sceneIndex: scene } = slotPositions[0] as SlotPosition;
+  // Non-empty by construction: a path or slots naming nothing is reported as
+  // naming nothing, so it never reaches here with an empty list.
+  const { sceneIndex: scene } = slotPositions[0] as SlotPosition;
 
-    throw pathError(
-      source.label,
-      source.input,
-      `names a session position; action "${PLAY_SCENE}" takes one scene, ` +
-        `as path "s${scene}" or sceneIndex ${scene}`,
-    );
-  }
+  throw pathError(
+    source.label,
+    source.input,
+    `names a session position; action "${PLAY_SCENE}" takes one scene, ` +
+      `as path "s${scene}" or sceneIndex ${scene}`,
+  );
+}
 
-  if (action !== PLAY_SCENE && sceneIndex != null) {
-    const wholeScene =
-      action === "play-session-clips"
-        ? `, or use action "${PLAY_SCENE}" for the whole scene`
-        : "";
+/**
+ * Refuse a path that names a scene when the action acts on clips.
+ * @param action - The playback action
+ * @param sceneIndex - The scene the path named, or null
+ * @param source - The param that named it, or null when none did
+ */
+function assertClipPath(
+  action: string,
+  sceneIndex: number | null,
+  source: PathSource | null,
+): void {
+  if (source == null || sceneIndex == null) return;
 
-    throw pathError(
-      source.label,
-      source.input,
-      `names a scene; action "${action}" takes session positions ` +
-        `"t<track>/s<scene>" (e.g., "t0/s${sceneIndex}")${wholeScene}`,
-    );
-  }
+  const wholeScene =
+    action === "play-session-clips"
+      ? `, or use action "${PLAY_SCENE}" for the whole scene`
+      : "";
+
+  throw pathError(
+    source.label,
+    source.input,
+    `names a scene; action "${action}" takes session positions ` +
+      `"t<track>/s<scene>" (e.g., "t0/s${sceneIndex}")${wholeScene}`,
+  );
 }
 
 /**
  * Warns for target params on an action that has no target to apply them to.
  * @param action - The playback action
- * @param path - Raw path param
- * @param slots - Raw deprecated slots param
- * @param ids - Normalized ids param
+ * @param params - The target params, with `ids` already normalized
+ * @param params.path - Raw path param
+ * @param params.slots - Raw deprecated slots param
+ * @param params.ids - Normalized ids param
+ * @param params.sceneIndex - Raw sceneIndex param
  */
 function warnUnusedTarget(
   action: string,
-  path: string | undefined,
-  slots: string | undefined,
-  ids: string | undefined,
+  { path, slots, ids, sceneIndex }: PlaybackTargetParams,
 ): void {
   const sent = [
     namedParam(path, "path") != null ? "path" : null,
     namedHiddenPath(slots) != null ? "slots" : null,
     ids != null ? "ids" : null,
+    sceneIndex != null ? "sceneIndex" : null,
   ].filter((param) => param != null);
 
   if (sent.length === 0) return;
 
-  console.warn(
-    `${sent.join("/")} ignored: action "${action}" names no clips to act on`,
-  );
+  console.warn(`${sent.join("/")} ignored: action "${action}" takes no target`);
 }

--- a/src/tools/session/helpers/playback-target-helpers.ts
+++ b/src/tools/session/helpers/playback-target-helpers.ts
@@ -7,6 +7,7 @@ import * as console from "#src/shared/max/v8-max-console.ts";
 import { namedParam, parseCommaSeparatedIds } from "#src/tools/shared/utils.ts";
 import { validateIdTypes } from "#src/tools/shared/validation/id-validation.ts";
 import {
+  formatObjectPath,
   pathError,
   type ObjectPath,
 } from "#src/tools/shared/validation/object-path.ts";
@@ -44,7 +45,12 @@ interface PathSource {
   input: string;
 }
 
-interface PathTarget extends Omit<PlaybackTarget, "ids"> {
+/**
+ * What `path` or the deprecated `slots` named. They accept different spellings
+ * but parse to the same kind of entry, so everything downstream narrows once.
+ */
+interface PathInput {
+  entries: ObjectPath[];
   source: PathSource | null;
 }
 
@@ -91,13 +97,15 @@ export function resolvePlaybackTarget(
     return { sceneIndex: null, slotPositions: null, ids: undefined };
   }
 
-  const { source, ...target } = resolvePathTarget(path, slots);
+  const { entries, source } = readPathParam(path, slots);
 
   if (action === PLAY_SCENE) {
-    assertScenePath(target.slotPositions, source);
-
     return {
-      sceneIndex: resolveSceneTarget(target.sceneIndex, sceneIndex, namedIds),
+      sceneIndex: resolveSceneTarget(
+        pathSceneRefs(entries, source),
+        sceneIndex,
+        namedIds,
+      ),
       slotPositions: null,
       ids: undefined,
     };
@@ -110,7 +118,9 @@ export function resolvePlaybackTarget(
     );
   }
 
-  assertClipPath(action, target.sceneIndex, source);
+  // Narrow before warning: a path this action can't use throws, and saying we
+  // ignored a param on a call that did nothing is noise the model has to read.
+  const slotPositions = slotPositionsFrom(action, entries, source);
 
   if (sceneIndex != null) {
     console.warn(
@@ -119,7 +129,7 @@ export function resolvePlaybackTarget(
     );
   }
 
-  return { ...target, ids: namedIds };
+  return { sceneIndex: null, slotPositions, ids: namedIds };
 }
 
 /**
@@ -165,16 +175,16 @@ export function resolveClipSlotPositions(
 // --- Helpers below main exports ---
 
 /**
- * Resolve what `path` or the deprecated `slots` names.
+ * Read `path` or the deprecated `slots` as parsed entries.
  * @param path - A scene, or comma-separated session positions
  * @param slots - Deprecated comma-separated trackIndex/sceneIndex positions
- * @returns The scene or positions named, null where nothing was, and which
- *   param named it
+ * @returns The entries named and which param named them, or nothing when
+ *   neither did
  */
-function resolvePathTarget(
+function readPathParam(
   path: string | undefined,
   slots: string | undefined,
-): PathTarget {
+): PathInput {
   const named = namedParam(path, "path");
   const legacy = namedHiddenPath(slots);
 
@@ -184,51 +194,100 @@ function resolvePathTarget(
     );
   }
 
-  if (named == null) {
-    if (legacy == null) {
-      return { sceneIndex: null, slotPositions: null, source: null };
-    }
-
-    // parseSlotList drops empty entries with a warning, so a value like ","
-    // parses to no positions at all. An empty list reads downstream as "act on
-    // these zero slots" — a silent no-op — so report it as the nothing it is.
-    const positions = parseSlotList(legacy, "slots");
-
-    if (positions.length === 0) {
-      return { sceneIndex: null, slotPositions: null, source: null };
-    }
-
+  if (named != null) {
     return {
-      sceneIndex: null,
-      slotPositions: positions,
-      source: { label: "slots", input: legacy },
+      entries: parseObjectPathList(named, "path"),
+      source: { label: "path", input: named },
     };
   }
 
-  const source = { label: "path", input: named };
-  const parsed = parseObjectPathList(named, "path");
-  const scene = parsed.find(
-    (entry): entry is Extract<ObjectPath, { kind: "scene" }> =>
-      entry.kind === "scene",
-  );
+  if (legacy == null) return { entries: [], source: null };
 
-  if (scene == null) {
-    return {
-      sceneIndex: null,
-      slotPositions: parsed.map((entry) => requireSessionSlot(entry, "path")),
-      source,
-    };
-  }
+  // parseSlotList drops empty entries with a warning, so a value like ","
+  // parses to no positions at all. An empty list reads downstream as "act on
+  // these zero slots" — a silent no-op — so report it as the nothing it is.
+  const positions = parseSlotList(legacy, "slots");
 
-  // A scene launches every track at once, so a list naming one alongside
-  // anything else is a caller who meant something else.
-  if (parsed.length > 1) {
-    throw new Error(
-      'playback failed: path names one scene ("s<scene>") or session positions ("t<track>/s<scene>"), not a mix',
+  if (positions.length === 0) return { entries: [], source: null };
+
+  return {
+    entries: positions.map(({ trackIndex, sceneIndex }) => ({
+      kind: "slot" as const,
+      trackIndex,
+      sceneIndex,
+    })),
+    source: { label: "slots", input: legacy },
+  };
+}
+
+/**
+ * The scene each path entry names. A session position names the scene it sits
+ * in: play-scene fires the whole scene whatever track the path sits on, so the
+ * track is surplus, not a contradiction, and dropping it beats refusing a
+ * caller who already told us the scene.
+ * @param entries - What the path param named
+ * @param source - The param that named them, or null when neither did
+ * @returns One ref per entry
+ */
+function pathSceneRefs(
+  entries: ObjectPath[],
+  source: PathSource | null,
+): SceneRef[] {
+  if (source == null) return [];
+
+  return entries.map((entry) => {
+    if (entry.kind === "scene" || entry.kind === "slot") {
+      return { scene: entry.sceneIndex, source: quoteEntry(entry, source) };
+    }
+
+    // Every other shape is missing the scene rather than carrying a spare one,
+    // so there is nothing to recover.
+    throw pathError(
+      source.label,
+      formatObjectPath(entry),
+      `names no scene; action "${PLAY_SCENE}" takes a scene "s<scene>" ` +
+        `or a session position "t<track>/s<scene>"`,
     );
-  }
+  });
+}
 
-  return { sceneIndex: scene.sceneIndex, slotPositions: null, source };
+/**
+ * Name one entry the way the param that carried it is written. The deprecated
+ * `slots` rejects path spelling, so quoting `t0/s1` back at a `slots` caller
+ * hands them a value that param won't take.
+ * @param entry - One entry the path param named
+ * @param source - The param that named it
+ * @returns The param and the entry, quoted (e.g. `path "t0/s1"`)
+ */
+function quoteEntry(entry: ObjectPath, source: PathSource): string {
+  const spelled =
+    source.label === "slots" && entry.kind === "slot"
+      ? `${entry.trackIndex}/${entry.sceneIndex}`
+      : formatObjectPath(entry);
+
+  return `${source.label} "${spelled}"`;
+}
+
+/**
+ * The session positions each path entry names, for the actions that act on
+ * clips rather than a whole scene.
+ * @param action - The playback action
+ * @param entries - What the path param named
+ * @param source - The param that named them, or null when neither did
+ * @returns One position per entry, or null when the param named nothing
+ */
+function slotPositionsFrom(
+  action: string,
+  entries: ObjectPath[],
+  source: PathSource | null,
+): SlotPosition[] | null {
+  if (source == null) return null;
+
+  return entries.map((entry) => {
+    assertClipPath(action, entry, source);
+
+    return requireSessionSlot(entry, source.label);
+  });
 }
 
 /**
@@ -236,21 +295,17 @@ function resolvePathTarget(
  * vote: `path`, `sceneIndex`, and each id in `ids`. Only one scene plays at a
  * time, so params naming different scenes are refused rather than ranked —
  * picking a winner would silently drop half of what the caller asked for.
- * @param pathScene - The scene named by `path`, or null when it named none
+ * @param pathRefs - The scenes the path param named, one per entry
  * @param sceneIndex - The `sceneIndex` param
  * @param ids - The normalized `ids` param
  * @returns The scene to play, or null when nothing named one
  */
 function resolveSceneTarget(
-  pathScene: number | null,
+  pathRefs: SceneRef[],
   sceneIndex: number | undefined,
   ids: string | undefined,
 ): number | null {
-  const refs: SceneRef[] = [];
-
-  if (pathScene != null) {
-    refs.push({ scene: pathScene, source: `path "s${pathScene}"` });
-  }
+  const refs: SceneRef[] = [...pathRefs];
 
   if (sceneIndex != null) {
     refs.push({ scene: sceneIndex, source: `sceneIndex ${sceneIndex}` });
@@ -317,42 +372,20 @@ function idSceneRefs(ids: string | undefined): SceneRef[] {
 }
 
 /**
- * Refuse a path that names session positions when the action plays one scene.
- * play-scene reads only the scene, so without this the path falls through to a
- * "you gave me nothing" error about the very param the caller did send.
- * @param slotPositions - The session positions the path named, or null
- * @param source - The param that named them, or null when none did
- */
-function assertScenePath(
-  slotPositions: SlotPosition[] | null,
-  source: PathSource | null,
-): void {
-  if (source == null || slotPositions == null) return;
-
-  // Non-empty by construction: a path or slots naming nothing is reported as
-  // naming nothing, so it never reaches here with an empty list.
-  const { sceneIndex: scene } = slotPositions[0] as SlotPosition;
-
-  throw pathError(
-    source.label,
-    source.input,
-    `names a session position; action "${PLAY_SCENE}" takes one scene, ` +
-      `as path "s${scene}" or sceneIndex ${scene}`,
-  );
-}
-
-/**
- * Refuse a path that names a scene when the action acts on clips.
+ * Refuse a path entry that names a scene when the action acts on clips. The
+ * reverse of the play-scene recovery: a scene is missing the track, so there is
+ * nothing to drop, and firing clips one at a time isn't what launching a scene
+ * does anyway.
  * @param action - The playback action
- * @param sceneIndex - The scene the path named, or null
- * @param source - The param that named it, or null when none did
+ * @param entry - One entry the path param named
+ * @param source - The param that named it
  */
 function assertClipPath(
   action: string,
-  sceneIndex: number | null,
-  source: PathSource | null,
+  entry: ObjectPath,
+  source: PathSource,
 ): void {
-  if (source == null || sceneIndex == null) return;
+  if (entry.kind !== "scene") return;
 
   const wholeScene =
     action === "play-session-clips"
@@ -361,9 +394,9 @@ function assertClipPath(
 
   throw pathError(
     source.label,
-    source.input,
+    formatObjectPath(entry),
     `names a scene; action "${action}" takes session positions ` +
-      `"t<track>/s<scene>" (e.g., "t0/s${sceneIndex}")${wholeScene}`,
+      `"t<track>/s<scene>" (e.g., "t0/s${entry.sceneIndex}")${wholeScene}`,
   );
 }
 

--- a/src/tools/session/helpers/playback-target-helpers.ts
+++ b/src/tools/session/helpers/playback-target-helpers.ts
@@ -6,7 +6,10 @@
 import * as console from "#src/shared/max/v8-max-console.ts";
 import { namedParam, parseCommaSeparatedIds } from "#src/tools/shared/utils.ts";
 import { validateIdTypes } from "#src/tools/shared/validation/id-validation.ts";
-import { type ObjectPath } from "#src/tools/shared/validation/object-path.ts";
+import {
+  pathError,
+  type ObjectPath,
+} from "#src/tools/shared/validation/object-path.ts";
 import {
   namedHiddenPath,
   parseObjectPathList,
@@ -34,9 +37,22 @@ export interface PlaybackTargetParams {
   slots?: string;
 }
 
+/** The param a target came from, and its value, for shape errors */
+interface PathSource {
+  label: string;
+  input: string;
+}
+
+interface PathTarget extends Omit<PlaybackTarget, "ids"> {
+  source: PathSource | null;
+}
+
+/** The one targeting action that takes a scene. The others take clips. */
+const PLAY_SCENE = "play-scene";
+
 /** The actions that read a target. The rest act on the transport alone. */
 const TARGETING_ACTIONS = new Set([
-  "play-scene",
+  PLAY_SCENE,
   "play-session-clips",
   "stop-session-clips",
 ]);
@@ -67,11 +83,16 @@ export function resolvePlaybackTarget(
     return { sceneIndex: null, slotPositions: null, ids: undefined };
   }
 
-  const target = resolvePathTarget(path, slots);
+  const { source, ...target } = resolvePathTarget(path, slots);
 
-  if (namedIds != null && target.slotPositions != null) {
-    throw new Error("playback failed: ids and path are mutually exclusive");
+  // Both name what to act on, so refusing beats guessing which the caller meant.
+  if (namedIds != null && source != null) {
+    throw new Error(
+      `playback failed: ids and ${source.label} are mutually exclusive`,
+    );
   }
+
+  assertTargetShape(action, target, source);
 
   return { ...target, ids: namedIds };
 }
@@ -122,12 +143,13 @@ export function resolveClipSlotPositions(
  * Resolve what `path` or the deprecated `slots` names.
  * @param path - A scene, or comma-separated session positions
  * @param slots - Deprecated comma-separated trackIndex/sceneIndex positions
- * @returns The scene or positions named, null where nothing was
+ * @returns The scene or positions named, null where nothing was, and which
+ *   param named it
  */
 function resolvePathTarget(
   path: string | undefined,
   slots: string | undefined,
-): Omit<PlaybackTarget, "ids"> {
+): PathTarget {
   const named = namedParam(path, "path");
   const legacy = namedHiddenPath(slots);
 
@@ -138,12 +160,27 @@ function resolvePathTarget(
   }
 
   if (named == null) {
+    if (legacy == null) {
+      return { sceneIndex: null, slotPositions: null, source: null };
+    }
+
+    // parseSlotList drops empty entries with a warning, so a value like ","
+    // parses to no positions at all. An empty list reads downstream as "act on
+    // these zero slots" — a silent no-op — so report it as the nothing it is.
+    const positions = parseSlotList(legacy, "slots");
+
+    if (positions.length === 0) {
+      return { sceneIndex: null, slotPositions: null, source: null };
+    }
+
     return {
       sceneIndex: null,
-      slotPositions: legacy != null ? parseSlotList(legacy, "slots") : null,
+      slotPositions: positions,
+      source: { label: "slots", input: legacy },
     };
   }
 
+  const source = { label: "path", input: named };
   const parsed = parseObjectPathList(named, "path");
   const scene = parsed.find(
     (entry): entry is Extract<ObjectPath, { kind: "scene" }> =>
@@ -154,6 +191,7 @@ function resolvePathTarget(
     return {
       sceneIndex: null,
       slotPositions: parsed.map((entry) => requireSessionSlot(entry, "path")),
+      source,
     };
   }
 
@@ -165,7 +203,52 @@ function resolvePathTarget(
     );
   }
 
-  return { sceneIndex: scene.sceneIndex, slotPositions: null };
+  return { sceneIndex: scene.sceneIndex, slotPositions: null, source };
+}
+
+/**
+ * Refuse a path whose shape is wrong for the action. Each handler reads only
+ * its own kind of target, so without this a wrong-shaped path falls through to
+ * a "you gave me nothing" error about the very param the caller did send.
+ * @param action - The playback action
+ * @param target - What the path named
+ * @param target.sceneIndex - The scene named, or null
+ * @param target.slotPositions - The session positions named, or null
+ * @param source - The param that named it, or null when neither did
+ */
+function assertTargetShape(
+  action: string,
+  { sceneIndex, slotPositions }: Omit<PlaybackTarget, "ids">,
+  source: PathSource | null,
+): void {
+  if (source == null) return;
+
+  if (action === PLAY_SCENE && slotPositions != null) {
+    // Non-empty by construction: a path or slots naming nothing is reported as
+    // naming nothing, so it never reaches here with an empty list.
+    const { sceneIndex: scene } = slotPositions[0] as SlotPosition;
+
+    throw pathError(
+      source.label,
+      source.input,
+      `names a session position; action "${PLAY_SCENE}" takes one scene, ` +
+        `as path "s${scene}" or sceneIndex ${scene}`,
+    );
+  }
+
+  if (action !== PLAY_SCENE && sceneIndex != null) {
+    const wholeScene =
+      action === "play-session-clips"
+        ? `, or use action "${PLAY_SCENE}" for the whole scene`
+        : "";
+
+    throw pathError(
+      source.label,
+      source.input,
+      `names a scene; action "${action}" takes session positions ` +
+        `"t<track>/s<scene>" (e.g., "t0/s${sceneIndex}")${wholeScene}`,
+    );
+  }
 }
 
 /**

--- a/src/tools/session/playback.def.ts
+++ b/src/tools/session/playback.def.ts
@@ -68,7 +68,7 @@ stop: session and arrangement`,
       .optional()
       .describe(
         "session position(s) 't<track>/s<scene>', both 0-based, comma-separated (e.g., 't0/s1' or 't0/s1,t2/s3'); " +
-          "or one scene 's<scene>' for play-scene (e.g., 's3')",
+          "for play-scene, a scene 's<scene>' (e.g., 's3') or any position in it",
       ),
     slots: deprecatedParam(z.coerce.string().optional(), {
       replacedBy: "path",

--- a/src/tools/session/playback.def.ts
+++ b/src/tools/session/playback.def.ts
@@ -60,7 +60,9 @@ stop: session and arrangement`,
     ids: z.coerce
       .string()
       .optional()
-      .describe("comma-separated ID(s) for clip operations"),
+      .describe(
+        "comma-separated clip ID(s); for play-scene, a scene ID (or a clip ID in that scene)",
+      ),
     path: z.coerce
       .string()
       .optional()

--- a/src/tools/session/playback.ts
+++ b/src/tools/session/playback.ts
@@ -110,9 +110,15 @@ export function playback(
     ids: namedIds,
   } = resolvePlaybackTarget(action, { ids, path, slots });
 
-  if (scenePathIndex != null && sceneIndex != null) {
+  // Only a disagreement is worth refusing. A model that names the same scene
+  // twice gets its scene, not an error about how it phrased the request.
+  if (
+    scenePathIndex != null &&
+    sceneIndex != null &&
+    scenePathIndex !== sceneIndex
+  ) {
     throw new Error(
-      "playback failed: path and sceneIndex both name a scene; use path alone",
+      "playback failed: path and sceneIndex name different scenes; use path alone",
     );
   }
 

--- a/src/tools/session/playback.ts
+++ b/src/tools/session/playback.ts
@@ -105,22 +105,10 @@ export function playback(
   }
 
   const {
-    sceneIndex: scenePathIndex,
+    sceneIndex: sceneTarget,
     slotPositions,
     ids: namedIds,
-  } = resolvePlaybackTarget(action, { ids, path, slots });
-
-  // Only a disagreement is worth refusing. A model that names the same scene
-  // twice gets its scene, not an error about how it phrased the request.
-  if (
-    scenePathIndex != null &&
-    sceneIndex != null &&
-    scenePathIndex !== sceneIndex
-  ) {
-    throw new Error(
-      "playback failed: path and sceneIndex name different scenes; use path alone",
-    );
-  }
+  } = resolvePlaybackTarget(action, { ids, path, slots, sceneIndex });
 
   // Validate mutual exclusivity of time and locator parameters
   validateLocatorOrTime(startTime, startLocator, "startTime");
@@ -178,7 +166,7 @@ export function playback(
       startTime,
       startTimeBeats,
       useLocatorStart,
-      sceneIndex: scenePathIndex ?? sceneIndex,
+      sceneIndex: sceneTarget ?? undefined,
       ids: namedIds,
       slotPositions,
     },

--- a/src/tools/session/tests/playback/playback-basic.test.ts
+++ b/src/tools/session/tests/playback/playback-basic.test.ts
@@ -286,7 +286,7 @@ describe("transport", () => {
 
   it("should throw an error when required parameters are missing for play-scene", () => {
     expect(() => playback({ action: "play-scene" })).toThrow(
-      'playback failed: sceneIndex is required for action "play-scene"',
+      'playback failed: sceneIndex or path "s<scene>" is required for action "play-scene"',
     );
   });
 
@@ -502,7 +502,7 @@ describe("transport", () => {
         ids: "clip1",
         slots: "0/0",
       }),
-    ).toThrow("playback failed: ids and path are mutually exclusive");
+    ).toThrow("playback failed: ids and slots are mutually exclusive");
   });
 
   it("should handle play-session-clips via slots with single slot", () => {

--- a/src/tools/session/tests/playback/playback-basic.test.ts
+++ b/src/tools/session/tests/playback/playback-basic.test.ts
@@ -286,7 +286,7 @@ describe("transport", () => {
 
   it("should throw an error when required parameters are missing for play-scene", () => {
     expect(() => playback({ action: "play-scene" })).toThrow(
-      'playback failed: sceneIndex or path "s<scene>" is required for action "play-scene"',
+      'playback failed: sceneIndex, path "s<scene>", or a scene id is required for action "play-scene"',
     );
   });
 

--- a/src/tools/session/tests/playback/playback-features.test.ts
+++ b/src/tools/session/tests/playback/playback-features.test.ts
@@ -129,10 +129,13 @@ describe("playback path param", () => {
     expect(scene.call).toHaveBeenCalledWith("fire");
   });
 
-  it("refuses a scene path and sceneIndex that disagree", () => {
+  it("refuses a scene path and sceneIndex that disagree, naming both", () => {
     expect(() =>
       playback({ action: "play-scene", path: "s3", sceneIndex: 1 }),
-    ).toThrow("playback failed: path and sceneIndex name different scenes");
+    ).toThrow(
+      'playback failed: action "play-scene" plays one scene, but got ' +
+        'scene 3 from path "s3", scene 1 from sceneIndex 1',
+    );
   });
 });
 

--- a/src/tools/session/tests/playback/playback-features.test.ts
+++ b/src/tools/session/tests/playback/playback-features.test.ts
@@ -98,9 +98,12 @@ describe("playback path param", () => {
     expect(scene.call).toHaveBeenCalledWith("fire");
   });
 
-  it("refuses a scene path alongside session positions", () => {
+  // A mixed list is no longer a special case: every entry names a scene, so the
+  // ordinary disagreement error covers it and says which entry named which.
+  it("refuses a scene path alongside a position in another scene", () => {
     expect(() => playback({ action: "play-scene", path: "s3,t0/s1" })).toThrow(
-      'playback failed: path names one scene ("s<scene>")',
+      'playback failed: action "play-scene" plays one scene, but got ' +
+        'scene 3 from path "s3", scene 1 from path "t0/s1"',
     );
   });
 

--- a/src/tools/session/tests/playback/playback-features.test.ts
+++ b/src/tools/session/tests/playback/playback-features.test.ts
@@ -104,10 +104,35 @@ describe("playback path param", () => {
     );
   });
 
-  it("refuses a scene path and sceneIndex together", () => {
+  // Only a disagreement is worth refusing. A model that says the same thing
+  // twice — path plus the param it replaced, in agreement — gets its scene, not
+  // an error about how it phrased the request.
+  it("fires the scene when path and sceneIndex agree", () => {
+    const scene = registerMockObject(livePath.scene(3), {
+      path: livePath.scene(3),
+    });
+
+    playback({ action: "play-scene", path: "s3", sceneIndex: 3 });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+  });
+
+  // Scene 0 is falsy, and the agreement check and the `??` that picks the
+  // winner both have to read it as a value rather than as "not given".
+  it("fires scene 0 when path and sceneIndex agree on it", () => {
+    const scene = registerMockObject(livePath.scene(0), {
+      path: livePath.scene(0),
+    });
+
+    playback({ action: "play-scene", path: "s0", sceneIndex: 0 });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+  });
+
+  it("refuses a scene path and sceneIndex that disagree", () => {
     expect(() =>
       playback({ action: "play-scene", path: "s3", sceneIndex: 1 }),
-    ).toThrow("playback failed: path and sceneIndex both name a scene");
+    ).toThrow("playback failed: path and sceneIndex name different scenes");
   });
 });
 

--- a/src/tools/session/tests/playback/playback-scene-target.test.ts
+++ b/src/tools/session/tests/playback/playback-scene-target.test.ts
@@ -152,6 +152,100 @@ describe("playback play-scene target agreement", () => {
   });
 });
 
+// A scene launch fires every track, so the track in "t0/s1" is surplus rather
+// than a contradiction. Drop it and fire the scene the caller already named.
+describe("playback play-scene from a session position", () => {
+  beforeEach(() => {
+    setupPlaybackLiveSet();
+  });
+
+  it("fires the scene a session position sits in", () => {
+    const scene = mockScene(1);
+
+    playback({ action: "play-scene", path: "t0/s1" });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+  });
+
+  it("recovers from the deprecated slots the same way", () => {
+    const scene = mockScene(1);
+
+    playback({ action: "play-scene", slots: "0/1" });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+  });
+
+  it("says nothing about dropping the track", () => {
+    const warn = vi.spyOn(console, "warn");
+
+    mockScene(1);
+    playback({ action: "play-scene", path: "t0/s1" });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("fires the scene when several positions sit in it", () => {
+    const scene = mockScene(1);
+
+    playback({ action: "play-scene", path: "t0/s1,t2/s1" });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+  });
+
+  // The old rule refused any list mixing a scene with a position, on shape
+  // alone. Now the shapes both name scene 1, so there is nothing to refuse.
+  it("fires the scene when a scene and a position in it agree", () => {
+    const scene = mockScene(1);
+
+    playback({ action: "play-scene", path: "s1,t0/s1" });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+  });
+
+  it("fires the scene when a position and sceneIndex agree", () => {
+    const scene = mockScene(1);
+
+    playback({ action: "play-scene", path: "t0/s1", sceneIndex: 1 });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+  });
+
+  it("refuses positions in different scenes, naming each", () => {
+    expect(() =>
+      playback({ action: "play-scene", path: "t0/s1,t2/s3" }),
+    ).toThrow(
+      'playback failed: action "play-scene" plays one scene, but got ' +
+        'scene 1 from path "t0/s1", scene 3 from path "t2/s3"',
+    );
+  });
+
+  // Quoting "t0/s1" back at a slots caller would hand them a value slots
+  // rejects, so each entry is named the way the param it came from is written.
+  it("quotes disagreeing slots entries in slots spelling", () => {
+    expect(() => playback({ action: "play-scene", slots: "0/1,2/3" })).toThrow(
+      'playback failed: action "play-scene" plays one scene, but got ' +
+        'scene 1 from slots "0/1", scene 3 from slots "2/3"',
+    );
+  });
+
+  it("refuses a position that disagrees with sceneIndex", () => {
+    expect(() =>
+      playback({ action: "play-scene", path: "t0/s1", sceneIndex: 3 }),
+    ).toThrow(
+      'playback failed: action "play-scene" plays one scene, but got ' +
+        'scene 1 from path "t0/s1", scene 3 from sceneIndex 3',
+    );
+  });
+
+  // The reverse direction stays refused: firing clips one at a time is not what
+  // launching a scene does, so recovering would swap which Live call runs.
+  it("does not recover a scene path for play-session-clips", () => {
+    expect(() =>
+      playback({ action: "play-session-clips", path: "s3" }),
+    ).toThrow('invalid path "s3" - names a scene');
+  });
+});
+
 // A bad id is a bad id, not a second scene: warn and skip it, the way the rest
 // of the tool treats ids, and let whatever else named a scene carry the call.
 describe("playback play-scene ids that name no scene", () => {

--- a/src/tools/session/tests/playback/playback-scene-target.test.ts
+++ b/src/tools/session/tests/playback/playback-scene-target.test.ts
@@ -1,0 +1,255 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import * as console from "#src/shared/max/v8-max-console.ts";
+import {
+  mockNonExistentObjects,
+  registerMockObject,
+  type RegisteredMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+import { playback } from "#src/tools/session/playback.ts";
+import { setupPlaybackLiveSet } from "./playback-test-helpers.ts";
+
+/**
+ * Register a scene, reachable by the given id and by its own path.
+ * @param sceneIndex - The scene's index
+ * @param id - The id a caller would pass in `ids`
+ * @returns The scene's mock, to assert it fired
+ */
+function mockScene(sceneIndex: number, id?: string): RegisteredMockObject {
+  return registerMockObject(id ?? livePath.scene(sceneIndex), {
+    path: livePath.scene(sceneIndex),
+    type: "Scene",
+  });
+}
+
+/**
+ * Register a session clip sitting in a scene.
+ * @param id - The clip's id
+ * @param trackIndex - The track it sits on
+ * @param sceneIndex - The scene it sits in
+ */
+function mockSessionClip(
+  id: string,
+  trackIndex: number,
+  sceneIndex: number,
+): void {
+  registerMockObject(id, {
+    path: livePath.track(trackIndex).clipSlot(sceneIndex).clip(),
+    type: "Clip",
+  });
+}
+
+// Only one scene plays at a time, so every param that names a scene has to name
+// the same one. Agreement fires it; disagreement is refused rather than ranked.
+describe("playback play-scene target agreement", () => {
+  beforeEach(() => {
+    setupPlaybackLiveSet();
+  });
+
+  it("fires the scene a lone scene id names", () => {
+    const scene = mockScene(3, "scene3");
+
+    playback({ action: "play-scene", ids: "scene3" });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+  });
+
+  it("fires the scene a lone clip id sits in", () => {
+    const scene = mockScene(3);
+
+    mockSessionClip("clip1", 0, 3);
+    playback({ action: "play-scene", ids: "clip1" });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+  });
+
+  // Scene 0 is falsy, so every hop that carries it has to read it as a value
+  // rather than as "nothing named a scene".
+  it("fires scene 0 named by an id alone", () => {
+    const scene = mockScene(0);
+
+    mockSessionClip("clip1", 0, 0);
+    playback({ action: "play-scene", ids: "clip1" });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+  });
+
+  it("fires the scene when path and an id agree", () => {
+    const scene = mockScene(3);
+
+    mockSessionClip("clip1", 0, 3);
+    playback({ action: "play-scene", path: "s3", ids: "clip1" });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+  });
+
+  it("fires the scene when sceneIndex and an id agree", () => {
+    const scene = mockScene(3, "scene3");
+
+    playback({ action: "play-scene", sceneIndex: 3, ids: "scene3" });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+  });
+
+  it("fires the scene when several ids agree on it", () => {
+    const scene = mockScene(3);
+
+    mockSessionClip("clip1", 0, 3);
+    mockSessionClip("clip2", 2, 3);
+    playback({ action: "play-scene", ids: "clip1,clip2" });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+  });
+
+  it("refuses a path and an id that name different scenes", () => {
+    mockSessionClip("clip1", 0, 5);
+
+    expect(() =>
+      playback({ action: "play-scene", path: "s3", ids: "clip1" }),
+    ).toThrow(
+      'playback failed: action "play-scene" plays one scene, but got ' +
+        'scene 3 from path "s3", scene 5 from ids "clip1"',
+    );
+  });
+
+  it("refuses a sceneIndex and an id that name different scenes", () => {
+    mockSessionClip("clip1", 0, 5);
+
+    expect(() =>
+      playback({ action: "play-scene", sceneIndex: 3, ids: "clip1" }),
+    ).toThrow(
+      'playback failed: action "play-scene" plays one scene, but got ' +
+        'scene 3 from sceneIndex 3, scene 5 from ids "clip1"',
+    );
+  });
+
+  it("refuses ids that name different scenes on their own", () => {
+    mockSessionClip("clip1", 0, 3);
+    mockSessionClip("clip2", 0, 5);
+
+    expect(() =>
+      playback({ action: "play-scene", ids: "clip1,clip2" }),
+    ).toThrow(
+      'playback failed: action "play-scene" plays one scene, but got ' +
+        'scene 3 from ids "clip1", scene 5 from ids "clip2"',
+    );
+  });
+
+  it("fires nothing when the scenes disagree", () => {
+    const scene = mockScene(3);
+
+    mockSessionClip("clip1", 0, 5);
+    expect(() =>
+      playback({ action: "play-scene", path: "s3", ids: "clip1" }),
+    ).toThrow('action "play-scene" plays one scene');
+
+    expect(scene.call).not.toHaveBeenCalledWith("fire");
+  });
+});
+
+// A bad id is a bad id, not a second scene: warn and skip it, the way the rest
+// of the tool treats ids, and let whatever else named a scene carry the call.
+describe("playback play-scene ids that name no scene", () => {
+  beforeEach(() => {
+    setupPlaybackLiveSet();
+  });
+
+  it("skips an id that does not exist, and says so", () => {
+    const warn = vi.spyOn(console, "warn");
+    const scene = mockScene(3);
+
+    mockNonExistentObjects();
+    playback({ action: "play-scene", sceneIndex: 3, ids: "gone" });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+    expect(warn).toHaveBeenCalledWith('playback: id "gone" does not exist');
+  });
+
+  it("skips an id that sits in no scene, naming its type", () => {
+    const warn = vi.spyOn(console, "warn");
+    const scene = mockScene(3);
+
+    registerMockObject("clip1", {
+      path: livePath.track(0).arrangementClip(0),
+      type: "Clip",
+    });
+    playback({ action: "play-scene", sceneIndex: 3, ids: "clip1" });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+    expect(warn).toHaveBeenCalledWith(
+      'playback: id "clip1" is in no scene (found Clip); action ' +
+        '"play-scene" takes a scene id or a session clip id',
+    );
+  });
+
+  it("skips an id of the wrong type entirely", () => {
+    const warn = vi.spyOn(console, "warn");
+    const scene = mockScene(3);
+
+    registerMockObject("track9", { path: livePath.track(5), type: "Track" });
+    playback({ action: "play-scene", sceneIndex: 3, ids: "track9" });
+
+    expect(scene.call).toHaveBeenCalledWith("fire");
+    expect(warn).toHaveBeenCalledWith(
+      'playback: id "track9" is in no scene (found Track); action ' +
+        '"play-scene" takes a scene id or a session clip id',
+    );
+  });
+
+  it("refuses the action when no id named a scene and nothing else did", () => {
+    registerMockObject("track9", { path: livePath.track(5), type: "Track" });
+
+    expect(() => playback({ action: "play-scene", ids: "track9" })).toThrow(
+      'playback failed: sceneIndex, path "s<scene>", or a scene id is required',
+    );
+  });
+});
+
+// sceneIndex used to vanish without a word on the clip actions, the same
+// silent-drop the path params were fixed for.
+describe("playback sceneIndex on an action that acts on clips", () => {
+  beforeEach(() => {
+    setupPlaybackLiveSet();
+    registerMockObject(livePath.track(0).clipSlot(1), {
+      path: livePath.track(0).clipSlot(1),
+    });
+  });
+
+  it("warns that play-session-clips ignored it", () => {
+    const warn = vi.spyOn(console, "warn");
+
+    playback({ action: "play-session-clips", path: "t0/s1", sceneIndex: 3 });
+
+    expect(warn).toHaveBeenCalledWith(
+      'sceneIndex ignored: action "play-session-clips" acts on session ' +
+        'positions; use action "play-scene" for the whole scene',
+    );
+  });
+
+  it("warns that stop-session-clips ignored it", () => {
+    const warn = vi.spyOn(console, "warn");
+
+    registerMockObject(livePath.track(0), { path: livePath.track(0) });
+    playback({ action: "stop-session-clips", path: "t0/s1", sceneIndex: 3 });
+
+    expect(warn).toHaveBeenCalledWith(
+      'sceneIndex ignored: action "stop-session-clips" acts on session ' +
+        'positions; use action "play-scene" for the whole scene',
+    );
+  });
+
+  it("warns that stop ignored it", () => {
+    const warn = vi.spyOn(console, "warn");
+
+    playback({ action: "stop", sceneIndex: 3 });
+
+    expect(warn).toHaveBeenCalledWith(
+      'sceneIndex ignored: action "stop" takes no target',
+    );
+  });
+});

--- a/src/tools/session/tests/playback/playback-target-params.test.ts
+++ b/src/tools/session/tests/playback/playback-target-params.test.ts
@@ -30,7 +30,7 @@ describe("playback target params on actions that have no target", () => {
     expect(liveSet.call).toHaveBeenCalledWith("stop_playing");
     expect(result.playing).toBe(false);
     expect(warn).toHaveBeenCalledWith(
-      'slots ignored: action "stop" names no clips to act on',
+      'slots ignored: action "stop" takes no target',
     );
   });
 
@@ -53,7 +53,7 @@ describe("playback target params on actions that have no target", () => {
 
     expect(liveSet.call).toHaveBeenCalledWith("stop_all_clips");
     expect(warn).toHaveBeenCalledWith(
-      'path/slots/ids ignored: action "stop-all-session-clips" names no clips to act on',
+      'path/slots/ids ignored: action "stop-all-session-clips" takes no target',
     );
   });
 
@@ -128,7 +128,7 @@ describe("playback slots that names no position", () => {
 
   it("refuses play-scene rather than crashing on the empty list", () => {
     expect(() => playback({ action: "play-scene", slots: "," })).toThrow(
-      'playback failed: sceneIndex or path "s<scene>" is required',
+      'playback failed: sceneIndex, path "s<scene>", or a scene id is required',
     );
   });
 

--- a/src/tools/session/tests/playback/playback-target-params.test.ts
+++ b/src/tools/session/tests/playback/playback-target-params.test.ts
@@ -109,4 +109,98 @@ describe("playback ids that names no clip", () => {
       playback({ action: "play-session-clips", path: "t0/s1", ids: "clip1" }),
     ).toThrow("playback failed: ids and path are mutually exclusive");
   });
+
+  // A scene path is still a path. Firing the ids and dropping it silently is
+  // the wrong-target bug these params exist to prevent.
+  it("refuses ids alongside a scene path too", () => {
+    expect(() =>
+      playback({ action: "play-session-clips", path: "s3", ids: "clip1" }),
+    ).toThrow("playback failed: ids and path are mutually exclusive");
+  });
+});
+
+// parseSlotList drops empty entries and returns none, and an empty list read as
+// a target is a call that acts on nothing while reporting success.
+describe("playback slots that names no position", () => {
+  beforeEach(() => {
+    setupPlaybackLiveSet();
+  });
+
+  it("refuses play-scene rather than crashing on the empty list", () => {
+    expect(() => playback({ action: "play-scene", slots: "," })).toThrow(
+      'playback failed: sceneIndex or path "s<scene>" is required',
+    );
+  });
+
+  it("refuses play-session-clips rather than reporting a launch", () => {
+    expect(() =>
+      playback({ action: "play-session-clips", slots: "," }),
+    ).toThrow("playback failed: ids or path is required");
+  });
+
+  it("refuses stop-session-clips the same way", () => {
+    expect(() =>
+      playback({ action: "stop-session-clips", slots: "," }),
+    ).toThrow("playback failed: ids or path is required");
+  });
+
+  it("lets ids carry the call when slots names nothing", () => {
+    const clipSlot = registerMockObject(livePath.track(0).clipSlot(1), {
+      path: livePath.track(0).clipSlot(1),
+    });
+
+    registerMockObject("clip1", {
+      path: livePath.track(0).clipSlot(1).clip(),
+      type: "Clip",
+    });
+
+    playback({ action: "play-session-clips", slots: ",", ids: "clip1" });
+
+    expect(clipSlot.call).toHaveBeenCalledWith("fire");
+  });
+});
+
+// Each handler reads only its own kind of target, so a wrong-shaped path used
+// to fall through to a "you gave me nothing" error naming the param that was
+// sent. Say what's wrong with it, and what the right shape looks like.
+describe("playback path shaped wrong for the action", () => {
+  beforeEach(() => {
+    setupPlaybackLiveSet();
+  });
+
+  it("refuses a session position for play-scene, naming the scene to use", () => {
+    expect(() => playback({ action: "play-scene", path: "t0/s1" })).toThrow(
+      'invalid path "t0/s1" - names a session position; action "play-scene" ' +
+        'takes one scene, as path "s1" or sceneIndex 1',
+    );
+  });
+
+  it("refuses a session position from the deprecated slots too", () => {
+    expect(() => playback({ action: "play-scene", slots: "0/1" })).toThrow(
+      'invalid slots "0/1" - names a session position',
+    );
+  });
+
+  it("refuses a scene for play-session-clips, pointing at play-scene", () => {
+    expect(() =>
+      playback({ action: "play-session-clips", path: "s3" }),
+    ).toThrow(
+      'invalid path "s3" - names a scene; action "play-session-clips" takes ' +
+        'session positions "t<track>/s<scene>" (e.g., "t0/s3"), or use ' +
+        'action "play-scene" for the whole scene',
+    );
+  });
+
+  // There's no "stop a scene" action to point at, so don't invent one.
+  it("refuses a scene for stop-session-clips without suggesting play-scene", () => {
+    expect(() =>
+      playback({ action: "stop-session-clips", path: "s3" }),
+    ).toThrow(
+      'invalid path "s3" - names a scene; action "stop-session-clips" takes ' +
+        'session positions "t<track>/s<scene>" (e.g., "t0/s3")',
+    );
+    expect(() =>
+      playback({ action: "stop-session-clips", path: "s3" }),
+    ).not.toThrow(/play-scene/);
+  });
 });

--- a/src/tools/session/tests/playback/playback-target-params.test.ts
+++ b/src/tools/session/tests/playback/playback-target-params.test.ts
@@ -168,16 +168,12 @@ describe("playback path shaped wrong for the action", () => {
     setupPlaybackLiveSet();
   });
 
-  it("refuses a session position for play-scene, naming the scene to use", () => {
-    expect(() => playback({ action: "play-scene", path: "t0/s1" })).toThrow(
-      'invalid path "t0/s1" - names a session position; action "play-scene" ' +
-        'takes one scene, as path "s1" or sceneIndex 1',
-    );
-  });
-
-  it("refuses a session position from the deprecated slots too", () => {
-    expect(() => playback({ action: "play-scene", slots: "0/1" })).toThrow(
-      'invalid slots "0/1" - names a session position',
+  // A path with no scene in it at all has nothing to recover, so play-scene
+  // says what it needs rather than borrowing the clip actions' wording.
+  it("refuses a track for play-scene, naming the shapes that work", () => {
+    expect(() => playback({ action: "play-scene", path: "t0" })).toThrow(
+      'invalid path "t0" - names no scene; action "play-scene" takes a scene ' +
+        '"s<scene>" or a session position "t<track>/s<scene>"',
     );
   });
 


### PR DESCRIPTION
`ppal-playback` refused param combinations that agreed, and its "required" errors named the very params the caller had sent. Three commits: refuse only real disagreements, then settle every scene-naming param against one rule, then accept a session position as the scene it sits in.

## 1. Accept params that agree

The `path` + `sceneIndex` conflict check fired on *presence*, not disagreement. Now only a disagreement is refused, matching `select`'s `merge()`.

```
play-scene + path:"s3" + sceneIndex:3   →  fires scene 3   (was: "both name a scene")
```

### Errors that name the real problem

Each handler reads only its own kind of target, so a path shaped for a different action fell through to a "you gave me nothing" error. The mismatch is now caught at resolve time, where the action and the parsed path are both in hand.

```
play-session-clips + path:"s3"
  was:  playback failed: ids or path is required for action "play-session-clips"
  now:  invalid path "s3" - names a scene; action "play-session-clips" takes
        session positions "t<track>/s<scene>" (e.g., "t0/s3"), or use action
        "play-scene" for the whole scene
```

`stop-session-clips` gets the same message minus the `play-scene` suggestion — there's no "stop a scene" action to point at.

### Two more wrong-named errors, found on the way

- `ids` alongside the deprecated `slots` was refused as `"ids and path are mutually exclusive"` — naming a param the caller never sent. The check also only fired when the path named positions, so `ids` plus a *scene* path was let through with one of the two silently dropped.

- A `slots` value that names nothing (`","`) parses to zero positions. That empty list read downstream as "act on these zero slots", so `play-session-clips` returned `playing: true` having fired nothing. It now reads as naming nothing.

## 2. One scene, agreed by every param that names one

Only one scene plays at a time, so `path`, `sceneIndex`, and each id in `ids` all vote. They agree, it fires; they name more than one, the error names each scene and the param that named it.

```
play-scene + sceneIndex:3 + an id in scene 5
  was:  fires scene 3, drops ids without a word
  now:  playback failed: action "play-scene" plays one scene, but got
        scene 3 from sceneIndex 3, scene 5 from ids "clip1"
```

That makes `ids` mean something for `play-scene`, where it was previously read and then dropped. A scene id names itself, and a session clip or clip slot id names the scene it sits in — so a model that just read a scene can play it with the id already in hand. Ids naming no scene are warned and skipped, like every other bad id in this tool.

Sweeping for the same silent-drop turned up one more: `sceneIndex` sent to an action that acts on clips, or on the transport alone, vanished without a word. It now warns, and on the clip actions it points at `play-scene`.

## 3. A session position is the scene it sits in

`play-scene` fires every track in a scene, so the track in `t0/s1` is surplus rather than a contradiction — it now fires scene 1, silently, since the caller already named the scene.

`path` and the deprecated `slots` now parse to the same entries, so every entry votes for its scene and the rule above covers the rest. `t0/s1,t2/s1` fires scene 1; `t0/s1,t2/s3` is refused for naming two. That retires the special case that refused any list mixing a scene with a position on shape alone.

Only surplus bends. A path *missing* what the action needs still errors, including where the reverse recovery looks symmetric: `play-session-clips` with `s3` stays refused, because firing clips one at a time is a different Live call than launching the scene. `dev/Object-Paths.md` gains this as a fourth tolerance tier — the existing three covered deprecated params, tolerant values, and conflicts, but had no category for surplus.

## Found but not fixed

Two more instances of the same silent-drop class, left alone because they're different subsystems:

- `focus: true` does nothing without a word on `stop`, `stop-session-clips`, `stop-all-session-clips`, `update-arrangement`.
- `startTime` on a session action isn't dropped, it's applied to the wrong thing: `play-scene` + `startTime:"5|1"` fires the scene **and** moves the arrangement playhead to bar 5, silently.

Plus three pre-existing bugs surfaced during review: `path:"s1"` + `slots:","` throws the wrong error; `play-session-clips` with ids naming only non-clips returns `playing: true` having fired nothing; and the `startTime` one above.

## Verification

`npm run fix`, `npm run check` (12375 tests pass, functions 100%, `playback-target-helpers.ts` at 100% statements *and* branches), and `npm run check:build` clean on every commit.

Each commit was reviewed by a subagent before pushing. The first caught a crash on empty `slots` that's fixed here. The second fuzzed ~9,200 action × path × slots × ids × sceneIndex combinations; the third fuzzed 12,325 against an independent oracle for which scene should fire, with a negative control confirming the oracle catches regressions. No wrong-scene fires, no crashes, no calls reporting success while firing nothing.
