### PR TITLE
Track and scene paths, round-tripped

### DIFF
--- a/dev/Object-Paths.md
+++ b/dev/Object-Paths.md
@@ -153,9 +153,10 @@ Four tiers, in order of preference.
      `duplicate` is half-way: its `id` takes a list, but `path` names one drum
      pad for the whole call, so naming both still throws.
    - **A set — union.** Where the call already acts on a list (`delete`,
-     `update-clip`, `playback`'s clip actions), `id` and `path` both name
-     members of it, so the targets combine. Duplicates collapse — firing a clip
-     twice is a different Live call than firing it once.
+     `update-clip`, `update-track`, `update-scene`, `playback`'s clip actions),
+     `id` and `path` both name members of it, so the targets combine. Duplicates
+     collapse — firing a clip twice is a different Live call than firing it
+     once.
 
 ## Results
 
@@ -206,7 +207,12 @@ requirement in index terms.
 
 Deliberate omissions, reasoned in
 [ADR-0025](decisions/0025-object-path-grammar.md): arrangement clips (addressed
-by id), locators (`locator` param, by id or name), track/scene addressing on the
-read and update tools (`trackIndex` / `sceneIndex` stay), and
-new-track/new-scene positions (they create the location rather than address
-one).
+by id), locators (`locator` param, by id or name), and new-track/new-scene
+positions (they create the location rather than address one).
+
+ADR-0025 also kept tracks and scenes off the grammar. That went the other way
+once write results started reporting `path`: a result handed back `t0` and no
+tool took it. `update-track`, `update-scene` and `delete` now accept a track or
+scene `path` alongside `id`, and reads report one. The read tools still address
+by `trackIndex` / `sceneIndex` — swapping those for a path is bound up with
+whether `trackType` collapses into the path, which is a separate call.

--- a/dev/plans/Path-Standardization.md
+++ b/dev/plans/Path-Standardization.md
@@ -115,8 +115,9 @@ Two rules about what these may assert, both learned the hard way:
 
 ### Phase 5 — `path` everywhere: rejected
 
-Considered and dropped. `path` addresses clips and devices;
-[ADR-0025](../decisions/0025-object-path-grammar.md)'s scope stands.
+Considered and dropped — this phase was about naming an _arrangement clip_ by
+path, which is still no. (Tracks and scenes went the other way later; see
+[Object-Paths.md](../Object-Paths.md) → Not paths.)
 
 The idea was to make `path` the general way to address any object. That needed
 one thing first: a way to name an arrangement clip, since a lane path names the
@@ -168,6 +169,18 @@ different track, and a deleted object has no next call to spend it on.
 Two shapes report nothing: a chain reached through a pad segment, whose
 rack-relative index isn't in the Live API path, and an object that resolved to
 nothing.
+
+### Phase 7 — tracks and scenes take a path
+
+Phase 6 handed back `t0` and `s3` from write results that no tool accepted,
+which is the second addressing spelling ADR-0025 named as its own revisit
+condition. Track and scene reads now report `path`, and `update-track`,
+`update-scene` and `delete` accept one beside `id`.
+
+Open: whether the read tools drop `trackIndex` / `sceneIndex` for a path, and
+whether `trackType` collapses into it (a path already says return vs main; only
+`midi` vs `audio` is left to report). Both are breaking, so they wait on eval
+evidence.
 
 ## Docs to update as the phases land
 

--- a/dev/plans/Path-Standardization.md
+++ b/dev/plans/Path-Standardization.md
@@ -177,10 +177,52 @@ which is the second addressing spelling ADR-0025 named as its own revisit
 condition. Track and scene reads now report `path`, and `update-track`,
 `update-scene` and `delete` accept one beside `id`.
 
-Open: whether the read tools drop `trackIndex` / `sceneIndex` for a path, and
-whether `trackType` collapses into it (a path already says return vs main; only
-`midi` vs `audio` is left to report). Both are breaking, so they wait on eval
-evidence.
+### Phase 8 — `type` stops carrying the role
+
+Decided, not yet built. `type` today says `midi | audio | return | master`,
+which is two questions in one field: what signal the track carries, and what
+role it plays. The path already answers the second (`t0`, `rt1`, `mt`), so the
+field keeps only the first.
+
+1. **A return or main track reports no `type` at all.** Not `"audio"`. They are
+   audio-only, so the value would be constant — and worse, misleading: it reads
+   as an invitation to put an audio clip there, which Live does not allow. The
+   field means "which signal, where there is a choice", and there is none.
+
+   This puts the whole weight of the role on the path, so the evals have to
+   prove models read and write `rt0` and `mt` reliably. If they don't, this is
+   the decision to revisit first.
+
+2. **`trackType` becomes a hidden param, not an error.** Same migration as the
+   other 2.x schema changes: accepted and validated, absent from the published
+   schema. Use `deprecatedParam({ replacedBy: "path" })` — it is going away,
+   unlike the permanent `aliasParam` guesses. `trackIndex` on the _track_ read
+   goes the same way; the `trackIndex` / `sceneIndex` aliases on the _clip_
+   tools stay permanent (Object-Paths.md tolerance, tier 1) and must not be
+   swept up with it.
+
+   This is what forces `path` onto the read tools: with `trackType` hidden,
+   `path` is the published way to name a return or the main track.
+
+3. **`create-track`'s `type` waits for Phase 9.** Its `return` is not addressing
+   — it picks a different Live call (`create_return_track`). It can only lose
+   the value once creation itself moves to a path (`t+`, `rt+`).
+
+4. **Say "main", not "master", in everything a model or user reads.** Live 12's
+   UI says Main and the path root `mt` reads as either. Tool and param
+   descriptions and the Skills all say main. Internal identifiers that mirror
+   the Live API property (`master_track`, `masterTrack`, `category: "master"`)
+   are a separate question — the `masterTrack` key in a Live Set read is
+   user-facing and still undecided.
+
+Both remaining sites of the conflation move together: `computeTrackType` in
+[read-track.ts](../../src/tools/track/read/read-track.ts) and the second copy in
+[select-response-helpers.ts](../../src/tools/session/helpers/select-response-helpers.ts).
+
+### Phase 9 — creating by path
+
+Not started. `create-track` / `create-scene` would take `t+` / `rt+` / `s+`
+instead of `type` + index, which is what lets Phase 8's item 3 finish.
 
 ## Docs to update as the phases land
 

--- a/src/test/mocks/mock-live-api.ts
+++ b/src/test/mocks/mock-live-api.ts
@@ -303,6 +303,7 @@ export class LiveAPI {
 
 interface TrackOverrides {
   id?: string;
+  path?: string;
   type?: string;
   name?: string;
   trackIndex?: number;
@@ -320,6 +321,7 @@ export const expectedTrack = (
   overrides: TrackOverrides = {},
 ): TrackOverrides => ({
   id: "1",
+  path: `t${overrides.trackIndex ?? 0}`,
   type: "midi",
   name: "Test Track",
   trackIndex: 0,

--- a/src/tools/actions/delete/delete.def.ts
+++ b/src/tools/actions/delete/delete.def.ts
@@ -12,7 +12,7 @@ export const toolDefDelete = defineTool("ppal-delete", {
   title: "Delete",
   description:
     "Delete objects. Supports tracks, scenes, clips, devices, drum pads, and drum rack chains. " +
-    "Use id for most types; path for clips, devices, drum pads, and chains.",
+    "Every type takes an id or a path.",
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,
@@ -29,7 +29,7 @@ export const toolDefDelete = defineTool("ppal-delete", {
     }),
     path: param(z.coerce.string().optional(), {
       default:
-        "path(s) to delete, comma-separated for multiple: session clips ('t0/s1'), devices ('t0/d1'), drum pads ('t1/d0/pC1'), one layer of a pad ('t1/d0/pC1/c1')",
+        "path(s) to delete, comma-separated for multiple: tracks ('t0', 'rt1'), scenes ('s0'), session clips ('t0/s1'), devices ('t0/d1'), drum pads ('t1/d0/pC1'), one layer of a pad ('t1/d0/pC1/c1')",
       smallModel: "path to delete (e.g., 't0/s1' or 't0/d1')",
     }),
 

--- a/src/tools/actions/delete/delete.ts
+++ b/src/tools/actions/delete/delete.ts
@@ -6,6 +6,10 @@
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import * as console from "#src/shared/max/v8-max-console.ts";
 import { clipIdPerPath } from "#src/tools/clip/helpers/clip-path-lookup.ts";
+import {
+  sceneIdPerPath,
+  trackIdPerPath,
+} from "#src/tools/shared/validation/path-target-lookup.ts";
 import { getHostTrackIndex } from "#src/tools/shared/arrangement/get-host-track-index.ts";
 import { isProducerPalDevice } from "#src/tools/shared/device/is-producer-pal-device.ts";
 import { isTakeLaneClip } from "#src/tools/shared/arrangement/helpers/take-lane-helpers.ts";
@@ -26,7 +30,18 @@ import {
   validateObjectTypes,
 } from "#src/tools/shared/validation/id-validation.ts";
 
-const PATH_SUPPORTED_TYPES = new Set(["clip", "device", "drum-pad", "chain"]);
+/**
+ * The types whose paths resolve one entry at a time, keeping a miss in place.
+ * Everything else goes through the device-chain resolver.
+ */
+const ID_PER_PATH: Record<
+  string,
+  (paths: string, tool: string) => Array<string | null>
+> = {
+  track: trackIdPerPath,
+  scene: sceneIdPerPath,
+  clip: clipIdPerPath,
+};
 
 const DELETABLE_TYPES = [
   "track",
@@ -65,7 +80,7 @@ interface DeleteArgs {
  * @param args - The parameters
  * @param args.id - Comma-separated list of object IDs
  * @param args.ids - Hidden alias for id
- * @param args.path - Comma-separated paths for clip/device/drum-pad/chain
+ * @param args.path - Comma-separated paths naming what to delete
  * @param args.paths - Hidden alias for path
  * @param args.type - Type of objects to delete
  * @param _context - Internal context object (unused, for consistent tool interface)
@@ -89,13 +104,6 @@ export function deleteObject(
     );
   }
 
-  // Handle path parameter - only valid for devices and drum-pads
-  if (path && !PATH_SUPPORTED_TYPES.has(type)) {
-    console.warn(
-      `delete: path parameter is only valid for types "clip", "device", "drum-pad", or "chain", ignoring paths`,
-    );
-  }
-
   // Collect IDs from both sources. targets is already confirmed non-blank, so
   // an id that parses to nothing (e.g. ",  ,") is worth a warning of its own
   // rather than reading the same as an omitted id.
@@ -107,11 +115,14 @@ export function deleteObject(
   // delete done.
   const unresolvedPaths: string[] = [];
 
-  if (path && PATH_SUPPORTED_TYPES.has(type)) {
+  // Every deletable type can be addressed by location, so a path is always
+  // usable by the time the type check above has passed.
+  if (path) {
+    const lookup = ID_PER_PATH[type];
     const resolvedPaths =
-      type === "clip"
-        ? resolveClipPaths(path)
-        : resolvePathsToIds(targetEntries(path, "path"), type);
+      lookup == null
+        ? resolvePathsToIds(targetEntries(path, "path"), type)
+        : resolvePerPath(path, lookup);
 
     objectIds.push(...resolvedPaths.ids);
     unresolvedPaths.push(...resolvedPaths.unresolved);
@@ -215,21 +226,25 @@ export function deleteObject(
 }
 
 /**
- * The clip lookup in the shape the path resolvers use, so both branches report
- * their misses the same way.
- * @param path - Comma-separated clip slot paths
- * @returns The clip ids found, plus the paths that held no clip
+ * A per-entry lookup in the shape the path resolvers use, so both branches
+ * report their misses the same way.
+ * @param path - Comma-separated paths
+ * @param lookup - The type's path-to-id lookup
+ * @returns The ids found, plus the paths that named nothing
  */
-function resolveClipPaths(path: string): ResolvedPaths {
+function resolvePerPath(
+  path: string,
+  lookup: (paths: string, tool: string) => Array<string | null>,
+): ResolvedPaths {
   const entries = targetEntries(path, "path");
   const ids: string[] = [];
   const unresolved: string[] = [];
 
-  for (const [index, clipId] of clipIdPerPath(path, "delete").entries()) {
-    if (clipId == null) {
+  for (const [index, id] of lookup(path, "delete").entries()) {
+    if (id == null) {
       unresolved.push(entries[index] ?? path);
     } else {
-      ids.push(clipId);
+      ids.push(id);
     }
   }
 

--- a/src/tools/actions/delete/tests/delete-device.test.ts
+++ b/src/tools/actions/delete/tests/delete-device.test.ts
@@ -9,7 +9,6 @@ import "#src/live-api-adapter/live-api-extensions.ts";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import {
   mockNonExistentObjects,
-  registerMockObject,
   simulateMockDeletes,
 } from "#src/test/mocks/mock-registry.ts";
 import {
@@ -460,21 +459,6 @@ describe("deleteObject device deletion", () => {
         type: "device",
         deleted: false,
       });
-    });
-
-    it("should warn when path is used with non-device/drum-pad type", () => {
-      const consoleSpy = vi.spyOn(console, "warn");
-
-      registerMockObject("track_1", {
-        path: livePath.track(0),
-        type: "Track",
-      });
-
-      deleteObject({ id: "track_1", path: "0/0", type: "track" });
-
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'delete: path parameter is only valid for types "clip", "device", "drum-pad", or "chain", ignoring paths',
-      );
     });
 
     it("should delete a device nested inside a drum chain by path", () => {

--- a/src/tools/actions/delete/tests/delete-track-scene-path.test.ts
+++ b/src/tools/actions/delete/tests/delete-track-scene-path.test.ts
@@ -1,0 +1,114 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import {
+  capturedWarnings,
+  clearCapturedWarnings,
+} from "#src/shared/max/v8-warning-capture.ts";
+import {
+  type RegisteredMockObject,
+  mockNonExistentObjects,
+  registerMockObject,
+  simulateMockDeletes,
+} from "#src/test/mocks/mock-registry.ts";
+import { setupSceneMocks, setupTrackMocks } from "./delete-test-helpers.ts";
+import { deleteObject } from "../delete.ts";
+
+describe("deleteObject by track and scene path", () => {
+  let liveSet: RegisteredMockObject;
+
+  beforeEach(() => {
+    clearCapturedWarnings();
+    // delete confirms the object is gone, so the mock has to model it going away
+    simulateMockDeletes();
+    liveSet = registerMockObject("live_set", { path: livePath.liveSet });
+  });
+
+  it("deletes the track a path names", () => {
+    setupTrackMocks({ track_2: String(livePath.track(1)) });
+
+    expect(deleteObject({ path: "t1", type: "track" })).toStrictEqual({
+      id: "track_2",
+      type: "track",
+      deleted: true,
+    });
+    expect(liveSet.call).toHaveBeenCalledWith("delete_track", 1);
+  });
+
+  it("deletes a return track a path names", () => {
+    setupTrackMocks({ ret_0: String(livePath.returnTrack(0)) });
+
+    expect(deleteObject({ path: "rt0", type: "track" })).toStrictEqual({
+      id: "ret_0",
+      type: "track",
+      deleted: true,
+    });
+    expect(liveSet.call).toHaveBeenCalledWith("delete_return_track", 0);
+  });
+
+  it("deletes the scene a path names", () => {
+    setupSceneMocks({ scene_3: livePath.scene(2) });
+
+    expect(deleteObject({ path: "s2", type: "scene" })).toStrictEqual({
+      id: "scene_3",
+      type: "scene",
+      deleted: true,
+    });
+    expect(liveSet.call).toHaveBeenCalledWith("delete_scene", 2);
+  });
+
+  it("deletes tracks named by id and by path in one call", () => {
+    setupTrackMocks({
+      track_1: String(livePath.track(0)),
+      track_2: String(livePath.track(1)),
+    });
+
+    const result = deleteObject({ id: "track_1", path: "t1", type: "track" });
+
+    // Highest index first, so the earlier delete doesn't shift the later one.
+    expect(result).toStrictEqual([
+      { id: "track_2", type: "track", deleted: true },
+      { id: "track_1", type: "track", deleted: true },
+    ]);
+  });
+
+  it("reports a path that names nothing rather than dropping it", () => {
+    mockNonExistentObjects();
+
+    expect(deleteObject({ path: "s9", type: "scene" })).toStrictEqual({
+      path: "s9",
+      type: "scene",
+      deleted: false,
+    });
+    expect(capturedWarnings()).toContain('delete: nothing at path "s9"');
+  });
+
+  it("reports a path that names the wrong kind of object", () => {
+    expect(deleteObject({ path: "t0/s1", type: "track" })).toStrictEqual({
+      path: "t0/s1",
+      type: "track",
+      deleted: false,
+    });
+    expect(capturedWarnings()).toContain(
+      'delete: invalid path "t0/s1" - names a clip slot, not a track; expected "t<index>", "rt<index>", or "mt"',
+    );
+  });
+
+  it("refuses to delete the main track, which Live has no call for", () => {
+    registerMockObject("main", {
+      path: livePath.masterTrack(),
+      type: "Track",
+    });
+
+    expect(deleteObject({ path: "mt", type: "track" })).toStrictEqual({
+      id: "main",
+      type: "track",
+      deleted: false,
+    });
+    expect(liveSet.call).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/clip/helpers/clip-path-lookup.ts
+++ b/src/tools/clip/helpers/clip-path-lookup.ts
@@ -12,10 +12,8 @@
 import { errorMessage } from "#src/shared/error-utils.ts";
 import { livePath } from "#src/shared/live-api-path-builders.ts";
 import * as console from "#src/shared/max/v8-max-console.ts";
-import {
-  pathEntries,
-  requireClipSlotPath,
-} from "#src/tools/shared/validation/object-path-helpers.ts";
+import { requireClipSlotPath } from "#src/tools/shared/validation/object-path-helpers.ts";
+import { pathEntriesOrNone } from "#src/tools/shared/validation/path-target-lookup.ts";
 import { parseObjectPath } from "#src/tools/shared/validation/object-path.ts";
 
 /**
@@ -52,7 +50,7 @@ export function clipIdPerPath(
 ): Array<string | null> {
   const ids: Array<string | null> = [];
 
-  for (const entry of entriesOrNone(paths, tool, label)) {
+  for (const entry of pathEntriesOrNone(paths, tool, label)) {
     try {
       const slot = requireClipSlotPath(parseObjectPath(entry, label), label);
       const clip = LiveAPI.from(
@@ -73,23 +71,4 @@ export function clipIdPerPath(
   }
 
   return ids;
-}
-
-/**
- * Splits the param into entries, treating a param that names nothing as naming
- * nothing rather than as an error: the same batch may also have named ids, and
- * those clips are still there to update.
- * @param paths - The raw path param
- * @param tool - Tool name, for warnings
- * @param label - Param name the paths came from, for warnings
- * @returns One trimmed entry per path, or none when the param is unusable
- */
-function entriesOrNone(paths: string, tool: string, label: string): string[] {
-  try {
-    return pathEntries(paths, label);
-  } catch (error) {
-    console.warn(`${tool}: ${errorMessage(error)}`);
-
-    return [];
-  }
 }

--- a/src/tools/live-set/tests/read-live-set-basic.test.ts
+++ b/src/tools/live-set/tests/read-live-set-basic.test.ts
@@ -157,6 +157,7 @@ describe("readLiveSet - basic reading", () => {
       tracks: [
         {
           id: "track1",
+          path: "t0",
           type: "midi",
           name: "MIDI Track 1",
           trackIndex: 0,
@@ -170,6 +171,7 @@ describe("readLiveSet - basic reading", () => {
         },
         {
           id: "track2",
+          path: "t1",
           type: "audio",
           name: "Audio Track 2",
           trackIndex: 1,
@@ -194,6 +196,7 @@ describe("readLiveSet - basic reading", () => {
       scenes: [
         {
           id: "scene1",
+          path: "s0",
           name: "Scene 1",
           sceneIndex: 0,
           clipCount: 2,
@@ -202,6 +205,7 @@ describe("readLiveSet - basic reading", () => {
         },
         {
           id: "scene2",
+          path: "s1",
           name: "Scene 2",
           sceneIndex: 1,
           clipCount: 0,
@@ -209,6 +213,7 @@ describe("readLiveSet - basic reading", () => {
         },
         {
           id: "scene3",
+          path: "s2",
           name: "Scene 3",
           sceneIndex: 2,
           clipCount: 1,

--- a/src/tools/scene/read-scene.ts
+++ b/src/tools/scene/read-scene.ts
@@ -16,6 +16,7 @@ import {
 } from "#src/tools/shared/tool-framework/include-params.ts";
 import { namedIdParam, stripFields } from "#src/tools/shared/utils.ts";
 import { validateIdType } from "#src/tools/shared/validation/id-validation.ts";
+import { pathField } from "#src/tools/shared/validation/object-path-for-api.ts";
 
 interface ReadSceneArgs {
   sceneIndex?: number;
@@ -33,6 +34,7 @@ interface ReadSceneArgs {
 
 interface ReadSceneResult {
   id: string | null;
+  path?: string;
   name: string | null;
   sceneIndex?: number | null;
   color?: string | null;
@@ -102,6 +104,7 @@ export function readScene(
 
   const result: ReadSceneResult = {
     id: scene.id,
+    ...pathField(scene),
     name: sceneDisplayName(scene, resolvedSceneIndex as number),
     sceneIndex: resolvedSceneIndex,
     ...(includeColor && { color: scene.getColor() }),

--- a/src/tools/scene/tests/read-scene.test.ts
+++ b/src/tools/scene/tests/read-scene.test.ts
@@ -83,6 +83,7 @@ describe("readScene", () => {
 
     expect(result).toStrictEqual({
       id: "scene1",
+      path: "s0",
       name: "Test Scene",
       sceneIndex: 0,
       clipCount: 0,
@@ -124,6 +125,7 @@ describe("readScene", () => {
 
     expect(result).toStrictEqual({
       id: "scene2",
+      path: "s1",
       name: "Scene with Disabled Properties",
       sceneIndex: 1,
       clipCount: 0,
@@ -139,6 +141,7 @@ describe("readScene", () => {
 
     expect(result).toStrictEqual({
       id: "scene3",
+      path: "s2",
       name: "3",
       sceneIndex: 2,
       clipCount: 0,
@@ -165,6 +168,7 @@ describe("readScene", () => {
 
     expect(result).toStrictEqual({
       id: "scene_0",
+      path: "s0",
       name: "Scene with 2 Clips",
       sceneIndex: 0,
       clipCount: 2,
@@ -219,6 +223,7 @@ describe("readScene", () => {
 
     expect(result).toStrictEqual({
       id: "scene_0",
+      path: "s0",
       name: "Scene with Clips",
       sceneIndex: 0,
       tempo: 120,
@@ -307,6 +312,7 @@ describe("readScene", () => {
 
       expect(result).toStrictEqual({
         id: "123",
+        path: "s5",
         name: "Scene by ID",
         sceneIndex: 5,
         clipCount: 0,
@@ -328,6 +334,7 @@ describe("readScene", () => {
         tempo: 120,
         timeSignature: "4/4",
         id: "123",
+        path: "s5",
         name: "Scene by ID",
       });
     });
@@ -353,6 +360,7 @@ describe("readScene", () => {
 
       expect(result).toStrictEqual({
         id: "456",
+        path: "s2",
         name: "Scene with Clips by ID",
         sceneIndex: 2,
         tempo: 110,

--- a/src/tools/scene/tests/update-scene-empty-target.test.ts
+++ b/src/tools/scene/tests/update-scene-empty-target.test.ts
@@ -26,7 +26,7 @@ describe("updateScene when id names nothing", () => {
 
     expect(updateScene({ id: "   " })).toStrictEqual([]);
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith("updateScene: id is required");
+    expect(warn).toHaveBeenCalledWith("updateScene: id or path is required");
   });
 });
 

--- a/src/tools/scene/tests/update-scene-path.test.ts
+++ b/src/tools/scene/tests/update-scene-path.test.ts
@@ -1,0 +1,81 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import {
+  capturedWarnings,
+  clearCapturedWarnings,
+} from "#src/shared/max/v8-warning-capture.ts";
+import {
+  type RegisteredMockObject,
+  mockNonExistentObjects,
+  registerMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+import { updateScene } from "../update-scene.ts";
+import "#src/live-api-adapter/live-api-extensions.ts";
+
+describe("updateScene by path", () => {
+  let scene0: RegisteredMockObject;
+  let scene1: RegisteredMockObject;
+
+  beforeEach(() => {
+    clearCapturedWarnings();
+    scene0 = registerMockObject("123", { path: livePath.scene(0) });
+    scene1 = registerMockObject("456", { path: livePath.scene(1) });
+  });
+
+  it("updates the scene a path names", () => {
+    const result = updateScene({ path: "s0", name: "By Path" });
+
+    expect(scene0.set).toHaveBeenCalledWith("name", "By Path");
+    expect(result).toStrictEqual({ id: "123", path: "s0" });
+  });
+
+  it("adds paths to the ids rather than pairing with them", () => {
+    const result = updateScene({
+      id: "123",
+      path: "s1",
+      name: "First,Second",
+    });
+
+    expect(scene0.set).toHaveBeenCalledWith("name", "First");
+    expect(scene1.set).toHaveBeenCalledWith("name", "Second");
+    expect(result).toStrictEqual([
+      { id: "123", path: "s0" },
+      { id: "456", path: "s1" },
+    ]);
+  });
+
+  it("says a path names the wrong kind of object, and keeps its place", () => {
+    const result = updateScene({ path: "t0,s1", name: "First,Second" });
+
+    // The skipped entry keeps its slot, so "Second" lands on s1 rather than
+    // sliding forward onto it.
+    expect(scene1.set).toHaveBeenCalledWith("name", "Second");
+    expect(result).toStrictEqual({ id: "456", path: "s1" });
+    expect(capturedWarnings()).toContain(
+      'updateScene: invalid path "t0" - names a track, not a scene; expected "s<index>"',
+    );
+  });
+
+  it("says when a path names a scene that isn't there", () => {
+    mockNonExistentObjects();
+
+    expect(updateScene({ path: "s9", name: "Nowhere" })).toStrictEqual([]);
+    expect(capturedWarnings()).toContain('updateScene: nothing at path "s9"');
+  });
+
+  it("still asks for a target when neither id nor path is given", () => {
+    expect(updateScene({ name: "Orphan" })).toStrictEqual([]);
+    expect(capturedWarnings()).toContain("updateScene: id or path is required");
+  });
+
+  it("counts ids and paths together when checking list lengths", () => {
+    expect(() =>
+      updateScene({ id: "123", path: "s1", name: "One,Two,Three" }),
+    ).toThrow("id and path names 2 entries but name names 3 entries.");
+  });
+});

--- a/src/tools/scene/tests/update-scene.test.ts
+++ b/src/tools/scene/tests/update-scene.test.ts
@@ -154,7 +154,7 @@ describe("updateScene", () => {
 
   it("refuses more names than scenes, naming both counts", () => {
     expect(() => updateScene({ id: "123,456", name: "A,B,C,D" })).toThrow(
-      "id names 2 entries but name names 4 entries.",
+      "id and path names 2 entries but name names 4 entries.",
     );
   });
 
@@ -178,11 +178,11 @@ describe("updateScene", () => {
 
   it("should warn and return empty when id is missing", () => {
     expect(updateScene({})).toStrictEqual([]);
-    expect(capturedWarnings()).toContain("updateScene: id is required");
+    expect(capturedWarnings()).toContain("updateScene: id or path is required");
 
     clearCapturedWarnings();
     expect(updateScene({ name: "Test" })).toStrictEqual([]);
-    expect(capturedWarnings()).toContain("updateScene: id is required");
+    expect(capturedWarnings()).toContain("updateScene: id or path is required");
   });
 
   // A permanent alias, not a migration: models reach for the plural on their

--- a/src/tools/scene/update-scene.def.ts
+++ b/src/tools/scene/update-scene.def.ts
@@ -24,6 +24,13 @@ export const toolDefUpdateScene = defineTool("ppal-update-scene", {
     ids: aliasParam(z.coerce.string().optional(), {
       canonical: "id",
     }),
+    path: param(z.coerce.string().optional(), {
+      default:
+        "scene path(s) to update instead of id, comma-separated (e.g., 's0' or 's0,s3')",
+      smallModel: "scene path to update instead of id (e.g., 's0')",
+    }),
+
+    paths: aliasParam(z.coerce.string().optional(), { canonical: "path" }),
     name: param(z.string().optional(), {
       default:
         "name for all, or comma-separated one per scene, in order (blank entry = unchanged)",

--- a/src/tools/scene/update-scene.ts
+++ b/src/tools/scene/update-scene.ts
@@ -9,6 +9,7 @@ import { verifyColorQuantization } from "#src/tools/shared/color-verification-he
 import {
   targetEntries,
   namedIdParam,
+  namedPathParam,
   parseTimeSignature,
   unwrapSingleResult,
 } from "#src/tools/shared/utils.ts";
@@ -22,7 +23,11 @@ import {
   getNameForIndex,
   parseNames,
 } from "#src/tools/shared/validation/name-utils.ts";
-import { validateListLengths } from "#src/tools/shared/validation/list-lengths.ts";
+import {
+  countListEntries,
+  validateListLengths,
+} from "#src/tools/shared/validation/list-lengths.ts";
+import { sceneIdPerPath } from "#src/tools/shared/validation/path-target-lookup.ts";
 import {
   applyTempoProperty,
   applyTimeSignatureProperty,
@@ -37,6 +42,9 @@ interface UpdateSceneArgs {
   id?: string;
   /** Hidden alias for id */
   ids?: string;
+  path?: string;
+  /** Hidden alias for path */
+  paths?: string;
   name?: string;
   color?: string;
   tempo?: number | null;
@@ -49,6 +57,8 @@ interface UpdateSceneArgs {
  * @param args - The scene parameters
  * @param args.id - Comma-separated scene IDs to update
  * @param args.ids - Hidden alias for id
+ * @param args.path - Comma-separated scene paths to update instead of ids
+ * @param args.paths - Hidden alias for path
  * @param args.name - Name for the scenes
  * @param args.color - Color for the scenes (CSS format: hex)
  * @param args.tempo - Tempo in BPM. Pass -1 to disable.
@@ -58,21 +68,37 @@ interface UpdateSceneArgs {
  * @returns Single scene object or array of scene objects
  */
 export function updateScene(
-  { id, ids, name, color, tempo, timeSignature, focus }: UpdateSceneArgs = {},
+  {
+    id,
+    ids,
+    path,
+    paths,
+    name,
+    color,
+    tempo,
+    timeSignature,
+    focus,
+  }: UpdateSceneArgs = {},
   _context: Partial<ToolContext> = {},
 ): UpdateSceneResult | UpdateSceneResult[] {
   const targets = namedIdParam(id, ids, "ids");
+  const targetPaths = namedPathParam(path, paths);
 
-  if (!targets) {
-    console.warn("updateScene: id is required");
+  if (!targets && !targetPaths) {
+    console.warn("updateScene: id or path is required");
 
     return [];
   }
 
   // Every list in the call is checked together, before any of them is split:
   // once one is split nothing knows whether the others are lists at all.
+  // `id` and `path` name different scenes and add up, so the target count is
+  // their sum — comparing the two would refuse a call naming two of each.
   validateListLengths([
-    { param: "id", value: targets },
+    {
+      param: "id and path",
+      count: countListEntries(targets) + countListEntries(targetPaths),
+    },
     { param: "name", value: name },
     { param: "color", value: color },
   ]);
@@ -80,7 +106,10 @@ export function updateScene(
   // Parse comma-separated string into array. An id that parses to nothing
   // (e.g. ",  ,") was still sent, so it gets a word of its own rather than
   // reading the same as an omitted id.
-  const sceneIds = targetEntries(targets, "id");
+  const sceneIds: Array<string | null> = [
+    ...(targets ? targetEntries(targets, "id") : []),
+    ...(targetPaths == null ? [] : sceneIdPerPath(targetPaths, "updateScene")),
+  ];
 
   // Parse names/colors against the original id count so the positional mapping
   // (name[k]/color[k] → ids[k]) survives even when an invalid id is skipped
@@ -98,17 +127,18 @@ export function updateScene(
   const updatedScenes: UpdateSceneResult[] = [];
 
   for (let i = 0; i < sceneIds.length; i++) {
+    const sceneId = sceneIds[i];
+
+    // A path that named no scene already warned; it keeps its slot so later
+    // names/colors don't shift onto the wrong scene.
+    if (sceneId == null) continue;
+
     // Validate one id at a time (skip invalid) so the loop index stays aligned
     // to the original ids: a skipped id must not pull later names/colors forward
     // onto the wrong scene.
-    const [scene] = validateIdTypes(
-      [sceneIds[i] as string],
-      "scene",
-      "updateScene",
-      {
-        skipInvalid: true,
-      },
-    );
+    const [scene] = validateIdTypes([sceneId], "scene", "updateScene", {
+      skipInvalid: true,
+    });
 
     if (scene == null) continue;
 

--- a/src/tools/shared/validation/path-target-lookup.ts
+++ b/src/tools/shared/validation/path-target-lookup.ts
@@ -1,0 +1,161 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Addressing tracks and scenes by where they are instead of by id, so a caller
+// that just read a Set can act on what it found without carrying ids around.
+//
+// A path that names the wrong kind of thing, or nothing at all, warns and
+// contributes nothing — the same as an id that doesn't resolve, so one bad
+// entry costs its own object rather than the whole batch.
+
+import { errorMessage } from "#src/shared/error-utils.ts";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import * as console from "#src/shared/max/v8-max-console.ts";
+import {
+  pathEntries,
+  trackSegmentPath,
+} from "#src/tools/shared/validation/object-path-helpers.ts";
+import {
+  parseObjectPath,
+  pathError,
+  type ObjectPath,
+} from "#src/tools/shared/validation/object-path.ts";
+
+/**
+ * Resolves track path(s) to the ids of the tracks they name.
+ * @param paths - Comma-separated track paths (e.g. "t0,rt1,mt")
+ * @param tool - Tool name, for warnings
+ * @param label - Param name the paths came from, for warnings
+ * @returns One track id per path entry, null where a path named none
+ */
+export function trackIdPerPath(
+  paths: string,
+  tool: string,
+  label = "path",
+): Array<string | null> {
+  return idPerPath(paths, tool, label, (path, entry) => {
+    if (
+      path.kind !== "track" &&
+      path.kind !== "return-track" &&
+      path.kind !== "master-track"
+    ) {
+      throw pathError(
+        label,
+        entry,
+        `names ${describePathKind(path)}, not a track; expected "t<index>", "rt<index>", or "mt"`,
+      );
+    }
+
+    return LiveAPI.from(trackSegmentPath(path));
+  });
+}
+
+/**
+ * Resolves scene path(s) to the ids of the scenes they name.
+ * @param paths - Comma-separated scene paths (e.g. "s0,s3")
+ * @param tool - Tool name, for warnings
+ * @param label - Param name the paths came from, for warnings
+ * @returns One scene id per path entry, null where a path named none
+ */
+export function sceneIdPerPath(
+  paths: string,
+  tool: string,
+  label = "path",
+): Array<string | null> {
+  return idPerPath(paths, tool, label, (path, entry) => {
+    if (path.kind !== "scene") {
+      throw pathError(
+        label,
+        entry,
+        `names ${describePathKind(path)}, not a scene; expected "s<index>"`,
+      );
+    }
+
+    return LiveAPI.from(livePath.scene(path.sceneIndex));
+  });
+}
+
+/**
+ * Splits a path param into entries, treating an unusable param as naming
+ * nothing rather than as an error: the same batch may also have named ids, and
+ * those objects are still there to act on.
+ * @param paths - The raw path param
+ * @param tool - Tool name, for warnings
+ * @param label - Param name the paths came from, for warnings
+ * @returns One trimmed entry per path, or none when the param is unusable
+ */
+export function pathEntriesOrNone(
+  paths: string,
+  tool: string,
+  label: string,
+): string[] {
+  try {
+    return pathEntries(paths, label);
+  } catch (error) {
+    console.warn(`${tool}: ${errorMessage(error)}`);
+
+    return [];
+  }
+}
+
+// --- Helpers below main exports ---
+
+/**
+ * Resolves each entry through a type-specific lookup, keeping one slot per
+ * path so a caller pairing paths against another list keeps its positions.
+ * @param paths - The raw path param
+ * @param tool - Tool name, for warnings
+ * @param label - Param name the paths came from, for warnings
+ * @param resolve - Turns a parsed path into the object it names, or throws
+ * @returns One id per path entry, null where a path named none
+ */
+function idPerPath(
+  paths: string,
+  tool: string,
+  label: string,
+  resolve: (path: ObjectPath, entry: string) => LiveAPI,
+): Array<string | null> {
+  const ids: Array<string | null> = [];
+
+  for (const entry of pathEntriesOrNone(paths, tool, label)) {
+    try {
+      const object = resolve(parseObjectPath(entry, label), entry);
+
+      if (object.exists()) {
+        ids.push(object.id);
+        continue;
+      }
+
+      console.warn(`${tool}: nothing at ${label} "${entry}"`);
+    } catch (error) {
+      console.warn(`${tool}: ${errorMessage(error)}`);
+    }
+
+    ids.push(null);
+  }
+
+  return ids;
+}
+
+/**
+ * Names what a path points at, for a message saying it's the wrong kind.
+ * @param path - A parsed path
+ * @returns What it names, as a noun phrase
+ */
+function describePathKind(path: ObjectPath): string {
+  switch (path.kind) {
+    case "scene":
+      return "a scene";
+    case "slot":
+      return "a clip slot";
+    case "take-lane":
+    case "new-take-lane":
+      return "a take lane";
+    case "device":
+      return "a device";
+    default:
+      return "a track";
+  }
+}

--- a/src/tools/shared/validation/tests/path-target-lookup.test.ts
+++ b/src/tools/shared/validation/tests/path-target-lookup.test.ts
@@ -1,0 +1,83 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import {
+  capturedWarnings,
+  clearCapturedWarnings,
+} from "#src/shared/max/v8-warning-capture.ts";
+import { registerMockObject } from "#src/test/mocks/mock-registry.ts";
+import { sceneIdPerPath, trackIdPerPath } from "../path-target-lookup.ts";
+import "#src/live-api-adapter/live-api-extensions.ts";
+
+describe("trackIdPerPath", () => {
+  beforeEach(() => {
+    clearCapturedWarnings();
+    registerMockObject("t0", { path: livePath.track(0) });
+  });
+
+  it("names the track at each path, in order", () => {
+    registerMockObject("rt0", { path: livePath.returnTrack(0) });
+    registerMockObject("mt", { path: livePath.masterTrack() });
+
+    expect(trackIdPerPath("t0, rt0, mt", "tool")).toStrictEqual([
+      "t0",
+      "rt0",
+      "mt",
+    ]);
+  });
+
+  // Every kind a path can name gets its own noun, so the model is told what it
+  // actually wrote rather than just that the path was wrong.
+  it.each([
+    ["s1", "a scene"],
+    ["t0/s1", "a clip slot"],
+    ["t0/l0", "a take lane"],
+    ["t0/l+", "a take lane"],
+    ["t0/d1", "a device"],
+  ])("says %s names %s, not a track", (path, noun) => {
+    expect(trackIdPerPath(path, "tool")).toStrictEqual([null]);
+    expect(capturedWarnings()).toContain(
+      `tool: invalid path "${path}" - names ${noun}, not a track; expected "t<index>", "rt<index>", or "mt"`,
+    );
+  });
+
+  it("keeps a bad entry's place so the good ones stay put", () => {
+    expect(trackIdPerPath("s1,t0", "tool")).toStrictEqual([null, "t0"]);
+  });
+
+  it("treats an unusable param as naming nothing", () => {
+    // A hole in the list is refused by pathEntries; the batch may also have
+    // named ids, so it warns rather than throwing.
+    expect(trackIdPerPath("t0,,t1", "tool")).toStrictEqual([]);
+    expect(capturedWarnings().join("\n")).toContain("tool: ");
+  });
+});
+
+describe("sceneIdPerPath", () => {
+  beforeEach(() => {
+    clearCapturedWarnings();
+    registerMockObject("s0", { path: livePath.scene(0) });
+  });
+
+  it("names the scene at each path, in order", () => {
+    registerMockObject("s2", { path: livePath.scene(2) });
+
+    expect(sceneIdPerPath("s0,s2", "tool")).toStrictEqual(["s0", "s2"]);
+  });
+
+  it.each([
+    ["t1", "a track"],
+    ["rt1", "a track"],
+    ["mt", "a track"],
+    ["t0/s1", "a clip slot"],
+  ])("says %s names %s, not a scene", (path, noun) => {
+    expect(sceneIdPerPath(path, "tool")).toStrictEqual([null]);
+    expect(capturedWarnings()).toContain(
+      `tool: invalid path "${path}" - names ${noun}, not a scene; expected "s<index>"`,
+    );
+  });
+});

--- a/src/tools/track/read/read-track.ts
+++ b/src/tools/track/read/read-track.ts
@@ -15,6 +15,7 @@ import {
 } from "#src/tools/shared/tool-framework/include-params.ts";
 import { namedIdParam, stripFields } from "#src/tools/shared/utils.ts";
 import { validateIdType } from "#src/tools/shared/validation/id-validation.ts";
+import { pathField } from "#src/tools/shared/validation/object-path-for-api.ts";
 import {
   categorizeDevices,
   readDevicesFlat,
@@ -345,6 +346,7 @@ export function readTrackGeneric({
 
   const result: Record<string, unknown> = {
     id: track.id,
+    ...pathField(track),
     type: computeTrackType(isMidiTrack, category),
     name: track.getProperty("name"),
     ...(includeColor && { color: track.getColor() }),

--- a/src/tools/track/read/tests/read-track-basic.test.ts
+++ b/src/tools/track/read/tests/read-track-basic.test.ts
@@ -146,6 +146,7 @@ describe("readTrack", () => {
 
     expect(result).toStrictEqual({
       id: "track2",
+      path: "t1",
       type: "audio",
       name: "Audio Track",
       trackIndex: 1,
@@ -181,6 +182,7 @@ describe("readTrack", () => {
       arrangementClipCount: 0,
       deviceCount: 0,
       id: "track2",
+      path: "t1",
       isArmed: true,
       name: "Boundary Track",
       sessionClipCount: 0,
@@ -277,6 +279,7 @@ describe("readTrack", () => {
 
     expect(result).toStrictEqual({
       id: "track3",
+      path: "t2",
       type: "midi",
       name: "Track with Clips",
       trackIndex: 2,
@@ -553,6 +556,7 @@ describe("readTrack", () => {
 function expectedSoloedMidiTrackResult(): Record<string, unknown> {
   return {
     id: "track1",
+    path: "t0",
     type: "midi",
     name: "Track 1",
     trackIndex: 0,

--- a/src/tools/track/read/tests/read-track-options.test.ts
+++ b/src/tools/track/read/tests/read-track-options.test.ts
@@ -206,6 +206,7 @@ describe("readTrack", () => {
 
         expect(result).toStrictEqual({
           id: "return_track_1",
+          path: "rt1",
           type: "return",
           name: "Return B",
           returnTrackIndex: 1,
@@ -295,6 +296,7 @@ describe("readTrack", () => {
 
         expect(result).toStrictEqual({
           id: "master_track",
+          path: "mt",
           type: "master",
           name: "Master",
           sessionClipCount: 0,
@@ -412,6 +414,7 @@ describe("readTrack", () => {
 
         expect(result).toStrictEqual({
           id: "master_track",
+          path: "mt",
           type: "master",
           name: "Master",
           sessionClipCount: 0,

--- a/src/tools/track/read/tests/read-track-parameters.test.ts
+++ b/src/tools/track/read/tests/read-track-parameters.test.ts
@@ -64,6 +64,7 @@ describe("readTrack", () => {
 
       expect(result).toStrictEqual({
         id: "123",
+        path: "t2",
         type: "midi",
         name: "Track by ID",
         trackIndex: 2,
@@ -90,6 +91,7 @@ describe("readTrack", () => {
         trackIndex: 2,
         type: "midi",
         id: "123",
+        path: "t2",
         name: "Track by ID",
       });
     });
@@ -110,6 +112,7 @@ describe("readTrack", () => {
 
       expect(result).toStrictEqual({
         id: "456",
+        path: "rt1",
         type: "return",
         name: "Return by ID",
         returnTrackIndex: 1,
@@ -135,6 +138,7 @@ describe("readTrack", () => {
 
       expect(result).toStrictEqual({
         id: "789",
+        path: "mt",
         type: "master",
         name: "Master by ID",
         sessionClipCount: 0,

--- a/src/tools/track/update/tests/update-track-empty-target.test.ts
+++ b/src/tools/track/update/tests/update-track-empty-target.test.ts
@@ -26,7 +26,7 @@ describe("updateTrack when id names nothing", () => {
 
     expect(updateTrack({ id: "   " })).toStrictEqual([]);
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith("updateTrack: id is required");
+    expect(warn).toHaveBeenCalledWith("updateTrack: id or path is required");
   });
 });
 

--- a/src/tools/track/update/tests/update-track-path.test.ts
+++ b/src/tools/track/update/tests/update-track-path.test.ts
@@ -1,0 +1,96 @@
+// Producer Pal
+// Copyright (C) 2026 Adam Murray
+// AI assistance: Claude (Anthropic)
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { livePath } from "#src/shared/live-api-path-builders.ts";
+import {
+  capturedWarnings,
+  clearCapturedWarnings,
+} from "#src/shared/max/v8-warning-capture.ts";
+import {
+  type RegisteredMockObject,
+  mockNonExistentObjects,
+  registerMockObject,
+} from "#src/test/mocks/mock-registry.ts";
+import { updateTrack } from "../update-track.ts";
+import "#src/live-api-adapter/live-api-extensions.ts";
+
+describe("updateTrack by path", () => {
+  let track0: RegisteredMockObject;
+  let track1: RegisteredMockObject;
+  let returnTrack: RegisteredMockObject;
+  let mainTrack: RegisteredMockObject;
+
+  beforeEach(() => {
+    clearCapturedWarnings();
+    track0 = registerMockObject("123", { path: livePath.track(0) });
+    track1 = registerMockObject("456", { path: livePath.track(1) });
+    returnTrack = registerMockObject("r1", { path: livePath.returnTrack(1) });
+    mainTrack = registerMockObject("m", { path: livePath.masterTrack() });
+  });
+
+  it("updates the track a path names", () => {
+    const result = updateTrack({ path: "t0", name: "By Path" });
+
+    expect(track0.set).toHaveBeenCalledWith("name", "By Path");
+    expect(result).toStrictEqual({ id: "123", path: "t0" });
+  });
+
+  it("reaches a return track and the main track", () => {
+    const result = updateTrack({ path: "rt1,mt", color: "#FF0000" });
+
+    expect(returnTrack.set).toHaveBeenCalledWith("color", 16711680);
+    expect(mainTrack.set).toHaveBeenCalledWith("color", 16711680);
+    expect(result).toStrictEqual([
+      { id: "r1", path: "rt1" },
+      { id: "m", path: "mt" },
+    ]);
+  });
+
+  it("adds paths to the ids rather than pairing with them", () => {
+    const result = updateTrack({
+      id: "123",
+      path: "t1",
+      name: "First,Second",
+    });
+
+    expect(track0.set).toHaveBeenCalledWith("name", "First");
+    expect(track1.set).toHaveBeenCalledWith("name", "Second");
+    expect(result).toStrictEqual([
+      { id: "123", path: "t0" },
+      { id: "456", path: "t1" },
+    ]);
+  });
+
+  it("says a path names the wrong kind of object, and keeps its place", () => {
+    const result = updateTrack({ path: "s0,t1", name: "First,Second" });
+
+    // The skipped entry keeps its slot: "Second" must not slide onto t1's
+    // neighbor, and t1 must not be renamed "First".
+    expect(track1.set).toHaveBeenCalledWith("name", "Second");
+    expect(result).toStrictEqual({ id: "456", path: "t1" });
+    expect(capturedWarnings()).toContain(
+      'updateTrack: invalid path "s0" - names a scene, not a track; expected "t<index>", "rt<index>", or "mt"',
+    );
+  });
+
+  it("says when a path names a track that isn't there", () => {
+    mockNonExistentObjects();
+
+    expect(updateTrack({ path: "t9", name: "Nowhere" })).toStrictEqual([]);
+    expect(capturedWarnings()).toContain('updateTrack: nothing at path "t9"');
+  });
+
+  it("still asks for a target when neither id nor path is given", () => {
+    expect(updateTrack({ name: "Orphan" })).toStrictEqual([]);
+    expect(capturedWarnings()).toContain("updateTrack: id or path is required");
+  });
+
+  it("counts ids and paths together when checking list lengths", () => {
+    expect(() =>
+      updateTrack({ id: "123", path: "t1", name: "One,Two,Three" }),
+    ).toThrow("id and path names 2 entries but name names 3 entries.");
+  });
+});

--- a/src/tools/track/update/tests/update-track.test.ts
+++ b/src/tools/track/update/tests/update-track.test.ts
@@ -102,11 +102,11 @@ describe("updateTrack", () => {
 
   it("should warn and return empty when id is missing", () => {
     expect(updateTrack({})).toStrictEqual([]);
-    expect(capturedWarnings()).toContain("updateTrack: id is required");
+    expect(capturedWarnings()).toContain("updateTrack: id or path is required");
 
     clearCapturedWarnings();
     expect(updateTrack({ name: "Test" })).toStrictEqual([]);
-    expect(capturedWarnings()).toContain("updateTrack: id is required");
+    expect(capturedWarnings()).toContain("updateTrack: id or path is required");
   });
 
   // A permanent alias, not a migration: models reach for the plural on their
@@ -184,7 +184,7 @@ describe("updateTrack", () => {
   // against 2, and refused.
   it("refuses a trailing comma that leaves the lists uneven", () => {
     expect(() => updateTrack({ id: "123,456,789", name: "A,B," })).toThrow(
-      "id names 3 entries but name names 2 entries.",
+      "id and path names 3 entries but name names 2 entries.",
     );
   });
 

--- a/src/tools/track/update/update-track.def.ts
+++ b/src/tools/track/update/update-track.def.ts
@@ -30,6 +30,13 @@ export const toolDefUpdateTrack = defineTool("ppal-update-track", {
     ids: aliasParam(z.coerce.string().optional(), {
       canonical: "id",
     }),
+    path: param(z.coerce.string().optional(), {
+      default:
+        "track path(s) to update instead of id, comma-separated: 't<index>', 'rt<index>' (return), or 'mt' (main) - e.g. 't0' or 't0,rt1'",
+      smallModel: "track path to update instead of id (e.g., 't0')",
+    }),
+
+    paths: aliasParam(z.coerce.string().optional(), { canonical: "path" }),
     name: param(z.string().optional(), {
       default:
         "name for all, or comma-separated one per track, in order (blank entry = unchanged), ideally unique",

--- a/src/tools/track/update/update-track.ts
+++ b/src/tools/track/update/update-track.ts
@@ -21,6 +21,7 @@ import {
   findReturnIndex,
   targetEntries,
   namedIdParam,
+  namedPathParam,
   unwrapSingleResult,
 } from "#src/tools/shared/utils.ts";
 import {
@@ -33,12 +34,19 @@ import {
   getNameForIndex,
   parseNames,
 } from "#src/tools/shared/validation/name-utils.ts";
-import { validateListLengths } from "#src/tools/shared/validation/list-lengths.ts";
+import {
+  countListEntries,
+  validateListLengths,
+} from "#src/tools/shared/validation/list-lengths.ts";
+import { trackIdPerPath } from "#src/tools/shared/validation/path-target-lookup.ts";
 
 interface UpdateTrackArgs {
   id?: string;
   /** Hidden alias for id */
   ids?: string;
+  path?: string;
+  /** Hidden alias for path */
+  paths?: string;
   name?: string;
   color?: string;
   gainDb?: number;
@@ -187,6 +195,8 @@ function applySendProperties(
  * @param args - The track parameters
  * @param args.id - Track ID or comma-separated list of track IDs to update
  * @param args.ids - Hidden alias for id
+ * @param args.path - Track path(s) to update instead of ids, comma-separated
+ * @param args.paths - Hidden alias for path
  * @param args.name - Optional track name
  * @param args.color - Optional track color (CSS format: hex)
  * @param args.gainDb - Optional track gain in dB (-70 to 6)
@@ -215,6 +225,8 @@ export function updateTrack(
   {
     id,
     ids,
+    path,
+    paths,
     name,
     color,
     gainDb,
@@ -240,17 +252,23 @@ export function updateTrack(
   _context: Partial<ToolContext> = {},
 ): UpdateTrackResult | UpdateTrackResult[] {
   const targets = namedIdParam(id, ids, "ids");
+  const targetPaths = namedPathParam(path, paths);
 
-  if (!targets) {
-    console.warn("updateTrack: id is required");
+  if (!targets && !targetPaths) {
+    console.warn("updateTrack: id or path is required");
 
     return [];
   }
 
   // Every list in the call is checked together, before any of them is split:
   // once one is split nothing knows whether the others are lists at all.
+  // `id` and `path` name different tracks and add up, so the target count is
+  // their sum — comparing the two would refuse a call naming two of each.
   validateListLengths([
-    { param: "id", value: targets },
+    {
+      param: "id and path",
+      count: countListEntries(targets) + countListEntries(targetPaths),
+    },
     { param: "name", value: name },
     { param: "color", value: color },
   ]);
@@ -258,7 +276,10 @@ export function updateTrack(
   // Parse comma-separated string into array. An id that parses to nothing
   // (e.g. ",  ,") was still sent, so it gets a word of its own rather than
   // reading the same as an omitted id.
-  const trackIds = targetEntries(targets, "id");
+  const trackIds: Array<string | null> = [
+    ...(targets ? targetEntries(targets, "id") : []),
+    ...(targetPaths == null ? [] : trackIdPerPath(targetPaths, "updateTrack")),
+  ];
 
   // Parse names/colors against the original id count so the positional mapping
   // (name[k]/color[k] → ids[k]) survives even when an invalid id is skipped
@@ -269,15 +290,18 @@ export function updateTrack(
   const updatedTracks: UpdateTrackResult[] = [];
 
   for (let i = 0; i < trackIds.length; i++) {
+    const trackId = trackIds[i];
+
+    // A path that named no track already warned; it keeps its slot so later
+    // names/colors don't shift onto the wrong track.
+    if (trackId == null) continue;
+
     // Validate one id at a time (skip invalid) so the loop index stays aligned
     // to the original ids: a skipped id must not pull later names/colors forward
     // onto the wrong track.
-    const [track] = validateIdTypes(
-      [trackIds[i] as string],
-      "track",
-      "updateTrack",
-      { skipInvalid: true },
-    );
+    const [track] = validateIdTypes([trackId], "track", "updateTrack", {
+      skipInvalid: true,
+    });
 
     if (track == null) continue;
 


### PR DESCRIPTION
Reads hand back the `path` of every track and scene, and the write tools take one wherever an id works.

- `ppal-read-track`, `ppal-read-scene` and `ppal-read-live-set` report `path` — `t0`, `rt1`, `mt`, `s3` — alongside `id`.
- `ppal-update-track`, `ppal-update-scene` and `ppal-delete` accept a track or scene `path` instead of an id. As on the clip tools, `id` and `path` name different objects and add up.
- A path that names nothing warns and skips that one item, keeping its place so later names and colors don't shift onto the wrong track.

This closes a round-trip gap: a result handed back `t0` and no tool would take it.

Later phases (collapsing `trackType` into the path, creating by path) are recorded in `dev/plans/Path-Standardization.md` and are not in this PR yet.