### PR TITLE
Say "clip slot" instead of "session position" or "session slot"

### DIFF
--- a/dev/Object-Paths.md
+++ b/dev/Object-Paths.md
@@ -69,7 +69,7 @@ occupy the location.
 | `t0`              | ✅ arrangement   | ✅ append | ✅     | —      |
 | `rt0`, `mt`       | ❌ no clip slots | ✅        | ✅     | —      |
 | `s3`              | ❌               | ❌        | —      | ✅     |
-| `t0/s3`           | ✅ session slot  | ❌        | —      | —      |
+| `t0/s3`           | ✅ clip slot     | ❌        | —      | —      |
 | `t0/l1`, `t0/l+`  | ✅ arrangement   | ❌        | —      | —      |
 | `t0/d1` and below | ❌               | ✅        | —      | —      |
 
@@ -152,11 +152,11 @@ Clip results report `path`, and nothing else positional — no `slot`, no
 | arrangement            | `path: "t0"`, `arrangementStart: "5\|1"`    |
 | arrangement, take lane | `path: "t0/l1"`, `arrangementStart: "5\|1"` |
 
-A session slot pastes straight back into any `path`/`toPath` param. An
-arrangement one doesn't address that clip — it names the track the clip is on,
-which is what a destination needs and not what a source needs. So it works as a
-destination (`create-clip`, `duplicate`), and a tool that wants one specific
-clip wants its id. `select` takes it and selects the track.
+A clip slot pastes straight back into any `path`/`toPath` param. An arrangement
+one doesn't address that clip — it names the track the clip is on, which is what
+a destination needs and not what a source needs. So it works as a destination
+(`create-clip`, `duplicate`), and a tool that wants one specific clip wants its
+id. `select` takes it and selects the track.
 
 Error messages follow: name the path and show the fix, never restate a
 requirement in index terms.

--- a/docs/features/tools.md
+++ b/docs/features/tools.md
@@ -121,8 +121,8 @@ Live, or make sure your standalone Max is up to date. See
 - Update selection and return only relevant fields
   - Select any object by ID (auto-detects track/scene/clip/device)
   - Select tracks by index/category, scenes by index
-  - Select by path: a session position (e.g., `t0/s3`), a track (`t0`), a return
-    track (`rt0`), the master track (`mt`), a scene (`s3`), or a device (e.g.,
+  - Select by path: a clip slot (e.g., `t0/s3`), a track (`t0`), a return track
+    (`rt0`), the master track (`mt`), a scene (`s3`), or a device (e.g.,
     `t0/d1`)
   - Switch between Session and Arrangement views
   - Auto-switches to session view for scene/clipSlot selection
@@ -280,7 +280,7 @@ for how it reads under [MIDI JSON](/features/midi-notation#midi-json) and
 
 - Generate MIDI clips with notes, velocities, and timing using
   [custom notation](/features#custom-music-notation)
-- Place clips in Session slots or Arrangement timeline
+- Place clips in clip slots or the Arrangement timeline
 - Place arrangement clips on [take lanes](/features#take-lanes) with a `t0/l1`
   or `t0/l+` path
 - Support for probability, velocity ranges, and complex rhythms

--- a/e2e/mcp/clip/arrangement/ppal-duplicate-cross-track.test.ts
+++ b/e2e/mcp/clip/arrangement/ppal-duplicate-cross-track.test.ts
@@ -104,7 +104,7 @@ describe("cross-track arrangement clip duplicate", () => {
       name: "Cross Copy C",
     });
 
-    // toSlot only ever named session slots, so it wins over arrangementStart —
+    // toSlot only ever named clip slots, so it wins over arrangementStart —
     // and then has nowhere to put an arrangement clip.
     expect(isToolError(result)).toBe(true);
     expect(getToolErrorMessage(result)).toContain(

--- a/e2e/mcp/clip/create/ppal-create-clip-pattern-brackets.test.ts
+++ b/e2e/mcp/clip/create/ppal-create-clip-pattern-brackets.test.ts
@@ -141,7 +141,7 @@ describe("ppal-create-clip pattern brackets (streams)", () => {
 /**
  * Create a MIDI clip with `notes` at `path`, read it back, and re-interpret the
  * serialized notation into note events (in the clip's own meter).
- * @param path - Session slot path (e.g. "t8/s0")
+ * @param path - Clip slot path (e.g. "t8/s0")
  * @param notes - bar|beat notation (may contain pattern brackets)
  * @returns The read-back notation string and its re-interpreted note events
  */

--- a/e2e/mcp/clip/helpers/audio-warp-test-helpers.ts
+++ b/e2e/mcp/clip/helpers/audio-warp-test-helpers.ts
@@ -114,9 +114,9 @@ export async function readClipFully(
 export const DRUM_LOOP_BEATS = 4;
 
 /**
- * Create an unwarped drum-loop clip in a session slot.
+ * Create an unwarped drum-loop clip in a clip slot.
  * @param client - The MCP client
- * @param path - The session position, "t<track>/s<scene>"
+ * @param path - The clip slot, "t<track>/s<scene>"
  * @returns The new clip's id
  */
 export async function createUnwarpedDrumLoop(

--- a/e2e/mcp/clip/helpers/ppal-clip-transforms-test-helpers.ts
+++ b/e2e/mcp/clip/helpers/ppal-clip-transforms-test-helpers.ts
@@ -60,7 +60,7 @@ export async function createMidiClip(
  * suites that vary looping/length/notes per case rather than taking
  * {@link createMidiClip}'s fixed 2-bar shape.
  * @param ctx - MCP test context with client
- * @param path - Session slot path (e.g. "t8/s0")
+ * @param path - Clip slot path (e.g. "t8/s0")
  * @param args - Create-clip arguments beyond the path (notes, length, looping)
  * @returns Clip ID
  */
@@ -269,7 +269,7 @@ export function setupClipTransformTest(): ReturnType<
  * inside the test body is what actually takes effect for the read-back). Shared
  * by the triplet round-trip suites (MIDI JSON ratios and Stark triplets).
  * @param ctx - MCP test context with client
- * @param path - Session slot path (e.g. "t8/s0")
+ * @param path - Clip slot path (e.g. "t8/s0")
  * @param notes - Notation string for the clip's notes
  * @param notation - Read-back notation mode to configure the server with
  * @param interpret - Re-interprets the read-back notation string into events

--- a/e2e/mcp/clip/ppal-note-write-ordering.test.ts
+++ b/e2e/mcp/clip/ppal-note-write-ordering.test.ts
@@ -64,7 +64,7 @@ async function createOrderingTrack(name: string): Promise<number> {
 /**
  * Create a clip and assert how many notes Live actually stored. noteCount is
  * read back from the clip, so it is the survival count, not the input count.
- * @param path - Session position ("t<track>/s<scene>")
+ * @param path - Clip slot ("t<track>/s<scene>")
  * @param notes - bar|beat notation for the clip
  * @param noteCount - Expected stored note count
  * @returns The created clip

--- a/e2e/mcp/clip/transforms/ppal-clip-transforms.test.ts
+++ b/e2e/mcp/clip/transforms/ppal-clip-transforms.test.ts
@@ -62,7 +62,7 @@ async function createAudioTrack(trackName: string): Promise<number> {
   return track.trackIndex!;
 }
 
-/** Creates a sample audio clip in a session slot and returns its id. */
+/** Creates a sample audio clip in a clip slot and returns its id. */
 async function createAudioSampleClip(
   trackIndex: number,
   sceneIndex: number,

--- a/e2e/mcp/clip/update/ppal-update-clip-loop-toggle.test.ts
+++ b/e2e/mcp/clip/update/ppal-update-clip-loop-toggle.test.ts
@@ -101,7 +101,7 @@ async function updateAndRead(
  * looping — the state a bare `looping: true` used to reset to the whole bar.
  * @param client - The MCP client
  * @param kind - Whether to build a MIDI clip or an audio one
- * @param sceneIndex - The session slot to build it in
+ * @param sceneIndex - The clip slot to build it in
  * @returns The new clip's id
  */
 async function halvedClip(

--- a/e2e/mcp/clip/update/ppal-update-clip.test.ts
+++ b/e2e/mcp/clip/update/ppal-update-clip.test.ts
@@ -443,7 +443,7 @@ describe("ppal-update-clip", () => {
     expect(oldSlot.id).toBeNull();
   });
 
-  it("warns instead of throwing when toPath isn't a session slot", async () => {
+  it("warns instead of throwing when toPath isn't a clip slot", async () => {
     const createResult = await ctx.client!.callTool({
       name: "ppal-create-clip",
       arguments: {
@@ -468,7 +468,7 @@ describe("ppal-update-clip", () => {
     }>(result);
 
     expect(isToolError(result)).toBe(false);
-    expect(warnings.join(" ")).toContain("is not a session slot");
+    expect(warnings.join(" ")).toContain("is not a clip slot");
 
     await sleep(100);
 

--- a/e2e/mcp/operations/ppal-duplicate.test.ts
+++ b/e2e/mcp/operations/ppal-duplicate.test.ts
@@ -233,7 +233,7 @@ describe("ppal-duplicate", () => {
 
     await sleep(100);
 
-    // Test 2: Session clip to multiple session slots with name
+    // Test 2: Session clip to multiple clip slots with name
     const dupClipMultiSlotsResult = await ctx.client!.callTool({
       name: "ppal-duplicate",
       arguments: {

--- a/evals/scenarios/defs/clip/duplicate.ts
+++ b/evals/scenarios/defs/clip/duplicate.ts
@@ -239,7 +239,7 @@ export const duplicateLoop: EvalScenario = {
 
   messages: [
     MSG_CONNECT,
-    "On the Lead track (track index 3), create a 2-bar clip in the first session slot with these notes: C3 at bar 1 beat 1, E3 at bar 1 beat 3, G3 at bar 2 beat 1, B3 at bar 2 beat 3.",
+    "On the Lead track (track index 3), create a 2-bar clip in the first clip slot with these notes: C3 at bar 1 beat 1, E3 at bar 1 beat 3, G3 at bar 2 beat 1, B3 at bar 2 beat 3.",
     "Now double that clip's length to 4 bars, copying the existing notes into the new second half — this is Ableton's Duplicate Loop action.",
   ],
 

--- a/evals/scenarios/defs/clip/helpers/clip-scenario-builders.ts
+++ b/evals/scenarios/defs/clip/helpers/clip-scenario-builders.ts
@@ -27,7 +27,7 @@ import {
 export const LEAD_LIVE_SET = "basic-midi-4-track";
 /** Lead is track 3 in basic-midi-4-track — a melodic (non-drum) track. */
 export const LEAD_TRACK = 3;
-/** Scene-1 session slot on the Lead track. */
+/** Scene-1 clip slot on the Lead track. */
 export const LEAD_SLOT_1 = `${LEAD_TRACK}/0`;
 
 /**
@@ -40,7 +40,7 @@ export const LEAD_SLOT_1 = `${LEAD_TRACK}/0`;
  * @param config.id - Scenario id
  * @param config.description - One-line description
  * @param config.messages - User turns after the connect turn
- * @param config.clearSlots - Session slots to clear in setup
+ * @param config.clearSlots - Clip slots to clear in setup
  * @param config.assertions - Assertions after the connect + create-clip checks
  * @param config.liveSet - Live Set to open (defaults to basic-midi-4-track)
  * @param config.requires - Capability requirements (e.g. `{ brackets: true }`)

--- a/evals/scenarios/defs/clip/notation/bar-beat/bar-beat-pitch-streams.ts
+++ b/evals/scenarios/defs/clip/notation/bar-beat/bar-beat-pitch-streams.ts
@@ -73,7 +73,7 @@ function assertMelody(
  * @param opts.id - Scenario id
  * @param opts.description - One-line description
  * @param opts.prompts - User turns after the connect turn
- * @param opts.slots - Session slots to clear in setup
+ * @param opts.slots - Clip slots to clear in setup
  * @param opts.melodies - Per-clip read-back checks
  * @param opts.judgePrompt - Advisory LLM-judge prompt
  * @returns The scenario

--- a/evals/scenarios/defs/clip/note-ops-roll-and-merge.ts
+++ b/evals/scenarios/defs/clip/note-ops-roll-and-merge.ts
@@ -321,7 +321,7 @@ export const noteOpsSplit: EvalScenario = {
 
   messages: [
     MSG_CONNECT,
-    "On the Lead track (track index 3), create a 2-bar clip in the first session slot containing a single note: C3 sustained for the entire 2 bars.",
+    "On the Lead track (track index 3), create a 2-bar clip in the first clip slot containing a single note: C3 sustained for the entire 2 bars.",
     "Break that one held note into separate notes by cutting it at bar 1 beat 3 and bar 2 beat 1.",
   ],
 
@@ -350,7 +350,7 @@ export const noteOpsRepeat: EvalScenario = {
 
   messages: [
     MSG_CONNECT,
-    "On the Lead track (track index 3), create a 2-bar clip in the first session slot with four quarter notes in bar 1: C3, E3, G3, B3 on beats 1, 2, 3, and 4.",
+    "On the Lead track (track index 3), create a 2-bar clip in the first clip slot with four quarter notes in bar 1: C3, E3, G3, B3 on beats 1, 2, 3, and 4.",
     "Now add a delayed echo: copy every note an eighth note later at the same pitch, layered on top of the originals. Keep the clip the same length — don't make it longer.",
   ],
 

--- a/evals/scenarios/defs/context/context-follow.ts
+++ b/evals/scenarios/defs/context/context-follow.ts
@@ -99,7 +99,7 @@ export const contextFollowProject: EvalScenario = contextFollowScenario({
   config: { projectContext: PROJECT_CONTEXT },
   seed: seedContext({ clearSlots: [LEAD_SLOT] }),
 
-  ask: "Add a bassline to the Lead track in the first session slot.",
+  ask: "Add a bassline to the Lead track in the first clip slot.",
 
   clipCheck: (events) =>
     events.length > 0 &&
@@ -132,7 +132,7 @@ export const contextFollowGlobal: EvalScenario = contextFollowScenario({
     clearSlots: [LEAD_SLOT],
   }),
 
-  ask: "Create a 1-bar chord progression on the Lead track in the first session slot.",
+  ask: "Create a 1-bar chord progression on the Lead track in the first clip slot.",
 
   clipCheck: (events) =>
     events.length > 0 && events.every((n) => n.velocity <= 80),
@@ -195,7 +195,7 @@ export const contextMemoryRecall: EvalScenario = {
 
   messages: [
     MSG_CONNECT,
-    "Write me a 1-bar bassline on the Lead track in the first session slot.",
+    "Write me a 1-bar bassline on the Lead track in the first clip slot.",
   ],
 
   assertions: [

--- a/evals/scenarios/defs/context/context-scenario-helpers.ts
+++ b/evals/scenarios/defs/context/context-scenario-helpers.ts
@@ -47,7 +47,7 @@ export const CONTEXT_LIVE_SET = "basic-midi-4-track";
 /** Lead is track 3 in basic-midi-4-track — a melodic (non-drum) track. */
 export const LEAD_TRACK = 3;
 
-/** Session slot the clip-writing context scenarios fill (and clear in setup). */
+/** Clip slot the clip-writing context scenarios fill (and clear in setup). */
 export const LEAD_SLOT = `${LEAD_TRACK}/0`;
 
 /**

--- a/examples/skills/ableton-audio-generator/targets/audio-clip.md
+++ b/examples/skills/ableton-audio-generator/targets/audio-clip.md
@@ -30,7 +30,7 @@ node ../producer-pal/ppal.mjs ppal-create-track \
   '{"type":"audio","name":"Generated"}'
 ```
 
-Then drop the file into a Session slot (`trackIndex/sceneIndex`, both 0-based),
+Then drop the file into a clip slot (`trackIndex/sceneIndex`, both 0-based),
 passing **`warping: false`** so it plays exactly as rendered:
 
 ```bash

--- a/scripts/build-and-release/tool-reference/example-live-set/writes.ts
+++ b/scripts/build-and-release/tool-reference/example-live-set/writes.ts
@@ -138,7 +138,7 @@ function createdScene(sceneIndex: number): string[] {
   return ["id", ID.newScene];
 }
 
-// Put a new clip in a session slot, and make the slot report it.
+// Put a new clip in a slot, and make the slot report it.
 function fillSlot(slotPath: string, lengthBeats: number): null {
   registerNewClip(`${slotPath} clip`, newClipProperties(lengthBeats));
 

--- a/src/skills/fragment-tool-gates.ts
+++ b/src/skills/fragment-tool-gates.ts
@@ -99,7 +99,7 @@ const DEVICE_WRITE_TOOLS = [
  * there, and two report an `arrangementStart` back — read-clip directly,
  * read-track in the `arrangementClips` entries it returns. A reader needs the
  * dual-meter rule to make sense of the number either way. read-scene is absent
- * because it reads session slots only, so no arrangement position ever reaches
+ * because it reads clip slots only, so no arrangement position ever reaches
  * it.
  */
 const ARRANGEMENT_TOOLS = [

--- a/src/skills/fragments/arrangement.ts
+++ b/src/skills/fragments/arrangement.ts
@@ -35,9 +35,9 @@ export const arrangementWrite = `### Clip Destinations
 
 One grammar names where a clip goes, 0-based throughout: \`t2/s0\` is track 2 in the first scene, \`t2\` is track 2's arrangement (which also needs \`arrangementStart\` or \`locator\`), and \`t2/l0\` is its first take lane. create-clip calls it \`path\`; update-clip and duplicate call it \`toPath\`, since they move or copy an existing clip. There are no separate track/scene index params — a destination is always one of these strings.
 
-create-clip's \`path\` takes a comma-separated list and may mix the two kinds, so one call can fill session positions and drop arrangement clips at the same time.
+create-clip's \`path\` takes a comma-separated list and may mix the two kinds, so one call can fill clip slots and drop arrangement clips at the same time.
 
-\`path\` also names clips to act *on*: update-clip and ppal-delete take a session position instead of \`ids\`, so knowing where a clip is saves reading it first just to learn its id.
+\`path\` also names clips to act *on*: update-clip and ppal-delete take a clip slot instead of \`ids\`, so knowing where a clip is saves reading it first just to learn its id.
 
 ### Moving Clips
 

--- a/src/skills/fragments/devices/devices.ts
+++ b/src/skills/fragments/devices/devices.ts
@@ -32,7 +32,7 @@ A Drum Rack nested inside a drum pad has no pads of its own — read-device list
 
 ppal-select takes these paths too: \`path: "t0/d0/pC1"\` shows a pad in Live, \`t0/d0/c1\` a rack chain.
 
-Clip destinations speak the same grammar: \`t0\` = that track's arrangement, \`t0/s1\` = a session slot.
+Clip destinations speak the same grammar: \`t0\` = that track's arrangement, \`t0/s1\` = a clip slot.
 
 Chains are auto-created when referenced (e.g., \`c0\` on an empty rack creates a chain). Up to 16 chains.
 

--- a/src/skills/skill-slots.ts
+++ b/src/skills/skill-slots.ts
@@ -287,7 +287,7 @@ export const SKILL_SLOTS: Record<SkillSlotName, SkillSlotDef> = {
   "arrangement-write": {
     title: "Arrangement: placing clips",
     description:
-      "Moving clips with toPath — along the arrangement timeline and between session slots — plus splitting them and stacking take lanes. It's the only place toPath is explained. Only create-clip, update-clip, and duplicate can act on it, so a read-only caller never gets it. Needs the arrangement guide it sits under.",
+      "Moving clips with toPath — along the arrangement timeline and between clip slots — plus splitting them and stacking take lanes. It's the only place toPath is explained. Only create-clip, update-clip, and duplicate can act on it, so a read-only caller never gets it. Needs the arrangement guide it sits under.",
     builtIn: arrangementWrite,
   },
 

--- a/src/skills/tests/fragment-tool-gates.test.ts
+++ b/src/skills/tests/fragment-tool-gates.test.ts
@@ -359,7 +359,7 @@ describe("gatedOutFragments", () => {
 
   it("keeps arrangement for read-track but not read-scene", () => {
     // read-track returns arrangementClips carrying arrangementStart; read-scene
-    // reads session slots only, so no arrangement position ever reaches it.
+    // reads clip slots only, so no arrangement position ever reaches it.
     expect(gatedOutFragments(["ppal-read-track"])).not.toContain("arrangement");
     expect(gatedOutFragments(["ppal-read-scene"])).toContain("arrangement");
   });

--- a/src/test/meta/tool-schemas/small-model-param-references.test.ts
+++ b/src/test/meta/tool-schemas/small-model-param-references.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import { z, type ZodType } from "zod";
 import { NOTATIONS, type Notation } from "#src/shared/notation.ts";
 import { type ToolDefFunction } from "#src/tools/shared/tool-framework/define-tool.ts";
+import { deprecatedParam } from "#src/tools/shared/tool-framework/hidden-param.ts";
 import {
   param,
   resolveModalDescription,
@@ -21,10 +22,15 @@ import { resolveToolSchema } from "#src/tools/shared/tool-framework/resolve-tool
 // Deprecation is the other way a param leaves the published schema, and it
 // applies in every mode — so both axes run here.
 //
-// There is no allowlist. Every surviving description is currently clean under a
-// plain word-boundary match, including the removed params whose names are also
-// ordinary English (`count`, `name`, `format`, `sort`). If a legitimate prose
-// use ever collides, add the allowlist then — don't loosen the match.
+// The one carve-out is "clip slot" — Live's own name for a `t0/s1` location,
+// which the descriptions say constantly and which has nothing to do with the
+// deprecated `slot`/`slots` params. It's blanked out of the text before
+// matching, so a bare "set slot to ..." still gets caught.
+//
+// Every other surviving description is clean under a plain word-boundary match,
+// including the removed params whose names are also ordinary English (`count`,
+// `name`, `format`, `sort`). If another legitimate prose use collides, blank
+// that term out the same way — don't loosen the match.
 
 // The `code` params only exist when this flag is on, and it is read when the
 // tool defs load — so stub it before importing them.
@@ -79,7 +85,43 @@ describe("published param references", () => {
       "fake (barbeat): tool description names removed param `takeLane`",
     ]);
   });
+
+  it("still catches a bare `slot` next to the allowed 'clip slot'", () => {
+    const def = slotDef("a clip slot 't0/s1'; set slot to the same thing");
+
+    expect(
+      danglingReferences(def, { notation: "barbeat", smallModelMode: false }),
+    ).toStrictEqual([
+      "fake (barbeat): tool description names removed param `slot`",
+    ]);
+  });
+
+  it("allows 'clip slot' on a tool that deprecated `slot`", () => {
+    const def = slotDef("a clip slot 't0/s1', or clip slots 't0/s1,t2/s3'");
+
+    expect(
+      danglingReferences(def, { notation: "barbeat", smallModelMode: false }),
+    ).toStrictEqual([]);
+  });
 });
+
+/**
+ * A tool that deprecated its `slot` param, for exercising the "clip slot"
+ * carve-out.
+ * @param description - The tool description to publish
+ * @returns A definition shaped enough for danglingReferences()
+ */
+function slotDef(description: string): ToolDefFunction {
+  return {
+    toolName: "fake",
+    toolOptions: {
+      description: { default: description },
+      inputSchema: {
+        slot: deprecatedParam(z.string().optional(), { replacedBy: "path" }),
+      },
+    },
+  } as unknown as ToolDefFunction;
+}
 
 /**
  * Finds text a tool still publishes that names a param it does not publish —
@@ -102,13 +144,16 @@ function danglingReferences(
   if (removed.length === 0) return [];
 
   const texts: [string, string][] = [
-    ["tool description", resolveModalDescription(description, context)],
+    [
+      "tool description",
+      searchable(resolveModalDescription(description, context)),
+    ],
   ];
 
   for (const [name, schema] of Object.entries(published)) {
     const text = (schema as ZodType).description;
 
-    if (text != null) texts.push([`\`${name}\` description`, text]);
+    if (text != null) texts.push([`\`${name}\` description`, searchable(text)]);
   }
 
   return removed.flatMap((name) =>
@@ -119,4 +164,14 @@ function danglingReferences(
           `${def.toolName} (${context.notation}): ${where} names removed param \`${name}\``,
       ),
   );
+}
+
+/**
+ * Blanks out "clip slot", so Live's term for a `t0/s1` location doesn't read as
+ * a reference to the deprecated `slot`/`slots` params.
+ * @param text - Published description text
+ * @returns The same text with the term removed
+ */
+function searchable(text: string): string {
+  return text.replaceAll(/\bclip slots?\b/gi, "");
 }

--- a/src/tools/actions/duplicate/duplicate.def.ts
+++ b/src/tools/actions/duplicate/duplicate.def.ts
@@ -16,10 +16,10 @@ export const toolDefDuplicate = defineTool("ppal-duplicate", {
     default:
       "Duplicate an object. Supports tracks, scenes, clips, devices, and drum pads. " +
       "Use count for multiple track/scene copies; arrangementStart or locator for clip placement, " +
-      "and toPath for the destination track, session slot, device chain, or drum pad.",
+      "and toPath for the destination track, clip slot, device chain, or drum pad.",
     smallModel:
       "Duplicate an object. Supports tracks, scenes, clips, devices, and drum pads. " +
-      "Use arrangementStart for clip placement; toPath for the destination track, session slot, device, or pad.",
+      "Use arrangementStart for clip placement; toPath for the destination track, clip slot, device, or pad.",
   },
 
   annotations: {
@@ -85,14 +85,14 @@ export const toolDefDuplicate = defineTool("ppal-duplicate", {
     }),
     toPath: param(z.coerce.string().optional(), {
       default:
-        "destination(s), comma-separated for multiple. Clips: 't2/s1' = session slot (track 2, scene 1), " +
+        "destination(s), comma-separated for multiple. Clips: 't2/s1' = clip slot (track 2, scene 1), " +
         "'t2' = track 2's arrangement (needs arrangementStart or locator, and a track matching the clip's MIDI/audio type), " +
         "'t2/l0' = its first take lane and 't2/l+' appends a fresh one (MIDI only); " +
         "omit for the source clip's own track. Devices: 't1/d0'. " +
         "Drum pads: 't0/d0/pD1', required, and must be in the same rack as the source pad (id or path names the source). " +
         "Cycles against arrangementStart when the lists differ in length",
       smallModel:
-        "destination(s): clip session slot 't2/s1', clip arrangement track 't2', device 't1/d0', drum pad 't0/d0/pD1'",
+        "destination(s): clip slot 't2/s1', clip arrangement track 't2', device 't1/d0', drum pad 't0/d0/pD1'",
     }),
 
     routeToSource: param(z.boolean().optional(), {

--- a/src/tools/actions/duplicate/duplicate.ts
+++ b/src/tools/actions/duplicate/duplicate.ts
@@ -88,7 +88,7 @@ interface DuplicateParams {
  * @param args.routeToSource - Route to source
  * @param args.focus - Focus duplicated clip/scene
  * @param args.toSlot - Deprecated destination clip slot(s); use toPath
- * @param args.toPath - Destination path(s): track, session slot, or device
+ * @param args.toPath - Destination path(s): track, clip slot, or device
  * @param args.transforms - Transform expressions broadcast across all copies
  * @param args.code - JavaScript function body broadcast across all copies
  * @param args.takeLane - Arrangement take lane target for clips (0/omitted = main, 1+, "new")

--- a/src/tools/actions/duplicate/helpers/clip/duplicate-clip-position-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/clip/duplicate-clip-position-helpers.ts
@@ -53,7 +53,7 @@ import {
 
 /**
  * Duplicates a clip to its resolved destinations
- * @param destinations - Where the copies go (session slots or arrangement tracks)
+ * @param destinations - Where the copies go (clip slots or arrangement tracks)
  * @param object - Live API object to duplicate
  * @param id - ID of the object
  * @param name - Base name for duplicated clips
@@ -80,7 +80,7 @@ export async function duplicateClipWithPositions(
   context: Partial<ToolContext>,
 ): Promise<object[]> {
   if (destinations.destination === "session") {
-    // A session slot can't name a lane, so nothing here has one to honor.
+    // A clip slot can't name a lane, so nothing here has one to honor.
     return duplicateClipToSlots(destinations.slots, object, id, name, color);
   }
 

--- a/src/tools/actions/duplicate/helpers/clip/duplicate-clip-slot-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/clip/duplicate-clip-slot-helpers.ts
@@ -109,7 +109,7 @@ export function duplicateClipSlot(
 }
 
 /**
- * Copies a session clip into session slots.
+ * Copies a session clip into clip slots.
  * @param slots - Destination slots, in order
  * @param object - Live API object to duplicate
  * @param id - ID of the object

--- a/src/tools/actions/duplicate/helpers/clip/duplicate-destination-helpers.test.ts
+++ b/src/tools/actions/duplicate/helpers/clip/duplicate-destination-helpers.test.ts
@@ -110,7 +110,7 @@ describe("resolveClipDestinations", () => {
 
     // toPath is where the copy goes; arrangementStart only says where on a
     // track. With no track named, the position has nothing to apply to.
-    it("drops an arrangement position when toPath names only session slots", () => {
+    it("drops an arrangement position when toPath names only clip slots", () => {
       const warnSpy = vi.spyOn(console, "warn");
 
       expect(resolveClipDestinations("t2/s1", undefined, true)).toStrictEqual({
@@ -123,7 +123,7 @@ describe("resolveClipDestinations", () => {
       );
     });
 
-    it("drops the session slots when toPath also names a track", () => {
+    it("drops the clip slots when toPath also names a track", () => {
       const warnSpy = vi.spyOn(console, "warn");
 
       expect(
@@ -167,12 +167,12 @@ describe("resolveClipDestinations", () => {
       });
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining(
-          "arrangementStart/locator ignored — toSlot names a session position",
+          "arrangementStart/locator ignored — toSlot names a clip slot",
         ),
       );
     });
 
-    // The mirror case. Nothing names a session slot, so arrangementStart is the
+    // The mirror case. Nothing names a clip slot, so arrangementStart is the
     // only destination left and it carries the call — where this used to refuse
     // the copy and ask for the deprecated param.
     it("honors the arrangement position when toSlot names nothing", () => {
@@ -197,13 +197,13 @@ describe("resolveClipDestinations", () => {
 
   it("names both possibilities for a bare track with no position", () => {
     expect(() => resolveClipDestinations("t2", undefined, false)).toThrow(
-      /"t2" names a track but not a spot on it.*arrangementStart or locator for track 2's arrangement.*"t2\/s<scene>" for a session slot/s,
+      /"t2" names a track but not a spot on it.*arrangementStart or locator for track 2's arrangement.*"t2\/s<scene>" for a clip slot/s,
     );
   });
 
   it("throws when nothing names a destination", () => {
     expect(() => resolveClipDestinations(undefined, undefined, false)).toThrow(
-      'duplicate failed: clip requires toPath ("t0/s1" for a session slot) or arrangementStart/locator (for the arrangement)',
+      'duplicate failed: clip requires toPath ("t0/s1" for a clip slot) or arrangementStart/locator (for the arrangement)',
     );
   });
 

--- a/src/tools/actions/duplicate/helpers/clip/duplicate-destination-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/clip/duplicate-destination-helpers.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 // Where a clip duplicate goes. `toPath` names it — `t7` for that track's
-// arrangement, `t7/s2` for a session slot — and the deprecated `toSlot` still
+// arrangement, `t7/s2` for a clip slot — and the deprecated `toSlot` still
 // works. Resolved before anything is created, so a bad destination fails
 // instead of quietly landing the copy somewhere else.
 
@@ -30,7 +30,7 @@ type ClipPath = ReturnType<typeof requireClipPath>;
 
 export interface ClipDestinations {
   destination: "session" | "arrangement";
-  /** Session slots, in order. Empty for arrangement destinations. */
+  /** Clip slots, in order. Empty for arrangement destinations. */
   slots: SlotPosition[];
   /** Arrangement destinations, in order. Empty means the source's own track. */
   arrangementTargets: ArrangementTrack[];
@@ -39,7 +39,7 @@ export interface ClipDestinations {
 /**
  * Resolves a clip duplicate's destination from its path params.
  * @param rawToPath - Destination path(s), comma-separated for multiple
- * @param rawToSlot - Deprecated session slot(s), trackIndex/sceneIndex format
+ * @param rawToSlot - Deprecated clip slot(s), trackIndex/sceneIndex format
  * @param hasArrangementParams - Whether arrangementStart or locator was given
  * @returns Where the copies go
  */
@@ -75,7 +75,7 @@ export function resolveClipDestinations(
 
   if (paths.length === 0) {
     throw new Error(
-      'duplicate failed: clip requires toPath ("t0/s1" for a session slot) or arrangementStart/locator (for the arrangement)',
+      'duplicate failed: clip requires toPath ("t0/s1" for a clip slot) or arrangementStart/locator (for the arrangement)',
     );
   }
 
@@ -141,7 +141,7 @@ export function warnUnusedArrangementParams(
  * Warns when a destination param was sent for a type that has no destination.
  * @param type - Type of object being duplicated
  * @param rawToPath - Destination path(s)
- * @param rawToSlot - Deprecated session slot(s)
+ * @param rawToSlot - Deprecated clip slot(s)
  */
 export function warnUnusedDestination(
   type: string,
@@ -167,8 +167,8 @@ export function warnUnusedDestination(
 // --- Helpers below main exports ---
 
 /**
- * Resolves the deprecated toSlot param, which only ever named session slots.
- * @param toSlot - Session slot(s), trackIndex/sceneIndex format
+ * Resolves the deprecated toSlot param, which only ever named clip slots.
+ * @param toSlot - Clip slot(s), trackIndex/sceneIndex format
  * @param hasArrangementParams - Whether arrangementStart or locator was given
  * @returns Session destinations
  */
@@ -180,12 +180,12 @@ function legacySlotDestinations(
   // gets at least one entry.
   const slots = parseSlotList(toSlot, "toSlot");
 
-  // toSlot only ever named session slots, so it can't be the arrangement
+  // toSlot only ever named clip slots, so it can't be the arrangement
   // destination arrangementStart wants. Drop the weaker of the two rather than
   // failing the call, the way toPath does for the same conflict.
   if (hasArrangementParams) {
     console.warn(
-      "duplicate: arrangementStart/locator ignored — toSlot names a session position; " +
+      "duplicate: arrangementStart/locator ignored — toSlot names a clip slot; " +
         'use toPath (e.g. "t2") for that track\'s arrangement',
     );
   }
@@ -194,9 +194,9 @@ function legacySlotDestinations(
 }
 
 /**
- * Reads arrangement destination tracks off the parsed paths. A session position
- * here contradicts arrangementStart/locator; warn and drop the weaker of the
- * two rather than failing the call, the way every other tool handles a position
+ * Reads arrangement destination tracks off the parsed paths. A clip slot here
+ * contradicts arrangementStart/locator; warn and drop the weaker of the two
+ * rather than failing the call, the way every other tool handles a position
  * that doesn't apply.
  * @param paths - Parsed clip destination paths
  * @returns Arrangement destinations, or session ones when only slots were named
@@ -218,7 +218,7 @@ function arrangementDestinations(paths: ClipPath[]): ClipDestinations {
 
   // Number the lanes here, off the list the caller wrote: the copy loop cycles
   // this list, and a cycled repeat must reuse its lane, not append one. Both
-  // arrangement returns below need it — dropped session slots don't change the
+  // arrangement returns below need it — dropped clip slots don't change the
   // numbering, but leaving it off one path collapses two "l+" into one lane.
   const arrangementTargets = withNewLaneOrdinals(targets);
 
@@ -231,11 +231,11 @@ function arrangementDestinations(paths: ClipPath[]): ClipDestinations {
     .join(", ");
 
   // toPath names where the copy goes; arrangementStart only says where on a
-  // track. With nothing but session positions, the position has no track to
-  // apply to, so toPath is the one that survives.
+  // track. With nothing but clip slots, the position has no track to apply
+  // to, so toPath is the one that survives.
   if (arrangementTargets.length === 0) {
     console.warn(
-      `duplicate: arrangementStart/locator ignored — toPath "${named}" names a session position; ` +
+      `duplicate: arrangementStart/locator ignored — toPath "${named}" names a clip slot; ` +
         'use "t<track>" for that track\'s arrangement',
     );
 
@@ -250,7 +250,7 @@ function arrangementDestinations(paths: ClipPath[]): ClipDestinations {
 }
 
 /**
- * Reads session slots off the parsed paths.
+ * Reads clip slots off the parsed paths.
  * @param paths - Parsed clip destination paths
  * @returns Session destinations
  */
@@ -265,7 +265,7 @@ function sessionDestinations(paths: ClipPath[]): ClipDestinations {
       throw new Error(
         `duplicate failed: toPath "${formatObjectPath(path)}" names a track but not a spot on it; add ` +
           `arrangementStart or locator for track ${path.trackIndex}'s arrangement, or use ` +
-          `"t${path.trackIndex}/s<scene>" for a session slot`,
+          `"t${path.trackIndex}/s<scene>" for a clip slot`,
       );
     }
 

--- a/src/tools/actions/duplicate/helpers/duplicate-helpers.ts
+++ b/src/tools/actions/duplicate/helpers/duplicate-helpers.ts
@@ -65,7 +65,7 @@ export function parseArrangementLength(
 export interface MinimalClipInfo {
   id: string;
   /** Where the clip is: "t0/s3" in the session, "t0" or "t0/l0" in the
-   * arrangement. A session slot pastes back into any path/toPath param; an
+   * arrangement. A clip slot pastes back into any path/toPath param; an
    * arrangement one names a whole track, so only tools that take a track
    * destination accept it — reach a specific arrangement clip by id. */
   path?: string;

--- a/src/tools/actions/duplicate/helpers/tests/duplicate-clip-slot.test.ts
+++ b/src/tools/actions/duplicate/helpers/tests/duplicate-clip-slot.test.ts
@@ -195,7 +195,7 @@ describe("duplicateClipSlot", () => {
   });
 });
 
-describe("duplicateClipWithPositions to session slots", () => {
+describe("duplicateClipWithPositions to clip slots", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/src/tools/actions/duplicate/tests/clip/duplicate-arrangement-length.test.ts
+++ b/src/tools/actions/duplicate/tests/clip/duplicate-arrangement-length.test.ts
@@ -318,7 +318,7 @@ describe("duplicate - arrangementLength functionality", () => {
   });
 });
 
-// Register the source clip under test ("clip1") in the session slot every test
+// Register the source clip under test ("clip1") in the clip slot every test
 // in this file duplicates from: track 0, scene 0.
 // Returns the registered mock object handle.
 function registerSourceClip(

--- a/src/tools/actions/duplicate/tests/clip/duplicate-clip.test.ts
+++ b/src/tools/actions/duplicate/tests/clip/duplicate-clip.test.ts
@@ -28,7 +28,7 @@ describe("duplicate - clip duplication", () => {
       path: livePath.track(0).clipSlot(0).clip(),
     });
     await expect(duplicate({ type: "clip", id: "clip1" })).rejects.toThrow(
-      'duplicate failed: clip requires toPath ("t0/s1" for a session slot) or arrangementStart/locator (for the arrangement)',
+      'duplicate failed: clip requires toPath ("t0/s1" for a clip slot) or arrangementStart/locator (for the arrangement)',
     );
   });
 
@@ -344,10 +344,10 @@ describe("duplicate - clip duplication", () => {
       ).rejects.toThrow(/"t2" names a track but not a spot on it/);
     });
 
-    // A session position and an arrangement position are different places, and
+    // A clip slot and an arrangement position are different places, and
     // toPath is the one that says where. Warn and make the session copy rather
     // than failing the call.
-    it("ignores arrangementStart when toPath names a session slot", async () => {
+    it("ignores arrangementStart when toPath names a clip slot", async () => {
       registerMockObject("clip1", {
         path: livePath.track(0).clipSlot(0).clip(),
         properties: { trackIndex: 0, sceneIndex: 0 },
@@ -464,7 +464,7 @@ describe("duplicate - clip duplication", () => {
       expect(outlet).toHaveBeenCalledWith(
         1,
         expect.stringContaining(
-          "arrangementStart/locator ignored — toSlot names a session position",
+          "arrangementStart/locator ignored — toSlot names a clip slot",
         ),
       );
     });

--- a/src/tools/clip/code-exec/tests/code-exec-helpers-coverage.test.ts
+++ b/src/tools/clip/code-exec/tests/code-exec-helpers-coverage.test.ts
@@ -188,7 +188,7 @@ describe("buildCodeExecutionContext", () => {
   });
 
   it("omits the slot for a session clip without a scene index", () => {
-    // Kills the `&&`→`||` and forced-true mutants on the session-slot guard:
+    // Kills the `&&`→`||` and forced-true mutants on the clip-slot guard:
     // view is "session" but sceneIndex is undefined, so no slot is set.
     registerLiveSet();
     registerTrack(2);

--- a/src/tools/clip/create/create-clip.def.ts
+++ b/src/tools/clip/create/create-clip.def.ts
@@ -35,7 +35,7 @@ export const toolDefCreateClip = defineTool("ppal-create-clip", {
   inputSchema: {
     path: param(z.coerce.string().optional(), {
       default:
-        "where the clip(s) go, comma-separated for multiple. 't<track>/s<scene>' is a session position; " +
+        "where the clip(s) go, comma-separated for multiple. 't<track>/s<scene>' is a clip slot; " +
         "'t<track>' is that track's arrangement, which also needs arrangementStart; 't<track>/l<lane>' is a " +
         "take lane on it and 't<track>/l+' appends a fresh one. All indices 0-based, " +
         "so 't0/s0' is the first track's first scene (e.g., 't0/s0' or 't0/s0,t0/s2' or 't1' with arrangementStart)",
@@ -69,7 +69,7 @@ export const toolDefCreateClip = defineTool("ppal-create-clip", {
 
     name: param(z.string().optional(), {
       default:
-        "name for all, or comma-separated for each (indexed: session positions first, then arrangement)",
+        "name for all, or comma-separated for each (indexed: clip slots first, then arrangement)",
       smallModel: "clip name",
     }),
 

--- a/src/tools/clip/create/create-clip.ts
+++ b/src/tools/clip/create/create-clip.ts
@@ -35,7 +35,7 @@ import {
 } from "./helpers/create-clip-validation-helpers.ts";
 
 export interface CreateClipArgs {
-  /** Where the clip(s) go: "t0/s1" session slot, "t0" arrangement, comma-separated */
+  /** Where the clip(s) go: "t0/s1" clip slot, "t0" arrangement, comma-separated */
   path?: string | null;
   /** Deprecated session clip slot(s), trackIndex/sceneIndex comma-separated */
   slot?: string | null;
@@ -277,7 +277,7 @@ function normalizeTransforms(transformString: string | null): string | null {
  * Handle auto-playback and focus for the created clips, then unwrap the result.
  * @param createdClips - All created clip result objects
  * @param auto - Automatic playback action
- * @param sessionSlots - Parsed session slot positions
+ * @param sessionSlots - Parsed clip slot positions
  * @param focus - Whether to select the last created clip
  * @returns Single clip object when one, array when multiple
  */

--- a/src/tools/clip/create/helpers/create-clip-destination-helpers.ts
+++ b/src/tools/clip/create/helpers/create-clip-destination-helpers.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 // Where new clips go. `path` names it in the grammar duplicate and update-clip
-// already speak — `t0/s1` for a session slot, `t0` for that track's arrangement
+// already speak — `t0/s1` for a clip slot, `t0` for that track's arrangement
 // — and the retired `slot` plus the trackIndex/sceneIndex models reach for on
 // their own still resolve to the same two buckets.
 //
@@ -37,7 +37,7 @@ export interface ArrangementPosition extends ArrangementTrack {
 }
 
 export interface ClipDestinations {
-  /** Session slots, in order. */
+  /** Clip slots, in order. */
   sessionSlots: SlotPosition[];
   /** Arrangement clips, one per track/position pair. */
   arrangementPositions: ArrangementPosition[];
@@ -65,7 +65,7 @@ interface SplitDestinations {
  * Resolves where a create-clip call's clips go.
  * @param params - The destination params as the tool received them
  * @param arrangementStarts - Parsed arrangement bar|beat positions
- * @returns Session slots and arrangement positions, both possibly empty
+ * @returns Clip slots and arrangement positions, both possibly empty
  */
 export function resolveCreateClipDestinations(
   params: ClipDestinationParams,
@@ -101,12 +101,12 @@ export function resolveCreateClipDestinations(
 // --- Helpers below main exports ---
 
 /**
- * Splits a parsed `path` into its session slots and arrangement tracks. A call
- * may name both, which is how one call fills a session slot and drops an
+ * Splits a parsed `path` into its clip slots and arrangement tracks. A call
+ * may name both, which is how one call fills a clip slot and drops an
  * arrangement clip at the same time.
  * @param path - The raw path param, already known to name something
  * @param params - The destination params as the tool received them
- * @returns Session slots and arrangement tracks, in order
+ * @returns Clip slots and arrangement tracks, in order
  */
 function splitPathDestinations(
   path: string,
@@ -151,7 +151,7 @@ function splitPathDestinations(
  * fallback for a caller that didn't use the segment.
  * @param tracks - Arrangement destinations, in order
  * @param takeLane - The raw takeLane param
- * @param sessionSlotCount - Number of session slots in this request
+ * @param sessionSlotCount - Number of clip slots in this request
  * @returns The destinations, with the alias applied where a lane was unnamed
  */
 function applyTakeLaneAlias(
@@ -198,7 +198,7 @@ function applyTakeLaneAlias(
  * @param slot - The deprecated slot list, or undefined
  * @param params - The destination params as the tool received them
  * @param hasArrangementStarts - Whether arrangementStart named any position
- * @returns Session slots and arrangement tracks, in order
+ * @returns Clip slots and arrangement tracks, in order
  */
 function legacyDestinations(
   slot: string | undefined,
@@ -233,7 +233,7 @@ function legacyDestinations(
   }
 
   // trackIndex alone means the arrangement, but only arrangementStart says
-  // where on it. Without one it named nothing the session slots didn't already.
+  // where on it. Without one it named nothing the clip slots didn't already.
   if (!hasArrangementStarts && sessionSlots.length > 0) {
     console.warn(
       "createClip: trackIndex ignored — an arrangement clip also needs arrangementStart",
@@ -273,7 +273,7 @@ function pairTracksWithStarts(
     const { trackIndex, takeLane } = tracks[0] as ArrangementTrack;
     const fix =
       takeLane == null
-        ? `add arrangementStart for its arrangement, or use "t${trackIndex}/s<scene>" for a session slot`
+        ? `add arrangementStart for its arrangement, or use "t${trackIndex}/s<scene>" for a clip slot`
         : "add arrangementStart; take lanes hold arrangement clips";
 
     throw new Error(

--- a/src/tools/clip/create/helpers/create-clip-loop-helpers.ts
+++ b/src/tools/clip/create/helpers/create-clip-loop-helpers.ts
@@ -147,7 +147,7 @@ async function createClipAtIndex(
     params;
 
   // clip.index/clip.count (transforms and code-exec) span the whole create
-  // batch, not just this view: a single call mixing session slots and
+  // batch, not just this view: a single call mixing clip slots and
   // arrangement positions runs createClips once per view, so the global index
   // is nameStartIndex + i (session view starts at 0, arrangement at
   // sessionSlots.length) and the count is the combined total. This mirrors the

--- a/src/tools/clip/create/helpers/create-clip-result-helpers.ts
+++ b/src/tools/clip/create/helpers/create-clip-result-helpers.ts
@@ -93,7 +93,7 @@ export function buildClipProperties(
 export interface ClipResultObject {
   id: string;
   /** Where the clip is: "t0/s3" in the session, "t0" or "t0/l0" in the
-   * arrangement. A session slot pastes back into any path/toPath param; an
+   * arrangement. A clip slot pastes back into any path/toPath param; an
    * arrangement one names a whole track, so only tools that take a track
    * destination accept it — reach a specific arrangement clip by id. */
   path?: string;

--- a/src/tools/clip/create/helpers/create-clip-validation-helpers.ts
+++ b/src/tools/clip/create/helpers/create-clip-validation-helpers.ts
@@ -12,7 +12,7 @@ import { type ClipDestinations } from "./create-clip-destination-helpers.ts";
 
 /**
  * Validates that the call named somewhere to put a clip
- * @param destinations - Resolved session slots and arrangement positions
+ * @param destinations - Resolved clip slots and arrangement positions
  */
 export function validatePositions(destinations: ClipDestinations): void {
   if (
@@ -20,14 +20,14 @@ export function validatePositions(destinations: ClipDestinations): void {
     destinations.arrangementPositions.length === 0
   ) {
     throw new Error(
-      'createClip failed: path is required — "t0/s1" for a session slot, or "t0" with arrangementStart for the arrangement',
+      'createClip failed: path is required — "t0/s1" for a clip slot, or "t0" with arrangementStart for the arrangement',
     );
   }
 }
 
 /**
  * Validates that every track the call targets exists
- * @param destinations - Resolved session slots and arrangement positions
+ * @param destinations - Resolved clip slots and arrangement positions
  */
 export function validateDestinationTracks(
   destinations: ClipDestinations,
@@ -138,7 +138,7 @@ export function calculateClipLength(
  * Handles automatic playback for session clips
  * @param auto - Auto playback mode (play-scene or play-clip)
  * @param view - View type
- * @param sessionSlots - Array of session slot positions
+ * @param sessionSlots - Array of clip slot positions
  */
 export function handleAutoPlayback(
   auto: string | null,

--- a/src/tools/clip/create/tests/create-clip-basic.test.ts
+++ b/src/tools/clip/create/tests/create-clip-basic.test.ts
@@ -388,7 +388,7 @@ describe("handleAutoPlayback (unit)", () => {
     ).not.toThrow();
   });
 
-  it("no-ops (does not reach the switch) when there are no session slots", () => {
+  it("no-ops (does not reach the switch) when there are no clip slots", () => {
     // Empty slots → guard returns early. The `sessionSlots.length === 0` → false
     // mutant would fall through to the switch and throw on the unknown auto value.
     expect(() =>

--- a/src/tools/clip/create/tests/create-clip-loop-helpers.test.ts
+++ b/src/tools/clip/create/tests/create-clip-loop-helpers.test.ts
@@ -89,7 +89,7 @@ describe("createClip - failure warnings (createClipAtIndex catch)", () => {
     vi.clearAllMocks();
   });
 
-  it("warns with the session slot position when a session clip fails to create", async () => {
+  it("warns with the clip slot position when a session clip fails to create", async () => {
     registerMockObject("live-set", {
       path: livePath.liveSet,
       properties: { ...FOUR_FOUR, scenes: children("scene_0") },
@@ -107,7 +107,7 @@ describe("createClip - failure warnings (createClipAtIndex catch)", () => {
       1,
       expect.stringContaining("Failed to create clip at t0/s0:"),
     );
-    // No bar|beat position: a session slot doesn't have one.
+    // No bar|beat position: a clip slot doesn't have one.
     expect(outlet).not.toHaveBeenCalledWith(1, expect.stringContaining("|"));
   });
 

--- a/src/tools/clip/create/tests/create-clip-path.test.ts
+++ b/src/tools/clip/create/tests/create-clip-path.test.ts
@@ -45,7 +45,7 @@ describe("createClip path param", () => {
   });
 
   // Preserves what slot + trackIndex + arrangementStart could already do: one
-  // call filling a session slot and dropping an arrangement clip.
+  // call filling a clip slot and dropping an arrangement clip.
   it("creates session and arrangement clips from one mixed path", async () => {
     setupArrangementClipMocks();
     const { clipSlot } = setupSessionMocks({
@@ -97,7 +97,7 @@ describe("createClip path param", () => {
   it("rejects a destination no clip can occupy", async () => {
     await expect(createClip({ path: "rt0" })).rejects.toThrow(
       'invalid path "rt0" - return and master tracks have no clips; ' +
-        'clips go to a track ("t0"), a take lane on it ("t0/l0"), or a session slot ("t0/s1")',
+        'clips go to a track ("t0"), a take lane on it ("t0/l0"), or a clip slot ("t0/s1")',
     );
   });
 
@@ -157,7 +157,7 @@ describe("createClip trackIndex/sceneIndex fallback", () => {
 
   // The whole point of the alias: a model that guesses these two gets the clip
   // it asked for instead of an error and a second round trip.
-  it("reads trackIndex + sceneIndex as a session slot", async () => {
+  it("reads trackIndex + sceneIndex as a clip slot", async () => {
     const { clipSlot } = setupSessionMocks({
       liveSet: { signature_numerator: 4, signature_denominator: 4 },
       clip: { length: 4 },

--- a/src/tools/clip/create/tests/create-clip-session.test.ts
+++ b/src/tools/clip/create/tests/create-clip-session.test.ts
@@ -286,7 +286,7 @@ describe("createClip - session view", () => {
     });
   });
 
-  it("should throw error when session slot track does not exist", async () => {
+  it("should throw error when clip slot track does not exist", async () => {
     mockNonExistentObjects();
     setupLiveSet();
 

--- a/src/tools/clip/create/tests/create-clip-take-lanes.test.ts
+++ b/src/tools/clip/create/tests/create-clip-take-lanes.test.ts
@@ -231,9 +231,9 @@ describe("createClip take lanes", () => {
   });
 
   it("warns that takeLane is ignored for the session portion of a mixed request", async () => {
-    // A request targeting BOTH an arrangement position and a session slot: the
+    // A request targeting BOTH an arrangement position and a clip slot: the
     // takeLane applies to the arrangement clip but must be flagged as ignored
-    // for the accompanying session slot.
+    // for the accompanying clip slot.
     registerEmptySessionSlot();
     registerTakeLaneTrack({ initialLanes: 0 });
 

--- a/src/tools/clip/helpers/clip-path-lookup.ts
+++ b/src/tools/clip/helpers/clip-path-lookup.ts
@@ -6,7 +6,7 @@
 // Addressing clips by where they are instead of by id, so a caller that knows
 // the location doesn't have to read the clip first just to learn its id.
 //
-// Session positions only: a slot holds one clip, while a track's arrangement
+// Clip slots only: a slot holds one clip, while a track's arrangement
 // holds many, so a bare track names no particular clip to act on.
 
 import { errorMessage } from "#src/shared/error-utils.ts";
@@ -19,11 +19,11 @@ import {
 import { parseObjectPath } from "#src/tools/shared/validation/object-path.ts";
 
 /**
- * Resolves session position path(s) to the ids of the clips sitting there.
+ * Resolves clip slot path(s) to the ids of the clips sitting there.
  * A malformed entry or an empty slot warns and contributes nothing, matching
  * how these tools skip an id that doesn't resolve — one bad entry costs its own
  * clip, not the whole batch.
- * @param paths - Comma-separated session positions (e.g. "t0/s1,t2/s3")
+ * @param paths - Comma-separated clip slots (e.g. "t0/s1,t2/s3")
  * @param tool - Tool name, for warnings
  * @param label - Param name the paths came from, for warnings
  * @returns The clip ids, in path order
@@ -40,7 +40,7 @@ export function clipIdsAtPaths(
  * The same lookup, keeping one entry per path with null where a path named no
  * clip. Callers that line paths up against another list — move destinations —
  * need the positions to hold even when an entry resolves to nothing.
- * @param paths - Comma-separated session positions (e.g. "t0/s1,t2/s3")
+ * @param paths - Comma-separated clip slots (e.g. "t0/s1,t2/s3")
  * @param tool - Tool name, for warnings
  * @param label - Param name the paths came from, for warnings
  * @returns One clip id per path entry, in path order

--- a/src/tools/clip/helpers/tests/clip-path-lookup.test.ts
+++ b/src/tools/clip/helpers/tests/clip-path-lookup.test.ts
@@ -14,7 +14,7 @@ import {
 import { clipIdsAtPaths } from "../clip-path-lookup.ts";
 
 /**
- * Put a clip in a session slot.
+ * Fills a clip slot.
  * @param trackIndex - 0-based track index
  * @param sceneIndex - 0-based scene index
  * @param id - The clip's id
@@ -36,7 +36,7 @@ describe("clipIdsAtPaths", () => {
     mockNonExistentObjects();
   });
 
-  it("resolves session positions to the clips sitting there", () => {
+  it("resolves clip slots to the clips sitting there", () => {
     registerClipAt(0, 1, "clip_a");
     registerClipAt(2, 3, "clip_b");
 
@@ -63,7 +63,7 @@ describe("clipIdsAtPaths", () => {
     expect(warn).toHaveBeenCalledWith('updateClip: no clip at path "t0/s1"');
   });
 
-  it("warns and skips an entry that names no session position", () => {
+  it("warns and skips an entry that names no clip slot", () => {
     const warn = vi.spyOn(console, "warn");
 
     registerClipAt(2, 3, "clip_b");

--- a/src/tools/clip/read/helpers/read-clip-helpers.ts
+++ b/src/tools/clip/read/helpers/read-clip-helpers.ts
@@ -88,7 +88,7 @@ export function resolveClip(
 }
 
 /**
- * Throw if a session slot's track or scene isn't there, naming which one.
+ * Throw if a clip slot's track or scene isn't there, naming which one.
  * @param trackIndex - Track index
  * @param sceneIndex - Scene index
  */

--- a/src/tools/clip/read/read-clip.def.ts
+++ b/src/tools/clip/read/read-clip.def.ts
@@ -25,7 +25,7 @@ export const toolDefReadClip = defineTool("ppal-read-clip", {
       .string()
       .optional()
       .describe(
-        "session position 't<track>/s<scene>', both 0-based (e.g., 't0/s3'). provide this or clipId",
+        "clip slot 't<track>/s<scene>', both 0-based (e.g., 't0/s3'). provide this or clipId",
       ),
 
     slot: deprecatedParam(z.coerce.string().optional(), {

--- a/src/tools/clip/read/read-clip.ts
+++ b/src/tools/clip/read/read-clip.ts
@@ -30,9 +30,9 @@ import {
 } from "./helpers/read-clip-helpers.ts";
 
 interface ReadClipArgs {
-  /** Session position, "t<track>/s<scene>" */
+  /** Clip slot, "t<track>/s<scene>" */
   path?: string | null;
-  /** Deprecated session slot, trackIndex/sceneIndex */
+  /** Deprecated clip slot, trackIndex/sceneIndex */
   slot?: string | null;
   clipId?: string | null;
   include?: string[];
@@ -79,7 +79,7 @@ export interface ReadClipResult {
 
   // Location properties
   /** Where the clip is: "t0/s3" in the session, "t0" or "t0/l0" in the
-   * arrangement. A session slot pastes back into any path/toPath param; an
+   * arrangement. A clip slot pastes back into any path/toPath param; an
    * arrangement one names a whole track, so only tools that take a track
    * destination accept it — reach a specific arrangement clip by id. */
   path?: string;

--- a/src/tools/clip/read/tests/read-clip-path.test.ts
+++ b/src/tools/clip/read/tests/read-clip-path.test.ts
@@ -10,7 +10,7 @@ import { readClip } from "#src/tools/clip/read/read-clip.ts";
 import { setupMidiClipMock } from "./read-clip-test-helpers.ts";
 
 describe("readClip path param", () => {
-  it("reads the clip at a session position", () => {
+  it("reads the clip at a clip slot", () => {
     setupMidiClipMock({
       trackIndex: 1,
       sceneIndex: 1,
@@ -45,7 +45,7 @@ describe("readClip path param", () => {
   it("rejects a take lane path and names what to send instead", () => {
     expect(() => readClip({ path: "t1/l0" })).toThrow(
       'invalid path "t1/l0" - take lanes hold arrangement clips; ' +
-        'name a session position as "t<track>/s<scene>" (e.g., "t1/s0")',
+        'name a clip slot as "t<track>/s<scene>" (e.g., "t1/s0")',
     );
   });
 

--- a/src/tools/clip/update/helpers/update-clip-session-helpers.ts
+++ b/src/tools/clip/update/helpers/update-clip-session-helpers.ts
@@ -247,7 +247,7 @@ interface HandlePositionOperationsArgs {
 }
 
 /**
- * Handle clip position operations: session slot move or arrangement operations
+ * Handle clip position operations: clip slot move or arrangement operations
  * @param args - Operation arguments
  */
 export function handlePositionOperations(
@@ -293,7 +293,7 @@ export function handlePositionOperations(
 }
 
 /**
- * Reads the session slots off a toPath, warning about each entry that names
+ * Reads the clip slots off a toPath, warning about each entry that names
  * something update-clip can't move a clip to.
  * @param toPath - Destination path(s), comma-separated
  * @returns One destination per entry, null where the entry names no slot
@@ -314,7 +314,7 @@ function pathDestinations(toPath: string): Array<SlotPosition | null> {
       }
 
       console.warn(
-        `toPath "${formatObjectPath(parsed)}" is not a session slot, so that clip was not moved; ` +
+        `toPath "${formatObjectPath(parsed)}" is not a clip slot, so that clip was not moved; ` +
           'update-clip moves a session clip to another slot ("t2/s3") — use ppal-duplicate to copy a clip to another track',
       );
     } catch (error) {

--- a/src/tools/clip/update/helpers/update-clip-test-helpers.ts
+++ b/src/tools/clip/update/helpers/update-clip-test-helpers.ts
@@ -434,8 +434,8 @@ export function setupSessionTilingMock(fileContentBoundary = 8.0) {
  * Assert that session-based file boundary detection ran correctly.
  * Verifies the session clip was created for boundary detection and cleaned up.
  * @param mockCreate - Spy on createAudioClipInSession
- * @param sessionSlot - Mock session slot with a call method
- * @param sessionSlot.call - Mock function for session slot calls
+ * @param sessionSlot - Mock clip slot with a call method
+ * @param sessionSlot.call - Mock function for clip slot calls
  * @param filePath - Expected audio file path
  */
 export function assertBoundaryDetection(

--- a/src/tools/clip/update/tests/session/update-clip-session-move.test.ts
+++ b/src/tools/clip/update/tests/session/update-clip-session-move.test.ts
@@ -642,12 +642,12 @@ describe("resolveMoveDestinations", () => {
     );
   });
 
-  it("warns and skips a destination that is not a session slot", () => {
+  it("warns and skips a destination that is not a clip slot", () => {
     // update-clip has no cross-track move; duplicate is the tool for that.
     expect(resolveMoveDestinations("t2", undefined, 1)).toStrictEqual([null]);
     expect(outlet).toHaveBeenCalledWith(
       1,
-      expect.stringContaining('toPath "t2" is not a session slot'),
+      expect.stringContaining('toPath "t2" is not a clip slot'),
     );
   });
 

--- a/src/tools/clip/update/update-clip.def.ts
+++ b/src/tools/clip/update/update-clip.def.ts
@@ -30,8 +30,8 @@ export const toolDefUpdateClip = defineTool("ppal-update-clip", {
       .describe("comma-separated clip ID(s) to update"),
     path: param(z.coerce.string().optional(), {
       default:
-        "session position(s) to update instead of ids, comma-separated (e.g., 't0/s1' or 't0/s1,t2/s3')",
-      smallModel: "session position to update instead of ids (e.g., 't0/s1')",
+        "clip slot(s) to update instead of ids, comma-separated (e.g., 't0/s1' or 't0/s1,t2/s3')",
+      smallModel: "clip slot to update instead of ids (e.g., 't0/s1')",
     }),
     name: param(z.string().optional(), {
       default:
@@ -94,7 +94,7 @@ export const toolDefUpdateClip = defineTool("ppal-update-clip", {
       .string()
       .optional()
       .describe(
-        "session slot(s) to move the clip(s) to, 't<track>/s<scene>', comma-separated for multiple " +
+        "clip slot(s) to move the clip(s) to, 't<track>/s<scene>', comma-separated for multiple " +
           "(e.g., 't2/s3' or 't2/s3,t2/s4'); session clips only. Paired 1:1 with the clips named by " +
           "ids/path, in order - destinations don't cycle, so name one slot per clip",
       ),

--- a/src/tools/clip/update/update-clip.ts
+++ b/src/tools/clip/update/update-clip.ts
@@ -81,7 +81,7 @@ interface ClipResult {
  *
  * @param args - The clip parameters
  * @param args.ids - Clip ID or comma-separated list of clip IDs to update
- * @param args.path - Session position(s) of clips to update, instead of ids
+ * @param args.path - Clip slot(s) of clips to update, instead of ids
  * @param args.notes - Musical notation string
  * @param args.transforms - Transform expressions applied AFTER merge, broadcast across all ids
  * @param args.preTransforms - Transform expressions applied to existing notes BEFORE merging new notes (works with or without notes; bare "v0" clears the clip)
@@ -96,7 +96,7 @@ interface ClipResult {
  * @param args.arrangementStart - Bar|beat position to move arrangement clip
  * @param args.arrangementLength - Duration for arrangement span: Nbar, n<fraction>, or Nbar+n<fraction>
  * @param args.toSlot - Deprecated session destination slot (trackIndex/sceneIndex); use toPath
- * @param args.toPath - Session slot to move the clip to (e.g., "t2/s3")
+ * @param args.toPath - Clip slot to move the clip to (e.g., "t2/s3")
  * @param args.arrangementSplit - Comma-separated song-timeline bar|beat positions to split clips at
  * @param args.split - Deprecated split positions, measured from each clip's start; use arrangementSplit
  * @param args.gainDb - Audio clip gain in decibels (-70 to 24)

--- a/src/tools/live-set/tests/read-live-set-build-budget.test.ts
+++ b/src/tools/live-set/tests/read-live-set-build-budget.test.ts
@@ -84,7 +84,7 @@ function setupGrid(): void {
 }
 
 /**
- * How many session slots the read built an object for.
+ * How many clip slots the read built an object for.
  * @returns Resolutions of the session clip shape
  */
 function slotResolves(): number {

--- a/src/tools/scene/read-scene.ts
+++ b/src/tools/scene/read-scene.ts
@@ -18,7 +18,7 @@ interface ReadSceneArgs {
   include?: string[];
   /**
    * Clips in this scene, when the caller already knows. A Live Set read counts
-   * every session slot for its tracks anyway, and counting again here would
+   * every clip slot for its tracks anyway, and counting again here would
    * build the whole grid a second time.
    */
   clipCount?: number;

--- a/src/tools/session/helpers/playback-target-helpers.ts
+++ b/src/tools/session/helpers/playback-target-helpers.ts
@@ -26,7 +26,7 @@ export interface SlotPosition {
 export interface PlaybackTarget {
   /** The one scene to play, agreed by every param that named one */
   sceneIndex: number | null;
-  /** Session positions named by `path` or the deprecated `slots` */
+  /** Clip slots named by `path` or the deprecated `slots` */
   slotPositions: SlotPosition[] | null;
   /** `ids` as the caller named it, or undefined when it names no clip */
   ids: string | undefined;
@@ -78,7 +78,7 @@ const TARGETING_ACTIONS = new Set([
  * @param action - The playback action, which decides whether a target applies
  * @param params - The raw target params
  * @param params.ids - Comma-separated clip IDs, or scene IDs for play-scene
- * @param params.path - A scene, or comma-separated session positions
+ * @param params.path - A scene, or comma-separated clip slots
  * @param params.slots - Deprecated comma-separated trackIndex/sceneIndex positions
  * @param params.sceneIndex - Scene index, an alternative to a "s<scene>" path
  * @returns What the params named, null where they named nothing
@@ -124,7 +124,7 @@ export function resolvePlaybackTarget(
 
   if (sceneIndex != null) {
     console.warn(
-      `sceneIndex ignored: action "${action}" acts on session positions; ` +
+      `sceneIndex ignored: action "${action}" acts on clip slots; ` +
         `use action "${PLAY_SCENE}" for the whole scene`,
     );
   }
@@ -135,7 +135,7 @@ export function resolvePlaybackTarget(
 /**
  * Resolve clip slot positions from either ids or the resolved path positions
  * @param ids - Comma-separated clip IDs
- * @param slotPositions - Resolved session positions, or null when none given
+ * @param slotPositions - Resolved clip slots, or null when none given
  * @param action - Action name for error messages
  * @returns Array of slot positions
  */
@@ -186,7 +186,7 @@ export function resolveClipSlotPositions(
 
 /**
  * Read `path` or the deprecated `slots` as parsed entries.
- * @param path - A scene, or comma-separated session positions
+ * @param path - A scene, or comma-separated clip slots
  * @param slots - Deprecated comma-separated trackIndex/sceneIndex positions
  * @returns The entries named and which param named them, or nothing when
  *   neither did
@@ -226,7 +226,7 @@ function readPathParam(
 }
 
 /**
- * The scene each path entry names. A session position names the scene it sits
+ * The scene each path entry names. A clip slot names the scene it sits
  * in: play-scene fires the whole scene whatever track the path sits on, so the
  * track is surplus, not a contradiction, and dropping it beats refusing a
  * caller who already told us the scene.
@@ -251,7 +251,7 @@ function pathSceneRefs(
       source.label,
       formatObjectPath(entry),
       `names no scene; action "${PLAY_SCENE}" takes a scene "s<scene>" ` +
-        `or a session position "t<track>/s<scene>"`,
+        `or a clip slot "t<track>/s<scene>"`,
     );
   });
 }
@@ -274,7 +274,7 @@ function quoteEntry(entry: ObjectPath, source: PathSource): string {
 }
 
 /**
- * The session positions each path entry names, for the actions that act on
+ * The clip slots each path entry names, for the actions that act on
  * clips rather than a whole scene.
  * @param action - The playback action
  * @param entries - What the path param named
@@ -400,7 +400,7 @@ function assertClipPath(
   throw pathError(
     source.label,
     formatObjectPath(entry),
-    `names a scene; action "${action}" takes session positions ` +
+    `names a scene; action "${action}" takes clip slots ` +
       `"t<track>/s<scene>" (e.g., "t0/s${entry.sceneIndex}")${wholeScene}`,
   );
 }

--- a/src/tools/session/helpers/select-existence-helpers.ts
+++ b/src/tools/session/helpers/select-existence-helpers.ts
@@ -34,7 +34,7 @@ interface SelectTargets {
  * @param targets.trackIndex - 0-based index within the category
  * @param targets.sceneId - Scene ID, when the scene came from an ID
  * @param targets.sceneIndex - 0-based scene index
- * @param targets.clipSlot - Session position coordinates
+ * @param targets.clipSlot - Clip slot coordinates
  * @param targets.devicePath - Device path, e.g. "t0/d1"
  */
 export function requireSelectTargets({
@@ -98,7 +98,7 @@ function requireTarget(api: LiveAPI, kind: string, path: string): void {
 }
 
 /**
- * Refuse a session position, saying whether the track or the scene is missing.
+ * Refuse a clip slot, saying whether the track or the scene is missing.
  * @param slot - The clip slot coordinates
  * @param slot.trackIndex - 0-based track index
  * @param slot.sceneIndex - 0-based scene index

--- a/src/tools/session/helpers/select-path-helpers.ts
+++ b/src/tools/session/helpers/select-path-helpers.ts
@@ -98,7 +98,7 @@ export function resolvePath(
  * Read `path` and the two params it replaced as what they name.
  * @param args - The path params as the tool received them
  * @param args.path - The path param
- * @param args.slot - The deprecated session slot
+ * @param args.slot - The deprecated clip slot
  * @param args.devicePath - The deprecated device path
  * @returns The clip slot, device, track, or scene the caller named
  */

--- a/src/tools/session/playback.def.ts
+++ b/src/tools/session/playback.def.ts
@@ -67,7 +67,7 @@ stop: session and arrangement`,
       .string()
       .optional()
       .describe(
-        "session position(s) 't<track>/s<scene>', both 0-based, comma-separated (e.g., 't0/s1' or 't0/s1,t2/s3'); " +
+        "clip slot(s) 't<track>/s<scene>', both 0-based, comma-separated (e.g., 't0/s1' or 't0/s1,t2/s3'); " +
           "for play-scene, a scene 's<scene>' (e.g., 's3') or any position in it",
       ),
     slots: deprecatedParam(z.coerce.string().optional(), {

--- a/src/tools/session/playback.ts
+++ b/src/tools/session/playback.ts
@@ -77,7 +77,7 @@ interface BuildPlaybackResultParams {
  * @param args.loopEndLocator - Locator ID or name for loop end
  * @param args.sceneIndex - Scene index for Session view operations
  * @param args.ids - Comma-separated clip IDs for Session view operations
- * @param args.path - A scene "s<scene>", or comma-separated session positions "t<track>/s<scene>"
+ * @param args.path - A scene "s<scene>", or comma-separated clip slots "t<track>/s<scene>"
  * @param args.slots - Deprecated comma-separated trackIndex/sceneIndex positions
  * @param args.focus - Switch to arrangement or session view based on action
  * @param _context - Internal context object (unused, for consistent tool interface)
@@ -279,7 +279,7 @@ function buildPlaybackResult({
  * @param action - Action name for error messages
  * @param liveSet - LiveAPI instance for live_set
  * @param ids - Comma-separated clip IDs
- * @param slotPositions - Resolved session positions, or null when none given
+ * @param slotPositions - Resolved clip slots, or null when none given
  * @param state - Current playback state
  * @returns Updated playback state
  */
@@ -324,7 +324,7 @@ function handlePlaySessionClips(
  *
  * @param action - Action name for error messages
  * @param ids - Comma-separated clip IDs
- * @param slotPositions - Resolved session positions, or null when none given
+ * @param slotPositions - Resolved clip slots, or null when none given
  * @param state - Current playback state
  * @returns Updated playback state
  */

--- a/src/tools/session/select.def.ts
+++ b/src/tools/session/select.def.ts
@@ -52,7 +52,7 @@ export const toolDefSelect = defineTool("ppal-select", {
       .string()
       .optional()
       .describe(
-        "select by path, 0-based: 't0/s3' a session position, 't0' a track, 'rt0' a return track, " +
+        "select by path, 0-based: 't0/s3' a clip slot, 't0' a track, 'rt0' a return track, " +
           "'mt' the master track, 's3' a scene, 't0/d1' a device, 't0/d0/c1' a rack chain, " +
           "'t0/d0/pC1' a drum pad",
       ),

--- a/src/tools/session/select.ts
+++ b/src/tools/session/select.ts
@@ -44,9 +44,9 @@ interface SelectArgs {
   trackType?: "return" | "master";
   trackIndex?: number;
   sceneIndex?: number;
-  /** Session position "t0/s3", a device "t0/d1", a drum pad "t0/d0/pC1", or a bare track "t0" */
+  /** Clip slot "t0/s3", a device "t0/d1", a drum pad "t0/d0/pC1", or a bare track "t0" */
   path?: string;
-  /** Deprecated session slot, trackIndex/sceneIndex */
+  /** Deprecated clip slot, trackIndex/sceneIndex */
   slot?: string;
   /** Deprecated device path */
   devicePath?: string;

--- a/src/tools/session/tests/playback/playback-scene-target.test.ts
+++ b/src/tools/session/tests/playback/playback-scene-target.test.ts
@@ -154,12 +154,12 @@ describe("playback play-scene target agreement", () => {
 
 // A scene launch fires every track, so the track in "t0/s1" is surplus rather
 // than a contradiction. Drop it and fire the scene the caller already named.
-describe("playback play-scene from a session position", () => {
+describe("playback play-scene from a clip slot", () => {
   beforeEach(() => {
     setupPlaybackLiveSet();
   });
 
-  it("fires the scene a session position sits in", () => {
+  it("fires the scene a clip slot sits in", () => {
     const scene = mockScene(1);
 
     playback({ action: "play-scene", path: "t0/s1" });
@@ -320,8 +320,8 @@ describe("playback sceneIndex on an action that acts on clips", () => {
     playback({ action: "play-session-clips", path: "t0/s1", sceneIndex: 3 });
 
     expect(warn).toHaveBeenCalledWith(
-      'sceneIndex ignored: action "play-session-clips" acts on session ' +
-        'positions; use action "play-scene" for the whole scene',
+      'sceneIndex ignored: action "play-session-clips" acts on clip ' +
+        'slots; use action "play-scene" for the whole scene',
     );
   });
 
@@ -332,8 +332,8 @@ describe("playback sceneIndex on an action that acts on clips", () => {
     playback({ action: "stop-session-clips", path: "t0/s1", sceneIndex: 3 });
 
     expect(warn).toHaveBeenCalledWith(
-      'sceneIndex ignored: action "stop-session-clips" acts on session ' +
-        'positions; use action "play-scene" for the whole scene',
+      'sceneIndex ignored: action "stop-session-clips" acts on clip ' +
+        'slots; use action "play-scene" for the whole scene',
     );
   });
 

--- a/src/tools/session/tests/playback/playback-target-params.test.ts
+++ b/src/tools/session/tests/playback/playback-target-params.test.ts
@@ -222,7 +222,7 @@ describe("playback path shaped wrong for the action", () => {
   it("refuses a track for play-scene, naming the shapes that work", () => {
     expect(() => playback({ action: "play-scene", path: "t0" })).toThrow(
       'invalid path "t0" - names no scene; action "play-scene" takes a scene ' +
-        '"s<scene>" or a session position "t<track>/s<scene>"',
+        '"s<scene>" or a clip slot "t<track>/s<scene>"',
     );
   });
 
@@ -231,7 +231,7 @@ describe("playback path shaped wrong for the action", () => {
       playback({ action: "play-session-clips", path: "s3" }),
     ).toThrow(
       'invalid path "s3" - names a scene; action "play-session-clips" takes ' +
-        'session positions "t<track>/s<scene>" (e.g., "t0/s3"), or use ' +
+        'clip slots "t<track>/s<scene>" (e.g., "t0/s3"), or use ' +
         'action "play-scene" for the whole scene',
     );
   });
@@ -242,7 +242,7 @@ describe("playback path shaped wrong for the action", () => {
       playback({ action: "stop-session-clips", path: "s3" }),
     ).toThrow(
       'invalid path "s3" - names a scene; action "stop-session-clips" takes ' +
-        'session positions "t<track>/s<scene>" (e.g., "t0/s3")',
+        'clip slots "t<track>/s<scene>" (e.g., "t0/s3")',
     );
     expect(() =>
       playback({ action: "stop-session-clips", path: "s3" }),

--- a/src/tools/session/tests/select/select-path.test.ts
+++ b/src/tools/session/tests/select/select-path.test.ts
@@ -32,7 +32,7 @@ describe("select path param", () => {
     resetSelectTestState();
   });
 
-  it("selects a session position", () => {
+  it("selects a clip slot", () => {
     const clipSlot = registerMockObject("clipslot_0_1", {
       path: livePath.track(0).clipSlot(1),
       type: "ClipSlot",
@@ -178,8 +178,8 @@ describe("select path param", () => {
     );
   });
 
-  // A session position names two things, so say which one is missing.
-  it("refuses a session position, naming the missing half", () => {
+  // A clip slot names two things, so say which one is missing.
+  it("refuses a clip slot, naming the missing half", () => {
     mockNonExistentObjects();
     registerMockObject("track_0", { path: livePath.track(0), type: "Track" });
     registerMockObject("scene_0", { path: livePath.scene(0), type: "Scene" });

--- a/src/tools/shared/arrangement/arrangement-tiling-helpers.ts
+++ b/src/tools/shared/arrangement/arrangement-tiling-helpers.ts
@@ -82,7 +82,7 @@ export function createAudioClipInSession(
   const trackIndex = track.trackIndex as number;
   const sceneIndex = sceneIds.indexOf(workingSceneId);
 
-  // Create clip in session slot with audio file
+  // Create the audio clip in a clip slot
   const slot = LiveAPI.from(livePath.track(trackIndex).clipSlot(sceneIndex));
 
   // create_audio_clip requires a file path

--- a/src/tools/shared/arrangement/tests/splitting/arrangement-splitting.test.ts
+++ b/src/tools/shared/arrangement/tests/splitting/arrangement-splitting.test.ts
@@ -551,7 +551,7 @@ describe("performSplitting", () => {
 
     // Should duplicate for audio content
     expectDuplicateCalled(callState.trackMock);
-    // Audio trims route through create_audio_clip in a session slot, never
+    // Audio trims route through create_audio_clip in a clip slot, never
     // create_midi_clip — so a MIDI-vs-audio misdetection would show up here.
     expectCreateMidiClipCount(callState.trackMock, 0);
   });

--- a/src/tools/shared/device/helpers/path/device-path-helpers.test.ts
+++ b/src/tools/shared/device/helpers/path/device-path-helpers.test.ts
@@ -431,7 +431,7 @@ describe("device-path-helpers", () => {
           /a scene holds no devices/,
         );
         expect(() => resolvePathToLiveApi("t0/s1")).toThrow(
-          /a session slot holds no devices/,
+          /a clip slot holds no devices/,
         );
       });
     });

--- a/src/tools/shared/validation/object-path-helpers.ts
+++ b/src/tools/shared/validation/object-path-helpers.ts
@@ -27,7 +27,7 @@ import {
 } from "#src/tools/shared/validation/object-path.ts";
 
 /**
- * Where a clip can go: a session slot, or a track's arrangement — its main lane
+ * Where a clip can go: a clip slot, or a track's arrangement — its main lane
  * (`t0`), one of its take lanes (`t0/l0`), or a fresh one (`t0/l+`).
  */
 export type ClipPath = Extract<
@@ -182,12 +182,12 @@ export function requireClipPath(path: ObjectPath, label = "path"): ClipPath {
   throw pathError(
     label,
     formatObjectPath(path),
-    `${describeNonClipPath(path)}; clips go to a track ("t0"), a take lane on it ("t0/l0"), or a session slot ("t0/s1")`,
+    `${describeNonClipPath(path)}; clips go to a track ("t0"), a take lane on it ("t0/l0"), or a clip slot ("t0/s1")`,
   );
 }
 
 /**
- * Narrows a path to a session position, for callers that can only act on one —
+ * Narrows a path to a clip slot, for callers that can only act on one —
  * reading, selecting, or launching a clip in the grid.
  * @param path - Parsed path
  * @param label - Param name for error messages
@@ -208,7 +208,7 @@ export function requireSessionSlot(
     throw pathError(
       label,
       formatObjectPath(clip),
-      `${problem}; name a session position as "t<track>/s<scene>" ` +
+      `${problem}; name a clip slot as "t<track>/s<scene>" ` +
         `(e.g., "t${clip.trackIndex}/s0")`,
     );
   }
@@ -217,7 +217,7 @@ export function requireSessionSlot(
 }
 
 /**
- * Parses a comma-separated list of session positions.
+ * Parses a comma-separated list of clip slots.
  * @param input - Comma-separated paths (e.g., "t0/s1" or "t0/s1,t2/s3")
  * @param label - Param name for error messages
  * @returns One track/scene pair per path, in order
@@ -328,7 +328,7 @@ function describeNonDevicePath(path: ObjectPath): string {
     case "scene":
       return "a scene holds no devices";
     case "slot":
-      return "a session slot holds no devices";
+      return "a clip slot holds no devices";
     default:
       return "a take lane holds no devices";
   }

--- a/src/tools/shared/validation/object-path.ts
+++ b/src/tools/shared/validation/object-path.ts
@@ -283,7 +283,7 @@ function parseTail(
     throw pathError(
       label,
       input,
-      `a scene has no parts; a session slot is "t<track>/s<scene>"`,
+      `a scene has no parts; a clip slot is "t<track>/s<scene>"`,
     );
   }
 
@@ -376,7 +376,7 @@ function isTrackChild(segment: string): boolean {
 }
 
 /**
- * Builds the session slot or take lane a track child names.
+ * Builds the clip slot or take lane a track child names.
  * @param root - The parsed root segment
  * @param segment - The child segment
  * @param tailLength - How many segments follow the root
@@ -430,7 +430,7 @@ function trackChildError(label: string, input: string, segment: string): Error {
     ? pathError(
         label,
         input,
-        `a session slot is "t<track>/s<scene>" (e.g. "t0/s1"); only regular tracks have scenes`,
+        `a clip slot is "t<track>/s<scene>" (e.g. "t0/s1"); only regular tracks have scenes`,
       )
     : pathError(
         label,

--- a/src/tools/shared/validation/tests/object-path-helpers.test.ts
+++ b/src/tools/shared/validation/tests/object-path-helpers.test.ts
@@ -125,7 +125,7 @@ describe("requireClipPath", () => {
     for (const [path, message] of cases) {
       expect(() => requireClipPath(parseObjectPath(path))).toThrow(message);
       expect(() => requireClipPath(parseObjectPath(path))).toThrow(
-        /clips go to a track \("t0"\), a take lane on it \("t0\/l0"\), or a session slot \("t0\/s1"\)/,
+        /clips go to a track \("t0"\), a take lane on it \("t0\/l0"\), or a clip slot \("t0\/s1"\)/,
       );
     }
   });
@@ -159,7 +159,7 @@ describe("requireSessionSlot", () => {
 
   it("rejects a bare track, which names no one clip", () => {
     expect(() => requireSessionSlot(parseObjectPath("t7"))).toThrow(
-      /a track has no one clip; name a session position as "t<track>\/s<scene>" \(e\.g\., "t7\/s0"\)/,
+      /a track has no one clip; name a clip slot as "t<track>\/s<scene>" \(e\.g\., "t7\/s0"\)/,
     );
   });
 
@@ -167,7 +167,7 @@ describe("requireSessionSlot", () => {
   it("rejects a take lane, which is an arrangement position", () => {
     for (const path of ["t7/l1", "t7/l+"]) {
       expect(() => requireSessionSlot(parseObjectPath(path))).toThrow(
-        /take lanes hold arrangement clips; name a session position as "t<track>\/s<scene>" \(e\.g\., "t7\/s0"\)/,
+        /take lanes hold arrangement clips; name a clip slot as "t<track>\/s<scene>" \(e\.g\., "t7\/s0"\)/,
       );
     }
   });
@@ -217,7 +217,7 @@ describe("requireDeviceContainer", () => {
   it("rejects everything that can't hold a device", () => {
     const cases: [string, RegExp][] = [
       ["s3", /a scene holds no devices/],
-      ["t0/s1", /a session slot holds no devices/],
+      ["t0/s1", /a clip slot holds no devices/],
       ["t0/l1", /a take lane holds no devices/],
     ];
 

--- a/src/tools/shared/validation/tests/object-path.test.ts
+++ b/src/tools/shared/validation/tests/object-path.test.ts
@@ -29,7 +29,7 @@ describe("parseObjectPath", () => {
     });
   });
 
-  it("reads a session slot", () => {
+  it("reads a clip slot", () => {
     expect(parseObjectPath("t7/s2")).toStrictEqual({
       kind: "slot",
       trackIndex: 7,
@@ -160,7 +160,7 @@ describe("parseObjectPath", () => {
   it("rejects a scene segment anywhere a slot can't be", () => {
     for (const path of ["rt0/s1", "mt/s1", "t0/d0/s1", "t0/s1/d0"]) {
       expect(() => parseObjectPath(path)).toThrow(
-        /a session slot is "t<track>\/s<scene>"/,
+        /a clip slot is "t<track>\/s<scene>"/,
       );
     }
   });
@@ -270,7 +270,7 @@ describe("parseObjectPath", () => {
   describe("the spellings results used before 2.2.0", () => {
     // A model pasting back what a result told it made a well-founded guess, so
     // honor it and warn — the same trade already taken on hidden params.
-    it("reads trackIndex/sceneIndex as a session slot", () => {
+    it("reads trackIndex/sceneIndex as a clip slot", () => {
       const warn = vi.spyOn(console, "warn");
 
       expect(parseObjectPath("0/3")).toStrictEqual({

--- a/src/tools/track/read/read-track.ts
+++ b/src/tools/track/read/read-track.ts
@@ -47,7 +47,7 @@ interface ReadTrackArgs {
   include?: string[];
   /**
    * Session clips on this track, when the caller already knows. A Live Set read
-   * counts every session slot for its scenes anyway, and counting again here
+   * counts every clip slot for its scenes anyway, and counting again here
    * would build the whole grid a second time.
    */
   sessionClipCount?: number;

--- a/src/tools/track/read/tests/read-track-build-budget.test.ts
+++ b/src/tools/track/read/tests/read-track-build-budget.test.ts
@@ -88,7 +88,7 @@ function shapeResolves(shape: string): number {
   );
 }
 
-/** Session slots on the fixture track. */
+/** Clip slots on the fixture track. */
 const SLOT_COUNT = 8;
 
 /** A track of SLOT_COUNT slots with a clip in every other one. */
@@ -149,7 +149,7 @@ describe("readTrack build budget", () => {
     expect(chainResolves()).toBe(CHAIN_COUNT * 2);
   });
 
-  it("builds one object per session slot, not three", () => {
+  it("builds one object per clip slot, not three", () => {
     setupTrackWithSessionClips();
 
     readTrack({ trackIndex: 0, include: ["session-clips"] });


### PR DESCRIPTION
A `t0/s3` location is a clip slot — `clip_slot` in the Live API, "clip slot" in the UI. We had two names for it, neither of which a user can look up, and the code already said "clip slot" in places. This settles on one. It still carries the Session-vs-Arrangement distinction the old wording was reaching for, since clip slots only exist in Session view.

Prose only, 79 files: schema descriptions, error messages, warnings, Skills, docs, and comments. Internal identifiers (`requireSessionSlot`, `SlotPosition`, `parseSessionSlotList`) still say session — those are a separate reviewable pass, tracked for 2.3.0.

Schema descriptions got shorter, not longer: "clip slot" beats "session position" by 7 characters, so it replaces the term directly rather than needing the sentences reworked around it.

## One thing worth a look

The `published param references` check started failing on read-clip, select, and create-clip: "clip slot" contains the name of their deprecated `slot` param, so the word-boundary match read it as a dangling reference.

That test has no allowlist by design, but its own comment anticipates this case. The fix blanks out the exact term `clip slot(s)` before matching, which is the narrowest thing that works — a bare `set slot to ...` sitting next to an allowed "clip slot" is still caught, and there are now tests for both directions. The carve-out goes away on its own once `slot`/`slots` are dropped from the schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)