### PR TITLE
fix: hold the tool-call timeout ceiling under the MCP client default

### DIFF
--- a/docs/guide/device.md
+++ b/docs/guide/device.md
@@ -73,8 +73,11 @@ editor — the same editor the **Open Editor** button opens. See
   and for the `npx producer-pal` bridge set the `MCP_SERVER_ORIGIN` environment
   variable (e.g. `MCP_SERVER_ORIGIN=http://localhost:3400`) — it defaults to
   `http://localhost:3350`.
-- **Timeout** - Maximum time for AI operations (default: 45 sec, increase on
-  slow computers if experiencing timeouts during complex operations)
+- **Timeout** - Maximum time for AI operations (default: 45 sec, max 55 sec;
+  increase on slow computers if experiencing timeouts during complex
+  operations). The cap stays under 60 sec because that is where most AI clients
+  give up — past it you would lose the partial results Producer Pal returns when
+  it times out
 
 ### Behavior
 

--- a/docs/guide/rest-api.md
+++ b/docs/guide/rest-api.md
@@ -164,8 +164,10 @@ curl -X POST 'http://localhost:3350/api/tools/ppal-create-clip?timeoutMs=10000' 
   -d '{"path": "t0/s0", "length": "16bar", "notes": "..."}'
 ```
 
-`timeoutMs` must be a positive integer up to **60000** (60 seconds). Other
-values return **400**. Combinable with `?format=`:
+`timeoutMs` must be a positive integer up to **55000** (55 seconds). Other
+values return **400**. The cap stays under 60 seconds because that is where most
+MCP clients give up — past it you lose the partial results and warnings Producer
+Pal returns on a timeout. Combinable with `?format=`:
 
 ```
 POST /api/tools/{name}?format=json&timeoutMs=10000

--- a/examples/skills/producer-pal/SKILL.md
+++ b/examples/skills/producer-pal/SKILL.md
@@ -101,7 +101,7 @@ node ppal.mjs ppal-read-live-set
 node ppal.mjs ppal-read-track '{"trackIndex": 0}'
 node ppal.mjs ppal-create-clip '{"slot":"0/0","length":"16bar","notes":"[{p:60,t:0,d:4,v:100}]"}' --notation midi-json
 
-# Long-running calls — bump the timeout (1–60000 ms)
+# Long-running calls — bump the timeout (1–55000 ms)
 node ppal.mjs ppal-create-clip '{"slot":"0/0","length":"16bar","notes":"..."}' --timeout-ms 10000
 
 # Non-default URL (e.g. remote machine over a tunnel)

--- a/examples/skills/producer-pal/ppal.mjs
+++ b/examples/skills/producer-pal/ppal.mjs
@@ -9,7 +9,7 @@
 //
 // Options:
 //   --url <baseUrl>          override Producer Pal URL (default http://localhost:3350)
-//   --timeout-ms <ms>        per-request timeout (1–60000)
+//   --timeout-ms <ms>        per-request timeout (1–55000)
 //   --set-config <json>      update device settings, e.g. '{"liveApiEnabled":true}'
 //   --notation <name>        barbeat | midi-json | stark, for this request only
 //   --disable-tools <names>  withhold tools from this request (comma-separated)
@@ -161,7 +161,7 @@ Usage:
 
 Options:
   --url <baseUrl>          override Producer Pal URL (default ${DEFAULT_BASE_URL})
-  --timeout-ms <ms>        per-request timeout (1–60000)
+  --timeout-ms <ms>        per-request timeout (1–55000)
   --set-config <json>      update device settings, e.g. '{"liveApiEnabled":true}'
                            Global to the device — it moves every other client too.
   --notation <name>        barbeat | midi-json | stark

--- a/max-for-live-device/tab-setup.maxpat
+++ b/max-for-live-device/tab-setup.maxpat
@@ -251,7 +251,7 @@
             },
             {
                 "box": {
-                    "annotation": "Maximum time to wait for AI tool operations to complete. Default is 45 seconds. A single operation may involve multiple Live API calls. Increase if experiencing timeout errors on complex operations or slower systems.",
+                    "annotation": "Maximum time to wait for AI tool operations to complete. Default is 45 seconds, max 55. A single operation may involve multiple Live API calls. Increase if experiencing timeout errors on complex operations or slower systems. The cap stays under 60 seconds because most AI clients give up at 60, and you would lose the partial results Producer Pal returns.",
                     "annotation_name": "Timeout",
                     "id": "obj-68",
                     "maxclass": "live.numbox",
@@ -268,7 +268,7 @@
                             "parameter_initial_enable": 1,
                             "parameter_invisible": 1,
                             "parameter_longname": "timeout",
-                            "parameter_mmax": 60.0,
+                            "parameter_mmax": 55.0,
                             "parameter_mmin": 1.0,
                             "parameter_modmode": 4,
                             "parameter_shortname": "timeout",
@@ -387,7 +387,7 @@
             {
                 "box": {
                     "angle": 270.0,
-                    "annotation": "Maximum time to wait for AI tool operations to complete. Default is 45 seconds. A single operation may involve multiple Live API calls. Increase if experiencing timeout errors on complex operations or slower systems.",
+                    "annotation": "Maximum time to wait for AI tool operations to complete. Default is 45 seconds, max 55. A single operation may involve multiple Live API calls. Increase if experiencing timeout errors on complex operations or slower systems. The cap stays under 60 seconds because most AI clients give up at 60, and you would lose the partial results Producer Pal returns.",
                     "bgcolor": [ 0.163688058058427, 0.163688010157025, 0.163688022674427, 0.0 ],
                     "hint": "",
                     "id": "obj-30",

--- a/src/mcp-server/helpers/request-overrides/request-overrides.ts
+++ b/src/mcp-server/helpers/request-overrides/request-overrides.ts
@@ -19,7 +19,7 @@ import { type Notation } from "#src/shared/notation.ts";
 export interface RequestOverrides {
   /** Override the global compactOutput config for this call. */
   compactOutput?: boolean;
-  /** Override the configured timeout (1–60000 ms) for this call. */
+  /** Override the configured timeout for this call, up to MAX_TIMEOUT_MS. */
   timeoutMs?: number;
   /**
    * Override the V8 session's notation for this call, so the clip tools parse
@@ -33,6 +33,3 @@ export interface RequestOverrides {
    */
   notation?: Notation;
 }
-
-/** Maximum value accepted for a `timeoutMs` override (mirrors the global cap). */
-export const MAX_TIMEOUT_MS = 60_000;

--- a/src/mcp-server/max-api-adapter.ts
+++ b/src/mcp-server/max-api-adapter.ts
@@ -14,6 +14,7 @@ import {
   WARNING_PREFIX,
   type McpErrorCode,
 } from "#src/shared/mcp-response-utils.ts";
+import { MAX_TIMEOUT_MS } from "#src/shared/config.ts";
 import { ensureSilenceWav } from "#src/shared/silent-wav-generator.ts";
 import { handleCodeExecRequest } from "./code-exec-protocol.ts";
 import { type RequestOverrides } from "./helpers/request-overrides/request-overrides.ts";
@@ -21,10 +22,7 @@ import * as console from "./node-for-max-logger.ts";
 import { handleNodeRequest } from "./rpc/node-request-protocol.ts";
 
 // Re-export for convenience so existing consumers can keep importing from here
-export {
-  MAX_TIMEOUT_MS,
-  type RequestOverrides,
-} from "./helpers/request-overrides/request-overrides.ts";
+export { type RequestOverrides } from "./helpers/request-overrides/request-overrides.ts";
 
 export interface McpResponseContent {
   type: string;
@@ -50,9 +48,8 @@ interface PendingRequest {
 // Generate silent WAV on module load
 const silenceWavPath = ensureSilenceWav();
 
-// Kept under 60s on purpose: that is the MCP SDK's own client-side default, so
-// a 60s server timeout races the client and the user gets a generic client
-// abort instead of our partial results and warnings.
+// Under MAX_TIMEOUT_MS, which is itself under the MCP SDK's client-side
+// default — see MAX_TIMEOUT_MS for why that matters.
 const DEFAULT_LIVE_API_CALL_TIMEOUT_MS = 45_000;
 
 // Map to store pending requests and their resolve functions
@@ -63,11 +60,19 @@ let timeoutMs = DEFAULT_LIVE_API_CALL_TIMEOUT_MS;
 Max.addHandler("timeoutMs", (input: unknown) => {
   const n = Number(input);
 
-  if (n > 0 && n <= 60_000) {
-    timeoutMs = n;
-  } else {
+  if (!(n > 0)) {
     console.error(`Invalid Live API timeoutMs: ${String(input)}`);
+
+    return;
   }
+
+  // Clamp rather than discard: dropping the value left the old timeout in
+  // place with nothing the user could see to explain it.
+  if (n > MAX_TIMEOUT_MS) {
+    console.warn(`Live API timeoutMs ${n} capped at ${MAX_TIMEOUT_MS}`);
+  }
+
+  timeoutMs = Math.min(n, MAX_TIMEOUT_MS);
 });
 
 /**

--- a/src/mcp-server/routes/rest-api-routes.ts
+++ b/src/mcp-server/routes/rest-api-routes.ts
@@ -5,6 +5,7 @@
 
 import { type Express, type Request, type Response } from "express";
 import { z, type ZodType } from "zod";
+import { MAX_TIMEOUT_MS } from "#src/shared/config.ts";
 import { WARNING_PREFIX } from "#src/shared/mcp-response-utils.ts";
 import { type Notation } from "#src/shared/notation.ts";
 import { toolDefLiveApi } from "#src/tools/advanced/live-api.def.ts";
@@ -22,11 +23,7 @@ import {
   resolveRequestProfile,
   type RequestProfile,
 } from "../helpers/http/request-profile.ts";
-import {
-  MAX_TIMEOUT_MS,
-  type McpResponse,
-  type RequestOverrides,
-} from "../max-api-adapter.ts";
+import { type McpResponse, type RequestOverrides } from "../max-api-adapter.ts";
 import * as console from "../node-for-max-logger.ts";
 
 interface RestApiConfig {

--- a/src/mcp-server/tests/rest-api/rest-api-routes.test.ts
+++ b/src/mcp-server/tests/rest-api/rest-api-routes.test.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { MAX_TIMEOUT_MS } from "#src/shared/config.ts";
 import {
   lastMcpContext,
   mcpRequests,
@@ -598,10 +599,20 @@ describe("REST API Routes", () => {
       expect(response.status).toBe(400);
     });
 
-    it("should return 400 for timeoutMs above the cap", async () => {
+    it("should accept timeoutMs exactly at the cap", async () => {
       const response = await callToolWithQuery(
         "ppal-connect",
-        "timeoutMs=60001",
+        `timeoutMs=${MAX_TIMEOUT_MS}`,
+      );
+
+      expect(response.status).toBe(200);
+      expect(lastMcpContext()).toMatchObject({ timeoutMs: MAX_TIMEOUT_MS });
+    });
+
+    it("should return 400 for timeoutMs one over the cap", async () => {
+      const response = await callToolWithQuery(
+        "ppal-connect",
+        `timeoutMs=${MAX_TIMEOUT_MS + 1}`,
       );
 
       expect(response.status).toBe(400);

--- a/src/mcp-server/tests/server/max-api-adapter.test.ts
+++ b/src/mcp-server/tests/server/max-api-adapter.test.ts
@@ -5,6 +5,7 @@
 
 import Max from "max-api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_TIMEOUT_MS } from "#src/shared/config.ts";
 import { MAX_ERROR_DELIMITER } from "#src/shared/mcp-response-utils.ts";
 import {
   callLiveApi,
@@ -290,15 +291,20 @@ describe("Max API Adapter", () => {
       expect(Max.post).not.toHaveBeenCalled();
     });
 
-    it("should reject timeout values above 60000ms", () => {
-      // Call with invalid timeout (too high)
+    it("should clamp timeout values above the cap instead of dropping them", () => {
+      vi.clearAllMocks();
+
       timeoutMsHandler!(70000);
 
-      // Should log an error
       expect(Max.post).toHaveBeenCalledWith(
-        expect.stringContaining("Invalid Live API timeoutMs: 70000"),
-        "error",
+        expect.stringContaining(
+          `Live API timeoutMs 70000 capped at ${MAX_TIMEOUT_MS}`,
+        ),
+        "warn",
       );
+      expect(captureContextJSON()).toMatchObject({
+        timeoutMs: MAX_TIMEOUT_MS,
+      });
     });
 
     it("should reject timeout values at or below 0", () => {

--- a/src/portal/stdio-http-bridge.ts
+++ b/src/portal/stdio-http-bridge.ts
@@ -12,7 +12,11 @@ import {
   ErrorCode,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { DISABLED_TOOLS_HEADER, VERSION } from "#src/shared/config.ts";
+import {
+  CLIENT_TOOL_TIMEOUT_MS,
+  DISABLED_TOOLS_HEADER,
+  VERSION,
+} from "#src/shared/config.ts";
 import { errorMessage } from "#src/shared/error-utils.ts";
 import { formatErrorResponse } from "#src/shared/mcp-response-utils.ts";
 import { type Notation } from "#src/shared/notation.ts";
@@ -347,8 +351,13 @@ Tell the user to check ${SETUP_URL} for configuration help.
           };
 
           // httpClient is guaranteed non-null after successful _ensureHttpConnection()
+          // Explicit timeout rather than the SDK's 60s default, which would
+          // sit too close to the device's ceiling. The upstream client's own
+          // deadline still binds first — this only keeps our leg out of the way.
           const result = await (this.httpClient as Client).callTool(
             toolRequest,
+            undefined,
+            { timeout: CLIENT_TOOL_TIMEOUT_MS },
           );
 
           logger.debug(

--- a/src/portal/tests/stdio-http-bridge.test.ts
+++ b/src/portal/tests/stdio-http-bridge.test.ts
@@ -13,6 +13,10 @@ import {
   type Mock,
 } from "vitest";
 import {
+  CLIENT_TOOL_TIMEOUT_MS,
+  DISABLED_TOOLS_HEADER,
+} from "#src/shared/config.ts";
+import {
   callToolRequest,
   callToolSuccessfully,
   callToolWithMcpError,
@@ -112,7 +116,6 @@ vi.mock(import("../file-logger.ts"), () => ({
 // Import the class after mocking
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { DISABLED_TOOLS_HEADER } from "#src/shared/config.ts";
 import { logger } from "../file-logger.ts";
 import { StdioHttpBridge } from "../stdio-http-bridge.ts";
 
@@ -630,10 +633,11 @@ describe("StdioHttpBridge", () => {
         callToolRequest("test-tool", { arg1: "value1" }),
       )) as { result: unknown; toolResult: unknown };
 
-      expect(mockClient.callTool).toHaveBeenCalledWith({
-        name: "test-tool",
-        arguments: { arg1: "value1" },
-      });
+      expect(mockClient.callTool).toHaveBeenCalledWith(
+        { name: "test-tool", arguments: { arg1: "value1" } },
+        undefined,
+        { timeout: CLIENT_TOOL_TIMEOUT_MS },
+      );
       expect(result).toStrictEqual(toolResult);
       expect(logger.debug).toHaveBeenCalledWith(
         "[Bridge] Tool call successful for test-tool",
@@ -661,10 +665,11 @@ describe("StdioHttpBridge", () => {
         { params: { name: "test-tool" } }, // arguments is undefined
       )) as { result: unknown; toolResult: unknown };
 
-      expect(mockClient.callTool).toHaveBeenCalledWith({
-        name: "test-tool",
-        arguments: {},
-      });
+      expect(mockClient.callTool).toHaveBeenCalledWith(
+        { name: "test-tool", arguments: {} },
+        undefined,
+        { timeout: CLIENT_TOOL_TIMEOUT_MS },
+      );
       expect(result).toStrictEqual(toolResult);
     });
 

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -53,6 +53,32 @@ export const MIN_LIVE_VERSION = "12.3.0";
  */
 export const SAME_TIME_EPSILON = 0.001;
 
+// --- Tool-call timeouts ---
+
+/**
+ * Ceiling on a tool call's server-side deadline: the max for the device's
+ * Timeout setting and for the REST `?timeoutMs=` override.
+ *
+ * Held under 60s on purpose — that is the MCP SDK's client-side default. At 60s
+ * the client's timer wins the race (it starts first) and the user gets a generic
+ * abort instead of the partial results and warnings our timeout returns. The gap
+ * is room to serialize that response.
+ *
+ * Lowering our ceiling is the only lever that works for external clients: the
+ * 60s belongs to whoever built the client, and nothing in the protocol lets a
+ * server ask for longer.
+ */
+export const MAX_TIMEOUT_MS = 55_000;
+
+/**
+ * Tool-call timeout for the MCP clients we DO own — the built-in chat and the
+ * voice bridges. A backstop for a wedged connection, not the normal way a long
+ * call ends: the server always answers by MAX_TIMEOUT_MS with whatever landed.
+ *
+ * Derived, so it can never collide with the ceiling the way a hardcoded 60s did.
+ */
+export const CLIENT_TOOL_TIMEOUT_MS = MAX_TIMEOUT_MS + 10_000;
+
 // --- Web UI chat system instruction ---
 
 // The webui chat's built-in system instruction (NOT the ppal-connect skills

--- a/webui/src/chat/sdk/mcp-tools.ts
+++ b/webui/src/chat/sdk/mcp-tools.ts
@@ -5,6 +5,7 @@
 
 import { type Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { type ToolSet, jsonSchema } from "ai";
+import { CLIENT_TOOL_TIMEOUT_MS } from "#src/shared/config";
 import { type Notation } from "#src/shared/notation";
 import { connectAndListTools } from "#webui/chat/helpers/connect-and-list-tools";
 import { extractMcpText } from "#webui/lib/utils/mcp-content";
@@ -52,10 +53,14 @@ export async function createMcpTools(
         t.inputSchema as Parameters<typeof jsonSchema>[0],
       ),
       execute: async (args: Record<string, unknown>) => {
-        const result = await mcpClient.callTool({
-          name: t.name,
-          arguments: args,
-        });
+        // Explicit timeout, not the SDK's 60s default: that default ties the
+        // client's deadline to the device's ceiling, and the device's answer
+        // (partial results plus a warning) has to win that race.
+        const result = await mcpClient.callTool(
+          { name: t.name, arguments: args },
+          undefined,
+          { timeout: CLIENT_TOOL_TIMEOUT_MS },
+        );
 
         if (result.isError) {
           // Content is always the array form for error responses

--- a/webui/src/chat/sdk/tests/mcp-tools.test.ts
+++ b/webui/src/chat/sdk/tests/mcp-tools.test.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { CLIENT_TOOL_TIMEOUT_MS } from "#src/shared/config";
 
 // Mock MCP client helpers. connectAndListTools is deliberately NOT mocked — it
 // owns the close-on-catalog-failure path asserted below.
@@ -136,10 +137,11 @@ describe("createMcpTools", () => {
       },
     );
 
-    expect(mockCallTool).toHaveBeenCalledWith({
-      name: "ppal-connect",
-      arguments: { arg: "value" },
-    });
+    expect(mockCallTool).toHaveBeenCalledWith(
+      { name: "ppal-connect", arguments: { arg: "value" } },
+      undefined,
+      { timeout: CLIENT_TOOL_TIMEOUT_MS },
+    );
     expect(result).toBe("result");
   });
 

--- a/webui/src/hooks/voice/gemini/tests/gemini-mcp-tools.test.ts
+++ b/webui/src/hooks/voice/gemini/tests/gemini-mcp-tools.test.ts
@@ -7,6 +7,7 @@
  * @vitest-environment happy-dom
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { CLIENT_TOOL_TIMEOUT_MS } from "#src/shared/config";
 import {
   callToolMock,
   closeMock,
@@ -130,7 +131,7 @@ describe("createGeminiMcpTools", () => {
     expect(callToolMock).toHaveBeenCalledWith(
       { name: "ppal-read-live-set", arguments: { foo: "bar" } },
       undefined,
-      { timeout: 60_000 },
+      { timeout: CLIENT_TOOL_TIMEOUT_MS },
     );
     expect(out).toBe("Track 1: Drums\nTrack 2: Bass");
   });

--- a/webui/src/hooks/voice/tests/realtime-mcp-tools.test.ts
+++ b/webui/src/hooks/voice/tests/realtime-mcp-tools.test.ts
@@ -7,6 +7,7 @@
  * @vitest-environment happy-dom
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { CLIENT_TOOL_TIMEOUT_MS } from "#src/shared/config";
 import { type McpToolDefinition } from "#webui/chat/helpers/mcp-client-helpers";
 import {
   callToolMock,
@@ -121,7 +122,7 @@ describe("createRealtimeMcpTools", () => {
     expect(callToolMock).toHaveBeenCalledWith(
       { name: "ppal-read-live-set", arguments: { foo: "bar" } },
       undefined,
-      { timeout: 60_000 },
+      { timeout: CLIENT_TOOL_TIMEOUT_MS },
     );
     expect(out).toBe("Track 1: Drums\nTrack 2: Bass");
   });
@@ -137,7 +138,7 @@ describe("createRealtimeMcpTools", () => {
     expect(callToolMock).toHaveBeenCalledWith(
       { name: "ppal-x", arguments: {} },
       undefined,
-      { timeout: 60_000 },
+      { timeout: CLIENT_TOOL_TIMEOUT_MS },
     );
   });
 
@@ -152,7 +153,7 @@ describe("createRealtimeMcpTools", () => {
     expect(callToolMock).toHaveBeenLastCalledWith(
       expect.anything(),
       undefined,
-      { timeout: 60_000 },
+      { timeout: CLIENT_TOOL_TIMEOUT_MS },
     );
   });
 

--- a/webui/src/hooks/voice/voice-mcp-call.ts
+++ b/webui/src/hooks/voice/voice-mcp-call.ts
@@ -4,16 +4,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import { type Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { CLIENT_TOOL_TIMEOUT_MS } from "#src/shared/config";
 import { extractMcpText } from "#webui/lib/utils/mcp-content";
-
-// Backstop for a wedged connection, not the normal way a long call ends: the
-// device enforces its own deadline (45s by default, 60s at most) and answers
-// with whatever landed plus a warning. Keep this at the SDK's 60s default so
-// that answer always wins the race — a cut-short tool stops ~4s before the
-// device's timeout, so its partial result arrives even at the 60s setting.
-// On timeout the SDK rejects with an McpError, which is caught below and
-// returned to the model as a normal tool-error string so it can recover.
-export const VOICE_TOOL_TIMEOUT_MS = 60_000;
 
 /**
  * Call an MCP tool and return its result as a string, never throwing. Shared by
@@ -35,12 +27,15 @@ export async function callMcpToolToString(
   args: Record<string, unknown>,
 ): Promise<string> {
   try {
+    // Backstop for a wedged connection, not the normal way a long call ends:
+    // the device answers by its own deadline with whatever landed plus a
+    // warning, and CLIENT_TOOL_TIMEOUT_MS sits above that cap so it wins the
+    // race. On timeout the SDK rejects with an McpError, caught below and
+    // returned to the model as a tool-error string it can recover from.
     const result = await mcpClient.callTool(
       { name, arguments: args },
       undefined,
-      {
-        timeout: VOICE_TOOL_TIMEOUT_MS,
-      },
+      { timeout: CLIENT_TOOL_TIMEOUT_MS },
     );
 
     const content = result.content as Array<{ type: string; text?: string }>;


### PR DESCRIPTION
The device's **Timeout** setting and the REST `?timeoutMs=` override both topped out at **60000** — exactly the MCP SDK's client-side default (`DEFAULT_REQUEST_TIMEOUT_MSEC`). The docs told users to raise the timeout on slow machines, which walked them straight onto that value. At 60s the client's timer wins (it starts first), so instead of the partial results and warnings our timeout is built to return, they got a generic client abort.

## Two directions, depending on who owns the timer

The 60s is a **client-side, per-request** value set by whoever constructs the `Client`. For Claude Desktop, Cursor, Claude Code, LM Studio, we ship no code and the protocol has no way for a server to ask for longer — so the only lever is to lower our own ceiling.

**Cap at 55s** (`MAX_TIMEOUT_MS`), enforced in the Max handler, the REST `?timeoutMs=` validator, and the device's numbox range.

For the clients we *do* own, the opposite fix applies — give them an explicit timeout *above* the cap instead of inheriting the SDK default that caused the collision:

| Client | Before | After |
| --- | --- | --- |
| Built-in chat (`mcp-tools.ts`) | bare `callTool()` → SDK's 60s | `CLIENT_TOOL_TIMEOUT_MS` (65s) |
| Voice bridges (`voice-mcp-call.ts`) | hardcoded `60_000` | `CLIENT_TOOL_TIMEOUT_MS` |
| Portal bridge (`stdio-http-bridge.ts`) | bare `callTool()` → SDK's 60s | `CLIENT_TOOL_TIMEOUT_MS` |

`CLIENT_TOOL_TIMEOUT_MS = MAX_TIMEOUT_MS + 10_000` is derived, so it can't drift back into a collision. Both constants moved to `src/shared/config.ts` — webui may only import from `#src/shared`, and a cap shared by server, portal, and browser belongs there anyway.

The portal is ours but sits mid-chain (`client → stdio → portal → HTTP → server`), so its own leg was never the binding constraint — the upstream client's deadline always fires first. Fixed for consistency, not because it was the bug.

## Secondary: the silent discard

An over-cap value sent to the device handler was dropped, keeping the previous timeout, with only a Node-for-Max log line. It now clamps to the cap and warns, so "I raised the timeout and nothing changed" has a visible explanation.

## Docs

`docs/guide/device.md`, `docs/guide/rest-api.md`, the example skill's SKILL.md and CLI help, and both copies of the device tooltip — each now states the cap and why it sits under 60s.

## Verification

`npm run check` (12355 passing, 100% function coverage), `npm run check:build`, and `npm run ui:test` (30 passing) all green. No e2e run: the suite drives tool calls through Live and never touches the device's parameter ranges.

**One thing to eyeball in Live:** the `tab-setup.maxpat` numbox `parameter_mmax` change (60 → 55) is the only piece nothing automated covers. A device saved at 60 will clamp to 55 on load, which is intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)