### PR TITLE
fix(playback): stop acting on params the action can't use, or that name nothing

### DIFF
--- a/dev/Tool-Schemas.md
+++ b/dev/Tool-Schemas.md
@@ -32,6 +32,24 @@ schema tolerant. There's no built-in "degrade to a comma-separated string"
 switch — tolerance lives in the schema, e.g. `device-params-schema.ts`'s
 `params` array adds a `preprocess` that also accepts a JSON-stringified array.
 
+## Params that don't apply to every action
+
+A modal tool publishes one schema for every action, so a caller can always send
+a param the chosen action has no use for. **Warn and skip it — never apply it,
+never drop it quietly.** Applying it is the worse half: `ppal-playback` used to
+write the arrangement playhead on `play-scene`, so "play scene 3 from bar 5"
+changed the Live Set in a way nobody asked for.
+
+Say which action ignored it, and point at the one that would have used it:
+
+```
+startTime ignored: action "play-scene" does not change the arrangement;
+use action "update-arrangement" for the playhead and loop
+```
+
+Group the params that share a reason into one warning rather than repeating the
+sentence per param.
+
 ## Length caps
 
 `z.string().max(n)` emits `maxLength: n`. llama.cpp-based clients (Jan, LM

--- a/src/tools/actions/duplicate/helpers/clip/duplicate-destination-helpers.test.ts
+++ b/src/tools/actions/duplicate/helpers/clip/duplicate-destination-helpers.test.ts
@@ -39,16 +39,31 @@ describe("resolveClipDestinations", () => {
       });
     });
 
-    it("throws when toSlot names no slot", () => {
+    // A toSlot that names nothing reads as unset, so the caller is told what to
+    // send — under the param they should be using, not the deprecated one.
+    it("reads a toSlot that names no slot as omitted, and says so", () => {
+      const warn = vi.spyOn(console, "warn");
+
       expect(() => resolveClipDestinations(undefined, ",", false)).toThrow(
-        "duplicate failed: toSlot is required for session clips",
+        "duplicate failed: clip requires toPath",
       );
+      expect(warn).toHaveBeenCalledWith('toSlot "," names nothing');
     });
 
     // z.coerce.string() turns a JSON null into "null" before we see it, so a
     // caller unsetting toSlot must not read as naming a second destination.
     it("reads a coerced null alongside a real toPath as omitted", () => {
       expect(resolveClipDestinations("t2/s1", "null", false)).toStrictEqual({
+        destination: "session",
+        slots: [{ trackIndex: 2, sceneIndex: 1 }],
+        arrangementTargets: [],
+      });
+    });
+
+    // The conflict check asks whether both params named a destination. A toSlot
+    // of "," named none, so honoring toPath is not picking between two.
+    it("honors toPath when toSlot names nothing", () => {
+      expect(resolveClipDestinations("t2/s1", ",", false)).toStrictEqual({
         destination: "session",
         slots: [{ trackIndex: 2, sceneIndex: 1 }],
         arrangementTargets: [],
@@ -155,6 +170,20 @@ describe("resolveClipDestinations", () => {
           "arrangementStart/locator ignored — toSlot names a session position",
         ),
       );
+    });
+
+    // The mirror case. Nothing names a session slot, so arrangementStart is the
+    // only destination left and it carries the call — where this used to refuse
+    // the copy and ask for the deprecated param.
+    it("honors the arrangement position when toSlot names nothing", () => {
+      const warnSpy = vi.spyOn(console, "warn");
+
+      expect(resolveClipDestinations(undefined, ",", true)).toStrictEqual({
+        destination: "arrangement",
+        slots: [],
+        arrangementTargets: [],
+      });
+      expect(warnSpy).toHaveBeenCalledWith('toSlot "," names nothing');
     });
   });
 

--- a/src/tools/actions/duplicate/helpers/clip/duplicate-destination-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/clip/duplicate-destination-helpers.ts
@@ -51,7 +51,7 @@ export function resolveClipDestinations(
   // A blank param names nothing, so read it as omitted rather than as a
   // destination that failed to parse.
   const toPath = namedParam(rawToPath, "toPath");
-  const toSlot = namedHiddenPath(rawToSlot);
+  const toSlot = namedHiddenPath(rawToSlot, "toSlot");
 
   // Honoring one and dropping the other is exactly the silent-destination bug
   // toPath replaces, so refuse instead of picking.
@@ -151,7 +151,7 @@ export function warnUnusedDestination(
   if (type === "clip") return;
 
   const toPath = namedParam(rawToPath, "toPath");
-  const toSlot = namedHiddenPath(rawToSlot);
+  const toSlot = namedHiddenPath(rawToSlot, "toSlot");
 
   if (type !== "device" && type !== "drum-pad" && toPath != null) {
     console.warn(
@@ -176,20 +176,18 @@ function legacySlotDestinations(
   toSlot: string,
   hasArrangementParams: boolean,
 ): ClipDestinations {
+  // namedHiddenPath already dropped a toSlot that names nothing, so this always
+  // gets at least one entry.
   const slots = parseSlotList(toSlot, "toSlot");
 
   // toSlot only ever named session slots, so it can't be the arrangement
   // destination arrangementStart wants. Drop the weaker of the two rather than
   // failing the call, the way toPath does for the same conflict.
-  if (hasArrangementParams && slots.length > 0) {
+  if (hasArrangementParams) {
     console.warn(
       "duplicate: arrangementStart/locator ignored — toSlot names a session position; " +
         'use toPath (e.g. "t2") for that track\'s arrangement',
     );
-  }
-
-  if (slots.length === 0) {
-    throw new Error("duplicate failed: toSlot is required for session clips");
   }
 
   return { destination: "session", slots, arrangementTargets: [] };

--- a/src/tools/actions/duplicate/tests/duplicate-validation.test.ts
+++ b/src/tools/actions/duplicate/tests/duplicate-validation.test.ts
@@ -68,7 +68,7 @@ describe("duplicate - input validation", () => {
 });
 
 describe("duplicate - clip session validation", () => {
-  it("should throw an error when toSlot is empty for session clip", async () => {
+  it("should ask for toPath when toSlot names nothing", async () => {
     registerMockObject("clip1", {
       path: livePath.track(0).clipSlot(0).clip(),
     });
@@ -79,7 +79,7 @@ describe("duplicate - clip session validation", () => {
         id: "clip1",
         toSlot: ",",
       }),
-    ).rejects.toThrow("duplicate failed: toSlot is required for session clips");
+    ).rejects.toThrow("duplicate failed: clip requires toPath");
   });
 
   // Every other inapplicable param on this tool warns; these two used to be

--- a/src/tools/clip/create/helpers/create-clip-destination-helpers.ts
+++ b/src/tools/clip/create/helpers/create-clip-destination-helpers.ts
@@ -74,7 +74,7 @@ export function resolveCreateClipDestinations(
   // A blank param names nothing, so read it as omitted rather than as a
   // destination that failed to parse.
   const path = namedParam(params.path, "path");
-  const slot = namedHiddenPath(params.slot ?? undefined);
+  const slot = namedHiddenPath(params.slot ?? undefined, "slot");
 
   // Honoring one and dropping the other is exactly the silent-destination bug
   // path replaces, so refuse instead of picking.

--- a/src/tools/clip/create/tests/create-clip-path.test.ts
+++ b/src/tools/clip/create/tests/create-clip-path.test.ts
@@ -168,6 +168,25 @@ describe("createClip trackIndex/sceneIndex fallback", () => {
     expect(clipSlot.call).toHaveBeenCalledWith("create_clip", 4);
   });
 
+  // A slot that names nothing is not a destination, so it can't shadow the
+  // aliases the way a real slot list does.
+  it("reads the aliases when the deprecated slot names nothing", async () => {
+    const { clipSlot } = setupSessionMocks({
+      liveSet: { signature_numerator: 4, signature_denominator: 4 },
+      clip: { length: 4 },
+    });
+
+    await createClip({
+      slot: ",",
+      trackIndex: 0,
+      sceneIndex: 0,
+      notes: "C3 1|1",
+    });
+
+    expect(clipSlot.call).toHaveBeenCalledWith("create_clip", 4);
+    expect(consoleMock.warn).toHaveBeenCalledWith('slot "," names nothing');
+  });
+
   it("still reads trackIndex alone as the arrangement", async () => {
     const { track } = setupArrangementClipMocks();
 

--- a/src/tools/clip/read/helpers/read-clip-helpers.ts
+++ b/src/tools/clip/read/helpers/read-clip-helpers.ts
@@ -276,7 +276,7 @@ interface ClipLocation {
 export function resolveClipLocation(args: ClipLocationArgs): ClipLocation {
   const clipId = namedParam(args.clipId, "clipId") ?? null;
   const path = namedParam(args.path, "path");
-  const slot = namedHiddenPath(args.slot ?? undefined);
+  const slot = namedHiddenPath(args.slot ?? undefined, "slot");
 
   // Honoring one and dropping the other is the silent wrong-clip bug path
   // replaces, so refuse instead of picking — the same trade every other tool

--- a/src/tools/clip/read/tests/read-clip-path.test.ts
+++ b/src/tools/clip/read/tests/read-clip-path.test.ts
@@ -87,6 +87,23 @@ describe("readClip path param", () => {
     expect(readClip({ trackIndex: 1, sceneIndex: 1 }).name).toBe("Test Clip");
   });
 
+  // A slot that names nothing is not a second clip, so it can't shadow the
+  // fallback. It used to throw on the way to parsing it.
+  it("falls back to trackIndex/sceneIndex when slot names nothing", () => {
+    const warn = vi.spyOn(console, "warn");
+
+    setupMidiClipMock({
+      trackIndex: 1,
+      sceneIndex: 1,
+      clipProps: { name: "Test Clip" },
+    });
+
+    expect(readClip({ slot: ",", trackIndex: 1, sceneIndex: 1 }).name).toBe(
+      "Test Clip",
+    );
+    expect(warn).toHaveBeenCalledWith('slot "," names nothing');
+  });
+
   // Picking one and reading the other clip is the silent wrong-clip bug path
   // replaces — and the framework would then append "the value was honored"
   // about the one that wasn't.

--- a/src/tools/clip/update/helpers/update-clip-session-helpers.ts
+++ b/src/tools/clip/update/helpers/update-clip-session-helpers.ts
@@ -19,6 +19,7 @@ import {
 import {
   namedHiddenPath,
   pathEntries,
+  pathNamesSomething,
   slotPath,
 } from "#src/tools/shared/validation/object-path-helpers.ts";
 import {
@@ -46,7 +47,7 @@ export function moveDestinationParam(
   rawToSlot: string | undefined,
 ): "toPath" | "toSlot" {
   // Silent: resolveMoveDestinations already warned about anything it dropped.
-  return !paramNamesSomething(rawToPath) && namedHiddenPath(rawToSlot) != null
+  return !paramNamesSomething(rawToPath) && pathNamesSomething(rawToSlot)
     ? "toSlot"
     : "toPath";
 }
@@ -73,7 +74,7 @@ export function resolveMoveDestinations(
   // A blank param names nothing, so read it as omitted rather than as a
   // destination that failed to parse.
   const toPath = namedParam(rawToPath, "toPath");
-  const toSlot = namedHiddenPath(rawToSlot);
+  const toSlot = namedHiddenPath(rawToSlot, "toSlot");
 
   // Honoring one and dropping the other would move the clip somewhere the
   // caller didn't ask for, so move it nowhere and say so.
@@ -88,11 +89,13 @@ export function resolveMoveDestinations(
   if (toPath == null && toSlot == null) return none;
 
   // A bad destination is one param out of many on a batch update, and the
-  // tool's rule is warn-and-skip so the notes still land.
+  // tool's rule is warn-and-skip so the notes still land. Neither param can be
+  // empty here: namedHiddenPath drops a toSlot that names nothing, and toPath
+  // refuses one when it splits its entries.
   try {
     const destinations =
       toSlot != null
-        ? requireDestinations(parseSlotList(toSlot, "toSlot"), "toSlot")
+        ? parseSlotList(toSlot, "toSlot")
         : pathDestinations(toPath as string);
 
     return pairWithClips(destinations, clipCount, toSlot == null);
@@ -353,24 +356,6 @@ function pairWithClips(
     { length: clipCount },
     (_unused, i) => destinations[i] ?? null,
   );
-}
-
-/**
- * Refuses a toSlot that was sent but names nothing (e.g. ","). toPath is
- * refused earlier, by its own entry splitting.
- * @param destinations - Parsed destinations, in order
- * @param label - Param name for the error
- * @returns The destinations
- * @throws When the param was sent but names nothing
- */
-function requireDestinations<T>(destinations: T[], label: string): T[] {
-  // Throwing rather than warning lets the caller's catch report it like any
-  // other destination that failed to parse.
-  if (destinations.length === 0) {
-    throw new Error(`${label} names no destination`);
-  }
-
-  return destinations;
 }
 
 interface HandleSessionSlotMoveArgs {

--- a/src/tools/clip/update/tests/session/update-clip-session-move.test.ts
+++ b/src/tools/clip/update/tests/session/update-clip-session-move.test.ts
@@ -625,6 +625,23 @@ describe("resolveMoveDestinations", () => {
     );
   });
 
+  // The worst version of the pairing bug: a toSlot of "," named no second
+  // destination, so the check refused a move the caller had asked for once —
+  // and the result said nothing about the clip staying put.
+  it("moves to toPath when toSlot names nothing", () => {
+    expect(resolveMoveDestinations("t2/s3", ",", 1)).toStrictEqual([
+      { trackIndex: 2, sceneIndex: 3 },
+    ]);
+    expect(outlet).toHaveBeenCalledWith(
+      1,
+      expect.stringContaining('toSlot "," names nothing'),
+    );
+    expect(outlet).not.toHaveBeenCalledWith(
+      1,
+      expect.stringContaining("no clip was moved"),
+    );
+  });
+
   it("warns and skips a destination that is not a session slot", () => {
     // update-clip has no cross-track move; duplicate is the tool for that.
     expect(resolveMoveDestinations("t2", undefined, 1)).toStrictEqual([null]);

--- a/src/tools/clip/update/tests/update-clip-basic.test.ts
+++ b/src/tools/clip/update/tests/update-clip-basic.test.ts
@@ -373,9 +373,10 @@ describe("updateClip - Basic operations", () => {
   // The silent-no-op twin of duplicate's ",": update-clip warns rather than
   // throwing, but it must not stay quiet about a move that never happened.
   it.each([
-    // toPath is refused when the entries are split; toSlot once they're parsed.
+    // toPath is refused when its entries are split; toSlot reads as unset, so
+    // it never reaches a parser — a pairing check must not count it as sent.
     ["toPath", 'invalid toPath "," - it names nothing'],
-    ["toSlot", "toSlot names no destination"],
+    ["toSlot", 'toSlot "," names nothing'],
   ])(
     "should warn when %s was sent but names nothing",
     async (param, reason) => {

--- a/src/tools/session/helpers/playback-helpers.ts
+++ b/src/tools/session/helpers/playback-helpers.ts
@@ -38,6 +38,46 @@ interface ResolvedStartTime {
   useLocatorStart: boolean;
 }
 
+/** The params that address the arrangement timeline: the playhead and the loop. */
+export interface ArrangementParams
+  extends StartTimeParams, LoopStartParams, LoopEndParams {
+  loop?: boolean;
+}
+
+/** The actions that read the arrangement timeline. The rest work the session. */
+const ARRANGEMENT_ACTIONS = new Set(["play-arrangement", "update-arrangement"]);
+
+/**
+ * Drop the arrangement-timeline params on an action that doesn't use them.
+ *
+ * These are written to the Live Set before the action runs, so a session action
+ * used to apply them anyway: "play scene 3 from bar 5" fired the scene and moved
+ * the arrangement playhead, without a word. The scene had nothing to do with the
+ * arrangement, so the caller got a change to their Live Set they never asked for.
+ * @param action - The playback action, which decides whether they apply
+ * @param params - The timeline params as the caller sent them
+ * @returns The params, or none of them when the action works the session
+ */
+export function resolveArrangementParams(
+  action: string,
+  params: ArrangementParams,
+): ArrangementParams {
+  if (ARRANGEMENT_ACTIONS.has(action)) return params;
+
+  const sent = (Object.keys(params) as Array<keyof ArrangementParams>).filter(
+    (key) => params[key] != null,
+  );
+
+  if (sent.length > 0) {
+    console.warn(
+      `${sent.join("/")} ignored: action "${action}" does not change the ` +
+        `arrangement; use action "update-arrangement" for the playhead and loop`,
+    );
+  }
+
+  return {};
+}
+
 /**
  * Get the current loop state from liveSet
  * @param liveSet - The live_set LiveAPI object

--- a/src/tools/session/helpers/playback-target-helpers.ts
+++ b/src/tools/session/helpers/playback-target-helpers.ts
@@ -159,6 +159,16 @@ export function resolveClipSlotPositions(
     skipInvalid: true,
   });
 
+  // Skipping a bad id among good ones still leaves a call to make. Skipping all
+  // of them leaves none, and an empty list reads downstream as "act on these
+  // zero clips" — so the tool fired nothing and reported playing: true. Each id
+  // already warned why it was skipped; this says the call has no target left.
+  if (clips.length === 0) {
+    throw new Error(
+      `playback failed: ids "${ids}" named no clip for action "${action}"`,
+    );
+  }
+
   return clips.map((clip) => {
     const { trackIndex, sceneIndex } = clip;
 

--- a/src/tools/session/helpers/playback-target-helpers.ts
+++ b/src/tools/session/helpers/playback-target-helpers.ts
@@ -186,7 +186,7 @@ function readPathParam(
   slots: string | undefined,
 ): PathInput {
   const named = namedParam(path, "path");
-  const legacy = namedHiddenPath(slots);
+  const legacy = namedHiddenPath(slots, "slots");
 
   if (named != null && legacy != null) {
     throw new Error(
@@ -203,19 +203,14 @@ function readPathParam(
 
   if (legacy == null) return { entries: [], source: null };
 
-  // parseSlotList drops empty entries with a warning, so a value like ","
-  // parses to no positions at all. An empty list reads downstream as "act on
-  // these zero slots" — a silent no-op — so report it as the nothing it is.
-  const positions = parseSlotList(legacy, "slots");
-
-  if (positions.length === 0) return { entries: [], source: null };
-
   return {
-    entries: positions.map(({ trackIndex, sceneIndex }) => ({
-      kind: "slot" as const,
-      trackIndex,
-      sceneIndex,
-    })),
+    entries: parseSlotList(legacy, "slots").map(
+      ({ trackIndex, sceneIndex }) => ({
+        kind: "slot" as const,
+        trackIndex,
+        sceneIndex,
+      }),
+    ),
     source: { label: "slots", input: legacy },
   };
 }
@@ -415,7 +410,7 @@ function warnUnusedTarget(
 ): void {
   const sent = [
     namedParam(path, "path") != null ? "path" : null,
-    namedHiddenPath(slots) != null ? "slots" : null,
+    namedHiddenPath(slots, "slots") != null ? "slots" : null,
     ids != null ? "ids" : null,
     sceneIndex != null ? "sceneIndex" : null,
   ].filter((param) => param != null);

--- a/src/tools/session/helpers/select-path-helpers.ts
+++ b/src/tools/session/helpers/select-path-helpers.ts
@@ -108,8 +108,8 @@ function targetFromParams({
   devicePath: rawDevicePath,
 }: PathParams): PathTarget {
   const path = namedParam(rawPath, "path");
-  const slot = namedHiddenPath(rawSlot);
-  const devicePath = namedHiddenPath(rawDevicePath);
+  const slot = namedHiddenPath(rawSlot, "slot");
+  const devicePath = namedHiddenPath(rawDevicePath, "devicePath");
 
   if (path == null) {
     return {

--- a/src/tools/session/playback.def.ts
+++ b/src/tools/session/playback.def.ts
@@ -30,7 +30,7 @@ export const toolDefPlayback = defineTool("ppal-playback", {
       ])
       .describe(
         `play-arrangement: from startTime
-update-arrangement: modify loop
+update-arrangement: set playhead/loop without playing
 play-scene: all clips in scene
 play-session-clips: by id(s) or path(s)
 stop-session-clips: by id(s) or path(s)

--- a/src/tools/session/playback.ts
+++ b/src/tools/session/playback.ts
@@ -10,6 +10,7 @@ import {
   getCurrentLoopState,
   handlePlayArrangement,
   handlePlayScene,
+  resolveArrangementParams,
   resolveLoopEnd,
   resolveLoopStart,
   resolveStartTime,
@@ -110,10 +111,26 @@ export function playback(
     ids: namedIds,
   } = resolvePlaybackTarget(action, { ids, path, slots, sceneIndex });
 
+  // Dropped before anything reads them, so a session action can't write the
+  // arrangement. Everything below sees only what this action actually uses.
+  const timeline = resolveArrangementParams(action, {
+    startTime,
+    startLocator,
+    loop,
+    loopStart,
+    loopStartLocator,
+    loopEnd,
+    loopEndLocator,
+  });
+
   // Validate mutual exclusivity of time and locator parameters
-  validateLocatorOrTime(startTime, startLocator, "startTime");
-  validateLocatorOrTime(loopStart, loopStartLocator, "loopStart");
-  validateLocatorOrTime(loopEnd, loopEndLocator, "loopEnd");
+  validateLocatorOrTime(timeline.startTime, timeline.startLocator, "startTime");
+  validateLocatorOrTime(
+    timeline.loopStart,
+    timeline.loopStartLocator,
+    "loopStart",
+  );
+  validateLocatorOrTime(timeline.loopEnd, timeline.loopEndLocator, "loopEnd");
 
   const liveSet = LiveAPI.from(livePath.liveSet);
 
@@ -128,19 +145,19 @@ export function playback(
   // Resolve start time from bar|beat or locator
   const { startTimeBeats, useLocatorStart } = resolveStartTime(
     liveSet,
-    { startTime, startLocator },
+    timeline,
     songTimeSigNumerator,
     songTimeSigDenominator,
   );
 
-  if (loop != null) {
-    liveSet.set("loop", loop);
+  if (timeline.loop != null) {
+    liveSet.set("loop", timeline.loop);
   }
 
   // Resolve loop start from bar|beat or locator
   const loopStartBeats = resolveLoopStart(
     liveSet,
-    { loopStart, loopStartLocator },
+    timeline,
     songTimeSigNumerator,
     songTimeSigDenominator,
   );
@@ -148,7 +165,7 @@ export function playback(
   // Resolve loop end from bar|beat or locator
   resolveLoopEnd(
     liveSet,
-    { loopEnd, loopEndLocator },
+    timeline,
     loopStartBeats,
     songTimeSigNumerator,
     songTimeSigDenominator,
@@ -163,7 +180,7 @@ export function playback(
     action,
     liveSet,
     {
-      startTime,
+      startTime: timeline.startTime,
       startTimeBeats,
       useLocatorStart,
       sceneIndex: sceneTarget ?? undefined,
@@ -195,7 +212,7 @@ export function playback(
   return buildPlaybackResult({
     isPlaying,
     currentTime,
-    loop,
+    loop: timeline.loop,
     currentLoopStart: currentLoop.start,
     currentLoopEnd: currentLoop.end,
     liveSet,

--- a/src/tools/session/tests/playback/playback-arrangement-params.test.ts
+++ b/src/tools/session/tests/playback/playback-arrangement-params.test.ts
@@ -1,0 +1,208 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import * as console from "#src/shared/max/v8-max-console.ts";
+import {
+  registerMockObject,
+  type RegisteredMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+import { playback } from "#src/tools/session/playback.ts";
+import { setupPlaybackLiveSet } from "./playback-test-helpers.ts";
+
+/** The actions that work the session or the transport, not the arrangement. */
+const SESSION_ACTIONS = [
+  "play-scene",
+  "play-session-clips",
+  "stop-session-clips",
+  "stop-all-session-clips",
+  "stop",
+];
+
+/** Everything any of the actions might fire, so each call gets that far. */
+function registerTargets(): void {
+  registerMockObject(livePath.scene(3), { path: livePath.scene(3) });
+  registerMockObject(livePath.track(0), { path: livePath.track(0) });
+  registerMockObject(livePath.track(0).clipSlot(1), {
+    path: livePath.track(0).clipSlot(1),
+  });
+}
+
+/** The target param each action needs, so the call gets as far as the timeline. */
+function targetFor(action: string): Record<string, unknown> {
+  if (action === "play-scene") return { sceneIndex: 3 };
+
+  if (action === "play-session-clips" || action === "stop-session-clips") {
+    return { path: "t0/s1" };
+  }
+
+  return {};
+}
+
+// These are written to the Live Set before the action runs, so a session action
+// used to apply them anyway — firing a scene *and* moving the playhead, silently.
+describe("playback arrangement params on a session action", () => {
+  let liveSet: RegisteredMockObject;
+
+  beforeEach(() => {
+    liveSet = setupPlaybackLiveSet();
+  });
+
+  it.each(SESSION_ACTIONS)("does not move the playhead for %s", (action) => {
+    registerTargets();
+    playback({ ...targetFor(action), action, startTime: "5|1" });
+
+    expect(liveSet.set).not.toHaveBeenCalledWith("start_time", 16);
+  });
+
+  it.each(SESSION_ACTIONS)("says it ignored startTime on %s", (action) => {
+    const warn = vi.spyOn(console, "warn");
+
+    registerTargets();
+    playback({ ...targetFor(action), action, startTime: "5|1" });
+
+    expect(warn).toHaveBeenCalledWith(
+      `startTime ignored: action "${action}" does not change the arrangement; ` +
+        `use action "update-arrangement" for the playhead and loop`,
+    );
+  });
+
+  // loopEnd is here too because it writes loop_length, not loop_start — a
+  // separate write that has to be dropped on its own.
+  it("does not touch the arrangement loop either", () => {
+    const warn = vi.spyOn(console, "warn");
+
+    registerTargets();
+    playback({
+      action: "play-scene",
+      sceneIndex: 3,
+      loop: true,
+      loopStart: "5|1",
+      loopEnd: "9|1",
+    });
+
+    expect(liveSet.set).not.toHaveBeenCalledWith("loop", true);
+    expect(liveSet.set).not.toHaveBeenCalledWith("loop_start", 16);
+    expect(liveSet.set).not.toHaveBeenCalledWith(
+      "loop_length",
+      expect.anything(),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("loop/loopStart/loopEnd ignored"),
+    );
+  });
+
+  // The result reports the loop the Live Set actually has. Echoing the param
+  // would claim a loop the call refused to set.
+  it("reports the Live Set's own loop, not the param it dropped", () => {
+    liveSet = setupPlaybackLiveSet({ loop: 0 });
+    registerTargets();
+
+    const result = playback({
+      action: "play-scene",
+      sceneIndex: 3,
+      loop: true,
+    });
+
+    expect(result.arrangementLoop).toBeUndefined();
+  });
+
+  // A locator resolves against the arrangement too, so it goes the same way.
+  it("drops startLocator without looking it up", () => {
+    const warn = vi.spyOn(console, "warn");
+
+    registerTargets();
+    playback({
+      action: "play-scene",
+      sceneIndex: 3,
+      startLocator: "no-such-locator",
+    });
+
+    expect(liveSet.set).not.toHaveBeenCalledWith(
+      "start_time",
+      expect.anything(),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("startLocator ignored"),
+    );
+  });
+
+  // The two params can't be used together, but neither one applies here, so
+  // there is nothing to refuse.
+  it("does not refuse startTime with startLocator once both are dropped", () => {
+    registerTargets();
+
+    expect(() =>
+      playback({
+        action: "play-scene",
+        sceneIndex: 3,
+        startTime: "5|1",
+        startLocator: "locator-0",
+      }),
+    ).not.toThrow();
+  });
+
+  it("names every param it dropped, in one warning", () => {
+    const warn = vi.spyOn(console, "warn");
+
+    registerTargets();
+    playback({
+      action: "stop",
+      startTime: "5|1",
+      loop: false,
+      loopEnd: "9|1",
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("startTime/loop/loopEnd ignored"),
+    );
+  });
+
+  it("says nothing when the caller sent none of them", () => {
+    const warn = vi.spyOn(console, "warn");
+
+    registerTargets();
+    playback({ action: "stop" });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  // stop resets the playhead as part of stopping. That is the action's own
+  // behavior, not the dropped param leaking through.
+  it("still lets stop reset the playhead itself", () => {
+    registerTargets();
+    playback({ action: "stop", startTime: "5|1" });
+
+    expect(liveSet.set).toHaveBeenCalledWith("start_time", 0);
+  });
+});
+
+describe("playback arrangement params on an arrangement action", () => {
+  let liveSet: RegisteredMockObject;
+
+  beforeEach(() => {
+    liveSet = setupPlaybackLiveSet();
+  });
+
+  it.each(["play-arrangement", "update-arrangement"])(
+    "still applies startTime on %s",
+    (action) => {
+      const warn = vi.spyOn(console, "warn");
+
+      playback({ action, startTime: "5|1" });
+
+      expect(liveSet.set).toHaveBeenCalledWith("start_time", 16);
+      expect(warn).not.toHaveBeenCalled();
+    },
+  );
+
+  it("still applies the loop params", () => {
+    playback({ action: "update-arrangement", loop: true, loopStart: "5|1" });
+
+    expect(liveSet.set).toHaveBeenCalledWith("loop", true);
+    expect(liveSet.set).toHaveBeenCalledWith("loop_start", 16);
+  });
+});

--- a/src/tools/session/tests/playback/playback-basic.test.ts
+++ b/src/tools/session/tests/playback/playback-basic.test.ts
@@ -233,19 +233,20 @@ describe("transport", () => {
     );
   });
 
-  it("should log warning when clip doesn't exist for play-session-clips", () => {
+  // Skipping the only id leaves nothing to fire, so the call has no target.
+  // Reporting playing: true here claimed a launch that never happened.
+  it("refuses play-session-clips when no id names a clip", () => {
     mockNonExistentObjects();
 
-    const result = playback({
-      action: "play-session-clips",
-      ids: "nonexistent_clip",
-    });
-
+    expect(() =>
+      playback({ action: "play-session-clips", ids: "nonexistent_clip" }),
+    ).toThrow(
+      'playback failed: ids "nonexistent_clip" named no clip for action "play-session-clips"',
+    );
     expect(outlet).toHaveBeenCalledWith(
       1,
       'playback: id "nonexistent_clip" does not exist',
     );
-    expect(result).toBeDefined(); // Operation continues but with no clips played
   });
 
   it("should throw error when clip slot doesn't exist for play-session-clips", () => {
@@ -361,19 +362,18 @@ describe("transport", () => {
     );
   });
 
-  it("should log warning when clip doesn't exist for stop-session-clips", () => {
+  it("refuses stop-session-clips when no id names a clip", () => {
     mockNonExistentObjects();
 
-    const result = playback({
-      action: "stop-session-clips",
-      ids: "nonexistent_clip",
-    });
-
+    expect(() =>
+      playback({ action: "stop-session-clips", ids: "nonexistent_clip" }),
+    ).toThrow(
+      'playback failed: ids "nonexistent_clip" named no clip for action "stop-session-clips"',
+    );
     expect(outlet).toHaveBeenCalledWith(
       1,
       'playback: id "nonexistent_clip" does not exist',
     );
-    expect(result).toBeDefined(); // Operation continues but with no clips stopped
   });
 
   it("should throw error when clip has no trackIndex for play-session-clips", () => {

--- a/src/tools/session/tests/playback/playback-features.test.ts
+++ b/src/tools/session/tests/playback/playback-features.test.ts
@@ -88,6 +88,20 @@ describe("playback path param", () => {
     ).toThrow("playback failed: path and slots both name clips");
   });
 
+  // The same check, on a slots that named nothing. A comma is not a second
+  // target, so refusing the call reported a conflict the caller never made.
+  it("fires what path names when slots names nothing", () => {
+    const warn = vi.spyOn(console, "warn");
+    const clipSlot = registerMockObject(livePath.track(0).clipSlot(1), {
+      path: livePath.track(0).clipSlot(1),
+    });
+
+    playback({ action: "play-session-clips", path: "t0/s1", slots: "," });
+
+    expect(clipSlot.call).toHaveBeenCalledWith("fire");
+    expect(warn).toHaveBeenCalledWith('slots "," names nothing');
+  });
+
   it("fires a scene a path names", () => {
     const scene = registerMockObject(livePath.scene(3), {
       path: livePath.scene(3),

--- a/src/tools/session/tests/playback/playback-target-params.test.ts
+++ b/src/tools/session/tests/playback/playback-target-params.test.ts
@@ -119,8 +119,9 @@ describe("playback ids that names no clip", () => {
   });
 });
 
-// parseSlotList drops empty entries and returns none, and an empty list read as
-// a target is a call that acts on nothing while reporting success.
+// slots reads as unset now, so the call falls through to "you named no target"
+// instead of carrying an empty list that acts on nothing while reporting
+// success.
 describe("playback slots that names no position", () => {
   beforeEach(() => {
     setupPlaybackLiveSet();

--- a/src/tools/session/tests/playback/playback-target-params.test.ts
+++ b/src/tools/session/tests/playback/playback-target-params.test.ts
@@ -117,6 +117,54 @@ describe("playback ids that names no clip", () => {
       playback({ action: "play-session-clips", path: "s3", ids: "clip1" }),
     ).toThrow("playback failed: ids and path are mutually exclusive");
   });
+
+  // Bad ids are warned and skipped, which is right until every one is skipped:
+  // the empty list left over read as "act on these zero clips", so the tool
+  // fired nothing and reported playing: true.
+  it("refuses the action when every id is skipped", () => {
+    const warn = vi.spyOn(console, "warn");
+
+    registerMockObject("scene3", { path: livePath.scene(3), type: "Scene" });
+
+    expect(() =>
+      playback({ action: "play-session-clips", ids: "scene3" }),
+    ).toThrow(
+      'playback failed: ids "scene3" named no clip for action "play-session-clips"',
+    );
+    expect(warn).toHaveBeenCalledWith(
+      'playback: id "scene3" is not a clip (found Scene)',
+    );
+  });
+
+  it("refuses stop-session-clips the same way", () => {
+    registerMockObject("scene3", { path: livePath.scene(3), type: "Scene" });
+
+    expect(() =>
+      playback({ action: "stop-session-clips", ids: "scene3" }),
+    ).toThrow(
+      'playback failed: ids "scene3" named no clip for action "stop-session-clips"',
+    );
+  });
+
+  // Nothing warned on this one at all: the entries were dropped before any id
+  // was looked at, so the call reported a launch with no message of any kind.
+  it("refuses an ids that names no id", () => {
+    expect(() => playback({ action: "play-session-clips", ids: "," })).toThrow(
+      'playback failed: ids "," named no clip for action "play-session-clips"',
+    );
+  });
+
+  it("still fires the good ids when only some are skipped", () => {
+    registerMockObject("scene3", { path: livePath.scene(3), type: "Scene" });
+    registerMockObject("clip1", {
+      path: livePath.track(0).clipSlot(1).clip(),
+      type: "Clip",
+    });
+
+    playback({ action: "play-session-clips", ids: "scene3,clip1" });
+
+    expect(clipSlot.call).toHaveBeenCalledWith("fire");
+  });
 });
 
 // slots reads as unset now, so the call falls through to "you named no target"

--- a/src/tools/session/tests/select/select-path.test.ts
+++ b/src/tools/session/tests/select/select-path.test.ts
@@ -387,6 +387,47 @@ describe("select path param", () => {
       "select failed: path and slot/devicePath both name a target",
     );
   });
+
+  // The same check, on a deprecated param that named nothing. A comma is not a
+  // second target, so refusing reported a conflict the caller never made.
+  it("selects what path names when the param it replaced names nothing", () => {
+    const warn = vi.spyOn(console, "warn");
+    const clipSlot = registerMockObject(livePath.track(0).clipSlot(1), {
+      path: livePath.track(0).clipSlot(1),
+      type: "ClipSlot",
+      properties: { has_clip: 0 },
+    });
+    const songView = setupSongViewMock();
+
+    setupAppViewMock();
+
+    select({ path: "t0/s1", slot: "," });
+
+    expect(songView.set).toHaveBeenCalledWith(
+      "highlighted_clip_slot",
+      `id ${clipSlot.id}`,
+    );
+    expect(warn).toHaveBeenCalledWith('slot "," names nothing');
+  });
+
+  // On its own it leaves select with no target, which is select's read mode.
+  // That reports the selection Live actually has, so nothing claims a move that
+  // didn't happen — the warning is what tells the caller why.
+  it("reads the current selection when the only param sent names nothing", () => {
+    const warn = vi.spyOn(console, "warn");
+    const songView = setupSongViewMock();
+
+    setupAppViewMock();
+
+    const result = select({ slot: "," });
+
+    expect(result.selectedClip).toBeUndefined();
+    expect(songView.set).not.toHaveBeenCalledWith(
+      "highlighted_clip_slot",
+      expect.anything(),
+    );
+    expect(warn).toHaveBeenCalledWith('slot "," names nothing');
+  });
 });
 
 /** The tracks, scenes, and clips the id-versus-path cases pick between. */

--- a/src/tools/shared/validation/object-path-helpers.ts
+++ b/src/tools/shared/validation/object-path-helpers.ts
@@ -93,15 +93,42 @@ export function pathEntries(input?: string | null, label = "path"): string[] {
 }
 
 /**
+ * Whether a path param names at least one entry. Silent, for a second read of
+ * a param {@link namedHiddenPath} already reported on.
+ * @param value - Raw param value
+ * @returns True when the value names something
+ */
+export function pathNamesSomething(value: string | null | undefined): boolean {
+  return paramNamesSomething(value) && parseCommaSeparatedIds(value).length > 0;
+}
+
+/**
  * Normalizes a hidden (deprecated or alias) path param. Like
  * {@link namedParam}, except a coerced null passes without a word: a caller
  * moving off the old param may send null for it, and there is nothing to tell
  * them about a param they were already meant to stop sending.
+ *
+ * A value whose entries are all empty (`","`) names nothing, so it reads as
+ * unset — every caller pairs this with a published param and asks "were both
+ * sent?", and counting an empty value as sent refuses a call that had no
+ * conflict, or reports a move that never happened.
  * @param value - Raw param value
+ * @param label - Param name, for the warning
  * @returns The trimmed value, or undefined when it names nothing
  */
-export function namedHiddenPath(value: string | undefined): string | undefined {
-  return paramNamesSomething(value) ? value?.trim() : undefined;
+export function namedHiddenPath(
+  value: string | undefined,
+  label: string,
+): string | undefined {
+  if (pathNamesSomething(value)) return value?.trim();
+
+  // Unlike a coerced null, a comma is something the caller typed, so say the
+  // value went nowhere. Silent otherwise, per the note above.
+  if (paramNamesSomething(value)) {
+    console.warn(`${label} "${value?.trim()}" names nothing`);
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/tools/shared/validation/tests/object-path-helpers.test.ts
+++ b/src/tools/shared/validation/tests/object-path-helpers.test.ts
@@ -10,6 +10,7 @@ import {
   namedHiddenPath,
   parseObjectPathList,
   parseSessionSlotList,
+  pathNamesSomething,
   requireClipPath,
   requireDeviceContainer,
   requireDevicePath,
@@ -275,17 +276,64 @@ describe("namedHiddenPath", () => {
   // A caller moving off toSlot may send null for it; that must not read as a
   // second destination alongside a real toPath.
   it("reads a coerced null as naming nothing", () => {
-    expect(namedHiddenPath("null")).toBeUndefined();
-    expect(namedHiddenPath("undefined")).toBeUndefined();
+    expect(namedHiddenPath("null", "toSlot")).toBeUndefined();
+    expect(namedHiddenPath("undefined", "toSlot")).toBeUndefined();
   });
 
   it("reads a blank param as naming nothing", () => {
-    expect(namedHiddenPath(undefined)).toBeUndefined();
-    expect(namedHiddenPath("")).toBeUndefined();
-    expect(namedHiddenPath("   ")).toBeUndefined();
+    expect(namedHiddenPath(undefined, "toSlot")).toBeUndefined();
+    expect(namedHiddenPath("", "toSlot")).toBeUndefined();
+    expect(namedHiddenPath("   ", "toSlot")).toBeUndefined();
+  });
+
+  it("says nothing about a param the caller left unset", () => {
+    const warn = vi.spyOn(console, "warn");
+
+    namedHiddenPath("null", "toSlot");
+    namedHiddenPath("", "toSlot");
+
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("trims a param that names something", () => {
-    expect(namedHiddenPath(" 2/1 ")).toBe("2/1");
+    expect(namedHiddenPath(" 2/1 ", "toSlot")).toBe("2/1");
+  });
+
+  // Every caller pairs this with a published param and asks "were both sent?",
+  // so a value that names nothing has to read as unset or the pair conflicts.
+  it("reads a value whose entries are all empty as naming nothing", () => {
+    expect(namedHiddenPath(",", "toSlot")).toBeUndefined();
+    expect(namedHiddenPath(" , , ", "toSlot")).toBeUndefined();
+  });
+
+  it("says so, since a comma is something the caller typed", () => {
+    const warn = vi.spyOn(console, "warn");
+
+    namedHiddenPath(",", "toSlot");
+
+    expect(warn).toHaveBeenCalledWith('toSlot "," names nothing');
+  });
+
+  it("keeps a value that names one entry among empties", () => {
+    expect(namedHiddenPath("0/1,,2/3", "toSlot")).toBe("0/1,,2/3");
+  });
+});
+
+describe("pathNamesSomething", () => {
+  it("is true only when the value names an entry", () => {
+    expect(pathNamesSomething("0/1")).toBe(true);
+    expect(pathNamesSomething("0/1,,2/3")).toBe(true);
+    expect(pathNamesSomething(",")).toBe(false);
+    expect(pathNamesSomething("null")).toBe(false);
+    expect(pathNamesSomething("")).toBe(false);
+    expect(pathNamesSomething(undefined)).toBe(false);
+  });
+
+  it("says nothing, so a second read does not repeat the warning", () => {
+    const warn = vi.spyOn(console, "warn");
+
+    pathNamesSomething(",");
+
+    expect(warn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Three ways a `ppal-playback` call could change something the caller never asked for, or report success it never reached. The first fix is shared, so it lands across six tools.

## A deprecated path param that names nothing now reads as unset

`namedHiddenPath` promised "the trimmed value, or undefined when it names nothing" but returned the value for `","` — entries that are all empty. Six tools pair it with the param that replaced it and ask "were both sent?", so an empty value counted as a second target and the pair read as a conflict the caller never made:

| call | before |
| --- | --- |
| `playback path:"s1" slots:","` | refused for a conflict |
| `select path:"t0/s1" slot:","` | refused for a conflict |
| `updateClip toPath:"t1/s1" toSlot:","` | warned "no clip was moved", then reported success anyway |

All three now do what the caller asked and say the old param named nothing. A coerced null stays silent, as before — nobody stops using a param by sending a comma.

Knock-on effects, all in the same direction: `read-clip` and `create-clip` fall through to their `trackIndex`/`sceneIndex` aliases instead of failing, and `duplicate` honors `arrangementStart` instead of demanding the deprecated param. Three per-tool workarounds became unreachable and were removed.

## Session actions no longer write the arrangement

`startTime`, `startLocator`, `loop`, `loopStart`, `loopEnd` and their locators were written to the Live Set before the action ran, so every action applied them — including the five that never touch the arrangement.

**"Play scene 3 from bar 5" fired the scene and moved the arrangement playhead to bar 5, silently.** The caller got a change to their Live Set they never asked for and no way to know it happened. The loop params did the same.

They are now dropped for anything but `play-arrangement` and `update-arrangement`, with one warning naming what was dropped and the action that would have used it. `stop` still resets the playhead to 0 — that is the action stopping, not a param leaking through.

## A clip action whose ids name no clip is refused

Bad ids are warned and skipped, which is right while good ones remain. Skipping every one left an empty list, and an empty list read downstream as "act on these zero clips" — so `play-session-clips` fired nothing and returned `playing: true`. With `ids: ","` there was no warning at all, because the entries were dropped before any id was read.

The call is now refused, naming the ids and the action. A call where only some ids are skipped is unchanged.

---

`dev/Tool-Schemas.md` gains a section on params that don't apply to every action: warn and skip, never apply and never drop quietly.

AJM-1019 — with two corrections to the ticket: issue 1 (`focus` silently doing nothing) is invalid, since `focus` has not been in any tool's schema since it was removed in March, and the loop params had the same bug as `startTime` and were folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
